### PR TITLE
[codex] Pass resolver behavior metadata tasks as bundle

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1815,6 +1815,9 @@ checked-in docs, tests, and commits only.
 - Resolver-backed type declaration metadata collection now receives the full
   resolver declaration metadata task bundle and selects type entries
   internally, keeping declaration metadata replay helpers bundle-shaped.
+- Resolver-backed behavior declaration metadata collection now receives the
+  full resolver declaration metadata task bundle and selects behavior entries
+  internally, completing the declaration metadata replay helper bundle shape.
 
 ## Current Phase
 

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -4337,15 +4337,15 @@ impl TypeChecker {
     ) {
         self.collect_resolver_callable_declaration_metadata(symbols, tasks);
         self.collect_resolver_type_declaration_metadata(symbols, tasks);
-        self.collect_resolver_behavior_declaration_metadata_pass(symbols, &tasks.behaviors);
+        self.collect_resolver_behavior_declaration_metadata_pass(symbols, tasks);
     }
 
     fn collect_resolver_behavior_declaration_metadata_pass(
         &mut self,
         symbols: &SymbolTable,
-        tasks: &[ResolverBehaviorDeclarationMetadataTask<'_>],
+        tasks: &ResolverDeclarationMetadataTasks<'_>,
     ) {
-        for task in tasks {
+        for task in &tasks.behaviors {
             self.collect_resolver_behavior_declaration(symbols, task.name, task.span);
         }
     }


### PR DESCRIPTION
## Summary

- Pass the full resolver declaration metadata task bundle into resolver-backed behavior declaration metadata collection.
- Let the helper select `tasks.behaviors` internally instead of receiving a behavior-task slice.
- Record the bundle-shape cleanup in the phase plan.

## Validation

- Changed the production call site first and observed the expected type mismatch.
- `cargo test --lib resolver_declaration_metadata_tasks_collect_impl_blocks_with_declarations`
- `cargo test --test docs_truth && cargo fmt --check && git diff --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`

Opened as draft to avoid starting Actions until ready.