### PR TITLE
[codex] Parse build zen shorthand variants

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1865,13 +1865,18 @@ checked-in docs, tests, and commits only.
   proves canonical graph emission for an executable target, and
   `build_graph_rejects_undeclared_host_effects` proves undeclared host effects
   are rejected before any `build.zen` execution is promoted.
+- The checked-in `examples/project/build.zen` syntax is covered by
+  `parse_project_build_zen_example`, and leading-dot enum shorthand used by
+  build-style result/config flows is covered by
+  `parse_shorthand_enum_variant_expr_and_pattern`.
 
 ## Current Phase
 
 Continue the smallest behavior-association and resolver/typechecker hardening
 slices. Phase 3 C codegen is sufficient for the current tested fixtures, but
 Phase 4 build-driver work is still gated by the lack of a constrained
-`build.zen` evaluator that lowers into the deterministic build graph.
+`build.zen` evaluator that lowers parsed build scripts into the deterministic
+build graph.
 
 Do not promote gated v1 features until the relevant positive and negative tests
 exist and pass through the same compiler path advertised in `docs/V1_SPEC.md`.
@@ -1879,7 +1884,7 @@ exist and pass through the same compiler path advertised in `docs/V1_SPEC.md`.
 ## Next Small Slice
 
 Continue the next smallest build-driver slice by adding a constrained
-`build.zen` evaluation boundary that can lower a declared executable target into
-`BuildGraph` without allowing undeclared host effects. Keep CLI `build.zen`
-execution gated until that boundary has positive and negative integration
-coverage.
+`build.zen` evaluation boundary that can lower the parsed project build script
+into `BuildGraph` without allowing undeclared host effects. Keep CLI
+`build.zen` execution gated until that boundary has positive and negative
+integration coverage.

--- a/src/parser/atoms.rs
+++ b/src/parser/atoms.rs
@@ -135,6 +135,8 @@ impl Parser {
                 })
             }
 
+            Token::Dot => self.parse_shorthand_enum_variant_expr(),
+
             // Module-qualified: @builtin.func(args), @std.mod.func(args)
             Token::AtBuiltin => {
                 let (_, span) = self.advance();
@@ -257,6 +259,30 @@ impl Parser {
                 ))
             }
         }
+    }
+
+    fn parse_shorthand_enum_variant_expr(&mut self) -> Result<Expression, CompileError> {
+        let (_, dot_span) = self.advance();
+        let (variant, variant_span) = self.expect_identifier()?;
+        let mut span = dot_span.merge(variant_span);
+
+        let payload = if matches!(self.peek(), Token::LParen) {
+            self.advance();
+            let expr = self.parse_expression()?;
+            let end = self.expect(&Token::RParen)?;
+            span = span.merge(end);
+            Some(Box::new(expr))
+        } else {
+            None
+        };
+
+        Ok(Expression::EnumVariant {
+            enum_name: String::new(),
+            type_args: Vec::new(),
+            variant,
+            payload,
+            span,
+        })
     }
 
     // ── Match / conditional / while ───────────────────────────

--- a/src/parser/patterns.rs
+++ b/src/parser/patterns.rs
@@ -18,6 +18,7 @@ impl Parser {
                 let (_, span) = self.advance();
                 Ok(Pattern::Wildcard { span })
             }
+            Token::Dot => self.parse_shorthand_enum_pattern(),
             Token::Identifier(ref name) if first_char_is_upper(name) => {
                 // Enum variant pattern: VariantName or VariantName(binding)
                 let name = name.clone();
@@ -84,5 +85,28 @@ impl Parser {
                 Some(self.peek_span()),
             )),
         }
+    }
+
+    fn parse_shorthand_enum_pattern(&mut self) -> Result<Pattern, CompileError> {
+        let (_, dot_span) = self.advance();
+        let (variant, variant_span) = self.expect_identifier()?;
+        let mut span = dot_span.merge(variant_span);
+
+        let payload = if matches!(self.peek(), Token::LParen) {
+            self.advance();
+            let inner = self.parse_pattern()?;
+            let end = self.expect(&Token::RParen)?;
+            span = span.merge(end);
+            Some(Box::new(inner))
+        } else {
+            None
+        };
+
+        Ok(Pattern::Enum {
+            enum_name: String::new(),
+            variant,
+            payload,
+            span,
+        })
     }
 }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -229,6 +229,18 @@ fn parse_enum_variant_payload_expr() {
 }
 
 #[test]
+fn parse_shorthand_enum_variant_expr_and_pattern() {
+    let prog = parse_ok(
+        r#"f = (value: Result<i32, str>) Result<i32, str> {
+    value ?
+        | .Ok(v) { .Ok(v) }
+        | .Err(msg) { .Err(msg) }
+}"#,
+    );
+    assert_eq!(prog.declarations.len(), 1);
+}
+
+#[test]
 fn parse_ufc_chain() {
     let prog = parse_ok("f = () void {\n    result = 5.double().add_ten()\n}");
     assert_eq!(prog.declarations.len(), 1);
@@ -313,6 +325,29 @@ fn parse_project_example() {
                     eprintln!("{:?}", e);
                 }
                 panic!("demo parse failed with {} errors", errs.len());
+            }
+        }
+    }
+}
+
+#[test]
+fn parse_project_build_zen_example() {
+    let src = std::fs::read_to_string("examples/project/build.zen");
+    if let Ok(src) = src {
+        let result = parse_str(&src);
+        match result {
+            Ok(prog) => {
+                assert!(
+                    !prog.declarations.is_empty(),
+                    "project build.zen should have declarations, got {}",
+                    prog.declarations.len()
+                );
+            }
+            Err(errs) => {
+                for e in &errs {
+                    eprintln!("{:?}", e);
+                }
+                panic!("project build.zen parse failed with {} errors", errs.len());
             }
         }
     }

--- a/tests/docs_truth.rs
+++ b/tests/docs_truth.rs
@@ -386,6 +386,8 @@ fn phase_plan_records_recovered_progress_and_next_slice() {
         "build.zen is deterministic comptime build graph",
         "deterministic_build_graph_creates_one_executable_target",
         "build_graph_rejects_undeclared_host_effects",
+        "parse_project_build_zen_example",
+        "parse_shorthand_enum_variant_expr_and_pattern",
         "collect_declarations_with_symbols_uses_resolver_behavior_impl_generic_method_template_target_and_name_metadata",
         "collect_declarations_with_symbols_clears_stale_behavior_impl_generic_method_template_after_key_restore",
         "resolver_declaration_metadata_skips_behavior_impl_methods_until_behavior_impl_pass",


### PR DESCRIPTION
## What changed

- Added parser support for leading-dot enum shorthand expressions like `.Ok(value)` and `.None`.
- Added parser support for leading-dot enum shorthand patterns like `| .Ok(value) { ... }`.
- Added parser regressions for shorthand enum expression/pattern parsing and the checked-in `examples/project/build.zen` file.
- Updated the phase plan and docs-truth assertions to record the new build-driver parser boundary.

## Why

The next build-driver slice needs parsed `build.zen` scripts before a constrained evaluator can lower them into `BuildGraph`. The checked-in project build file already uses result/config shorthand variants, so this parser support is a prerequisite while CLI `build.zen` execution remains gated.

## Validation

- `cargo test parse_project_build_zen_example --lib`
- `cargo test parse_shorthand_enum_variant_expr_and_pattern --lib`
- `cargo test --test docs_truth && cargo fmt --check && git diff --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`