### PR TITLE
Cover declared build env effects

### DIFF
--- a/tests/integration/cli_build/graph_validation.rs
+++ b/tests/integration/cli_build/graph_validation.rs
@@ -180,6 +180,51 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
 }
 
 #[test]
+fn check_command_build_zen_accepts_declared_env_read_with_fallback() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    std_path = b.os.env("ZEN_STD") ?
+        | .Ok(path) { path }
+        | .Err { "~/.zen/std" }
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("main.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write main.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["check", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen check build.zen");
+
+    assert!(
+        output.status.success(),
+        "zen check build.zen failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("1 build targets"),
+        "expected build graph check summary, stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
 fn check_command_build_zen_rejects_undeclared_host_effects_before_source_validation() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(


### PR DESCRIPTION
## Summary
- add a CLI build.zen graph-validation test proving an env read with an explicit fallback/declaration is accepted
- pair it with the existing undeclared-env negative checks for deterministic host effects

## Verification
- `cargo test --test integration cli_build::graph_validation -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Opened as draft first so the branch push does not create a noisy real CI run.