### PR TITLE
[codex] Split monomorphization dependency overlays

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -198,6 +198,9 @@ checked-in docs, tests, and commits only.
   module, keeping the public lexer API and character-span helpers compact.
 - Parser block, closure, and argument-list helpers now live in a dedicated
   parser module, keeping atom parsing focused on prefix expression dispatch.
+- Typechecker monomorphization template dependency install/restore now lives in
+  a dedicated helper module, keeping generic specialization flow separate from
+  temporary source-module dependency overlays.
 - Module-system unit tests now live beside the module-system implementation in
   a dedicated test module, keeping module graph/load entry points compact.
 - Resolver expected-local traversal now lives in a dedicated validation support

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -21,6 +21,7 @@ mod generic_bound_validation;
 mod generic_type_reference_walker;
 mod generic_type_validation;
 mod monomorphize;
+mod monomorphize_dependencies;
 mod monomorphize_inference;
 mod monomorphize_types;
 mod patterns;

--- a/src/typechecker/monomorphize.rs
+++ b/src/typechecker/monomorphize.rs
@@ -11,32 +11,6 @@ pub(crate) use super::monomorphize_types::type_to_ast;
 use super::monomorphize_types::{substitute_ast_type, type_mangle_key};
 use super::TypeChecker;
 
-fn install_dependency_map<T: Clone>(
-    target: &mut HashMap<String, T>,
-    dependencies: &HashMap<String, T>,
-) -> Vec<super::TemplateDependencyEntry<T>> {
-    dependencies
-        .iter()
-        .map(|(name, value)| super::TemplateDependencyEntry {
-            name: name.clone(),
-            previous: target.insert(name.clone(), value.clone()),
-        })
-        .collect()
-}
-
-fn restore_dependency_map<T>(
-    target: &mut HashMap<String, T>,
-    state: Vec<super::TemplateDependencyEntry<T>>,
-) {
-    for entry in state {
-        if let Some(previous) = entry.previous {
-            target.insert(entry.name, previous);
-        } else {
-            target.remove(&entry.name);
-        }
-    }
-}
-
 impl TypeChecker {
     pub(crate) fn mangle_generic_type_name(&self, name: &str, type_args: &[AstType]) -> String {
         if type_args.is_empty() {
@@ -215,35 +189,6 @@ impl TypeChecker {
             ));
         }
         Some(self.resolve_type(&AstType::Named(receiver_name.to_string())))
-    }
-
-    fn install_template_dependencies(
-        &mut self,
-        template: &super::GenericFunctionTemplate,
-    ) -> super::TemplateDependencyState {
-        super::TemplateDependencyState {
-            structs: install_dependency_map(&mut self.structs, &template.dependency_structs),
-            enums: install_dependency_map(&mut self.enums, &template.dependency_enums),
-            functions: install_dependency_map(&mut self.functions, &template.dependency_functions),
-            generic_functions: install_dependency_map(
-                &mut self.generic_functions,
-                &template.dependency_generic_functions,
-            ),
-            methods: install_dependency_map(&mut self.methods, &template.dependency_methods),
-            generic_methods: install_dependency_map(
-                &mut self.generic_methods,
-                &template.dependency_generic_methods,
-            ),
-        }
-    }
-
-    fn restore_template_dependencies(&mut self, state: super::TemplateDependencyState) {
-        restore_dependency_map(&mut self.structs, state.structs);
-        restore_dependency_map(&mut self.enums, state.enums);
-        restore_dependency_map(&mut self.functions, state.functions);
-        restore_dependency_map(&mut self.generic_functions, state.generic_functions);
-        restore_dependency_map(&mut self.methods, state.methods);
-        restore_dependency_map(&mut self.generic_methods, state.generic_methods);
     }
 
     fn generic_receiver_self_type(

--- a/src/typechecker/monomorphize_dependencies.rs
+++ b/src/typechecker/monomorphize_dependencies.rs
@@ -1,0 +1,60 @@
+use std::collections::HashMap;
+
+use super::{TemplateDependencyEntry, TemplateDependencyState, TypeChecker};
+
+fn install_dependency_map<T: Clone>(
+    target: &mut HashMap<String, T>,
+    dependencies: &HashMap<String, T>,
+) -> Vec<TemplateDependencyEntry<T>> {
+    dependencies
+        .iter()
+        .map(|(name, value)| TemplateDependencyEntry {
+            name: name.clone(),
+            previous: target.insert(name.clone(), value.clone()),
+        })
+        .collect()
+}
+
+fn restore_dependency_map<T>(
+    target: &mut HashMap<String, T>,
+    state: Vec<TemplateDependencyEntry<T>>,
+) {
+    for entry in state {
+        if let Some(previous) = entry.previous {
+            target.insert(entry.name, previous);
+        } else {
+            target.remove(&entry.name);
+        }
+    }
+}
+
+impl TypeChecker {
+    pub(super) fn install_template_dependencies(
+        &mut self,
+        template: &super::GenericFunctionTemplate,
+    ) -> TemplateDependencyState {
+        TemplateDependencyState {
+            structs: install_dependency_map(&mut self.structs, &template.dependency_structs),
+            enums: install_dependency_map(&mut self.enums, &template.dependency_enums),
+            functions: install_dependency_map(&mut self.functions, &template.dependency_functions),
+            generic_functions: install_dependency_map(
+                &mut self.generic_functions,
+                &template.dependency_generic_functions,
+            ),
+            methods: install_dependency_map(&mut self.methods, &template.dependency_methods),
+            generic_methods: install_dependency_map(
+                &mut self.generic_methods,
+                &template.dependency_generic_methods,
+            ),
+        }
+    }
+
+    pub(super) fn restore_template_dependencies(&mut self, state: TemplateDependencyState) {
+        restore_dependency_map(&mut self.structs, state.structs);
+        restore_dependency_map(&mut self.enums, state.enums);
+        restore_dependency_map(&mut self.functions, state.functions);
+        restore_dependency_map(&mut self.generic_functions, state.generic_functions);
+        restore_dependency_map(&mut self.methods, state.methods);
+        restore_dependency_map(&mut self.generic_methods, state.generic_methods);
+    }
+}


### PR DESCRIPTION
## Summary

- Move generic-template dependency install/restore helpers into `monomorphize_dependencies.rs`.
- Keep `monomorphize.rs` focused on generic specialization and type substitution flow.
- Record the split in `docs/PHASE_PLAN.md`.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --tests generic_specializations`
- `cargo test --tests generic_worklist`
- `cargo test --tests generic_method`
- `cargo test --tests generated_c`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`