### PR TITLE
[codex] Pass resolver behavior associations as bundle

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1830,6 +1830,9 @@ checked-in docs, tests, and commits only.
 - Resolver-backed type-reference validation now receives the full resolver
   declaration metadata task bundle and selects type-reference replay entries
   internally, keeping collected semantic replay on the bundled task shape.
+- Behavior association semantic validation now accepts either the standalone
+  behavior-association bundle or the full resolver declaration metadata bundle,
+  so resolver semantic replay no longer passes a nested association slice.
 
 ## Current Phase
 

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -267,6 +267,16 @@ struct BehaviorAssociationValidationTasks<'a> {
     requires: Vec<BehaviorRequiresValidationTask<'a>>,
 }
 
+trait BehaviorAssociationValidationTaskSource<'a> {
+    fn behavior_association_tasks(&self) -> &BehaviorAssociationValidationTasks<'a>;
+}
+
+impl<'a> BehaviorAssociationValidationTaskSource<'a> for BehaviorAssociationValidationTasks<'a> {
+    fn behavior_association_tasks(&self) -> &BehaviorAssociationValidationTasks<'a> {
+        self
+    }
+}
+
 #[derive(Default)]
 struct ResolverDeclarationMetadataTasks<'a> {
     callable: Vec<ResolverCallableDeclarationMetadataTask<'a>>,
@@ -274,6 +284,12 @@ struct ResolverDeclarationMetadataTasks<'a> {
     behaviors: Vec<ResolverBehaviorDeclarationMetadataTask<'a>>,
     behavior_associations: BehaviorAssociationValidationTasks<'a>,
     type_references: Vec<ResolverTypeReferenceValidationTask<'a>>,
+}
+
+impl<'a> BehaviorAssociationValidationTaskSource<'a> for ResolverDeclarationMetadataTasks<'a> {
+    fn behavior_association_tasks(&self) -> &BehaviorAssociationValidationTasks<'a> {
+        &self.behavior_associations
+    }
 }
 
 struct ResolverBehaviorImplBlockDeclarationTask<'a> {
@@ -4492,8 +4508,7 @@ impl TypeChecker {
         tasks: &ResolverDeclarationMetadataTasks<'_>,
     ) {
         self.with_resolver_backed_collection(|checker| {
-            checker
-                .validate_behavior_association_tasks(&tasks.behavior_associations, Some(symbols));
+            checker.validate_behavior_association_tasks(tasks, Some(symbols));
             checker.validate_resolver_type_reference_tasks(tasks, Some(symbols));
             checker.validate_resolver_struct_field_default_tasks(tasks, Some(symbols));
         });
@@ -4629,11 +4644,12 @@ impl TypeChecker {
         tasks
     }
 
-    fn validate_behavior_association_tasks(
+    fn validate_behavior_association_tasks<'a>(
         &mut self,
-        tasks: &BehaviorAssociationValidationTasks<'_>,
+        tasks: &impl BehaviorAssociationValidationTaskSource<'a>,
         symbols: Option<&SymbolTable>,
     ) {
+        let tasks = tasks.behavior_association_tasks();
         self.validate_behavior_impl_tasks(tasks, symbols);
         self.validate_behavior_requires_tasks(tasks, symbols);
     }


### PR DESCRIPTION
## Summary

- Let behavior association semantic validation accept either the standalone association bundle or the full resolver declaration metadata bundle.
- Pass the full resolver metadata bundle from resolver semantic replay instead of peeling out `behavior_associations` at the call site.
- Record the semantic replay handoff cleanup in the phase plan.

## Validation

- Changed the resolver replay call site first and observed the expected type mismatch.
- `cargo test --lib behavior_association_validation_tasks_collect_extends_impls_and_requires_together`
- `cargo test --test docs_truth && cargo fmt --check && git diff --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`

Opened as draft to avoid starting Actions until ready.