### PR TITLE
[codex] Split typechecker resolver callable signatures

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -199,6 +199,8 @@ checked-in docs, tests, and commits only.
   graph model, keeping graph validation separate from AST traversal details.
 - Resolver symbol-table behavior edge recording now lives in a focused helper,
   keeping symbol definition and lookup separate from association mutation.
+- Typechecker resolver callable signature restoration now lives in a focused
+  helper, keeping the main typechecker module below broad dispatcher size.
 - Resolver validation replay now collects expected declaration symbols,
   expected local symbols, import-validation state, and behavior-association
   replay tasks in one declaration pass before checking resolver-owned extras,

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -125,146 +125,6 @@ impl TypeChecker {
         }
     }
 
-    fn collect_resolver_value_signature(&mut self, symbols: &SymbolTable, name: &str) {
-        let Some(symbol) = symbols.lookup(Namespace::Value, name) else {
-            self.remove_callable_signature(name);
-            return;
-        };
-        let Some(signature) = Self::resolver_callable_signature_metadata(symbol) else {
-            self.remove_callable_signature(name);
-            return;
-        };
-        let info = func_info_from_resolver_signature(
-            name.to_string(),
-            symbol,
-            signature.parameter_names,
-            signature.parameter_types,
-            signature.return_type,
-        );
-        self.insert_callable_signature(name, info);
-        let type_parameter_names = resolver_type_param_names(symbol);
-        self.collect_resolver_generic_template_signature(
-            name,
-            &type_parameter_names,
-            signature.parameter_names,
-            signature.parameter_types,
-            signature.return_type,
-        );
-    }
-
-    fn resolver_callable_signature_metadata(
-        symbol: &Symbol,
-    ) -> Option<ResolverCallableSignature<'_>> {
-        Some(ResolverCallableSignature {
-            parameter_names: symbol.parameter_names.as_deref()?,
-            parameter_types: symbol.parameter_types.as_deref()?,
-            return_type: symbol.return_type.as_ref()?,
-        })
-    }
-
-    fn remove_callable_signature(&mut self, name: &str) {
-        self.functions.remove(name);
-        self.methods.remove(name);
-        self.generic_functions.remove(name);
-        self.generic_methods.remove(name);
-    }
-
-    fn insert_callable_signature(&mut self, name: &str, info: FuncInfo) {
-        self.functions.remove(name);
-        self.methods.remove(name);
-        if is_method_signature_key(name) {
-            self.methods.insert(name.to_string(), info);
-        } else {
-            self.functions.insert(name.to_string(), info);
-        }
-    }
-
-    fn generic_callable_template_mut(
-        &mut self,
-        name: &str,
-    ) -> Option<&mut GenericFunctionTemplate> {
-        if is_method_signature_key(name) {
-            self.generic_methods.get_mut(name)
-        } else {
-            self.generic_functions.get_mut(name)
-        }
-    }
-
-    fn collect_resolver_generic_template_signature(
-        &mut self,
-        name: &str,
-        type_parameter_names: &[String],
-        parameter_names: &[String],
-        parameter_types: &[AstType],
-        return_type: &AstType,
-    ) {
-        let Some(template) = self.generic_callable_template_mut(name) else {
-            return;
-        };
-        template.type_params = type_parameter_names.to_vec();
-        let existing_params = template.params.clone();
-        template.params = Self::resolver_params_from_metadata(
-            &existing_params,
-            parameter_names,
-            parameter_types,
-            template.span,
-        );
-        template.return_type = Self::resolver_optional_return_type(return_type);
-    }
-
-    fn collect_resolver_method_signature(
-        &mut self,
-        symbols: &SymbolTable,
-        type_name: &str,
-        method_name: &str,
-        span: Span,
-    ) {
-        let ast_key = Self::method_key(type_name, method_name);
-        let restored_key =
-            Self::resolver_method_signature_name_for(symbols, &ast_key, type_name, span);
-
-        self.collect_resolver_callable_signature_for_key(symbols, &ast_key, &restored_key);
-    }
-
-    fn collect_resolver_function_signature(
-        &mut self,
-        symbols: &SymbolTable,
-        name: &str,
-        span: Span,
-    ) {
-        let restored_name = Self::resolver_symbol_name_for(symbols, Namespace::Value, name, span);
-
-        self.collect_resolver_callable_signature_for_key(symbols, name, &restored_name);
-    }
-
-    fn collect_resolver_callable_signature_for_key(
-        &mut self,
-        symbols: &SymbolTable,
-        ast_key: &str,
-        restored_key: &str,
-    ) {
-        if restored_key != ast_key {
-            self.rekey_callable_template(ast_key, restored_key);
-            self.remove_callable_signature(ast_key);
-        }
-        self.collect_resolver_value_signature(symbols, restored_key);
-    }
-
-    fn rekey_callable_template(&mut self, old_key: &str, new_key: &str) {
-        let template = self
-            .generic_functions
-            .remove(old_key)
-            .or_else(|| self.generic_methods.remove(old_key));
-
-        if let Some(template) = template {
-            if is_method_signature_key(new_key) {
-                self.generic_methods.insert(new_key.to_string(), template);
-            } else {
-                self.generic_functions.insert(new_key.to_string(), template);
-            }
-        }
-    }
-
     fn collect_resolver_struct_fields(
         &mut self,
         symbols: &SymbolTable,
@@ -643,6 +503,8 @@ impl TypeChecker {
         Some(ast_substitutions)
     }
 }
+
+include!("resolver_callable_signatures.rs");
 
 #[cfg(test)]
 mod tests;

--- a/src/typechecker/resolver_callable_signatures.rs
+++ b/src/typechecker/resolver_callable_signatures.rs
@@ -1,0 +1,141 @@
+impl TypeChecker {
+    fn collect_resolver_value_signature(&mut self, symbols: &SymbolTable, name: &str) {
+        let Some(symbol) = symbols.lookup(Namespace::Value, name) else {
+            self.remove_callable_signature(name);
+            return;
+        };
+        let Some(signature) = Self::resolver_callable_signature_metadata(symbol) else {
+            self.remove_callable_signature(name);
+            return;
+        };
+        let info = func_info_from_resolver_signature(
+            name.to_string(),
+            symbol,
+            signature.parameter_names,
+            signature.parameter_types,
+            signature.return_type,
+        );
+        self.insert_callable_signature(name, info);
+        let type_parameter_names = resolver_type_param_names(symbol);
+        self.collect_resolver_generic_template_signature(
+            name,
+            &type_parameter_names,
+            signature.parameter_names,
+            signature.parameter_types,
+            signature.return_type,
+        );
+    }
+
+    fn resolver_callable_signature_metadata(
+        symbol: &Symbol,
+    ) -> Option<ResolverCallableSignature<'_>> {
+        Some(ResolverCallableSignature {
+            parameter_names: symbol.parameter_names.as_deref()?,
+            parameter_types: symbol.parameter_types.as_deref()?,
+            return_type: symbol.return_type.as_ref()?,
+        })
+    }
+
+    fn remove_callable_signature(&mut self, name: &str) {
+        self.functions.remove(name);
+        self.methods.remove(name);
+        self.generic_functions.remove(name);
+        self.generic_methods.remove(name);
+    }
+
+    fn insert_callable_signature(&mut self, name: &str, info: FuncInfo) {
+        self.functions.remove(name);
+        self.methods.remove(name);
+        if is_method_signature_key(name) {
+            self.methods.insert(name.to_string(), info);
+        } else {
+            self.functions.insert(name.to_string(), info);
+        }
+    }
+
+    fn generic_callable_template_mut(
+        &mut self,
+        name: &str,
+    ) -> Option<&mut GenericFunctionTemplate> {
+        if is_method_signature_key(name) {
+            self.generic_methods.get_mut(name)
+        } else {
+            self.generic_functions.get_mut(name)
+        }
+    }
+
+    fn collect_resolver_generic_template_signature(
+        &mut self,
+        name: &str,
+        type_parameter_names: &[String],
+        parameter_names: &[String],
+        parameter_types: &[AstType],
+        return_type: &AstType,
+    ) {
+        let Some(template) = self.generic_callable_template_mut(name) else {
+            return;
+        };
+        template.type_params = type_parameter_names.to_vec();
+        let existing_params = template.params.clone();
+        template.params = Self::resolver_params_from_metadata(
+            &existing_params,
+            parameter_names,
+            parameter_types,
+            template.span,
+        );
+        template.return_type = Self::resolver_optional_return_type(return_type);
+    }
+
+    fn collect_resolver_method_signature(
+        &mut self,
+        symbols: &SymbolTable,
+        type_name: &str,
+        method_name: &str,
+        span: Span,
+    ) {
+        let ast_key = Self::method_key(type_name, method_name);
+        let restored_key =
+            Self::resolver_method_signature_name_for(symbols, &ast_key, type_name, span);
+
+        self.collect_resolver_callable_signature_for_key(symbols, &ast_key, &restored_key);
+    }
+
+    fn collect_resolver_function_signature(
+        &mut self,
+        symbols: &SymbolTable,
+        name: &str,
+        span: Span,
+    ) {
+        let restored_name = Self::resolver_symbol_name_for(symbols, Namespace::Value, name, span);
+
+        self.collect_resolver_callable_signature_for_key(symbols, name, &restored_name);
+    }
+
+    fn collect_resolver_callable_signature_for_key(
+        &mut self,
+        symbols: &SymbolTable,
+        ast_key: &str,
+        restored_key: &str,
+    ) {
+        if restored_key != ast_key {
+            self.rekey_callable_template(ast_key, restored_key);
+            self.remove_callable_signature(ast_key);
+        }
+        self.collect_resolver_value_signature(symbols, restored_key);
+    }
+
+    fn rekey_callable_template(&mut self, old_key: &str, new_key: &str) {
+        let template = self
+            .generic_functions
+            .remove(old_key)
+            .or_else(|| self.generic_methods.remove(old_key));
+
+        if let Some(template) = template {
+            if is_method_signature_key(new_key) {
+                self.generic_methods.insert(new_key.to_string(), template);
+            } else {
+                self.generic_functions.insert(new_key.to_string(), template);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move resolver-backed callable signature and generic template refresh helpers into `src/typechecker/resolver_callable_signatures.rs`
- reduce `src/typechecker/mod.rs` below broad dispatcher size
- note the split in the phase plan

## Validation
- `cargo test --lib resolver_collection::function_method_templates`
- `cargo test --lib resolver_metadata`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`