### PR TITLE
[codex] Collect AST declaration tasks in one pass

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1845,6 +1845,9 @@ checked-in docs, tests, and commits only.
 - AST behavior extends validation now receives the full behavior-association
   task bundle and selects `.extends` entries internally, removing another
   association sub-slice handoff.
+- The main AST declaration collection path now builds behavior, type,
+  callable, impl-block, and import collection task lists in one declaration
+  pass before replaying them in the existing collection order.
 
 ## Current Phase
 

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -142,6 +142,15 @@ struct AstImportDeclarationTask<'a> {
     module_path: &'a [String],
 }
 
+#[derive(Default)]
+struct AstDeclarationCollectionTasks<'a> {
+    behaviors: Vec<BehaviorDeclarationTask<'a>>,
+    types: Vec<AstTypeDeclarationTask<'a>>,
+    callable: Vec<CallableDeclarationTask<'a>>,
+    impl_blocks: Vec<ImplBlockDeclarationTask<'a>>,
+    imports: Vec<AstImportDeclarationTask<'a>>,
+}
+
 struct AstStructFieldDefaultValidationTask<'a> {
     type_params: &'a [ast::TypeParam],
     fields: &'a [StructField],
@@ -3403,19 +3412,32 @@ impl TypeChecker {
     // ── Phase 1: Collect ──────────────────────────────────────────
 
     fn collect_declarations(&mut self, decls: &[Declaration]) {
-        self.collect_behavior_declarations(decls);
+        let tasks = Self::collect_ast_declaration_collection_tasks(decls);
+        self.collect_behavior_declarations_from_tasks(&tasks.behaviors);
         self.validate_behavior_extends(decls);
-        self.collect_type_declarations(decls);
-        self.collect_callable_declarations(decls);
-        self.collect_impl_block_declarations(decls);
-        self.collect_ast_import_declarations(decls);
+        if !self.resolver_backed_collection {
+            self.collect_ast_type_declarations_from_tasks(&tasks.types);
+        }
+        self.collect_callable_declarations_from_tasks(&tasks.callable);
+        self.collect_impl_block_declarations_from_tasks(&tasks.impl_blocks);
+        self.collect_ast_import_declarations_from_tasks(&tasks.imports);
     }
 
-    fn collect_ast_import_declarations(&mut self, decls: &[Declaration]) {
-        let tasks = Self::collect_ast_import_declaration_tasks(decls);
-        self.collect_ast_import_declarations_from_tasks(&tasks);
+    fn collect_ast_declaration_collection_tasks(
+        decls: &[Declaration],
+    ) -> AstDeclarationCollectionTasks<'_> {
+        let mut tasks = AstDeclarationCollectionTasks::default();
+        for decl in decls {
+            Self::push_behavior_declaration_task(decl, &mut tasks.behaviors);
+            Self::push_ast_type_declaration_task(decl, &mut tasks.types);
+            Self::push_callable_declaration_task(decl, &mut tasks.callable);
+            Self::push_impl_block_declaration_task(decl, &mut tasks.impl_blocks);
+            Self::push_ast_import_declaration_task(decl, &mut tasks.imports);
+        }
+        tasks
     }
 
+    #[cfg(test)]
     fn collect_ast_import_declaration_tasks(
         decls: &[Declaration],
     ) -> Vec<AstImportDeclarationTask<'_>> {
@@ -3449,11 +3471,7 @@ impl TypeChecker {
         }
     }
 
-    fn collect_impl_block_declarations(&mut self, decls: &[Declaration]) {
-        let tasks = Self::collect_impl_block_declaration_tasks(decls);
-        self.collect_impl_block_declarations_from_tasks(&tasks);
-    }
-
+    #[cfg(test)]
     fn collect_impl_block_declaration_tasks(
         decls: &[Declaration],
     ) -> Vec<ImplBlockDeclarationTask<'_>> {
@@ -3533,11 +3551,7 @@ impl TypeChecker {
         }
     }
 
-    fn collect_callable_declarations(&mut self, decls: &[Declaration]) {
-        let tasks = Self::collect_callable_declaration_tasks(decls);
-        self.collect_callable_declarations_from_tasks(&tasks);
-    }
-
+    #[cfg(test)]
     fn collect_callable_declaration_tasks(
         decls: &[Declaration],
     ) -> Vec<CallableDeclarationTask<'_>> {
@@ -3729,19 +3743,7 @@ impl TypeChecker {
         }
     }
 
-    fn collect_type_declarations(&mut self, decls: &[Declaration]) {
-        if self.resolver_backed_collection {
-            return;
-        }
-
-        self.collect_ast_type_declarations(decls);
-    }
-
-    fn collect_ast_type_declarations(&mut self, decls: &[Declaration]) {
-        let tasks = Self::collect_ast_type_declaration_tasks(decls);
-        self.collect_ast_type_declarations_from_tasks(&tasks);
-    }
-
+    #[cfg(test)]
     fn collect_ast_type_declaration_tasks(
         decls: &[Declaration],
     ) -> Vec<AstTypeDeclarationTask<'_>> {
@@ -3810,11 +3812,7 @@ impl TypeChecker {
         }
     }
 
-    fn collect_behavior_declarations(&mut self, decls: &[Declaration]) {
-        let tasks = Self::collect_behavior_declaration_tasks(decls);
-        self.collect_behavior_declarations_from_tasks(&tasks);
-    }
-
+    #[cfg(test)]
     fn collect_behavior_declaration_tasks(
         decls: &[Declaration],
     ) -> Vec<BehaviorDeclarationTask<'_>> {


### PR DESCRIPTION
## Summary

- Build one AST declaration collection task bundle for behavior, type, callable, impl-block, and import work.
- Replay the existing collection order from that bundle while preserving the resolver-backed type collection skip.
- Keep the focused per-task collectors available only for tests.

## Validation

- Changed the production call site first and observed the expected missing-helper compile failure.
- `cargo test --lib callable_declaration_tasks_collect_functions_and_methods`
- `cargo test --lib collect_declarations_with_symbols_uses_resolver_behavior_impl_metadata`
- `cargo test --test docs_truth && cargo fmt --check && git diff --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`

Opened as draft first to avoid CI running on synchronize commits.