### PR TITLE
[codex] Pass behavior extends validation as bundle

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1842,6 +1842,9 @@ checked-in docs, tests, and commits only.
 - Stripped resolver import validation now receives the full resolver
   validation replay task bundle and reads the import-validation flag
   internally, completing the current resolver replay call-site bundle shape.
+- AST behavior extends validation now receives the full behavior-association
+  task bundle and selects `.extends` entries internally, removing another
+  association sub-slice handoff.
 
 ## Current Phase
 

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -3902,7 +3902,7 @@ impl TypeChecker {
 
     fn validate_ast_behavior_extends_declarations(&mut self, decls: &[Declaration]) {
         let tasks = Self::collect_behavior_association_validation_tasks(decls);
-        self.validate_behavior_extends_tasks(&tasks.extends);
+        self.validate_behavior_extends_tasks(&tasks);
         self.validate_behavior_extends_cycles();
         self.validate_behavior_method_coherence();
     }
@@ -3930,8 +3930,8 @@ impl TypeChecker {
         }
     }
 
-    fn validate_behavior_extends_tasks(&mut self, tasks: &[BehaviorExtendsValidationTask<'_>]) {
-        for task in tasks {
+    fn validate_behavior_extends_tasks(&mut self, tasks: &BehaviorAssociationValidationTasks<'_>) {
+        for task in &tasks.extends {
             self.check_behavior_extends(
                 task.behavior,
                 task.parent,


### PR DESCRIPTION
## Summary

- Pass the full behavior-association task bundle into AST behavior-extends validation.
- Let `validate_behavior_extends_tasks` select `.extends` entries internally.
- Record the association sub-slice handoff cleanup in the phase plan.

## Validation

- Changed the production call site first and observed the expected type mismatch.
- `cargo test --lib behavior_association_validation_tasks_collect_extends_impls_and_requires_together`
- `cargo test --test docs_truth && cargo fmt --check && git diff --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`

Opened as draft to avoid starting Actions until ready.