### PR TITLE
[codex] Pass behavior association validators as bundle

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1821,6 +1821,9 @@ checked-in docs, tests, and commits only.
 - Resolver behavior impl-block restoration now receives the full resolver
   declaration metadata task bundle and selects `.implements` entries
   internally, keeping behavior impl metadata replay on the bundled task shape.
+- Behavior association impl and requires validators now receive the full
+  behavior-association task bundle and select their entries internally,
+  shrinking the remaining slice handoffs in association validation replay.
 
 ## Current Phase
 

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -4631,16 +4631,16 @@ impl TypeChecker {
         tasks: &BehaviorAssociationValidationTasks<'_>,
         symbols: Option<&SymbolTable>,
     ) {
-        self.validate_behavior_impl_tasks(&tasks.impls, symbols);
-        self.validate_behavior_requires_tasks(&tasks.requires, symbols);
+        self.validate_behavior_impl_tasks(tasks, symbols);
+        self.validate_behavior_requires_tasks(tasks, symbols);
     }
 
     fn validate_behavior_impl_tasks(
         &mut self,
-        impl_tasks: &[ResolverBehaviorImplBlockDeclarationTask<'_>],
+        tasks: &BehaviorAssociationValidationTasks<'_>,
         symbols: Option<&SymbolTable>,
     ) {
-        for task in impl_tasks {
+        for task in &tasks.impls {
             self.validate_collected_behavior_impl_declaration(
                 symbols,
                 task.ast_type_name,
@@ -4677,10 +4677,10 @@ impl TypeChecker {
 
     fn validate_behavior_requires_tasks(
         &mut self,
-        requires_tasks: &[BehaviorRequiresValidationTask<'_>],
+        tasks: &BehaviorAssociationValidationTasks<'_>,
         symbols: Option<&SymbolTable>,
     ) {
-        for task in requires_tasks {
+        for task in &tasks.requires {
             self.validate_collected_behavior_requires_declaration(
                 symbols,
                 task.type_name,


### PR DESCRIPTION
## Summary

- Pass the full behavior-association task bundle into impl and requires validation helpers.
- Let each helper select its own `impls` or `requires` entries internally.
- Record the remaining association validation handoff cleanup in the phase plan.

## Validation

- Changed the production call sites first and observed the expected type mismatches.
- `cargo test --lib behavior_association_validation_tasks_collect_extends_impls_and_requires_together`
- `cargo test --test docs_truth && cargo fmt --check && git diff --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`

Opened as draft to avoid starting Actions until ready.