### PR TITLE
Strengthen generic C emission tests

### DIFF
--- a/tests/integration/generic_specializations.rs
+++ b/tests/integration/generic_specializations.rs
@@ -1,6 +1,41 @@
 use super::support::*;
 
 #[test]
+fn generic_specializations_emit_each_generated_c_definition_once() {
+    let fixtures = [
+        "generic_enum_method.zen",
+        "generic_enum_option.zen",
+        "generic_identity.zen",
+        "generic_method.zen",
+        "generic_method_nested_result.zen",
+        "generic_method_self.zen",
+        "generic_method_worklist.zen",
+        "generic_nested_result_enum.zen",
+        "generic_result_enum.zen",
+        "generic_struct.zen",
+        "generic_ufc_function.zen",
+        "generic_vec.zen",
+        "generic_worklist.zen",
+        "generic_worklist_dedup.zen",
+        "multi_file_generic/main.zen",
+        "multi_file_generic_enum_method/main.zen",
+        "multi_file_generic_imported_transitive_dependency/main.zen",
+        "multi_file_generic_imported_type_dependency/main.zen",
+        "multi_file_generic_imported_worklist_chain/main.zen",
+        "multi_file_imported_generic_function_return_enum_dependency/main.zen",
+        "multi_file_type_impl_return_enum_dependency/main.zen",
+        "multi_file_type_method_nested_result_dependency/main.zen",
+        "multi_file_type_method_return_enum_dependency/main.zen",
+        "multi_file_type_method_worklist/main.zen",
+    ];
+
+    for fixture in fixtures {
+        let c_source = compile_to_c_with_generated_call_check(&test_dir().join(fixture));
+        assert_generated_c_function_definitions_are_unique(&c_source);
+    }
+}
+
+#[test]
 fn generic_specializations_do_not_emit_unspecialized_c_symbols() {
     let c_source = compile_to_c_with_generated_call_check(&test_dir().join("generic_method.zen"));
     assert!(c_source.contains("int32_t Box_get_i32(Box_i32 self)"));

--- a/tests/integration/support.rs
+++ b/tests/integration/support.rs
@@ -138,6 +138,28 @@ pub fn assert_c_function_definition_count(c_source: &str, name: &str, expected: 
     );
 }
 
+pub fn assert_generated_c_function_definitions_are_unique(c_source: &str) {
+    let definitions = c_function_definitions(c_source);
+    let mut duplicates = Vec::new();
+
+    for definition in &definitions {
+        if definitions
+            .iter()
+            .filter(|candidate| *candidate == definition)
+            .count()
+            > 1
+            && !duplicates.contains(definition)
+        {
+            duplicates.push(definition.clone());
+        }
+    }
+
+    assert!(
+        duplicates.is_empty(),
+        "generated C emitted duplicate function definitions: {duplicates:?}\n{c_source}"
+    );
+}
+
 pub fn assert_c_call_resolves_to_definition(c_source: &str, name: &str) {
     assert_c_function_definition(c_source, name);
     assert!(


### PR DESCRIPTION
## Summary
- add a generated-C assertion that every emitted generated function definition is unique
- run that assertion across the generic specialization fixture set, alongside the existing undefined-call checks

## Verification
- `cargo test --test integration generic_specializations -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Opened as draft first so the branch push does not create a noisy real CI run.