### PR TITLE
[codex] Route loop control parsing through action enum

### DIFF
--- a/src/ast/expressions.rs
+++ b/src/ast/expressions.rs
@@ -79,14 +79,18 @@ pub enum LoopControlAction {
 impl LoopControlAction {
     pub const DONE: &'static str = "done";
     pub const NEXT: &'static str = "next";
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Done => Self::DONE,
+            Self::Next => Self::NEXT,
+        }
+    }
 }
 
 impl fmt::Display for LoopControlAction {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
-            Self::Done => Self::DONE,
-            Self::Next => Self::NEXT,
-        })
+        f.write_str(self.as_str())
     }
 }
 
@@ -94,10 +98,12 @@ impl FromStr for LoopControlAction {
     type Err = ();
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            Self::DONE => Ok(Self::Done),
-            Self::NEXT => Ok(Self::Next),
-            _ => Err(()),
+        if value == Self::Done.as_str() {
+            Ok(Self::Done)
+        } else if value == Self::Next.as_str() {
+            Ok(Self::Next)
+        } else {
+            Err(())
         }
     }
 }
@@ -360,5 +366,27 @@ impl Expression {
             | Expression::Defer { span, .. }
             | Expression::Error { span, .. } => *span,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loop_control_action_owns_text_spelling() {
+        assert_eq!(LoopControlAction::Done.as_str(), "done");
+        assert_eq!(LoopControlAction::Next.as_str(), "next");
+        assert_eq!(
+            "done".parse::<LoopControlAction>(),
+            Ok(LoopControlAction::Done)
+        );
+        assert_eq!(
+            "next".parse::<LoopControlAction>(),
+            Ok(LoopControlAction::Next)
+        );
+        assert!("stop".parse::<LoopControlAction>().is_err());
+        assert_eq!(LoopControlAction::Done.to_string(), "done");
+        assert_eq!(LoopControlAction::Next.to_string(), "next");
     }
 }

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -80,12 +80,10 @@ impl Parser {
                         let args = self.parse_arg_list()?;
                         let end = self.expect(&Token::RParen)?;
                         let span = id_span.merge(end);
-                        if let Some((action, target_label)) = self.loop_control_call(&name, &args) {
-                            lhs = Expression::LoopControl {
-                                action,
-                                target_label,
-                                span,
-                            };
+                        if let Some(loop_control) =
+                            self.parse_loop_control_function_call(&name, &args, span)
+                        {
+                            lhs = loop_control;
                             continue;
                         }
                         lhs = Expression::FunctionCall {
@@ -310,23 +308,10 @@ impl Parser {
             let end = self.expect(&Token::RParen)?;
             let span = lhs.span().merge(end);
 
-            if args.is_empty() {
-                if let Expression::Identifier {
-                    name: ref receiver_name,
-                    ..
-                } = lhs
-                {
-                    if let (Ok(action), Some(target_label)) = (
-                        name.parse::<LoopControlAction>(),
-                        self.loop_control_label(receiver_name),
-                    ) {
-                        return Ok(Expression::LoopControl {
-                            action,
-                            target_label,
-                            span,
-                        });
-                    }
-                }
+            if let Some(loop_control) =
+                self.parse_loop_control_method_call(&lhs, &name, &args, span)
+            {
+                return Ok(loop_control);
             }
 
             // If lhs is an identifier, this could be module.func(args) or ufc
@@ -367,11 +352,12 @@ impl Parser {
         })
     }
 
-    fn loop_control_call(
+    fn parse_loop_control_function_call(
         &self,
         name: &str,
         args: &[Expression],
-    ) -> Option<(LoopControlAction, String)> {
+        span: Span,
+    ) -> Option<Expression> {
         let action = name.parse::<LoopControlAction>().ok()?;
         (args.len() == 1).then_some(())?;
 
@@ -383,7 +369,36 @@ impl Parser {
         };
 
         self.loop_control_label(control_name)
-            .map(|target_label| (action, target_label))
+            .map(|target_label| Expression::LoopControl {
+                action,
+                target_label,
+                span,
+            })
+    }
+
+    fn parse_loop_control_method_call(
+        &self,
+        receiver: &Expression,
+        name: &str,
+        args: &[Expression],
+        span: Span,
+    ) -> Option<Expression> {
+        let action = name.parse::<LoopControlAction>().ok()?;
+        args.is_empty().then_some(())?;
+
+        let Expression::Identifier {
+            name: control_name, ..
+        } = receiver
+        else {
+            return None;
+        };
+
+        self.loop_control_label(control_name)
+            .map(|target_label| Expression::LoopControl {
+                action,
+                target_label,
+                span,
+            })
     }
 
     // ── Struct literal ────────────────────────────────────────


### PR DESCRIPTION
## What changed

- Added `LoopControlAction::as_str()` and made `Display` delegate to the enum-owned spelling.
- Kept `FromStr` as the only parser-facing conversion boundary for `done` and `next`.
- Changed loop-control parser helpers to return `Expression::LoopControl` directly for both `l.done()`/`l.next()` and UFC `done(l)`/`next(l)` forms.
- Added a unit test for the enum string boundary.

## Why

The parser should not re-match loop-control names or carry raw spellings after parsing. This keeps `done` and `next` centralized on `LoopControlAction` and avoids the hard-coded action-to-AST mapping pattern.

## Validation

- `cargo test loop_control --lib`
- `cargo test --test docs_truth && cargo fmt --check && git diff --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`