### PR TITLE
[codex] Split generic bound validation

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -156,6 +156,9 @@ checked-in docs, tests, and commits only.
 - Typechecker AST-side declaration collection now lives in a dedicated helper
   module, keeping import, callable, type, behavior, and precollection task
   helpers out of resolver metadata collection.
+- Typechecker generic behavior-bound validation now lives in a dedicated helper
+  module, keeping bound declaration checks and substitution-based impl checks
+  out of the broad generic type-reference traversal.
 - Resolver validation replay now collects expected declaration symbols,
   expected local symbols, import-validation state, and behavior-association
   replay tasks in one declaration pass before checking resolver-owned extras,

--- a/src/typechecker/generic_bound_validation.rs
+++ b/src/typechecker/generic_bound_validation.rs
@@ -1,0 +1,93 @@
+use super::*;
+
+impl TypeChecker {
+    pub(super) fn validate_generic_bounds(&mut self, type_params: &[ast::TypeParam]) {
+        for param in type_params {
+            if let Some(bound) = &param.constraint {
+                if !self.behaviors.contains_key(bound) {
+                    self.diagnostics.push(Diagnostic::error(
+                        "E5002",
+                        format!(
+                            "generic bound `{}` on type parameter `{}` references undefined behavior",
+                            bound, param.name
+                        ),
+                        param.span,
+                    ));
+                } else {
+                    let expected = self
+                        .behaviors
+                        .get(bound)
+                        .map(|info| info.type_params.len())
+                        .unwrap_or(0);
+                    let found = param.constraint_type_args.len();
+                    if expected != found {
+                        self.diagnostics.push(Diagnostic::error(
+                            "E6012",
+                            format!(
+                                "generic behavior `{}` expects {} type arguments, found {}",
+                                bound, expected, found
+                            ),
+                            param.span,
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    pub(crate) fn check_generic_bounds(
+        &mut self,
+        bounds: &HashMap<String, BehaviorBound>,
+        substitutions: &HashMap<String, Type>,
+        span: Span,
+    ) {
+        for (param, bound) in bounds {
+            let Some(concrete) = substitutions.get(param) else {
+                continue;
+            };
+            let behavior_key = self.behavior_bound_key(bound, substitutions);
+            let behavior_display = behavior_bound_display(bound, substitutions);
+            let Some(type_name) = Self::behavior_bound_type_name(concrete) else {
+                self.diagnostics.push(Diagnostic::error(
+                    "E6004",
+                    format!(
+                        "type `{}` does not implement behavior `{}` required by `{}`",
+                        concrete.display_name(),
+                        behavior_display,
+                        param
+                    ),
+                    span,
+                ));
+                continue;
+            };
+            if !self.type_implements_behavior(&type_name, &behavior_key) {
+                self.diagnostics.push(Diagnostic::error(
+                    "E6004",
+                    format!(
+                        "type `{}` does not implement behavior `{}` required by `{}`",
+                        type_name, behavior_display, param
+                    ),
+                    span,
+                ));
+            }
+        }
+    }
+
+    fn behavior_bound_key(
+        &self,
+        bound: &BehaviorBound,
+        substitutions: &HashMap<String, Type>,
+    ) -> String {
+        let type_args = substitute_behavior_bound_type_args(&bound.type_args, substitutions);
+        self.behavior_reference_key(&bound.behavior, &type_args)
+    }
+
+    fn behavior_bound_type_name(ty: &Type) -> Option<String> {
+        match ty {
+            Type::Named(name) | Type::Struct { name, .. } | Type::Enum { name, .. } => {
+                Some(name.clone())
+            }
+            _ => None,
+        }
+    }
+}

--- a/src/typechecker/generic_type_validation.rs
+++ b/src/typechecker/generic_type_validation.rs
@@ -1,40 +1,6 @@
 use super::*;
 
 impl TypeChecker {
-    pub(super) fn validate_generic_bounds(&mut self, type_params: &[ast::TypeParam]) {
-        for param in type_params {
-            if let Some(bound) = &param.constraint {
-                if !self.behaviors.contains_key(bound) {
-                    self.diagnostics.push(Diagnostic::error(
-                        "E5002",
-                        format!(
-                            "generic bound `{}` on type parameter `{}` references undefined behavior",
-                            bound, param.name
-                        ),
-                        param.span,
-                    ));
-                } else {
-                    let expected = self
-                        .behaviors
-                        .get(bound)
-                        .map(|info| info.type_params.len())
-                        .unwrap_or(0);
-                    let found = param.constraint_type_args.len();
-                    if expected != found {
-                        self.diagnostics.push(Diagnostic::error(
-                            "E6012",
-                            format!(
-                                "generic behavior `{}` expects {} type arguments, found {}",
-                                bound, expected, found
-                            ),
-                            param.span,
-                        ));
-                    }
-                }
-            }
-        }
-    }
-
     #[cfg(test)]
     pub(super) fn collect_ast_type_reference_validation_tasks(
         decls: &[Declaration],
@@ -906,62 +872,6 @@ impl TypeChecker {
                     self.validate_generic_statement_type_references(statement, scoped_type_params);
                 }
             }
-        }
-    }
-
-    pub(crate) fn check_generic_bounds(
-        &mut self,
-        bounds: &HashMap<String, BehaviorBound>,
-        substitutions: &HashMap<String, Type>,
-        span: Span,
-    ) {
-        for (param, bound) in bounds {
-            let Some(concrete) = substitutions.get(param) else {
-                continue;
-            };
-            let behavior_key = self.behavior_bound_key(bound, substitutions);
-            let behavior_display = behavior_bound_display(bound, substitutions);
-            let Some(type_name) = self.behavior_bound_type_name(concrete) else {
-                self.diagnostics.push(Diagnostic::error(
-                    "E6004",
-                    format!(
-                        "type `{}` does not implement behavior `{}` required by `{}`",
-                        concrete.display_name(),
-                        behavior_display,
-                        param
-                    ),
-                    span,
-                ));
-                continue;
-            };
-            if !self.type_implements_behavior(&type_name, &behavior_key) {
-                self.diagnostics.push(Diagnostic::error(
-                    "E6004",
-                    format!(
-                        "type `{}` does not implement behavior `{}` required by `{}`",
-                        type_name, behavior_display, param
-                    ),
-                    span,
-                ));
-            }
-        }
-    }
-
-    fn behavior_bound_key(
-        &self,
-        bound: &BehaviorBound,
-        substitutions: &HashMap<String, Type>,
-    ) -> String {
-        let type_args = substitute_behavior_bound_type_args(&bound.type_args, substitutions);
-        self.behavior_reference_key(&bound.behavior, &type_args)
-    }
-
-    fn behavior_bound_type_name(&self, ty: &Type) -> Option<String> {
-        match ty {
-            Type::Named(name) | Type::Struct { name, .. } | Type::Enum { name, .. } => {
-                Some(name.clone())
-            }
-            _ => None,
         }
     }
 }

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -17,6 +17,7 @@ mod declaration_collection;
 mod declaration_collection_ast;
 mod environment;
 mod expressions;
+mod generic_bound_validation;
 mod generic_type_validation;
 mod monomorphize;
 mod patterns;


### PR DESCRIPTION
## Summary

- Move generic behavior-bound validation into `src/typechecker/generic_bound_validation.rs`.
- Keep recursive generic type-reference validation in `generic_type_validation.rs`.
- Record the extraction in `docs/PHASE_PLAN.md`.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`