### PR TITLE
[codex] Build one target from build graph

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1879,21 +1879,26 @@ checked-in docs, tests, and commits only.
   covers the positive CLI path, and
   `emit_json_build_graph_rejects_undeclared_host_effects` covers the negative
   host-effect path through the advertised compiler command.
+- `build-graph <build.zen>` now consumes the deterministic graph for one
+  executable target without widening the accepted `build.zen` subset.
+  `build_graph_command_compiles_single_executable_target` covers the positive
+  path, and `build_graph_command_rejects_missing_root_source` covers a target
+  execution failure before normal `zen build build.zen` is ungated.
 
 ## Current Phase
 
 Continue the smallest behavior-association and resolver/typechecker hardening
 slices. Phase 3 C codegen is sufficient for the current tested fixtures, but
-Phase 4 build-driver work is still gated by the lack of target graph execution:
-`build.zen` can now emit a deterministic compiler-owned graph, but
-`zen build build.zen` still does not execute targets.
+Phase 4 build-driver work is still gated by the normal `zen build build.zen`
+entrypoint: deterministic graph emission and one-target execution exist through
+explicit experimental commands, but the standard build command remains gated.
 
 Do not promote gated v1 features until the relevant positive and negative tests
 exist and pass through the same compiler path advertised in `docs/V1_SPEC.md`.
 
 ## Next Small Slice
 
-Continue the next smallest build-driver slice by adding target graph execution
-tests that consume the deterministic graph without widening the accepted
-`build.zen` language subset. Keep normal `zen build build.zen` gated until one
-executable target can be compiled from graph data with matching negative tests.
+Continue the next smallest build-driver slice by routing normal
+`zen build build.zen` through the constrained graph pipeline while preserving
+the existing negative cases for `check`, `emit`, and direct `build.zen`
+execution. Do not widen the accepted `build.zen` subset while doing so.

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ fn main() {
         eprintln!("Commands:");
         eprintln!("  check <file>   Parse and typecheck a .zen file");
         eprintln!("  build <file>   Compile a .zen file to a binary");
+        eprintln!("  build-graph <build.zen>   Compile one target from deterministic build graph");
         eprintln!("  emit  <file>   Emit C source (no compilation)");
         eprintln!("  emit-json ast <file>   Emit resolved AST JSON");
         eprintln!("  emit-json symbols <file>   Emit resolver symbol tables JSON");
@@ -40,6 +41,13 @@ fn main() {
                 process::exit(1);
             }
             cmd_build(&args[2]);
+        }
+        "build-graph" => {
+            if args.len() < 3 {
+                eprintln!("Usage: zen build-graph <build.zen>");
+                process::exit(1);
+            }
+            cmd_build_graph(&args[2]);
         }
         "emit" => {
             if args.len() < 3 {
@@ -213,6 +221,17 @@ fn cmd_emit_json_diagnostics(path_str: &str) {
 }
 
 fn cmd_emit_json_build_graph(path_str: &str) {
+    let graph = load_build_graph(path_str);
+    match graph.canonical_json() {
+        Ok(json) => println!("{json}"),
+        Err(err) => {
+            eprintln!("json emit error: {}", err);
+            process::exit(1);
+        }
+    }
+}
+
+fn load_build_graph(path_str: &str) -> zen::build_graph::BuildGraph {
     let path = Path::new(path_str);
     if !path.exists() {
         eprintln!("error: file not found: {}", path_str);
@@ -255,13 +274,7 @@ fn cmd_emit_json_build_graph(path_str: &str) {
         }
     };
 
-    match graph.canonical_json() {
-        Ok(json) => println!("{json}"),
-        Err(err) => {
-            eprintln!("json emit error: {}", err);
-            process::exit(1);
-        }
-    }
+    graph
 }
 
 fn cmd_emit(path_str: &str) {
@@ -281,7 +294,48 @@ fn cmd_emit(path_str: &str) {
 
 fn cmd_build(path_str: &str) {
     reject_build_zen(path_str);
+    compile_file_to_binary(path_str, None, None);
+}
 
+fn cmd_build_graph(path_str: &str) {
+    let graph = load_build_graph(path_str);
+    let [target] = graph.targets() else {
+        eprintln!(
+            "build graph execution supports exactly one target, found {}",
+            graph.targets().len()
+        );
+        process::exit(1);
+    };
+
+    let build_path = Path::new(path_str);
+    let base_dir = build_path.parent().unwrap_or_else(|| Path::new("."));
+    let zen::build_graph::BuildTargetKind::Executable {
+        root_source_file,
+        out_dir,
+    } = target.kind();
+    let root_path = base_dir.join(root_source_file);
+    if !root_path.exists() {
+        eprintln!(
+            "build graph target `{}` root source not found: {}",
+            target.name(),
+            root_source_file
+        );
+        process::exit(1);
+    }
+    let out_dir = base_dir.join(out_dir);
+    if let Err(err) = std::fs::create_dir_all(&out_dir) {
+        eprintln!("error creating {}: {}", out_dir.display(), err);
+        process::exit(1);
+    }
+
+    compile_file_to_binary(
+        root_path.to_str().unwrap_or(root_source_file),
+        Some(&out_dir),
+        Some(target.name()),
+    );
+}
+
+fn compile_file_to_binary(path_str: &str, output_dir: Option<&Path>, output_name: Option<&str>) {
     let typed = graph_frontend(path_str);
     let backend = CBackend;
     let c_source = match backend.generate(&typed) {
@@ -297,25 +351,33 @@ fn cmd_build(path_str: &str) {
         .file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or("out");
-    let c_path = format!("{}.c", stem);
-    let bin_path = stem.to_string();
+    let output_stem = output_name.unwrap_or(stem);
+    let c_path = output_dir
+        .map(|dir| dir.join(format!("{output_stem}.c")))
+        .unwrap_or_else(|| Path::new(&format!("{output_stem}.c")).to_path_buf());
+    let bin_path = output_dir
+        .map(|dir| dir.join(output_stem))
+        .unwrap_or_else(|| Path::new(output_stem).to_path_buf());
 
     // Write C source
     if let Err(e) = std::fs::write(&c_path, &c_source) {
-        eprintln!("error writing {}: {}", c_path, e);
+        eprintln!("error writing {}: {}", c_path.display(), e);
         process::exit(1);
     }
-    println!("  emitted {}", c_path);
+    println!("  emitted {}", c_path.display());
 
     // Compile with cc
     let cc = std::env::var("CC").unwrap_or_else(|_| "cc".into());
     let status = process::Command::new(&cc)
-        .args([&c_path, "-o", &bin_path, "-lm"])
+        .arg(&c_path)
+        .arg("-o")
+        .arg(&bin_path)
+        .arg("-lm")
         .status();
 
     match status {
         Ok(s) if s.success() => {
-            println!("  compiled → {}", bin_path);
+            println!("  compiled → {}", bin_path.display());
         }
         Ok(s) => {
             eprintln!("  {} exited with {}", cc, s);
@@ -323,7 +385,7 @@ fn cmd_build(path_str: &str) {
         }
         Err(e) => {
             eprintln!("  failed to run {}: {}", cc, e);
-            eprintln!("  (C source saved to {})", c_path);
+            eprintln!("  (C source saved to {})", c_path.display());
             process::exit(1);
         }
     }

--- a/tests/docs_truth.rs
+++ b/tests/docs_truth.rs
@@ -392,6 +392,8 @@ fn phase_plan_records_recovered_progress_and_next_slice() {
         "build_program_lowering_rejects_undeclared_env_reads",
         "emit_json_build_graph_outputs_project_build_graph",
         "emit_json_build_graph_rejects_undeclared_host_effects",
+        "build_graph_command_compiles_single_executable_target",
+        "build_graph_command_rejects_missing_root_source",
         "collect_declarations_with_symbols_uses_resolver_behavior_impl_generic_method_template_target_and_name_metadata",
         "collect_declarations_with_symbols_clears_stale_behavior_impl_generic_method_template_after_key_restore",
         "resolver_declaration_metadata_skips_behavior_impl_methods_until_behavior_impl_pass",

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1612,6 +1612,90 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
     );
 }
 
+#[test]
+fn build_graph_command_compiles_single_executable_target() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("main.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write main.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build-graph", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build-graph");
+
+    assert!(
+        output.status.success(),
+        "zen build-graph failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let bin_path = tmp.path().join("build").join("myapp");
+    assert!(
+        bin_path.exists(),
+        "expected {} to exist",
+        bin_path.display()
+    );
+    let run = Command::new(&bin_path).output().expect("run built binary");
+    assert!(
+        run.status.success(),
+        "built binary exited with {}",
+        run.status
+    );
+}
+
+#[test]
+fn build_graph_command_rejects_missing_root_source() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable { name: "myapp", main: "missing.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build-graph", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build-graph");
+
+    assert!(
+        !output.status.success(),
+        "zen build-graph unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("build graph target `myapp` root source not found: missing.zen"),
+        "expected missing root source diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 fn assert_build_zen_rejected(prefix_args: &[&str], command_name: &str) {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let build_path = tmp.path().join("build.zen");


### PR DESCRIPTION
## What changed

- Added explicit experimental `zen build-graph <build.zen>` command.
- Reused the constrained `BuildGraph` lowering path and current C backend to compile exactly one executable target.
- Writes target artifacts under the target `out_dir` using the target name.
- Added integration coverage for:
  - successful single-target build graph execution
  - missing root source rejection
- Kept normal `zen build build.zen` gated, alongside existing `check`, `emit`, and direct-file gate tests.
- Updated phase-plan/docs-truth evidence and next-slice guidance.

## Why

This proves target graph consumption with one executable before ungating the standard `zen build build.zen` entrypoint. It keeps the accepted `build.zen` subset narrow and tested.

## Validation

- `cargo test --test integration build_graph_command`
- `cargo test --test docs_truth && cargo fmt --check && git diff --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`