### PR TITLE
[codex] Pass resolver extra symbol replay as bundle

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1836,6 +1836,9 @@ checked-in docs, tests, and commits only.
 - Resolver validation replay now passes the full replay task bundle into
   behavior association list validation, which selects type and parent
   association lists internally.
+- Resolver extra declaration/local symbol validation now receives the full
+  resolver validation replay task bundle and selects expected symbol sets
+  internally, reducing another replay sub-bundle handoff.
 
 ## Current Phase
 

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -8470,11 +8470,8 @@ impl TypeChecker {
             }
         }
         let replay_tasks = Self::collect_resolver_validation_replay_tasks(program, symbols);
-        self.validate_no_extra_resolver_declaration_symbols(
-            &replay_tasks.expected_symbols,
-            symbols,
-        );
-        self.validate_no_extra_resolver_local_symbols(&replay_tasks.expected_symbols, symbols);
+        self.validate_no_extra_resolver_declaration_symbols(&replay_tasks, symbols);
+        self.validate_no_extra_resolver_local_symbols(&replay_tasks, symbols);
         self.validate_resolver_behavior_association_lists(&replay_tasks);
         self.validate_stripped_resolver_import_symbols(
             replay_tasks.expected_symbols.validate_imports,
@@ -8506,9 +8503,10 @@ impl TypeChecker {
 
     fn validate_no_extra_resolver_declaration_symbols(
         &mut self,
-        expected: &ResolverExpectedSymbolSets,
+        tasks: &ResolverValidationReplayTasks<'_>,
         symbols: &SymbolTable,
     ) {
+        let expected = &tasks.expected_symbols;
         for symbol in symbols.symbols() {
             if !expected.validate_imports
                 && matches!(symbol.namespace, Namespace::Module | Namespace::Import)
@@ -8542,9 +8540,10 @@ impl TypeChecker {
 
     fn validate_no_extra_resolver_local_symbols(
         &mut self,
-        expected: &ResolverExpectedSymbolSets,
+        tasks: &ResolverValidationReplayTasks<'_>,
         symbols: &SymbolTable,
     ) {
+        let expected = &tasks.expected_symbols;
         for symbol in symbols.symbols() {
             if symbol.namespace != Namespace::Local {
                 continue;


### PR DESCRIPTION
## Summary

- Pass the full resolver validation replay task bundle into extra declaration and local symbol validation.
- Let those helpers select `expected_symbols` internally.
- Record the replay sub-bundle handoff cleanup in the phase plan.

## Validation

- Changed the production call sites first and observed the expected type mismatches.
- `cargo test --lib resolver_expected_symbol_sets_collect_declarations_and_locals_together`
- `cargo test --test docs_truth && cargo fmt --check && git diff --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`

Opened as draft to avoid starting Actions until ready.