### PR TITLE
[codex] Split resolver declaration definition

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -171,6 +171,9 @@ checked-in docs, tests, and commits only.
 - Resolver metadata construction helpers now live in a dedicated resolver
   module, keeping value signatures, type-parameter metadata, behavior refs, and
   method-key formatting out of the broad resolver traversal.
+- Resolver declaration definition now lives in a dedicated resolver helper
+  module, keeping top-level symbol registration separate from resolver
+  validation replay.
 - Resolver validation replay now collects expected declaration symbols,
   expected local symbols, import-validation state, and behavior-association
   replay tasks in one declaration pass before checking resolver-owned extras,

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -8,18 +8,16 @@ use crate::error::{Diagnostic, Span};
 #[cfg(test)]
 mod symbol_table_test_support;
 
+mod declaration_definition;
 mod metadata_helpers;
 mod symbol_table;
 
-use metadata_helpers::{
-    behavior_ref_display, resolver_behavior_method_signatures, resolver_behavior_method_types,
-    resolver_field_types, resolver_method_key, resolver_value_signature, resolver_variant_names,
-};
+use metadata_helpers::behavior_ref_display;
+use symbol_table::ScopeStack;
 pub use symbol_table::{
     BehaviorMethodTypeMetadata, BehaviorRefMetadata, MethodSignatureMetadata, Namespace, Symbol,
     SymbolId, SymbolTable, TypeParameterBoundMetadata, TypeParameterBoundRefMetadata,
 };
-use symbol_table::{ScopeStack, TypeLikeMembers};
 
 #[derive(Debug, Default)]
 pub struct Resolver;
@@ -48,148 +46,6 @@ impl Resolver {
         } else {
             Err(diagnostics)
         }
-    }
-
-    fn define_declaration(
-        &self,
-        table: &mut SymbolTable,
-        decl: &Declaration,
-    ) -> Result<(), Box<Diagnostic>> {
-        match decl {
-            Declaration::Function {
-                name,
-                type_params,
-                params,
-                return_type,
-                public,
-                span,
-                ..
-            } => {
-                table.define_value(
-                    name,
-                    *public,
-                    resolver_value_signature(params, return_type, type_params),
-                    *span,
-                )?;
-            }
-            Declaration::Method {
-                type_name,
-                method_name,
-                type_params,
-                params,
-                return_type,
-                public,
-                span,
-                ..
-            } => {
-                table.define_value(
-                    &resolver_method_key(type_name, method_name),
-                    *public,
-                    resolver_value_signature(params, return_type, type_params),
-                    *span,
-                )?;
-            }
-            Declaration::Struct {
-                name,
-                type_params,
-                fields,
-                public,
-                span,
-                ..
-            } => {
-                table.define_type_like(
-                    Namespace::Type,
-                    name,
-                    *public,
-                    type_params,
-                    TypeLikeMembers::Fields(resolver_field_types(fields)),
-                    *span,
-                )?;
-            }
-            Declaration::Enum {
-                name,
-                type_params,
-                variants,
-                public,
-                span,
-                ..
-            } => {
-                table.define_type_like(
-                    Namespace::Type,
-                    name,
-                    *public,
-                    type_params,
-                    TypeLikeMembers::Variants(resolver_variant_names(variants)),
-                    *span,
-                )?;
-                for variant in variants {
-                    table.define_variant(
-                        name,
-                        &variant.name,
-                        *public,
-                        variant.payload.clone(),
-                        variant.span,
-                    )?;
-                }
-            }
-            Declaration::Behavior {
-                name,
-                type_params,
-                methods,
-                public,
-                span,
-                ..
-            } => {
-                table.define_behavior(
-                    name,
-                    *public,
-                    type_params,
-                    resolver_behavior_method_signatures(methods),
-                    resolver_behavior_method_types(methods),
-                    *span,
-                )?;
-            }
-            Declaration::Import {
-                names,
-                module_path,
-                span,
-                ..
-            } => {
-                let source = module_path.join(".");
-                table.define(Namespace::Module, &source, false, None, *span)?;
-                for name in names {
-                    table.define(Namespace::Import, name, false, Some(source.clone()), *span)?;
-                }
-            }
-            Declaration::ImplBlock {
-                type_name, methods, ..
-            } => {
-                for method in methods {
-                    if let Declaration::Function {
-                        name,
-                        type_params,
-                        params,
-                        return_type,
-                        public,
-                        span,
-                        ..
-                    } = method
-                    {
-                        table.define_value(
-                            &resolver_method_key(type_name, name),
-                            *public,
-                            resolver_value_signature(params, return_type, type_params),
-                            *span,
-                        )?;
-                    }
-                }
-            }
-            Declaration::Requires { .. }
-            | Declaration::BehaviorExtends { .. }
-            | Declaration::TopLevelExpr { .. }
-            | Declaration::Error { .. } => {}
-        }
-        Ok(())
     }
 
     fn validate_declaration_types(

--- a/src/resolver/declaration_definition.rs
+++ b/src/resolver/declaration_definition.rs
@@ -1,0 +1,153 @@
+use crate::ast::Declaration;
+use crate::error::Diagnostic;
+
+use super::metadata_helpers::{
+    resolver_behavior_method_signatures, resolver_behavior_method_types, resolver_field_types,
+    resolver_method_key, resolver_value_signature, resolver_variant_names,
+};
+use super::symbol_table::TypeLikeMembers;
+use super::{Namespace, Resolver, SymbolTable};
+
+impl Resolver {
+    pub(super) fn define_declaration(
+        &self,
+        table: &mut SymbolTable,
+        decl: &Declaration,
+    ) -> Result<(), Box<Diagnostic>> {
+        match decl {
+            Declaration::Function {
+                name,
+                type_params,
+                params,
+                return_type,
+                public,
+                span,
+                ..
+            } => {
+                table.define_value(
+                    name,
+                    *public,
+                    resolver_value_signature(params, return_type, type_params),
+                    *span,
+                )?;
+            }
+            Declaration::Method {
+                type_name,
+                method_name,
+                type_params,
+                params,
+                return_type,
+                public,
+                span,
+                ..
+            } => {
+                table.define_value(
+                    &resolver_method_key(type_name, method_name),
+                    *public,
+                    resolver_value_signature(params, return_type, type_params),
+                    *span,
+                )?;
+            }
+            Declaration::Struct {
+                name,
+                type_params,
+                fields,
+                public,
+                span,
+                ..
+            } => {
+                table.define_type_like(
+                    Namespace::Type,
+                    name,
+                    *public,
+                    type_params,
+                    TypeLikeMembers::Fields(resolver_field_types(fields)),
+                    *span,
+                )?;
+            }
+            Declaration::Enum {
+                name,
+                type_params,
+                variants,
+                public,
+                span,
+                ..
+            } => {
+                table.define_type_like(
+                    Namespace::Type,
+                    name,
+                    *public,
+                    type_params,
+                    TypeLikeMembers::Variants(resolver_variant_names(variants)),
+                    *span,
+                )?;
+                for variant in variants {
+                    table.define_variant(
+                        name,
+                        &variant.name,
+                        *public,
+                        variant.payload.clone(),
+                        variant.span,
+                    )?;
+                }
+            }
+            Declaration::Behavior {
+                name,
+                type_params,
+                methods,
+                public,
+                span,
+                ..
+            } => {
+                table.define_behavior(
+                    name,
+                    *public,
+                    type_params,
+                    resolver_behavior_method_signatures(methods),
+                    resolver_behavior_method_types(methods),
+                    *span,
+                )?;
+            }
+            Declaration::Import {
+                names,
+                module_path,
+                span,
+                ..
+            } => {
+                let source = module_path.join(".");
+                table.define(Namespace::Module, &source, false, None, *span)?;
+                for name in names {
+                    table.define(Namespace::Import, name, false, Some(source.clone()), *span)?;
+                }
+            }
+            Declaration::ImplBlock {
+                type_name, methods, ..
+            } => {
+                for method in methods {
+                    if let Declaration::Function {
+                        name,
+                        type_params,
+                        params,
+                        return_type,
+                        public,
+                        span,
+                        ..
+                    } = method
+                    {
+                        table.define_value(
+                            &resolver_method_key(type_name, name),
+                            *public,
+                            resolver_value_signature(params, return_type, type_params),
+                            *span,
+                        )?;
+                    }
+                }
+            }
+            Declaration::Requires { .. }
+            | Declaration::BehaviorExtends { .. }
+            | Declaration::TopLevelExpr { .. }
+            | Declaration::Error { .. } => {}
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- move resolver top-level declaration symbol registration into `src/resolver/declaration_definition.rs`
- keep `src/resolver.rs` focused on orchestration and validation replay
- update the phase plan with the resolver extraction note

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test resolver_phase2 core_symbols::resolver_records_method_signatures_as_value_symbols`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`