### PR TITLE
[codex] Pass resolver impl metadata tasks as bundle

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1806,6 +1806,9 @@ checked-in docs, tests, and commits only.
 - Resolver-backed type behavior refresh now receives the full resolver
   declaration metadata task bundle and selects type declarations internally,
   keeping the final replay step aligned with the bundled call sites.
+- Resolver-backed behavior impl metadata collection now receives the full
+  resolver declaration metadata task bundle and selects behavior impl entries
+  internally, so collected replay call sites all use the same bundle shape.
 
 ## Current Phase
 

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -3930,7 +3930,7 @@ impl TypeChecker {
 
         let tasks = Self::collect_resolver_declaration_metadata_tasks(decls);
         self.collect_resolver_declaration_metadata(symbols, &tasks);
-        self.collect_resolver_behavior_impl_metadata(&tasks.behavior_associations, symbols);
+        self.collect_resolver_behavior_impl_metadata(&tasks, symbols);
         self.validate_resolver_collected_declaration_semantics(symbols, &tasks);
         self.clear_resolver_behavior_ref_state();
         self.refresh_resolver_type_behavior_impls(&tasks, symbols);
@@ -4453,13 +4453,14 @@ impl TypeChecker {
 
     fn collect_resolver_behavior_impl_metadata(
         &mut self,
-        association_tasks: &BehaviorAssociationValidationTasks<'_>,
+        tasks: &ResolverDeclarationMetadataTasks<'_>,
         symbols: &SymbolTable,
     ) {
-        let tasks = self.resolver_behavior_impl_block_tasks(&association_tasks.impls, symbols);
+        let impl_tasks =
+            self.resolver_behavior_impl_block_tasks(&tasks.behavior_associations.impls, symbols);
 
         self.with_resolver_backed_collection(|checker| {
-            for task in &tasks {
+            for task in &impl_tasks {
                 checker.collect_resolver_behavior_impl_method_signatures(
                     symbols,
                     task.ast_type_name,
@@ -4472,7 +4473,7 @@ impl TypeChecker {
 
             checker.validate_collected_behavior_extends_semantics();
 
-            for task in &tasks {
+            for task in &impl_tasks {
                 checker.collect_behavior_default_method_signatures(
                     &task.restored_type_name,
                     task.behavior,


### PR DESCRIPTION
## Summary

- Passes the full resolver declaration metadata task bundle into resolver-backed behavior impl metadata collection.
- Lets the helper select behavior impl entries internally instead of receiving the behavior-association task slice from the call site.
- Records the bundle-shape cleanup in the phase plan.

## Validation

Targeted TDD check:

- changed the production call site first and observed the expected type mismatch
- `cargo test --lib resolver_declaration_metadata_tasks_collect_impl_blocks_with_declarations`

Full local gate on `b0407603`:

- `cargo test --test docs_truth`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

## CI noise

Opened as draft so pull-request jobs stay skipped until this PR is marked ready.