### PR TITLE
[codex] Pass resolver callable tasks as bundle

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1809,6 +1809,9 @@ checked-in docs, tests, and commits only.
 - Resolver-backed behavior impl metadata collection now receives the full
   resolver declaration metadata task bundle and selects behavior impl entries
   internally, so collected replay call sites all use the same bundle shape.
+- Resolver-backed callable metadata collection now receives the full resolver
+  declaration metadata task bundle and selects callable entries internally,
+  continuing the resolver replay move away from parallel slices.
 
 ## Current Phase
 

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -4335,7 +4335,7 @@ impl TypeChecker {
         symbols: &SymbolTable,
         tasks: &ResolverDeclarationMetadataTasks<'_>,
     ) {
-        self.collect_resolver_callable_declaration_metadata(symbols, &tasks.callable);
+        self.collect_resolver_callable_declaration_metadata(symbols, tasks);
         self.collect_resolver_type_declaration_metadata(symbols, &tasks.types);
         self.collect_resolver_behavior_declaration_metadata_pass(symbols, &tasks.behaviors);
     }
@@ -4370,9 +4370,9 @@ impl TypeChecker {
     fn collect_resolver_callable_declaration_metadata(
         &mut self,
         symbols: &SymbolTable,
-        tasks: &[ResolverCallableDeclarationMetadataTask<'_>],
+        tasks: &ResolverDeclarationMetadataTasks<'_>,
     ) {
-        for task in tasks {
+        for task in &tasks.callable {
             match task {
                 ResolverCallableDeclarationMetadataTask::Function { name, span } => {
                     self.collect_resolver_function_signature(symbols, name, *span);


### PR DESCRIPTION
## Summary

- Passes the full resolver declaration metadata task bundle into resolver-backed callable metadata collection.
- Lets the callable replay helper select callable entries internally instead of receiving a callable-task slice.
- Records the resolver replay bundle cleanup in the phase plan.

## Validation

Targeted TDD check:

- changed the production call site first and observed the expected type mismatch
- `cargo test --lib resolver_declaration_metadata_tasks_collect_impl_blocks_with_declarations`

Full local gate on `2c3e1aad`:

- `cargo test --test docs_truth`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

## CI noise

Opened as draft so pull-request jobs stay skipped until this PR is marked ready.