### PR TITLE
Split typechecker scope management

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -142,6 +142,8 @@ checked-in docs, tests, and commits only.
 - Expression checking now delegates match, conditional, and loop lowering
   through focused control-flow helpers, keeping pattern binding, exhaustiveness,
   and loop-control lowering behavior unchanged while shrinking the dispatcher.
+- Typechecker scope and import lookup methods now live in a dedicated
+  scope-management helper module instead of the broad typechecker root.
 - Resolver validation replay now collects expected declaration symbols,
   expected local symbols, import-validation state, and behavior-association
   replay tasks in one declaration pass before checking resolver-owned extras,

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -22,6 +22,7 @@ mod program_checking;
 mod resolve;
 mod resolver_lookup;
 mod resolver_validation;
+mod scope_management;
 mod self_type_validation;
 mod statements;
 
@@ -1295,49 +1296,6 @@ impl TypeChecker {
         }
 
         Some(ast_substitutions)
-    }
-
-    // ── Scope Management ──────────────────────────────────────────
-
-    pub(crate) fn push_scope(&mut self) {
-        self.scopes.push(Scope::new());
-    }
-
-    pub(crate) fn pop_scope(&mut self) {
-        self.scopes.pop();
-    }
-
-    pub(crate) fn define_var(&mut self, name: &str, ty: Type) {
-        self.define_var_with_mutability(name, ty, false);
-    }
-
-    pub(crate) fn define_var_with_mutability(&mut self, name: &str, ty: Type, mutable: bool) {
-        if let Some(scope) = self.scopes.last_mut() {
-            scope.vars.insert(name.to_string(), VarInfo { ty, mutable });
-        }
-    }
-
-    pub(crate) fn lookup_var(&self, name: &str) -> Option<Type> {
-        self.lookup_var_info(name).map(|info| info.ty.clone())
-    }
-
-    pub(crate) fn lookup_var_info(&self, name: &str) -> Option<&VarInfo> {
-        for scope in self.scopes.iter().rev() {
-            if let Some(info) = scope.vars.get(name) {
-                return Some(info);
-            }
-        }
-        None
-    }
-
-    pub(crate) fn is_import(&self, name: &str) -> bool {
-        self.imports.contains_key(name)
-    }
-
-    pub(crate) fn is_root_std_import(&self, name: &str) -> bool {
-        self.imports
-            .get(name)
-            .is_some_and(|path| path == &["std".to_string()] || path == &["@std".to_string()])
     }
 }
 

--- a/src/typechecker/scope_management.rs
+++ b/src/typechecker/scope_management.rs
@@ -1,0 +1,44 @@
+use super::*;
+
+impl TypeChecker {
+    pub(crate) fn push_scope(&mut self) {
+        self.scopes.push(Scope::new());
+    }
+
+    pub(crate) fn pop_scope(&mut self) {
+        self.scopes.pop();
+    }
+
+    pub(crate) fn define_var(&mut self, name: &str, ty: Type) {
+        self.define_var_with_mutability(name, ty, false);
+    }
+
+    pub(crate) fn define_var_with_mutability(&mut self, name: &str, ty: Type, mutable: bool) {
+        if let Some(scope) = self.scopes.last_mut() {
+            scope.vars.insert(name.to_string(), VarInfo { ty, mutable });
+        }
+    }
+
+    pub(crate) fn lookup_var(&self, name: &str) -> Option<Type> {
+        self.lookup_var_info(name).map(|info| info.ty.clone())
+    }
+
+    pub(crate) fn lookup_var_info(&self, name: &str) -> Option<&VarInfo> {
+        for scope in self.scopes.iter().rev() {
+            if let Some(info) = scope.vars.get(name) {
+                return Some(info);
+            }
+        }
+        None
+    }
+
+    pub(crate) fn is_import(&self, name: &str) -> bool {
+        self.imports.contains_key(name)
+    }
+
+    pub(crate) fn is_root_std_import(&self, name: &str) -> bool {
+        self.imports
+            .get(name)
+            .is_some_and(|path| path == &["std".to_string()] || path == &["@std".to_string()])
+    }
+}


### PR DESCRIPTION
## Summary
- move TypeChecker scope push/pop, variable lookup, and import lookup helpers into `typechecker/scope_management.rs`
- keep the scope data types in the existing included support path for this narrow slice
- record the refactor in `docs/PHASE_PLAN.md`

## Verification
- `cargo test --lib typechecker::tests::scope_variable_lookup -- --nocapture`
- `cargo test --lib typechecker::tests::core_semantics::enum_assignment_and_modules::known_root_std_runtime_standins_remain_allowed -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`