### PR TITLE
[codex] Split resolver type validation

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -174,6 +174,9 @@ checked-in docs, tests, and commits only.
 - Resolver declaration definition now lives in a dedicated resolver helper
   module, keeping top-level symbol registration separate from resolver
   validation replay.
+- Resolver type-reference validation now lives in a dedicated resolver helper
+  module, keeping parameter, type-parameter, and known-symbol checks separate
+  from declaration and expression traversal.
 - Resolver validation replay now collects expected declaration symbols,
   expected local symbols, import-validation state, and behavior-association
   replay tasks in one declaration pass before checking resolver-owned extras,

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use crate::ast::{
-    AstType, Declaration, Expression, Param, Pattern, Program, Statement, StringPart, TypeParam,
+    Declaration, Expression, Param, Pattern, Program, Statement, StringPart, TypeParam,
 };
 use crate::error::{Diagnostic, Span};
 
@@ -11,6 +11,7 @@ mod symbol_table_test_support;
 mod declaration_definition;
 mod metadata_helpers;
 mod symbol_table;
+mod type_validation;
 
 use metadata_helpers::behavior_ref_display;
 use symbol_table::ScopeStack;
@@ -397,199 +398,6 @@ impl Resolver {
                 );
             }
         }
-    }
-
-    fn validate_params(
-        &self,
-        table: &SymbolTable,
-        type_params: &[TypeParam],
-        params: &[Param],
-        allow_self_type: bool,
-        diagnostics: &mut Vec<Diagnostic>,
-    ) {
-        let mut seen_params = HashSet::new();
-        for param in params {
-            if !seen_params.insert(param.name.as_str()) {
-                diagnostics.push(Diagnostic::error(
-                    "E0214",
-                    format!("duplicate parameter `{}`", param.name),
-                    param.span,
-                ));
-            }
-            self.validate_type_ref(
-                table,
-                type_params,
-                &param.ty,
-                param.span,
-                allow_self_type,
-                diagnostics,
-            );
-        }
-    }
-
-    fn validate_type_param_constraints(
-        &self,
-        table: &SymbolTable,
-        type_params: &[TypeParam],
-        allow_self_type: bool,
-        diagnostics: &mut Vec<Diagnostic>,
-    ) {
-        let mut seen_type_params = HashSet::new();
-        for type_param in type_params {
-            if !seen_type_params.insert(type_param.name.as_str()) {
-                diagnostics.push(Diagnostic::error(
-                    "E0213",
-                    format!("duplicate type parameter `{}`", type_param.name),
-                    type_param.span,
-                ));
-            }
-            if let Some(constraint) = &type_param.constraint {
-                if !self.is_known_behavior_name(table, constraint) {
-                    diagnostics.push(Diagnostic::error(
-                        "E0202",
-                        format!("unknown behavior symbol '{constraint}'"),
-                        type_param.span,
-                    ));
-                }
-                for type_arg in &type_param.constraint_type_args {
-                    self.validate_type_ref(
-                        table,
-                        type_params,
-                        type_arg,
-                        type_param.span,
-                        allow_self_type,
-                        diagnostics,
-                    );
-                }
-            }
-        }
-    }
-
-    fn validate_type_ref(
-        &self,
-        table: &SymbolTable,
-        type_params: &[TypeParam],
-        ast_type: &AstType,
-        span: Span,
-        allow_self_type: bool,
-        diagnostics: &mut Vec<Diagnostic>,
-    ) {
-        match ast_type {
-            AstType::Named(name) => {
-                if !self.is_known_type_name(table, type_params, name) {
-                    diagnostics.push(Diagnostic::error(
-                        "E0201",
-                        format!("unknown type symbol '{name}'"),
-                        span,
-                    ));
-                }
-            }
-            AstType::Generic { name, type_args } => {
-                if !self.is_known_type_name(table, type_params, name) {
-                    diagnostics.push(Diagnostic::error(
-                        "E0201",
-                        format!("unknown type symbol '{name}'"),
-                        span,
-                    ));
-                }
-                for type_arg in type_args {
-                    self.validate_type_ref(
-                        table,
-                        type_params,
-                        type_arg,
-                        span,
-                        allow_self_type,
-                        diagnostics,
-                    );
-                }
-            }
-            AstType::Array { elem, .. }
-            | AstType::Slice(elem)
-            | AstType::Ptr(elem)
-            | AstType::MutPtr(elem)
-            | AstType::RawPtr(elem) => {
-                self.validate_type_ref(
-                    table,
-                    type_params,
-                    elem,
-                    span,
-                    allow_self_type,
-                    diagnostics,
-                );
-            }
-            AstType::Function { params, ret } => {
-                for param in params {
-                    self.validate_type_ref(
-                        table,
-                        type_params,
-                        param,
-                        span,
-                        allow_self_type,
-                        diagnostics,
-                    );
-                }
-                self.validate_type_ref(table, type_params, ret, span, allow_self_type, diagnostics);
-            }
-            AstType::SelfType => {
-                if !allow_self_type {
-                    diagnostics.push(Diagnostic::error(
-                        "E0204",
-                        "Self type is only valid in method or behavior contexts",
-                        span,
-                    ));
-                }
-            }
-            AstType::I8
-            | AstType::I16
-            | AstType::I32
-            | AstType::I64
-            | AstType::U8
-            | AstType::U16
-            | AstType::U32
-            | AstType::U64
-            | AstType::Usize
-            | AstType::F32
-            | AstType::F64
-            | AstType::Bool
-            | AstType::Void
-            | AstType::Str
-            | AstType::String
-            | AstType::Inferred => {}
-        }
-    }
-
-    fn is_known_type_name(
-        &self,
-        table: &SymbolTable,
-        type_params: &[TypeParam],
-        name: &str,
-    ) -> bool {
-        table.lookup(Namespace::Type, name).is_some()
-            || table.lookup(Namespace::Import, name).is_some()
-            || type_params.iter().any(|type_param| type_param.name == name)
-    }
-
-    fn is_known_behavior_name(&self, table: &SymbolTable, name: &str) -> bool {
-        table.lookup(Namespace::Behavior, name).is_some()
-            || table.lookup(Namespace::Import, name).is_some()
-    }
-
-    fn behavior_type_params_for_ref(&self, table: &SymbolTable, behavior: &str) -> Vec<TypeParam> {
-        table
-            .lookup(Namespace::Behavior, behavior)
-            .and_then(|symbol| symbol.type_parameter_names.as_ref())
-            .map(|names| {
-                names
-                    .iter()
-                    .map(|name| TypeParam {
-                        name: name.clone(),
-                        constraint: None,
-                        constraint_type_args: Vec::new(),
-                        span: Span::dummy(),
-                    })
-                    .collect()
-            })
-            .unwrap_or_default()
     }
 
     fn validate_expr_refs(

--- a/src/resolver/symbol_table_test_support.rs
+++ b/src/resolver/symbol_table_test_support.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::ast::AstType;
 
 impl SymbolTable {
     #[cfg(test)]

--- a/src/resolver/type_validation.rs
+++ b/src/resolver/type_validation.rs
@@ -1,0 +1,205 @@
+use std::collections::HashSet;
+
+use crate::ast::{AstType, Param, TypeParam};
+use crate::error::{Diagnostic, Span};
+
+use super::{Namespace, Resolver, SymbolTable};
+
+impl Resolver {
+    pub(super) fn validate_params(
+        &self,
+        table: &SymbolTable,
+        type_params: &[TypeParam],
+        params: &[Param],
+        allow_self_type: bool,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        let mut seen_params = HashSet::new();
+        for param in params {
+            if !seen_params.insert(param.name.as_str()) {
+                diagnostics.push(Diagnostic::error(
+                    "E0214",
+                    format!("duplicate parameter `{}`", param.name),
+                    param.span,
+                ));
+            }
+            self.validate_type_ref(
+                table,
+                type_params,
+                &param.ty,
+                param.span,
+                allow_self_type,
+                diagnostics,
+            );
+        }
+    }
+
+    pub(super) fn validate_type_param_constraints(
+        &self,
+        table: &SymbolTable,
+        type_params: &[TypeParam],
+        allow_self_type: bool,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        let mut seen_type_params = HashSet::new();
+        for type_param in type_params {
+            if !seen_type_params.insert(type_param.name.as_str()) {
+                diagnostics.push(Diagnostic::error(
+                    "E0213",
+                    format!("duplicate type parameter `{}`", type_param.name),
+                    type_param.span,
+                ));
+            }
+            if let Some(constraint) = &type_param.constraint {
+                if !self.is_known_behavior_name(table, constraint) {
+                    diagnostics.push(Diagnostic::error(
+                        "E0202",
+                        format!("unknown behavior symbol '{constraint}'"),
+                        type_param.span,
+                    ));
+                }
+                for type_arg in &type_param.constraint_type_args {
+                    self.validate_type_ref(
+                        table,
+                        type_params,
+                        type_arg,
+                        type_param.span,
+                        allow_self_type,
+                        diagnostics,
+                    );
+                }
+            }
+        }
+    }
+
+    pub(super) fn validate_type_ref(
+        &self,
+        table: &SymbolTable,
+        type_params: &[TypeParam],
+        ast_type: &AstType,
+        span: Span,
+        allow_self_type: bool,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        match ast_type {
+            AstType::Named(name) => {
+                if !self.is_known_type_name(table, type_params, name) {
+                    diagnostics.push(Diagnostic::error(
+                        "E0201",
+                        format!("unknown type symbol '{name}'"),
+                        span,
+                    ));
+                }
+            }
+            AstType::Generic { name, type_args } => {
+                if !self.is_known_type_name(table, type_params, name) {
+                    diagnostics.push(Diagnostic::error(
+                        "E0201",
+                        format!("unknown type symbol '{name}'"),
+                        span,
+                    ));
+                }
+                for type_arg in type_args {
+                    self.validate_type_ref(
+                        table,
+                        type_params,
+                        type_arg,
+                        span,
+                        allow_self_type,
+                        diagnostics,
+                    );
+                }
+            }
+            AstType::Array { elem, .. }
+            | AstType::Slice(elem)
+            | AstType::Ptr(elem)
+            | AstType::MutPtr(elem)
+            | AstType::RawPtr(elem) => {
+                self.validate_type_ref(
+                    table,
+                    type_params,
+                    elem,
+                    span,
+                    allow_self_type,
+                    diagnostics,
+                );
+            }
+            AstType::Function { params, ret } => {
+                for param in params {
+                    self.validate_type_ref(
+                        table,
+                        type_params,
+                        param,
+                        span,
+                        allow_self_type,
+                        diagnostics,
+                    );
+                }
+                self.validate_type_ref(table, type_params, ret, span, allow_self_type, diagnostics);
+            }
+            AstType::SelfType => {
+                if !allow_self_type {
+                    diagnostics.push(Diagnostic::error(
+                        "E0204",
+                        "Self type is only valid in method or behavior contexts",
+                        span,
+                    ));
+                }
+            }
+            AstType::I8
+            | AstType::I16
+            | AstType::I32
+            | AstType::I64
+            | AstType::U8
+            | AstType::U16
+            | AstType::U32
+            | AstType::U64
+            | AstType::Usize
+            | AstType::F32
+            | AstType::F64
+            | AstType::Bool
+            | AstType::Void
+            | AstType::Str
+            | AstType::String
+            | AstType::Inferred => {}
+        }
+    }
+
+    pub(super) fn is_known_type_name(
+        &self,
+        table: &SymbolTable,
+        type_params: &[TypeParam],
+        name: &str,
+    ) -> bool {
+        table.lookup(Namespace::Type, name).is_some()
+            || table.lookup(Namespace::Import, name).is_some()
+            || type_params.iter().any(|type_param| type_param.name == name)
+    }
+
+    pub(super) fn is_known_behavior_name(&self, table: &SymbolTable, name: &str) -> bool {
+        table.lookup(Namespace::Behavior, name).is_some()
+            || table.lookup(Namespace::Import, name).is_some()
+    }
+
+    pub(super) fn behavior_type_params_for_ref(
+        &self,
+        table: &SymbolTable,
+        behavior: &str,
+    ) -> Vec<TypeParam> {
+        table
+            .lookup(Namespace::Behavior, behavior)
+            .and_then(|symbol| symbol.type_parameter_names.as_ref())
+            .map(|names| {
+                names
+                    .iter()
+                    .map(|name| TypeParam {
+                        name: name.clone(),
+                        constraint: None,
+                        constraint_type_args: Vec::new(),
+                        span: Span::dummy(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+}


### PR DESCRIPTION
## Summary
- move resolver type-reference, parameter, and known-symbol validation into `src/resolver/type_validation.rs`
- keep `src/resolver.rs` focused on declaration and expression traversal
- make resolver test-support's `AstType` import explicit
- update the phase plan with the resolver type-validation extraction note

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test resolver_phase2`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`