### PR TITLE
[codex] Pass resolver type reference tasks as bundle

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1827,6 +1827,9 @@ checked-in docs, tests, and commits only.
 - Resolver-backed struct field-default validation now receives the full
   resolver declaration metadata task bundle and selects type declarations
   internally, removing another `tasks.types` handoff from semantic replay.
+- Resolver-backed type-reference validation now receives the full resolver
+  declaration metadata task bundle and selects type-reference replay entries
+  internally, keeping collected semantic replay on the bundled task shape.
 
 ## Current Phase
 

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -4258,6 +4258,7 @@ impl TypeChecker {
         }
     }
 
+    #[cfg(test)]
     fn collect_resolver_type_reference_validation_tasks(
         decls: &[Declaration],
     ) -> Vec<ResolverTypeReferenceValidationTask<'_>> {
@@ -4493,7 +4494,7 @@ impl TypeChecker {
         self.with_resolver_backed_collection(|checker| {
             checker
                 .validate_behavior_association_tasks(&tasks.behavior_associations, Some(symbols));
-            checker.validate_resolver_type_reference_tasks(&tasks.type_references, Some(symbols));
+            checker.validate_resolver_type_reference_tasks(tasks, Some(symbols));
             checker.validate_resolver_struct_field_default_tasks(tasks, Some(symbols));
         });
     }
@@ -6970,16 +6971,16 @@ impl TypeChecker {
         decls: &[Declaration],
         symbols: Option<&SymbolTable>,
     ) {
-        let tasks = Self::collect_resolver_type_reference_validation_tasks(decls);
+        let tasks = Self::collect_resolver_declaration_metadata_tasks(decls);
         self.validate_resolver_type_reference_tasks(&tasks, symbols);
     }
 
     fn validate_resolver_type_reference_tasks(
         &mut self,
-        tasks: &[ResolverTypeReferenceValidationTask<'_>],
+        tasks: &ResolverDeclarationMetadataTasks<'_>,
         symbols: Option<&SymbolTable>,
     ) {
-        for task in tasks {
+        for task in &tasks.type_references {
             match task {
                 ResolverTypeReferenceValidationTask::Struct { name, fields, span } => {
                     self.validate_resolver_struct_type_references(symbols, name, fields, *span);


### PR DESCRIPTION
## Summary

- Pass the full resolver declaration metadata task bundle into resolver-backed type-reference validation.
- Let `validate_resolver_type_reference_tasks` select `type_references` internally.
- Move the old type-reference-only collector behind `#[cfg(test)]` now that production callers collect the full bundle.
- Record the semantic replay handoff cleanup in the phase plan.

## Validation

- Changed the production call site first and observed the expected type mismatch.
- `cargo test --lib resolver_type_reference_validation_tasks_collect_only_type_reference_work`
- `cargo test --test docs_truth && cargo fmt --check && git diff --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`

Opened as draft to avoid starting Actions until ready.