### PR TITLE
[codex] Pass resolver import replay as bundle

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1839,6 +1839,9 @@ checked-in docs, tests, and commits only.
 - Resolver extra declaration/local symbol validation now receives the full
   resolver validation replay task bundle and selects expected symbol sets
   internally, reducing another replay sub-bundle handoff.
+- Stripped resolver import validation now receives the full resolver
+  validation replay task bundle and reads the import-validation flag
+  internally, completing the current resolver replay call-site bundle shape.
 
 ## Current Phase
 

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -8473,10 +8473,7 @@ impl TypeChecker {
         self.validate_no_extra_resolver_declaration_symbols(&replay_tasks, symbols);
         self.validate_no_extra_resolver_local_symbols(&replay_tasks, symbols);
         self.validate_resolver_behavior_association_lists(&replay_tasks);
-        self.validate_stripped_resolver_import_symbols(
-            replay_tasks.expected_symbols.validate_imports,
-            symbols,
-        );
+        self.validate_stripped_resolver_import_symbols(&replay_tasks, symbols);
     }
 
     fn require_resolver_callable_locals(
@@ -8919,10 +8916,10 @@ impl TypeChecker {
 
     fn validate_stripped_resolver_import_symbols(
         &mut self,
-        validate_imports: bool,
+        tasks: &ResolverValidationReplayTasks<'_>,
         symbols: &SymbolTable,
     ) {
-        if validate_imports {
+        if tasks.expected_symbols.validate_imports {
             return;
         }
 


### PR DESCRIPTION
## Summary

- Pass the full resolver validation replay task bundle into stripped import validation.
- Let the helper read the import-validation flag internally.
- Record the replay call-site bundle cleanup in the phase plan.

## Validation

- Changed the production call site first and observed the expected type mismatch.
- `cargo test --lib resolver_expected_symbol_sets_collect_declarations_and_locals_together`
- `cargo test --test docs_truth && cargo fmt --check && git diff --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`

Opened as draft to avoid starting Actions until ready.