### PR TITLE
[codex] Lower parsed build zen into graph

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1869,22 +1869,26 @@ checked-in docs, tests, and commits only.
   `parse_project_build_zen_example`, and leading-dot enum shorthand used by
   build-style result/config flows is covered by
   `parse_shorthand_enum_variant_expr_and_pattern`.
+- A constrained `build.zen` lowering boundary now maps parsed build scripts into
+  `BuildGraph` without enabling CLI execution. `parsed_project_build_zen_lowers_to_executable_graph`
+  covers the checked-in project executable target, and
+  `build_program_lowering_rejects_undeclared_env_reads` keeps undeclared host
+  effects rejected during lowering.
 
 ## Current Phase
 
 Continue the smallest behavior-association and resolver/typechecker hardening
 slices. Phase 3 C codegen is sufficient for the current tested fixtures, but
-Phase 4 build-driver work is still gated by the lack of a constrained
-`build.zen` evaluator that lowers parsed build scripts into the deterministic
-build graph.
+Phase 4 build-driver work is still gated by the lack of a CLI integration path
+that executes only the constrained `build.zen` subset and emits the
+deterministic build graph.
 
 Do not promote gated v1 features until the relevant positive and negative tests
 exist and pass through the same compiler path advertised in `docs/V1_SPEC.md`.
 
 ## Next Small Slice
 
-Continue the next smallest build-driver slice by adding a constrained
-`build.zen` evaluation boundary that can lower the parsed project build script
-into `BuildGraph` without allowing undeclared host effects. Keep CLI
-`build.zen` execution gated until that boundary has positive and negative
-integration coverage.
+Continue the next smallest build-driver slice by adding positive and negative
+CLI integration coverage for the constrained `build.zen` graph-emission path.
+Keep normal `zen build build.zen` execution gated until graph emission proves the
+lowering boundary through the advertised compiler path.

--- a/src/build_graph.rs
+++ b/src/build_graph.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 use std::fmt;
 
+use crate::ast::{Declaration, Expression, MatchArm, Program, Statement};
 use serde::Serialize;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -57,6 +58,8 @@ pub enum BuildGraphError {
     DuplicateTargetName(String),
     MissingTargets,
     UndeclaredHostEffect(HostEffect),
+    MissingBuildFunction,
+    UnsupportedBuildScript(String),
 }
 
 impl BuildGraph {
@@ -107,11 +110,38 @@ impl BuildGraph {
     pub fn canonical_json(&self) -> Result<String, serde_json::Error> {
         serde_json::to_string(self)
     }
+
+    pub fn from_build_program(program: &Program) -> Result<Self, BuildGraphError> {
+        let build_body = program
+            .declarations
+            .iter()
+            .find_map(|decl| match decl {
+                Declaration::Function { name, body, .. } if name == "build" => Some(body),
+                _ => None,
+            })
+            .ok_or(BuildGraphError::MissingBuildFunction)?;
+
+        let mut lowering = BuildProgramLowering::default();
+        lowering.collect_expr(build_body);
+        Self::from_input(lowering.into_input())
+    }
 }
 
 impl BuildTarget {
     pub fn is_executable(&self) -> bool {
         matches!(self.kind, BuildTargetKind::Executable { .. })
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn kind(&self) -> &BuildTargetKind {
+        &self.kind
+    }
+
+    pub fn sources(&self) -> &[String] {
+        &self.sources
     }
 }
 
@@ -135,6 +165,8 @@ impl fmt::Display for BuildGraphError {
             Self::UndeclaredHostEffect(effect) => {
                 write!(f, "undeclared host effect: {effect}")
             }
+            Self::MissingBuildFunction => f.write_str("build.zen is missing `build` function"),
+            Self::UnsupportedBuildScript(message) => f.write_str(message),
         }
     }
 }
@@ -150,4 +182,250 @@ where
         .collect::<BTreeSet<_>>()
         .into_iter()
         .collect()
+}
+
+#[derive(Default)]
+struct BuildProgramLowering {
+    targets: Vec<BuildTargetInput>,
+    declared_host_effects: Vec<HostEffect>,
+    used_host_effects: Vec<HostEffect>,
+}
+
+impl BuildProgramLowering {
+    fn into_input(self) -> BuildGraphInput {
+        BuildGraphInput {
+            targets: self.targets,
+            declared_host_effects: self.declared_host_effects,
+            used_host_effects: self.used_host_effects,
+        }
+    }
+
+    fn collect_expr(&mut self, expr: &Expression) {
+        if let Some(effect) = env_read_effect(expr) {
+            self.used_host_effects.push(effect);
+        }
+        if let Some(effect) = declared_env_read_effect(expr) {
+            self.declared_host_effects.push(effect);
+        }
+        if let Some(target) = executable_target_from_builder_add(expr) {
+            self.targets.push(target);
+        }
+
+        match expr {
+            Expression::BinaryOp { left, right, .. } => {
+                self.collect_expr(left);
+                self.collect_expr(right);
+            }
+            Expression::UnaryOp { operand, .. } => self.collect_expr(operand),
+            Expression::FunctionCall { args, .. }
+            | Expression::ArrayLiteral { elements: args, .. } => {
+                for arg in args {
+                    self.collect_expr(arg);
+                }
+            }
+            Expression::MethodCall { receiver, args, .. } => {
+                self.collect_expr(receiver);
+                for arg in args {
+                    self.collect_expr(arg);
+                }
+            }
+            Expression::MemberAccess { object, .. } => self.collect_expr(object),
+            Expression::IndexAccess { object, index, .. } => {
+                self.collect_expr(object);
+                self.collect_expr(index);
+            }
+            Expression::StructLiteral { fields, .. } => {
+                for (_, field) in fields {
+                    self.collect_expr(field);
+                }
+            }
+            Expression::EnumVariant { payload, .. } => {
+                if let Some(payload) = payload {
+                    self.collect_expr(payload);
+                }
+            }
+            Expression::Match {
+                scrutinee, arms, ..
+            } => {
+                self.collect_expr(scrutinee);
+                for MatchArm { guard, body, .. } in arms {
+                    if let Some(guard) = guard {
+                        self.collect_expr(guard);
+                    }
+                    self.collect_expr(body);
+                }
+            }
+            Expression::WhileLoop {
+                condition, body, ..
+            }
+            | Expression::If {
+                condition,
+                then_body: body,
+                ..
+            } => {
+                self.collect_expr(condition);
+                self.collect_expr(body);
+                if let Expression::If {
+                    else_body: Some(else_body),
+                    ..
+                } = expr
+                {
+                    self.collect_expr(else_body);
+                }
+            }
+            Expression::Loop { body, .. } => self.collect_expr(body),
+            Expression::Block {
+                statements, expr, ..
+            } => {
+                for statement in statements {
+                    self.collect_statement(statement);
+                }
+                if let Some(expr) = expr {
+                    self.collect_expr(expr);
+                }
+            }
+            Expression::Return { value, .. } => {
+                if let Some(value) = value {
+                    self.collect_expr(value);
+                }
+            }
+            Expression::Closure { body, .. } => self.collect_expr(body),
+            Expression::Cast { expr, .. } | Expression::Defer { expr, .. } => {
+                self.collect_expr(expr)
+            }
+            Expression::StringInterpolation { parts, .. } => {
+                for part in parts {
+                    if let crate::ast::StringPart::Expr(expr) = part {
+                        self.collect_expr(expr);
+                    }
+                }
+            }
+            Expression::Range { start, end, .. } => {
+                self.collect_expr(start);
+                self.collect_expr(end);
+            }
+            Expression::IntLiteral { .. }
+            | Expression::FloatLiteral { .. }
+            | Expression::StringLiteral { .. }
+            | Expression::BoolLiteral { .. }
+            | Expression::CharLiteral { .. }
+            | Expression::Identifier { .. }
+            | Expression::LoopControl { .. }
+            | Expression::Break { .. }
+            | Expression::Continue { .. }
+            | Expression::Error { .. } => {}
+        }
+    }
+
+    fn collect_statement(&mut self, statement: &Statement) {
+        match statement {
+            Statement::VarDecl { value, .. } | Statement::Expression { expr: value, .. } => {
+                self.collect_expr(value);
+            }
+            Statement::Assignment { target, value, .. } => {
+                self.collect_expr(target);
+                self.collect_expr(value);
+            }
+            Statement::Block { stmts, .. } => {
+                for stmt in stmts {
+                    self.collect_statement(stmt);
+                }
+            }
+        }
+    }
+}
+
+fn executable_target_from_builder_add(expr: &Expression) -> Option<BuildTargetInput> {
+    let Expression::MethodCall {
+        receiver,
+        method,
+        args,
+        ..
+    } = expr
+    else {
+        return None;
+    };
+    if method != "add"
+        || !matches!(receiver.as_ref(), Expression::Identifier { name, .. } if name == "b")
+    {
+        return None;
+    }
+    let [arg] = args.as_slice() else {
+        return None;
+    };
+    let Expression::StructLiteral { name, fields, .. } = arg else {
+        return None;
+    };
+    if name != "Executable" {
+        return None;
+    }
+
+    let target_name = string_field(fields, "name")?;
+    let root_source_file =
+        string_field(fields, "main").or_else(|| string_field(fields, "root_source_file"))?;
+    let out_dir = string_field(fields, "out_dir")?;
+
+    Some(BuildTargetInput {
+        name: target_name,
+        kind: BuildTargetKind::Executable {
+            root_source_file: root_source_file.clone(),
+            out_dir,
+        },
+        sources: vec![root_source_file],
+        dependencies: Vec::new(),
+        features: Vec::new(),
+    })
+}
+
+fn string_field(fields: &[(String, Expression)], field_name: &str) -> Option<String> {
+    fields.iter().find_map(|(name, value)| {
+        (name == field_name).then(|| match value {
+            Expression::StringLiteral { value, .. } => Some(value.clone()),
+            _ => None,
+        })?
+    })
+}
+
+fn declared_env_read_effect(expr: &Expression) -> Option<HostEffect> {
+    let Expression::Match {
+        scrutinee, arms, ..
+    } = expr
+    else {
+        return None;
+    };
+    let has_fallback = arms.iter().any(|arm| {
+        matches!(
+            &arm.pattern,
+            crate::ast::Pattern::Enum { variant, .. } if variant == "Err"
+        )
+    });
+    has_fallback.then(|| env_read_effect(scrutinee)).flatten()
+}
+
+fn env_read_effect(expr: &Expression) -> Option<HostEffect> {
+    let Expression::MethodCall {
+        receiver,
+        method,
+        args,
+        ..
+    } = expr
+    else {
+        return None;
+    };
+    if method != "env" || !is_builder_os(receiver) {
+        return None;
+    }
+    let [Expression::StringLiteral { value, .. }] = args.as_slice() else {
+        return None;
+    };
+    Some(HostEffect::ReadEnv(value.clone()))
+}
+
+fn is_builder_os(expr: &Expression) -> bool {
+    matches!(
+        expr,
+        Expression::MemberAccess { object, field, .. }
+            if field == "os"
+                && matches!(object.as_ref(), Expression::Identifier { name, .. } if name == "b")
+    )
 }

--- a/tests/build_graph.rs
+++ b/tests/build_graph.rs
@@ -1,6 +1,13 @@
 use zen::build_graph::{
     BuildGraph, BuildGraphInput, BuildTargetInput, BuildTargetKind, HostEffect,
 };
+use zen::lexer;
+use zen::parser;
+
+fn parse_program(src: &str) -> zen::ast::Program {
+    let tokens = lexer::tokenize(src, 0).expect("lex build script");
+    parser::parse(tokens, 0).expect("parse build script")
+}
 
 fn executable_target(name: &str, sources: &[&str]) -> BuildTargetInput {
     BuildTargetInput {
@@ -53,6 +60,47 @@ fn build_graph_rejects_undeclared_host_effects() {
         used_host_effects: vec![HostEffect::ReadEnv("ZEN_STD".to_string())],
     })
     .expect_err("undeclared host effects should be rejected");
+
+    assert_eq!(
+        err.to_string(),
+        "undeclared host effect: read env `ZEN_STD`"
+    );
+}
+
+#[test]
+fn parsed_project_build_zen_lowers_to_executable_graph() {
+    let program = parse_program(include_str!("../examples/project/build.zen"));
+    let graph = BuildGraph::from_build_program(&program).expect("lower build graph");
+
+    assert_eq!(graph.targets().len(), 1);
+    let target = &graph.targets()[0];
+    assert_eq!(target.name(), "myapp");
+    assert_eq!(target.sources(), ["main.zen"]);
+    match target.kind() {
+        BuildTargetKind::Executable {
+            root_source_file,
+            out_dir,
+        } => {
+            assert_eq!(root_source_file, "main.zen");
+            assert_eq!(out_dir, "build/");
+        }
+    }
+}
+
+#[test]
+fn build_program_lowering_rejects_undeclared_env_reads() {
+    let program = parse_program(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    std_path = b.os.env("ZEN_STD")
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    );
+
+    let err = BuildGraph::from_build_program(&program)
+        .expect_err("undeclared build.zen env read should fail");
 
     assert_eq!(
         err.to_string(),

--- a/tests/docs_truth.rs
+++ b/tests/docs_truth.rs
@@ -388,6 +388,8 @@ fn phase_plan_records_recovered_progress_and_next_slice() {
         "build_graph_rejects_undeclared_host_effects",
         "parse_project_build_zen_example",
         "parse_shorthand_enum_variant_expr_and_pattern",
+        "parsed_project_build_zen_lowers_to_executable_graph",
+        "build_program_lowering_rejects_undeclared_env_reads",
         "collect_declarations_with_symbols_uses_resolver_behavior_impl_generic_method_template_target_and_name_metadata",
         "collect_declarations_with_symbols_clears_stale_behavior_impl_generic_method_template_after_key_restore",
         "resolver_declaration_metadata_skips_behavior_impl_methods_until_behavior_impl_pass",


### PR DESCRIPTION
## What changed

- Added `BuildGraph::from_build_program` as a constrained lowering boundary from parsed `build.zen` AST into `BuildGraph`.
- Added read-only target accessors for graph assertions and future CLI graph emission.
- Lowered `b.add(Executable { name, main/root_source_file, out_dir })` into deterministic executable target input.
- Tracked `b.os.env("...")` host effects and only declared env reads when they are handled through a result match with an `.Err` fallback.
- Added tests for lowering the checked-in project `build.zen` and rejecting undeclared env reads.
- Updated phase-plan/docs-truth evidence while keeping normal CLI `build.zen` execution gated.

## Why

The next build-driver work needs an internal, tested boundary before any CLI path can expose build graph emission. This keeps host-effect handling explicit and keeps `zen build build.zen` gated until integration tests prove the advertised path.

## Validation

- `cargo test --test build_graph`
- `cargo test --test docs_truth && cargo fmt --check && git diff --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`