### PR TITLE
[codex] Add deterministic build graph core

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1860,19 +1860,26 @@ checked-in docs, tests, and commits only.
 - Resolver-backed declaration semantic validation now builds one resolver
   metadata task bundle and replays behavior-association, type-reference, and
   struct field-default validation from it.
+- The first deterministic build-graph core is covered by
+  `tests/build_graph.rs`: `deterministic_build_graph_creates_one_executable_target`
+  proves canonical graph emission for an executable target, and
+  `build_graph_rejects_undeclared_host_effects` proves undeclared host effects
+  are rejected before any `build.zen` execution is promoted.
 
 ## Current Phase
 
 Continue the smallest behavior-association and resolver/typechecker hardening
 slices. Phase 3 C codegen is sufficient for the current tested fixtures, but
-Phase 4 build-driver work is still gated by the lack of deterministic
-`build.zen` graph tests and implementation.
+Phase 4 build-driver work is still gated by the lack of a constrained
+`build.zen` evaluator that lowers into the deterministic build graph.
 
 Do not promote gated v1 features until the relevant positive and negative tests
 exist and pass through the same compiler path advertised in `docs/V1_SPEC.md`.
 
 ## Next Small Slice
 
-Continue the next smallest behavior-association handoff or resolver/typechecker
-integration slice that reduces duplicate declaration collection. Do not promote
-`build.zen` until a dedicated deterministic graph test exists.
+Continue the next smallest build-driver slice by adding a constrained
+`build.zen` evaluation boundary that can lower a declared executable target into
+`BuildGraph` without allowing undeclared host effects. Keep CLI `build.zen`
+execution gated until that boundary has positive and negative integration
+coverage.

--- a/src/build_graph.rs
+++ b/src/build_graph.rs
@@ -1,0 +1,153 @@
+use std::collections::BTreeSet;
+use std::fmt;
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuildGraphInput {
+    pub targets: Vec<BuildTargetInput>,
+    pub declared_host_effects: Vec<HostEffect>,
+    pub used_host_effects: Vec<HostEffect>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuildTargetInput {
+    pub name: String,
+    pub kind: BuildTargetKind,
+    pub sources: Vec<String>,
+    pub dependencies: Vec<String>,
+    pub features: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum BuildTargetKind {
+    Executable {
+        root_source_file: String,
+        out_dir: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(tag = "kind", content = "value", rename_all = "snake_case")]
+pub enum HostEffect {
+    ReadEnv(String),
+    ReadFile(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BuildGraph {
+    targets: Vec<BuildTarget>,
+    declared_host_effects: Vec<HostEffect>,
+    used_host_effects: Vec<HostEffect>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BuildTarget {
+    name: String,
+    kind: BuildTargetKind,
+    sources: Vec<String>,
+    dependencies: Vec<String>,
+    features: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BuildGraphError {
+    EmptyTargetName,
+    DuplicateTargetName(String),
+    MissingTargets,
+    UndeclaredHostEffect(HostEffect),
+}
+
+impl BuildGraph {
+    pub fn from_input(input: BuildGraphInput) -> Result<Self, BuildGraphError> {
+        if input.targets.is_empty() {
+            return Err(BuildGraphError::MissingTargets);
+        }
+
+        let declared_host_effects = sorted_unique(input.declared_host_effects);
+        let used_host_effects = sorted_unique(input.used_host_effects);
+        let declared_set: BTreeSet<_> = declared_host_effects.iter().cloned().collect();
+        for effect in &used_host_effects {
+            if !declared_set.contains(effect) {
+                return Err(BuildGraphError::UndeclaredHostEffect(effect.clone()));
+            }
+        }
+
+        let mut target_names = BTreeSet::new();
+        let mut targets = Vec::with_capacity(input.targets.len());
+        for target in input.targets {
+            if target.name.is_empty() {
+                return Err(BuildGraphError::EmptyTargetName);
+            }
+            if !target_names.insert(target.name.clone()) {
+                return Err(BuildGraphError::DuplicateTargetName(target.name));
+            }
+            targets.push(BuildTarget {
+                name: target.name,
+                kind: target.kind,
+                sources: sorted_unique(target.sources),
+                dependencies: sorted_unique(target.dependencies),
+                features: sorted_unique(target.features),
+            });
+        }
+        targets.sort_by(|left, right| left.name.cmp(&right.name));
+
+        Ok(Self {
+            targets,
+            declared_host_effects,
+            used_host_effects,
+        })
+    }
+
+    pub fn targets(&self) -> &[BuildTarget] {
+        &self.targets
+    }
+
+    pub fn canonical_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
+    }
+}
+
+impl BuildTarget {
+    pub fn is_executable(&self) -> bool {
+        matches!(self.kind, BuildTargetKind::Executable { .. })
+    }
+}
+
+impl fmt::Display for HostEffect {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ReadEnv(name) => write!(f, "read env `{name}`"),
+            Self::ReadFile(path) => write!(f, "read file `{path}`"),
+        }
+    }
+}
+
+impl fmt::Display for BuildGraphError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyTargetName => f.write_str("build target name cannot be empty"),
+            Self::DuplicateTargetName(name) => {
+                write!(f, "duplicate build target name `{name}`")
+            }
+            Self::MissingTargets => f.write_str("build graph must contain at least one target"),
+            Self::UndeclaredHostEffect(effect) => {
+                write!(f, "undeclared host effect: {effect}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for BuildGraphError {}
+
+fn sorted_unique<T>(values: Vec<T>) -> Vec<T>
+where
+    T: Ord,
+{
+    values
+        .into_iter()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod ast;
+pub mod build_graph;
 pub mod codegen;
 pub mod error;
 pub mod ir_json;

--- a/tests/build_graph.rs
+++ b/tests/build_graph.rs
@@ -1,0 +1,61 @@
+use zen::build_graph::{
+    BuildGraph, BuildGraphInput, BuildTargetInput, BuildTargetKind, HostEffect,
+};
+
+fn executable_target(name: &str, sources: &[&str]) -> BuildTargetInput {
+    BuildTargetInput {
+        name: name.to_string(),
+        kind: BuildTargetKind::Executable {
+            root_source_file: "src/main.zen".to_string(),
+            out_dir: "build".to_string(),
+        },
+        sources: sources.iter().map(|source| source.to_string()).collect(),
+        dependencies: vec!["std".to_string(), "math".to_string()],
+        features: vec!["release".to_string(), "lto".to_string()],
+    }
+}
+
+#[test]
+fn deterministic_build_graph_creates_one_executable_target() {
+    let first = BuildGraph::from_input(BuildGraphInput {
+        targets: vec![executable_target(
+            "app",
+            &["src/main.zen", "src/math.zen", "src/main.zen"],
+        )],
+        declared_host_effects: vec![HostEffect::ReadEnv("ZEN_STD".to_string())],
+        used_host_effects: vec![HostEffect::ReadEnv("ZEN_STD".to_string())],
+    })
+    .expect("build graph");
+
+    let second = BuildGraph::from_input(BuildGraphInput {
+        targets: vec![executable_target(
+            "app",
+            &["src/main.zen", "src/main.zen", "src/math.zen"],
+        )],
+        declared_host_effects: vec![HostEffect::ReadEnv("ZEN_STD".to_string())],
+        used_host_effects: vec![HostEffect::ReadEnv("ZEN_STD".to_string())],
+    })
+    .expect("build graph");
+
+    assert_eq!(first.targets().len(), 1);
+    assert!(first.targets()[0].is_executable());
+    assert_eq!(
+        first.canonical_json().unwrap(),
+        second.canonical_json().unwrap()
+    );
+}
+
+#[test]
+fn build_graph_rejects_undeclared_host_effects() {
+    let err = BuildGraph::from_input(BuildGraphInput {
+        targets: vec![executable_target("app", &["src/main.zen"])],
+        declared_host_effects: Vec::new(),
+        used_host_effects: vec![HostEffect::ReadEnv("ZEN_STD".to_string())],
+    })
+    .expect_err("undeclared host effects should be rejected");
+
+    assert_eq!(
+        err.to_string(),
+        "undeclared host effect: read env `ZEN_STD`"
+    );
+}

--- a/tests/docs_truth.rs
+++ b/tests/docs_truth.rs
@@ -384,6 +384,8 @@ fn phase_plan_records_recovered_progress_and_next_slice() {
         "JSON is compiler-owned IR output",
         "YAML is human-authored config/spec input",
         "build.zen is deterministic comptime build graph",
+        "deterministic_build_graph_creates_one_executable_target",
+        "build_graph_rejects_undeclared_host_effects",
         "collect_declarations_with_symbols_uses_resolver_behavior_impl_generic_method_template_target_and_name_metadata",
         "collect_declarations_with_symbols_clears_stale_behavior_impl_generic_method_template_after_key_restore",
         "resolver_declaration_metadata_skips_behavior_impl_methods_until_behavior_impl_pass",


### PR DESCRIPTION
## What changed

- Added `zen::build_graph` with a deterministic `BuildGraph` model, executable target input, host effect tracking, canonical JSON emission, and validation errors.
- Added tests for the v1 build-system backlog:
  - one executable target graph canonicalizes deterministically
  - undeclared host effects are rejected
- Updated `docs/PHASE_PLAN.md` and docs-truth coverage so the plan reflects that the graph core now exists while CLI `build.zen` execution remains gated.

## Why

`build.zen` was blocked on the absence of deterministic graph tests. This slice adds the internal graph boundary without promoting build script execution or allowing host effects without declaration.

## Validation

- `cargo test --test build_graph`
- `cargo test --test docs_truth && cargo fmt --check && git diff --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`