### PR TITLE
[codex] Split symbol table behavior edges

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -197,6 +197,8 @@ checked-in docs, tests, and commits only.
   helper, keeping expected metadata formatting separate from scoped local walks.
 - Build graph lowering from parsed build.zen programs now lives beside the
   graph model, keeping graph validation separate from AST traversal details.
+- Resolver symbol-table behavior edge recording now lives in a focused helper,
+  keeping symbol definition and lookup separate from association mutation.
 - Resolver validation replay now collects expected declaration symbols,
   expected local symbols, import-validation state, and behavior-association
   replay tasks in one declaration pass before checking resolver-owned extras,

--- a/src/resolver/symbol_table.rs
+++ b/src/resolver/symbol_table.rs
@@ -4,7 +4,7 @@ use crate::ast::{AstType, TypeParam};
 use crate::error::{Diagnostic, Span};
 
 use super::metadata_helpers::{
-    behavior_ref_display, resolver_type_parameter_bound_refs, resolver_type_parameter_bounds,
+    resolver_type_parameter_bound_refs, resolver_type_parameter_bounds,
     resolver_type_parameter_names,
 };
 
@@ -580,76 +580,6 @@ impl SymbolTable {
         self.next_scope_id += 1;
         self.next_scope_id
     }
-
-    pub(super) fn record_behavior_parent(
-        &mut self,
-        behavior: &str,
-        parent_ref: BehaviorRefMetadata,
-    ) -> bool {
-        if let Some(symbol) = self
-            .symbols
-            .iter_mut()
-            .find(|symbol| symbol.namespace == Namespace::Behavior && symbol.name == behavior)
-        {
-            let parent = behavior_ref_display(&parent_ref.name, &parent_ref.type_args);
-            let parents = symbol.behavior_parent_names.get_or_insert_with(Vec::new);
-            if parents.iter().any(|recorded| recorded == &parent) {
-                return false;
-            }
-            parents.push(parent);
-            symbol
-                .behavior_parent_refs
-                .get_or_insert_with(Vec::new)
-                .push(parent_ref);
-        }
-        true
-    }
-
-    pub(super) fn record_behavior_impl(
-        &mut self,
-        type_name: &str,
-        behavior_ref: BehaviorRefMetadata,
-    ) -> bool {
-        if let Some(symbol) = self
-            .symbols
-            .iter_mut()
-            .find(|symbol| symbol.namespace == Namespace::Type && symbol.name == type_name)
-        {
-            let behavior = behavior_ref_display(&behavior_ref.name, &behavior_ref.type_args);
-            let impls = symbol.behavior_impl_names.get_or_insert_with(Vec::new);
-            if impls.iter().any(|recorded| recorded == &behavior) {
-                return false;
-            }
-            impls.push(behavior);
-            symbol
-                .behavior_impl_refs
-                .get_or_insert_with(Vec::new)
-                .push(behavior_ref);
-        }
-        true
-    }
-
-    pub(super) fn record_behavior_required(
-        &mut self,
-        type_name: &str,
-        behavior_ref: BehaviorRefMetadata,
-    ) -> bool {
-        if let Some(symbol) = self
-            .symbols
-            .iter_mut()
-            .find(|symbol| symbol.namespace == Namespace::Type && symbol.name == type_name)
-        {
-            let behavior = behavior_ref_display(&behavior_ref.name, &behavior_ref.type_args);
-            let required = symbol.behavior_required_names.get_or_insert_with(Vec::new);
-            if required.iter().any(|recorded| recorded == &behavior) {
-                return false;
-            }
-            required.push(behavior);
-            symbol
-                .behavior_required_refs
-                .get_or_insert_with(Vec::new)
-                .push(behavior_ref);
-        }
-        true
-    }
 }
+
+include!("symbol_table/behavior_edges.rs");

--- a/src/resolver/symbol_table/behavior_edges.rs
+++ b/src/resolver/symbol_table/behavior_edges.rs
@@ -1,0 +1,75 @@
+use super::metadata_helpers::behavior_ref_display;
+
+impl SymbolTable {
+    pub(super) fn record_behavior_parent(
+        &mut self,
+        behavior: &str,
+        parent_ref: BehaviorRefMetadata,
+    ) -> bool {
+        if let Some(symbol) = self
+            .symbols
+            .iter_mut()
+            .find(|symbol| symbol.namespace == Namespace::Behavior && symbol.name == behavior)
+        {
+            let parent = behavior_ref_display(&parent_ref.name, &parent_ref.type_args);
+            let parents = symbol.behavior_parent_names.get_or_insert_with(Vec::new);
+            if parents.iter().any(|recorded| recorded == &parent) {
+                return false;
+            }
+            parents.push(parent);
+            symbol
+                .behavior_parent_refs
+                .get_or_insert_with(Vec::new)
+                .push(parent_ref);
+        }
+        true
+    }
+
+    pub(super) fn record_behavior_impl(
+        &mut self,
+        type_name: &str,
+        behavior_ref: BehaviorRefMetadata,
+    ) -> bool {
+        if let Some(symbol) = self
+            .symbols
+            .iter_mut()
+            .find(|symbol| symbol.namespace == Namespace::Type && symbol.name == type_name)
+        {
+            let behavior = behavior_ref_display(&behavior_ref.name, &behavior_ref.type_args);
+            let impls = symbol.behavior_impl_names.get_or_insert_with(Vec::new);
+            if impls.iter().any(|recorded| recorded == &behavior) {
+                return false;
+            }
+            impls.push(behavior);
+            symbol
+                .behavior_impl_refs
+                .get_or_insert_with(Vec::new)
+                .push(behavior_ref);
+        }
+        true
+    }
+
+    pub(super) fn record_behavior_required(
+        &mut self,
+        type_name: &str,
+        behavior_ref: BehaviorRefMetadata,
+    ) -> bool {
+        if let Some(symbol) = self
+            .symbols
+            .iter_mut()
+            .find(|symbol| symbol.namespace == Namespace::Type && symbol.name == type_name)
+        {
+            let behavior = behavior_ref_display(&behavior_ref.name, &behavior_ref.type_args);
+            let required = symbol.behavior_required_names.get_or_insert_with(Vec::new);
+            if required.iter().any(|recorded| recorded == &behavior) {
+                return false;
+            }
+            required.push(behavior);
+            symbol
+                .behavior_required_refs
+                .get_or_insert_with(Vec::new)
+                .push(behavior_ref);
+        }
+        true
+    }
+}


### PR DESCRIPTION
## Summary
- move resolver symbol-table behavior parent/impl/required edge recording into `src/resolver/symbol_table/behavior_edges.rs`
- keep `src/resolver/symbol_table.rs` focused on symbol metadata, definition, lookup, and scope allocation
- note the split in the phase plan

## Validation
- `cargo test --lib resolver::`
- `cargo test --lib resolver_metadata`
- `cargo test --lib resolver_behavior`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`