### PR TITLE
[codex] Split resolver expression validation helpers

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -95,6 +95,9 @@ checked-in docs, tests, and commits only.
 - Resolver validation now keeps expression, statement, and pattern local-scope
   traversal in a focused include, separate from resolver symbol/import and local
   symbol metadata validation.
+- Resolver expression validation now keeps constructor-specific reference checks
+  and scoped traversal helpers in a focused module, leaving the main expression
+  validator as the dispatcher.
 - Resolver-backed callable type-reference validation now shares the collected
   signature/body validation helper after function, top-level method, and
   `Type.impl` method dispatch restore the resolver-owned callable key, with

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -8,6 +8,7 @@ mod symbol_table_test_support;
 
 mod declaration_definition;
 mod expression_validation;
+mod expression_validation_constructs;
 mod local_validation;
 mod metadata_helpers;
 mod symbol_table;

--- a/src/resolver/expression_validation.rs
+++ b/src/resolver/expression_validation.rs
@@ -1,10 +1,11 @@
-use std::collections::HashSet;
-
 use crate::ast::{Expression, StringPart, TypeParam};
 use crate::error::Diagnostic;
 
+use super::expression_validation_constructs::{
+    BlockRef, ClosureRef, EnumVariantRef, StructLiteralRef,
+};
 use super::symbol_table::ScopeStack;
-use super::{Namespace, Resolver, SymbolTable};
+use super::{Resolver, SymbolTable};
 
 impl Resolver {
     pub(super) fn validate_expr_refs(
@@ -24,16 +25,14 @@ impl Resolver {
                 args,
                 span,
             } => {
-                for type_arg in type_args {
-                    self.validate_type_ref(
-                        table,
-                        type_params,
-                        type_arg,
-                        *span,
-                        allow_self_type,
-                        diagnostics,
-                    );
-                }
+                self.validate_type_arg_refs(
+                    table,
+                    type_params,
+                    type_args,
+                    *span,
+                    allow_self_type,
+                    diagnostics,
+                );
                 if module.is_none() && !self.is_known_value_name(table, locals, name) {
                     diagnostics.push(Diagnostic::error(
                         "E0203",
@@ -41,16 +40,14 @@ impl Resolver {
                         *span,
                     ));
                 }
-                for arg in args {
-                    self.validate_expr_refs(
-                        table,
-                        type_params,
-                        arg,
-                        locals,
-                        allow_self_type,
-                        diagnostics,
-                    );
-                }
+                self.validate_expr_arg_refs(
+                    table,
+                    type_params,
+                    args,
+                    locals,
+                    allow_self_type,
+                    diagnostics,
+                );
             }
             Expression::Identifier { name, span } => {
                 if !self.is_known_value_name(table, locals, name) {
@@ -76,26 +73,22 @@ impl Resolver {
                     allow_self_type,
                     diagnostics,
                 );
-                for type_arg in type_args {
-                    self.validate_type_ref(
-                        table,
-                        type_params,
-                        type_arg,
-                        *span,
-                        allow_self_type,
-                        diagnostics,
-                    );
-                }
-                for arg in args {
-                    self.validate_expr_refs(
-                        table,
-                        type_params,
-                        arg,
-                        locals,
-                        allow_self_type,
-                        diagnostics,
-                    );
-                }
+                self.validate_type_arg_refs(
+                    table,
+                    type_params,
+                    type_args,
+                    *span,
+                    allow_self_type,
+                    diagnostics,
+                );
+                self.validate_expr_arg_refs(
+                    table,
+                    type_params,
+                    args,
+                    locals,
+                    allow_self_type,
+                    diagnostics,
+                );
             }
             Expression::BinaryOp { left, right, .. } => {
                 self.validate_expr_refs(
@@ -152,68 +145,19 @@ impl Resolver {
                 fields,
                 span,
             } => {
-                if let Some(symbol) = table.lookup(Namespace::Type, name) {
-                    if let Some(field_type_names) = symbol.field_type_names.as_ref() {
-                        let expected_fields: HashSet<&str> = field_type_names
-                            .iter()
-                            .map(|(field_name, _)| field_name.as_str())
-                            .collect();
-                        let mut provided_fields = HashSet::new();
-
-                        for (field_name, _) in fields {
-                            if !provided_fields.insert(field_name.as_str()) {
-                                diagnostics.push(Diagnostic::error(
-                                    "E0208",
-                                    format!("duplicate field `{field_name}` for struct `{name}`"),
-                                    *span,
-                                ));
-                            }
-                            if !expected_fields.contains(field_name.as_str()) {
-                                diagnostics.push(Diagnostic::error(
-                                    "E0209",
-                                    format!("unknown field `{field_name}` for struct `{name}`"),
-                                    *span,
-                                ));
-                            }
-                        }
-
-                        for expected_field in expected_fields {
-                            if !provided_fields.contains(expected_field) {
-                                diagnostics.push(Diagnostic::error(
-                                    "E0210",
-                                    format!("missing field `{expected_field}` for struct `{name}`"),
-                                    *span,
-                                ));
-                            }
-                        }
-                    }
-                } else if !self.is_known_type_name(table, type_params, name) {
-                    diagnostics.push(Diagnostic::error(
-                        "E0201",
-                        format!("unknown type symbol '{name}'"),
-                        *span,
-                    ));
-                }
-                for type_arg in type_args {
-                    self.validate_type_ref(
-                        table,
-                        type_params,
-                        type_arg,
-                        *span,
-                        allow_self_type,
-                        diagnostics,
-                    );
-                }
-                for (_, value) in fields {
-                    self.validate_expr_refs(
-                        table,
-                        type_params,
-                        value,
-                        locals,
-                        allow_self_type,
-                        diagnostics,
-                    );
-                }
+                self.validate_struct_literal_refs(
+                    table,
+                    type_params,
+                    StructLiteralRef {
+                        name,
+                        type_args,
+                        fields,
+                        span: *span,
+                    },
+                    locals,
+                    allow_self_type,
+                    diagnostics,
+                );
             }
             Expression::EnumVariant {
                 enum_name,
@@ -222,72 +166,30 @@ impl Resolver {
                 payload,
                 span,
             } => {
-                if table.lookup(Namespace::Type, enum_name).is_some() {
-                    if let Some(variant_symbol) = table.lookup_variant(enum_name, variant) {
-                        match (
-                            variant_symbol.variant_payload_count.unwrap_or(0),
-                            payload.is_some(),
-                        ) {
-                            (1, false) => diagnostics.push(Diagnostic::error(
-                                "E0206",
-                                format!("enum variant `{enum_name}.{variant}` requires a payload"),
-                                *span,
-                            )),
-                            (0, true) => diagnostics.push(Diagnostic::error(
-                                "E0207",
-                                format!(
-                                    "enum variant `{enum_name}.{variant}` does not accept a payload"
-                                ),
-                                *span,
-                            )),
-                            _ => {}
-                        }
-                    } else {
-                        diagnostics.push(Diagnostic::error(
-                            "E0205",
-                            format!("enum `{enum_name}` has no variant `{variant}`"),
-                            *span,
-                        ));
-                    }
-                } else if !self.is_known_type_name(table, type_params, enum_name) {
-                    diagnostics.push(Diagnostic::error(
-                        "E0201",
-                        format!("unknown type symbol '{enum_name}'"),
-                        *span,
-                    ));
-                }
-                for type_arg in type_args {
-                    self.validate_type_ref(
-                        table,
-                        type_params,
-                        type_arg,
-                        *span,
-                        allow_self_type,
-                        diagnostics,
-                    );
-                }
-                if let Some(payload) = payload {
-                    self.validate_expr_refs(
-                        table,
-                        type_params,
-                        payload,
-                        locals,
-                        allow_self_type,
-                        diagnostics,
-                    );
-                }
+                self.validate_enum_variant_refs(
+                    table,
+                    type_params,
+                    EnumVariantRef {
+                        enum_name,
+                        type_args,
+                        variant,
+                        payload: payload.as_deref(),
+                        span: *span,
+                    },
+                    locals,
+                    allow_self_type,
+                    diagnostics,
+                );
             }
             Expression::ArrayLiteral { elements, .. } => {
-                for element in elements {
-                    self.validate_expr_refs(
-                        table,
-                        type_params,
-                        element,
-                        locals,
-                        allow_self_type,
-                        diagnostics,
-                    );
-                }
+                self.validate_expr_arg_refs(
+                    table,
+                    type_params,
+                    elements,
+                    locals,
+                    allow_self_type,
+                    diagnostics,
+                );
             }
             Expression::Match {
                 scrutinee, arms, ..
@@ -301,27 +203,11 @@ impl Resolver {
                     diagnostics,
                 );
                 for arm in arms {
-                    if let Some(guard) = &arm.guard {
-                        let arm_scope_id = table.new_scope();
-                        let mut arm_locals = ScopeStack::with_parent(arm_scope_id, locals);
-                        self.bind_pattern_locals(table, &arm.pattern, &mut arm_locals, diagnostics);
-                        self.validate_expr_refs(
-                            table,
-                            type_params,
-                            guard,
-                            &mut arm_locals,
-                            allow_self_type,
-                            diagnostics,
-                        );
-                    }
-                    let arm_scope_id = table.new_scope();
-                    let mut arm_locals = ScopeStack::with_parent(arm_scope_id, locals);
-                    self.bind_pattern_locals(table, &arm.pattern, &mut arm_locals, diagnostics);
-                    self.validate_expr_refs(
+                    self.validate_match_arm_refs(
                         table,
                         type_params,
-                        &arm.body,
-                        &mut arm_locals,
+                        arm,
+                        locals,
                         allow_self_type,
                         diagnostics,
                     );
@@ -343,13 +229,11 @@ impl Resolver {
                     allow_self_type,
                     diagnostics,
                 );
-                let body_scope_id = table.new_scope();
-                let mut body_locals = ScopeStack::with_parent(body_scope_id, locals);
-                self.validate_expr_refs(
+                self.validate_child_scope_expr_refs(
                     table,
                     type_params,
                     body,
-                    &mut body_locals,
+                    locals,
                     allow_self_type,
                     diagnostics,
                 );
@@ -358,26 +242,22 @@ impl Resolver {
                     ..
                 } = expr
                 {
-                    let else_scope_id = table.new_scope();
-                    let mut else_locals = ScopeStack::with_parent(else_scope_id, locals);
-                    self.validate_expr_refs(
+                    self.validate_child_scope_expr_refs(
                         table,
                         type_params,
                         else_body,
-                        &mut else_locals,
+                        locals,
                         allow_self_type,
                         diagnostics,
                     );
                 }
             }
             Expression::Loop { body, .. } => {
-                let body_scope_id = table.new_scope();
-                let mut body_locals = ScopeStack::with_parent(body_scope_id, locals);
-                self.validate_expr_refs(
+                self.validate_child_scope_expr_refs(
                     table,
                     type_params,
                     body,
-                    &mut body_locals,
+                    locals,
                     allow_self_type,
                     diagnostics,
                 );
@@ -385,28 +265,17 @@ impl Resolver {
             Expression::Block {
                 statements, expr, ..
             } => {
-                let block_scope_id = table.new_scope();
-                let mut block_locals = ScopeStack::with_parent(block_scope_id, locals);
-                for statement in statements {
-                    self.validate_statement_refs(
-                        table,
-                        type_params,
-                        statement,
-                        &mut block_locals,
-                        allow_self_type,
-                        diagnostics,
-                    );
-                }
-                if let Some(expr) = expr {
-                    self.validate_expr_refs(
-                        table,
-                        type_params,
-                        expr,
-                        &mut block_locals,
-                        allow_self_type,
-                        diagnostics,
-                    );
-                }
+                self.validate_block_refs(
+                    table,
+                    type_params,
+                    BlockRef {
+                        statements,
+                        expr: expr.as_deref(),
+                    },
+                    locals,
+                    allow_self_type,
+                    diagnostics,
+                );
             }
             Expression::Return { value, .. } => {
                 if let Some(value) = value {
@@ -426,41 +295,16 @@ impl Resolver {
                 body,
                 span,
             } => {
-                let closure_scope_id = table.new_scope();
-                let mut closure_locals = ScopeStack::with_parent(closure_scope_id, locals);
-                for param in params {
-                    self.validate_type_ref(
-                        table,
-                        type_params,
-                        &param.ty,
-                        param.span,
-                        allow_self_type,
-                        diagnostics,
-                    );
-                    self.define_local_symbol(
-                        table,
-                        &param.name,
-                        param.mutable,
-                        param.span,
-                        &mut closure_locals,
-                        diagnostics,
-                    );
-                }
-                if let Some(return_type) = return_type {
-                    self.validate_type_ref(
-                        table,
-                        type_params,
-                        return_type,
-                        *span,
-                        allow_self_type,
-                        diagnostics,
-                    );
-                }
-                self.validate_expr_refs(
+                self.validate_closure_refs(
                     table,
                     type_params,
-                    body,
-                    &mut closure_locals,
+                    ClosureRef {
+                        params,
+                        return_type: return_type.as_ref(),
+                        body,
+                        span: *span,
+                    },
+                    locals,
                     allow_self_type,
                     diagnostics,
                 );

--- a/src/resolver/expression_validation_constructs.rs
+++ b/src/resolver/expression_validation_constructs.rs
@@ -1,0 +1,375 @@
+use std::collections::HashSet;
+
+use crate::ast::{AstType, Expression, MatchArm, Param, Statement, TypeParam};
+use crate::error::{Diagnostic, Span};
+
+use super::symbol_table::ScopeStack;
+use super::{Namespace, Resolver, SymbolTable};
+
+pub(super) struct StructLiteralRef<'a> {
+    pub name: &'a str,
+    pub type_args: &'a [AstType],
+    pub fields: &'a [(String, Expression)],
+    pub span: Span,
+}
+
+pub(super) struct EnumVariantRef<'a> {
+    pub enum_name: &'a str,
+    pub type_args: &'a [AstType],
+    pub variant: &'a str,
+    pub payload: Option<&'a Expression>,
+    pub span: Span,
+}
+
+pub(super) struct BlockRef<'a> {
+    pub statements: &'a [Statement],
+    pub expr: Option<&'a Expression>,
+}
+
+pub(super) struct ClosureRef<'a> {
+    pub params: &'a [Param],
+    pub return_type: Option<&'a AstType>,
+    pub body: &'a Expression,
+    pub span: Span,
+}
+
+impl Resolver {
+    pub(super) fn validate_type_arg_refs(
+        &self,
+        table: &mut SymbolTable,
+        type_params: &[TypeParam],
+        type_args: &[AstType],
+        span: Span,
+        allow_self_type: bool,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        for type_arg in type_args {
+            self.validate_type_ref(
+                table,
+                type_params,
+                type_arg,
+                span,
+                allow_self_type,
+                diagnostics,
+            );
+        }
+    }
+
+    pub(super) fn validate_expr_arg_refs(
+        &self,
+        table: &mut SymbolTable,
+        type_params: &[TypeParam],
+        args: &[Expression],
+        locals: &mut ScopeStack,
+        allow_self_type: bool,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        for arg in args {
+            self.validate_expr_refs(
+                table,
+                type_params,
+                arg,
+                locals,
+                allow_self_type,
+                diagnostics,
+            );
+        }
+    }
+
+    pub(super) fn validate_struct_literal_refs(
+        &self,
+        table: &mut SymbolTable,
+        type_params: &[TypeParam],
+        literal: StructLiteralRef<'_>,
+        locals: &mut ScopeStack,
+        allow_self_type: bool,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        let StructLiteralRef {
+            name,
+            type_args,
+            fields,
+            span,
+        } = literal;
+
+        if let Some(symbol) = table.lookup(Namespace::Type, name) {
+            if let Some(field_type_names) = symbol.field_type_names.as_ref() {
+                let expected_fields: HashSet<&str> = field_type_names
+                    .iter()
+                    .map(|(field_name, _)| field_name.as_str())
+                    .collect();
+                let mut provided_fields = HashSet::new();
+
+                for (field_name, _) in fields {
+                    if !provided_fields.insert(field_name.as_str()) {
+                        diagnostics.push(Diagnostic::error(
+                            "E0208",
+                            format!("duplicate field `{field_name}` for struct `{name}`"),
+                            span,
+                        ));
+                    }
+                    if !expected_fields.contains(field_name.as_str()) {
+                        diagnostics.push(Diagnostic::error(
+                            "E0209",
+                            format!("unknown field `{field_name}` for struct `{name}`"),
+                            span,
+                        ));
+                    }
+                }
+
+                for expected_field in expected_fields {
+                    if !provided_fields.contains(expected_field) {
+                        diagnostics.push(Diagnostic::error(
+                            "E0210",
+                            format!("missing field `{expected_field}` for struct `{name}`"),
+                            span,
+                        ));
+                    }
+                }
+            }
+        } else if !self.is_known_type_name(table, type_params, name) {
+            diagnostics.push(Diagnostic::error(
+                "E0201",
+                format!("unknown type symbol '{name}'"),
+                span,
+            ));
+        }
+
+        self.validate_type_arg_refs(
+            table,
+            type_params,
+            type_args,
+            span,
+            allow_self_type,
+            diagnostics,
+        );
+        for (_, value) in fields {
+            self.validate_expr_refs(
+                table,
+                type_params,
+                value,
+                locals,
+                allow_self_type,
+                diagnostics,
+            );
+        }
+    }
+
+    pub(super) fn validate_enum_variant_refs(
+        &self,
+        table: &mut SymbolTable,
+        type_params: &[TypeParam],
+        variant_ref: EnumVariantRef<'_>,
+        locals: &mut ScopeStack,
+        allow_self_type: bool,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        let EnumVariantRef {
+            enum_name,
+            type_args,
+            variant,
+            payload,
+            span,
+        } = variant_ref;
+
+        if table.lookup(Namespace::Type, enum_name).is_some() {
+            if let Some(variant_symbol) = table.lookup_variant(enum_name, variant) {
+                match (
+                    variant_symbol.variant_payload_count.unwrap_or(0),
+                    payload.is_some(),
+                ) {
+                    (1, false) => diagnostics.push(Diagnostic::error(
+                        "E0206",
+                        format!("enum variant `{enum_name}.{variant}` requires a payload"),
+                        span,
+                    )),
+                    (0, true) => diagnostics.push(Diagnostic::error(
+                        "E0207",
+                        format!("enum variant `{enum_name}.{variant}` does not accept a payload"),
+                        span,
+                    )),
+                    _ => {}
+                }
+            } else {
+                diagnostics.push(Diagnostic::error(
+                    "E0205",
+                    format!("enum `{enum_name}` has no variant `{variant}`"),
+                    span,
+                ));
+            }
+        } else if !self.is_known_type_name(table, type_params, enum_name) {
+            diagnostics.push(Diagnostic::error(
+                "E0201",
+                format!("unknown type symbol '{enum_name}'"),
+                span,
+            ));
+        }
+
+        self.validate_type_arg_refs(
+            table,
+            type_params,
+            type_args,
+            span,
+            allow_self_type,
+            diagnostics,
+        );
+        if let Some(payload) = payload {
+            self.validate_expr_refs(
+                table,
+                type_params,
+                payload,
+                locals,
+                allow_self_type,
+                diagnostics,
+            );
+        }
+    }
+
+    pub(super) fn validate_match_arm_refs(
+        &self,
+        table: &mut SymbolTable,
+        type_params: &[TypeParam],
+        arm: &MatchArm,
+        locals: &ScopeStack,
+        allow_self_type: bool,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        if let Some(guard) = &arm.guard {
+            let arm_scope_id = table.new_scope();
+            let mut arm_locals = ScopeStack::with_parent(arm_scope_id, locals);
+            self.bind_pattern_locals(table, &arm.pattern, &mut arm_locals, diagnostics);
+            self.validate_expr_refs(
+                table,
+                type_params,
+                guard,
+                &mut arm_locals,
+                allow_self_type,
+                diagnostics,
+            );
+        }
+
+        let arm_scope_id = table.new_scope();
+        let mut arm_locals = ScopeStack::with_parent(arm_scope_id, locals);
+        self.bind_pattern_locals(table, &arm.pattern, &mut arm_locals, diagnostics);
+        self.validate_expr_refs(
+            table,
+            type_params,
+            &arm.body,
+            &mut arm_locals,
+            allow_self_type,
+            diagnostics,
+        );
+    }
+
+    pub(super) fn validate_child_scope_expr_refs(
+        &self,
+        table: &mut SymbolTable,
+        type_params: &[TypeParam],
+        expr: &Expression,
+        locals: &ScopeStack,
+        allow_self_type: bool,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        let scope_id = table.new_scope();
+        let mut child_locals = ScopeStack::with_parent(scope_id, locals);
+        self.validate_expr_refs(
+            table,
+            type_params,
+            expr,
+            &mut child_locals,
+            allow_self_type,
+            diagnostics,
+        );
+    }
+
+    pub(super) fn validate_block_refs(
+        &self,
+        table: &mut SymbolTable,
+        type_params: &[TypeParam],
+        block: BlockRef<'_>,
+        locals: &ScopeStack,
+        allow_self_type: bool,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        let BlockRef { statements, expr } = block;
+
+        let block_scope_id = table.new_scope();
+        let mut block_locals = ScopeStack::with_parent(block_scope_id, locals);
+        for statement in statements {
+            self.validate_statement_refs(
+                table,
+                type_params,
+                statement,
+                &mut block_locals,
+                allow_self_type,
+                diagnostics,
+            );
+        }
+        if let Some(expr) = expr {
+            self.validate_expr_refs(
+                table,
+                type_params,
+                expr,
+                &mut block_locals,
+                allow_self_type,
+                diagnostics,
+            );
+        }
+    }
+
+    pub(super) fn validate_closure_refs(
+        &self,
+        table: &mut SymbolTable,
+        type_params: &[TypeParam],
+        closure: ClosureRef<'_>,
+        locals: &ScopeStack,
+        allow_self_type: bool,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        let ClosureRef {
+            params,
+            return_type,
+            body,
+            span,
+        } = closure;
+
+        let closure_scope_id = table.new_scope();
+        let mut closure_locals = ScopeStack::with_parent(closure_scope_id, locals);
+        for param in params {
+            self.validate_type_ref(
+                table,
+                type_params,
+                &param.ty,
+                param.span,
+                allow_self_type,
+                diagnostics,
+            );
+            self.define_local_symbol(
+                table,
+                &param.name,
+                param.mutable,
+                param.span,
+                &mut closure_locals,
+                diagnostics,
+            );
+        }
+        if let Some(return_type) = return_type {
+            self.validate_type_ref(
+                table,
+                type_params,
+                return_type,
+                span,
+                allow_self_type,
+                diagnostics,
+            );
+        }
+        self.validate_expr_refs(
+            table,
+            type_params,
+            body,
+            &mut closure_locals,
+            allow_self_type,
+            diagnostics,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Move resolver expression constructor reference checks into `src/resolver/expression_validation_constructs.rs`.
- Keep `expression_validation.rs` focused on dispatching expression variants.
- Record the cleanup in `docs/PHASE_PLAN.md`.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --test resolver_phase2`
- `cargo test --lib`
- `cargo test --tests`