### PR TITLE
[codex] Emit build graph JSON from build zen

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1874,21 +1874,26 @@ checked-in docs, tests, and commits only.
   covers the checked-in project executable target, and
   `build_program_lowering_rejects_undeclared_env_reads` keeps undeclared host
   effects rejected during lowering.
+- `emit-json build-graph <build.zen>` now exposes the constrained graph-emission
+  path without enabling normal build execution. `emit_json_build_graph_outputs_project_build_graph`
+  covers the positive CLI path, and
+  `emit_json_build_graph_rejects_undeclared_host_effects` covers the negative
+  host-effect path through the advertised compiler command.
 
 ## Current Phase
 
 Continue the smallest behavior-association and resolver/typechecker hardening
 slices. Phase 3 C codegen is sufficient for the current tested fixtures, but
-Phase 4 build-driver work is still gated by the lack of a CLI integration path
-that executes only the constrained `build.zen` subset and emits the
-deterministic build graph.
+Phase 4 build-driver work is still gated by the lack of target graph execution:
+`build.zen` can now emit a deterministic compiler-owned graph, but
+`zen build build.zen` still does not execute targets.
 
 Do not promote gated v1 features until the relevant positive and negative tests
 exist and pass through the same compiler path advertised in `docs/V1_SPEC.md`.
 
 ## Next Small Slice
 
-Continue the next smallest build-driver slice by adding positive and negative
-CLI integration coverage for the constrained `build.zen` graph-emission path.
-Keep normal `zen build build.zen` execution gated until graph emission proves the
-lowering boundary through the advertised compiler path.
+Continue the next smallest build-driver slice by adding target graph execution
+tests that consume the deterministic graph without widening the accepted
+`build.zen` language subset. Keep normal `zen build build.zen` gated until one
+executable target can be compiled from graph data with matching negative tests.

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ fn main() {
         eprintln!("  emit-json symbols <file>   Emit resolver symbol tables JSON");
         eprintln!("  emit-json typed <file>   Emit checked typed program JSON");
         eprintln!("  emit-json diagnostics <file>   Emit diagnostics JSON");
+        eprintln!("  emit-json build-graph <build.zen>   Emit deterministic build graph JSON");
         eprintln!("  <file>         Run a .zen file");
         process::exit(1);
     }
@@ -57,8 +58,11 @@ fn main() {
                 "symbols" => cmd_emit_json_symbols(&args[3]),
                 "typed" => cmd_emit_json_typed(&args[3]),
                 "diagnostics" => cmd_emit_json_diagnostics(&args[3]),
+                "build-graph" => cmd_emit_json_build_graph(&args[3]),
                 _ => {
-                    eprintln!("Usage: zen emit-json <ast|symbols|typed|diagnostics> <file.zen>");
+                    eprintln!(
+                        "Usage: zen emit-json <ast|symbols|typed|diagnostics|build-graph> <file.zen>"
+                    );
                     process::exit(1);
                 }
             }
@@ -205,6 +209,58 @@ fn cmd_emit_json_diagnostics(path_str: &str) {
 
     if has_errors {
         process::exit(1);
+    }
+}
+
+fn cmd_emit_json_build_graph(path_str: &str) {
+    let path = Path::new(path_str);
+    if !path.exists() {
+        eprintln!("error: file not found: {}", path_str);
+        process::exit(1);
+    }
+    if !is_build_zen_path(path_str) {
+        eprintln!("error: emit-json build-graph expects a build.zen file");
+        process::exit(1);
+    }
+
+    let source = match std::fs::read_to_string(path) {
+        Ok(source) => source,
+        Err(err) => {
+            eprintln!("error reading {}: {}", path_str, err);
+            process::exit(1);
+        }
+    };
+
+    let mut files = FileTable::new();
+    let file_id = files.add_file(path_str.to_string(), source.clone());
+    let tokens = match zen::lexer::tokenize(&source, file_id) {
+        Ok(tokens) => tokens,
+        Err(err) => {
+            print_errors(&[err], &files);
+            process::exit(1);
+        }
+    };
+    let program = match zen::parser::parse(tokens, file_id) {
+        Ok(program) => program,
+        Err(errs) => {
+            print_errors(&errs, &files);
+            process::exit(1);
+        }
+    };
+    let graph = match zen::build_graph::BuildGraph::from_build_program(&program) {
+        Ok(graph) => graph,
+        Err(err) => {
+            eprintln!("build graph error: {}", err);
+            process::exit(1);
+        }
+    };
+
+    match graph.canonical_json() {
+        Ok(json) => println!("{json}"),
+        Err(err) => {
+            eprintln!("json emit error: {}", err);
+            process::exit(1);
+        }
     }
 }
 

--- a/tests/docs_truth.rs
+++ b/tests/docs_truth.rs
@@ -390,6 +390,8 @@ fn phase_plan_records_recovered_progress_and_next_slice() {
         "parse_shorthand_enum_variant_expr_and_pattern",
         "parsed_project_build_zen_lowers_to_executable_graph",
         "build_program_lowering_rejects_undeclared_env_reads",
+        "emit_json_build_graph_outputs_project_build_graph",
+        "emit_json_build_graph_rejects_undeclared_host_effects",
         "collect_declarations_with_symbols_uses_resolver_behavior_impl_generic_method_template_target_and_name_metadata",
         "collect_declarations_with_symbols_clears_stale_behavior_impl_generic_method_template_after_key_restore",
         "resolver_declaration_metadata_skips_behavior_impl_methods_until_behavior_impl_pass",

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1557,6 +1557,61 @@ fn direct_file_command_rejects_build_zen_until_deterministic_graph_exists() {
     assert_build_zen_rejected(&[], "zen build.zen");
 }
 
+#[test]
+fn emit_json_build_graph_outputs_project_build_graph() {
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "build-graph", "examples/project/build.zen"])
+        .output()
+        .expect("run zen emit-json build-graph");
+
+    assert!(
+        output.status.success(),
+        "emit-json build-graph failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("build graph json");
+    assert_eq!(json["targets"][0]["name"], "myapp");
+    assert_eq!(json["targets"][0]["kind"]["root_source_file"], "main.zen");
+    assert_eq!(json["targets"][0]["kind"]["out_dir"], "build/");
+}
+
+#[test]
+fn emit_json_build_graph_rejects_undeclared_host_effects() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let build_path = tmp.path().join("build.zen");
+    std::fs::write(
+        &build_path,
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    std_path = b.os.env("ZEN_STD")
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "build-graph", build_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json build-graph");
+
+    assert!(
+        !output.status.success(),
+        "emit-json build-graph unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("undeclared host effect: read env `ZEN_STD`"),
+        "expected undeclared host effect diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 fn assert_build_zen_rejected(prefix_args: &[&str], command_name: &str) {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let build_path = tmp.path().join("build.zen");


### PR DESCRIPTION
## What changed

- Added explicit CLI support for `zen emit-json build-graph <build.zen>`.
- The new path parses `build.zen`, lowers through `BuildGraph::from_build_program`, and emits canonical build graph JSON.
- Kept normal `zen build build.zen`, `zen check build.zen`, `zen emit build.zen`, and direct `zen build.zen` execution gated.
- Added positive/negative integration tests for build graph JSON emission and undeclared host-effect rejection through the CLI path.
- Updated phase-plan/docs-truth evidence and next slice guidance.

## Why

The build-driver work needed an advertised compiler path that proves deterministic graph emission without enabling target execution yet. This exposes graph emission while preserving the normal build execution gate.

## Validation

- `cargo test --test integration emit_json_build_graph`
- `cargo test --test docs_truth && cargo fmt --check && git diff --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`