### PR TITLE
[codex] Add Result enum method diagnostic coverage

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -114,6 +114,8 @@ checked-in docs, tests, and commits only.
   in a focused submodule, separate from template shape and mutability metadata.
 - Generic enum specialization coverage now includes a `Result<T, E>` enum method
   fixture with generated-C assertions for the concrete mangled method.
+- Generic diagnostics now cover explicit type-argument arity failures for
+  two-parameter `Result<T, E>` enum methods without noisy followup diagnostics.
 - Resolver-backed callable type-reference validation now shares the collected
   signature/body validation helper after function, top-level method, and
   `Type.impl` method dispatch restore the resolver-owned callable key, with

--- a/tests/generic_diagnostics/method_type_args.rs
+++ b/tests/generic_diagnostics/method_type_args.rs
@@ -88,6 +88,45 @@ main = () i32 {
 }
 
 #[test]
+fn generic_result_enum_method_explicit_type_arg_arity_is_error() {
+    let errors = typecheck_errors(
+        r#"
+Result<T, E>:
+    Ok(T),
+    Err(E)
+
+Result.unwrap_or<T, E> = (self: Self, fallback: T) T {
+    self ?
+        | Ok(value) { value }
+        | Err(_) { fallback }
+}
+
+main = () i32 {
+    value = Result<i32, str>.Ok(1)
+    value.unwrap_or<i32>(0)
+}
+"#,
+    );
+
+    assert!(
+        errors.iter().any(|d| d
+            .message
+            .contains("generic method `Result.unwrap_or` expects 2 type arguments, found 1")),
+        "expected generic Result enum method arity diagnostic, got {errors:?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .all(|d| !d.message.contains("cannot infer type argument")),
+        "malformed generic Result enum method type arguments should not also report inference, got {errors:?}"
+    );
+    assert!(
+        errors.iter().all(|d| !d.message.contains("argument 2")),
+        "malformed generic Result enum method type arguments should not also report argument mismatch, got {errors:?}"
+    );
+}
+
+#[test]
 fn generic_method_inference_failure_is_error() {
     let errors = typecheck_errors(
         r#"


### PR DESCRIPTION
## Summary
- Add a generic diagnostic regression test for `Result.unwrap_or<T, E>` explicit type-argument arity.
- Assert malformed enum method type arguments do not emit inference or argument-mismatch followups.
- Record the diagnostic coverage in the phase plan.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --test generic_diagnostics generic_result_enum_method_explicit_type_arg_arity_is_error`
- `cargo test --lib`
- `cargo test --tests`