### PR TITLE
[codex] Pass resolver field default tasks as bundle

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1824,6 +1824,9 @@ checked-in docs, tests, and commits only.
 - Behavior association impl and requires validators now receive the full
   behavior-association task bundle and select their entries internally,
   shrinking the remaining slice handoffs in association validation replay.
+- Resolver-backed struct field-default validation now receives the full
+  resolver declaration metadata task bundle and selects type declarations
+  internally, removing another `tasks.types` handoff from semantic replay.
 
 ## Current Phase
 

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -3988,6 +3988,7 @@ impl TypeChecker {
         tasks
     }
 
+    #[cfg(test)]
     fn collect_resolver_type_declaration_metadata_tasks(
         decls: &[Declaration],
     ) -> Vec<ResolverTypeDeclarationMetadataTask<'_>> {
@@ -3998,6 +3999,7 @@ impl TypeChecker {
         tasks
     }
 
+    #[cfg(test)]
     fn push_resolver_type_declaration_metadata_task<'a>(
         decl: &'a Declaration,
         tasks: &mut Vec<ResolverTypeDeclarationMetadataTask<'a>>,
@@ -4492,7 +4494,7 @@ impl TypeChecker {
             checker
                 .validate_behavior_association_tasks(&tasks.behavior_associations, Some(symbols));
             checker.validate_resolver_type_reference_tasks(&tasks.type_references, Some(symbols));
-            checker.validate_resolver_struct_field_default_tasks(&tasks.types, Some(symbols));
+            checker.validate_resolver_struct_field_default_tasks(tasks, Some(symbols));
         });
     }
 
@@ -4747,7 +4749,7 @@ impl TypeChecker {
         symbols: Option<&SymbolTable>,
     ) {
         if self.resolver_backed_collection {
-            let tasks = Self::collect_resolver_type_declaration_metadata_tasks(decls);
+            let tasks = Self::collect_resolver_declaration_metadata_tasks(decls);
             self.validate_resolver_struct_field_default_tasks(&tasks, symbols);
             return;
         }
@@ -4814,10 +4816,10 @@ impl TypeChecker {
 
     fn validate_resolver_struct_field_default_tasks(
         &mut self,
-        type_tasks: &[ResolverTypeDeclarationMetadataTask<'_>],
+        tasks: &ResolverDeclarationMetadataTasks<'_>,
         symbols: Option<&SymbolTable>,
     ) {
-        for task in type_tasks {
+        for task in &tasks.types {
             if let ResolverTypeDeclarationMetadataTask::Struct { name, span, .. } = task {
                 self.validate_resolver_struct_field_defaults(symbols, name, *span);
             }
@@ -18692,7 +18694,7 @@ Point: { x: i32 = true }
         tc.collect_resolver_declaration_metadata(&symbols, &tasks);
 
         tc.with_resolver_backed_collection(|checker| {
-            checker.validate_resolver_struct_field_default_tasks(&tasks.types, Some(&symbols));
+            checker.validate_resolver_struct_field_default_tasks(&tasks, Some(&symbols));
         });
 
         assert!(


### PR DESCRIPTION
## Summary

- Pass the full resolver declaration metadata task bundle into resolver-backed struct field-default validation.
- Let `validate_resolver_struct_field_default_tasks` select type declarations internally.
- Move the older type-only resolver metadata collector behind `#[cfg(test)]` now that production callers use the full bundle.
- Record the semantic replay handoff cleanup in the phase plan.

## Validation

- Changed the production call site first and observed the expected type mismatch.
- `cargo test --lib resolver_struct_field_defaults_validate_from_type_metadata_tasks`
- `cargo test --test docs_truth && cargo fmt --check && git diff --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`

Opened as draft to avoid starting Actions until ready.