### PR TITLE
[codex] Split behavior method collection tests

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -108,6 +108,8 @@ checked-in docs, tests, and commits only.
   focused module, separate from statement and inline-expression emission.
 - C codegen now keeps closure definition scanning in a focused module, separate
   from type, program, function, and global emission.
+- Resolver collection tests now keep behavior default-method synthesis cases in
+  a focused behavior-methods submodule, separate from signature metadata cases.
 - Resolver-backed callable type-reference validation now shares the collected
   signature/body validation helper after function, top-level method, and
   `Type.impl` method dispatch restore the resolver-owned callable key, with

--- a/src/typechecker/tests/resolver_collection/behavior_methods.rs
+++ b/src/typechecker/tests/resolver_collection/behavior_methods.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod default_methods;
+
 #[test]
 fn collect_declarations_with_symbols_uses_resolver_behavior_method_metadata() {
     let mut program = parse_program(
@@ -399,132 +401,6 @@ Point.implements(Json) {
     assert!(
         tc.diagnostics.is_empty(),
         "resolver-restored behavior methods should avoid stale AST impl diagnostics: {:?}",
-        tc.diagnostics
-    );
-}
-
-#[test]
-fn collect_declarations_with_symbols_uses_resolver_behavior_default_method_metadata() {
-    let mut program = parse_program(
-        r#"
-Point: { x: i32 }
-Mapper: behavior {
-    map: (self: Self, callback: (i32) i32) (i32) i32 { callback }
-}
-
-Point.implements(Mapper) {
-}
-"#,
-    );
-    let symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    if let Declaration::Behavior { methods, .. } = &mut program.declarations[1] {
-        methods[0].params[1].ty = AstType::I32;
-        methods[0].return_type = Some(AstType::I32);
-    }
-    let mut tc = TypeChecker::new();
-
-    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
-
-    let info = tc.methods.get("Point.map").expect("default method info");
-    assert_eq!(
-        info.params[1].1,
-        AstType::Function {
-            params: vec![AstType::I32],
-            ret: Box::new(AstType::I32),
-        }
-    );
-    assert_eq!(
-        info.return_type,
-        AstType::Function {
-            params: vec![AstType::I32],
-            ret: Box::new(AstType::I32),
-        }
-    );
-}
-
-#[test]
-fn collect_declarations_with_symbols_uses_resolver_behavior_default_method_name_metadata() {
-    let mut program = parse_program(
-        r#"
-Point: { x: i32 }
-Json: behavior {
-    encode: (self: Self) str { "default" }
-}
-
-Point.implements(Json) {
-}
-"#,
-    );
-    let symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    if let Declaration::Behavior { methods, .. } = &mut program.declarations[1] {
-        methods[0].name = "missing".to_string();
-    }
-    let mut tc = TypeChecker::new();
-
-    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
-
-    let info = tc
-        .methods
-        .get("Point.encode")
-        .expect("resolver-restored default method");
-    assert_eq!(info.params[0].0, "self");
-    assert_eq!(info.return_type, AstType::Str);
-    assert!(
-        !tc.methods.contains_key("Point.missing"),
-        "stale AST-only behavior default method name should not be synthesized"
-    );
-    assert!(
-            tc.diagnostics.is_empty(),
-            "resolver-restored behavior default method name should drive omitted default synthesis: {:?}",
-            tc.diagnostics
-        );
-}
-
-#[test]
-fn collect_declarations_with_symbols_skips_default_when_resolver_restores_impl_method_name() {
-    let mut program = parse_program(
-        r#"
-Point: { x: i32 }
-Json: behavior {
-    encode: (self: Self) str { "default" }
-}
-
-Point.implements(Json) {
-    encode = (value: Point) str { "point" }
-}
-"#,
-    );
-    let symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    if let Declaration::ImplBlock { methods, .. } = &mut program.declarations[2] {
-        if let Declaration::Function { name, .. } = &mut methods[0] {
-            *name = "missing".to_string();
-        }
-    }
-    let mut tc = TypeChecker::new();
-
-    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
-
-    let method = tc
-        .methods
-        .get("Point.encode")
-        .expect("restored impl method");
-    assert_eq!(
-        method.params[0].0, "value",
-        "resolver-restored explicit impl method should not be overwritten by the behavior default"
-    );
-    assert!(
-        !tc.methods.contains_key("Point.missing"),
-        "stale AST-only impl method key should be removed"
-    );
-    assert!(
-        tc.diagnostics.is_empty(),
-        "resolver-restored impl method name should suppress default insertion: {:?}",
         tc.diagnostics
     );
 }

--- a/src/typechecker/tests/resolver_collection/behavior_methods/default_methods.rs
+++ b/src/typechecker/tests/resolver_collection/behavior_methods/default_methods.rs
@@ -1,0 +1,127 @@
+use super::*;
+
+#[test]
+fn collect_declarations_with_symbols_uses_resolver_behavior_default_method_metadata() {
+    let mut program = parse_program(
+        r#"
+Point: { x: i32 }
+Mapper: behavior {
+    map: (self: Self, callback: (i32) i32) (i32) i32 { callback }
+}
+
+Point.implements(Mapper) {
+}
+"#,
+    );
+    let symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    if let Declaration::Behavior { methods, .. } = &mut program.declarations[1] {
+        methods[0].params[1].ty = AstType::I32;
+        methods[0].return_type = Some(AstType::I32);
+    }
+    let mut tc = TypeChecker::new();
+
+    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
+
+    let info = tc.methods.get("Point.map").expect("default method info");
+    assert_eq!(
+        info.params[1].1,
+        AstType::Function {
+            params: vec![AstType::I32],
+            ret: Box::new(AstType::I32),
+        }
+    );
+    assert_eq!(
+        info.return_type,
+        AstType::Function {
+            params: vec![AstType::I32],
+            ret: Box::new(AstType::I32),
+        }
+    );
+}
+
+#[test]
+fn collect_declarations_with_symbols_uses_resolver_behavior_default_method_name_metadata() {
+    let mut program = parse_program(
+        r#"
+Point: { x: i32 }
+Json: behavior {
+    encode: (self: Self) str { "default" }
+}
+
+Point.implements(Json) {
+}
+"#,
+    );
+    let symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    if let Declaration::Behavior { methods, .. } = &mut program.declarations[1] {
+        methods[0].name = "missing".to_string();
+    }
+    let mut tc = TypeChecker::new();
+
+    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
+
+    let info = tc
+        .methods
+        .get("Point.encode")
+        .expect("resolver-restored default method");
+    assert_eq!(info.params[0].0, "self");
+    assert_eq!(info.return_type, AstType::Str);
+    assert!(
+        !tc.methods.contains_key("Point.missing"),
+        "stale AST-only behavior default method name should not be synthesized"
+    );
+    assert!(
+            tc.diagnostics.is_empty(),
+            "resolver-restored behavior default method name should drive omitted default synthesis: {:?}",
+            tc.diagnostics
+        );
+}
+
+#[test]
+fn collect_declarations_with_symbols_skips_default_when_resolver_restores_impl_method_name() {
+    let mut program = parse_program(
+        r#"
+Point: { x: i32 }
+Json: behavior {
+    encode: (self: Self) str { "default" }
+}
+
+Point.implements(Json) {
+    encode = (value: Point) str { "point" }
+}
+"#,
+    );
+    let symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    if let Declaration::ImplBlock { methods, .. } = &mut program.declarations[2] {
+        if let Declaration::Function { name, .. } = &mut methods[0] {
+            *name = "missing".to_string();
+        }
+    }
+    let mut tc = TypeChecker::new();
+
+    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
+
+    let method = tc
+        .methods
+        .get("Point.encode")
+        .expect("restored impl method");
+    assert_eq!(
+        method.params[0].0, "value",
+        "resolver-restored explicit impl method should not be overwritten by the behavior default"
+    );
+    assert!(
+        !tc.methods.contains_key("Point.missing"),
+        "stale AST-only impl method key should be removed"
+    );
+    assert!(
+        tc.diagnostics.is_empty(),
+        "resolver-restored impl method name should suppress default insertion: {:?}",
+        tc.diagnostics
+    );
+}


### PR DESCRIPTION
## Summary
- Move resolver-backed behavior default-method synthesis tests into `behavior_methods/default_methods.rs`.
- Keep `behavior_methods.rs` focused on behavior method signature/name/parameter metadata restoration.
- Record the split in the phase plan.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib typechecker::tests::resolver_collection::behavior_methods`
- `cargo test --lib`
- `cargo test --tests`