### PR TITLE
[codex] Pass resolver type metadata tasks as bundle

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1812,6 +1812,9 @@ checked-in docs, tests, and commits only.
 - Resolver-backed callable metadata collection now receives the full resolver
   declaration metadata task bundle and selects callable entries internally,
   continuing the resolver replay move away from parallel slices.
+- Resolver-backed type declaration metadata collection now receives the full
+  resolver declaration metadata task bundle and selects type entries
+  internally, keeping declaration metadata replay helpers bundle-shaped.
 
 ## Current Phase
 

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -4336,7 +4336,7 @@ impl TypeChecker {
         tasks: &ResolverDeclarationMetadataTasks<'_>,
     ) {
         self.collect_resolver_callable_declaration_metadata(symbols, tasks);
-        self.collect_resolver_type_declaration_metadata(symbols, &tasks.types);
+        self.collect_resolver_type_declaration_metadata(symbols, tasks);
         self.collect_resolver_behavior_declaration_metadata_pass(symbols, &tasks.behaviors);
     }
 
@@ -4353,9 +4353,9 @@ impl TypeChecker {
     fn collect_resolver_type_declaration_metadata(
         &mut self,
         symbols: &SymbolTable,
-        tasks: &[ResolverTypeDeclarationMetadataTask<'_>],
+        tasks: &ResolverDeclarationMetadataTasks<'_>,
     ) {
-        for task in tasks {
+        for task in &tasks.types {
             match task {
                 ResolverTypeDeclarationMetadataTask::Struct { name, fields, span } => {
                     self.collect_resolver_struct_declaration_metadata(symbols, name, fields, *span);


### PR DESCRIPTION
## Summary

- Passes the full resolver declaration metadata task bundle into resolver-backed type declaration metadata collection.
- Lets the type replay helper select type entries internally instead of receiving a type-task slice.
- Records the resolver replay bundle cleanup in the phase plan.

## Validation

Targeted TDD check:

- changed the production call site first and observed the expected type mismatch
- `cargo test --lib resolver_declaration_metadata_tasks_collect_impl_blocks_with_declarations`

Full local gate on `b27e49a4`:

- `cargo test --test docs_truth`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

## CI noise

Opened as draft so pull-request jobs stay skipped until this PR is marked ready.