### PR TITLE
[codex] Update GitHub Actions runtime versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -31,11 +31,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry/index/
@@ -52,9 +52,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry/index/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -55,7 +55,7 @@ jobs:
           cd dist && tar -czvf ../zen-linux-x86_64.tar.gz zen
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: zen-linux-x86_64
           path: zen-linux-x86_64.tar.gz
@@ -67,10 +67,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: artifacts
 


### PR DESCRIPTION
## Summary

- Update CI to use `actions/checkout@v5` and `actions/cache@v5`, which run on the Node 24 runtime.
- Update release workflow first-party artifact actions to Node-24-native versions: `checkout@v5`, `cache@v5`, `upload-artifact@v6`, and `download-artifact@v7`.
- Keep the existing draft-PR guard and no-`synchronize` policy intact.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth repo_hygiene::ci_and_release_only_advertise_existing_targets`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Manual CI run on updated branch: https://github.com/lantos1618/zenlang/actions/runs/25972963061

Note: tried a local Ruby YAML parse, but Ruby is not installed in this environment.