### PR TITLE
[codex] Pass resolver impl block tasks as bundle

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1818,6 +1818,9 @@ checked-in docs, tests, and commits only.
 - Resolver-backed behavior declaration metadata collection now receives the
   full resolver declaration metadata task bundle and selects behavior entries
   internally, completing the declaration metadata replay helper bundle shape.
+- Resolver behavior impl-block restoration now receives the full resolver
+  declaration metadata task bundle and selects `.implements` entries
+  internally, keeping behavior impl metadata replay on the bundled task shape.
 
 ## Current Phase
 

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -4456,8 +4456,7 @@ impl TypeChecker {
         tasks: &ResolverDeclarationMetadataTasks<'_>,
         symbols: &SymbolTable,
     ) {
-        let impl_tasks =
-            self.resolver_behavior_impl_block_tasks(&tasks.behavior_associations.impls, symbols);
+        let impl_tasks = self.resolver_behavior_impl_block_tasks(tasks, symbols);
 
         self.with_resolver_backed_collection(|checker| {
             for task in &impl_tasks {
@@ -4523,18 +4522,18 @@ impl TypeChecker {
 
     fn resolver_behavior_impl_block_tasks<'a>(
         &self,
-        raw_tasks: &'a [ResolverBehaviorImplBlockDeclarationTask<'a>],
+        tasks: &'a ResolverDeclarationMetadataTasks<'a>,
         symbols: &SymbolTable,
     ) -> Vec<ResolverBehaviorImplBlockTask<'a>> {
-        let mut tasks = Vec::new();
-        for raw_task in raw_tasks {
+        let mut impl_tasks = Vec::new();
+        for raw_task in &tasks.behavior_associations.impls {
             let restored_type_name = self.resolver_impl_type_name_for(
                 symbols,
                 raw_task.ast_type_name,
                 raw_task.methods,
                 Some((raw_task.behavior, raw_task.behavior_type_args)),
             );
-            tasks.push(ResolverBehaviorImplBlockTask {
+            impl_tasks.push(ResolverBehaviorImplBlockTask {
                 ast_type_name: raw_task.ast_type_name,
                 restored_type_name,
                 behavior: raw_task.behavior,
@@ -4542,7 +4541,7 @@ impl TypeChecker {
                 methods: raw_task.methods,
             });
         }
-        tasks
+        impl_tasks
     }
 
     fn resolver_type_behavior_refresh_tasks(


### PR DESCRIPTION
## Summary

- Pass the full resolver declaration metadata task bundle into behavior impl-block restoration.
- Let `resolver_behavior_impl_block_tasks` select `.implements` entries internally instead of receiving an impl-task slice.
- Record the bundled task-shape cleanup in the phase plan.

## Validation

- Changed the production call site first and observed the expected type mismatch.
- `cargo test --lib resolver_declaration_metadata_tasks_collect_impl_blocks_with_declarations`
- `cargo test --test docs_truth && cargo fmt --check && git diff --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`

Opened as draft to avoid starting Actions until ready.