### PR TITLE
[codex] Pass resolver validation replay tasks as bundle

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1833,6 +1833,9 @@ checked-in docs, tests, and commits only.
 - Behavior association semantic validation now accepts either the standalone
   behavior-association bundle or the full resolver declaration metadata bundle,
   so resolver semantic replay no longer passes a nested association slice.
+- Resolver validation replay now passes the full replay task bundle into
+  behavior association list validation, which selects type and parent
+  association lists internally.
 
 ## Current Phase
 

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -8475,7 +8475,7 @@ impl TypeChecker {
             symbols,
         );
         self.validate_no_extra_resolver_local_symbols(&replay_tasks.expected_symbols, symbols);
-        self.validate_resolver_behavior_association_lists(replay_tasks.behavior_associations);
+        self.validate_resolver_behavior_association_lists(&replay_tasks);
         self.validate_stripped_resolver_import_symbols(
             replay_tasks.expected_symbols.validate_imports,
             symbols,
@@ -8565,9 +8565,9 @@ impl TypeChecker {
 
     fn validate_resolver_behavior_association_lists(
         &mut self,
-        tasks: ResolverBehaviorAssociationListTasks<'_>,
+        tasks: &ResolverValidationReplayTasks<'_>,
     ) {
-        for task in tasks.type_associations {
+        for task in &tasks.behavior_associations.type_associations {
             self.validate_resolver_behavior_impl_list(
                 task.symbol,
                 task.name,
@@ -8582,7 +8582,7 @@ impl TypeChecker {
             );
         }
 
-        for task in tasks.behavior_parents {
+        for task in &tasks.behavior_associations.behavior_parents {
             self.validate_resolver_behavior_parent_list(
                 task.symbol,
                 task.name,


### PR DESCRIPTION
## Summary

- Pass the full resolver validation replay task bundle into behavior association list validation.
- Let `validate_resolver_behavior_association_lists` select type and behavior-parent association entries internally.
- Record the replay handoff cleanup in the phase plan.

## Validation

- Changed the production call site first and observed the expected type mismatch.
- `cargo test --lib resolver_behavior_association_list_tasks_collect_type_and_parent_edges_together`
- `cargo test --test docs_truth && cargo fmt --check && git diff --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`

Opened as draft to avoid starting Actions until ready.