### PR TITLE
[codex] Stop generic inference conflict followups

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -116,6 +116,8 @@ checked-in docs, tests, and commits only.
   fixture with generated-C assertions for the concrete mangled method.
 - Generic diagnostics now cover explicit type-argument arity failures for
   two-parameter `Result<T, E>` enum methods without noisy followup diagnostics.
+- Generic diagnostics now cover receiver-vs-argument inference conflicts for
+  two-parameter `Result<T, E>` enum methods.
 - Resolver-backed callable type-reference validation now shares the collected
   signature/body validation helper after function, top-level method, and
   `Type.impl` method dispatch restore the resolver-owned callable key, with

--- a/src/typechecker/expressions/call_support.rs
+++ b/src/typechecker/expressions/call_support.rs
@@ -31,8 +31,9 @@ impl TypeChecker {
                         &info.params,
                         &arg_types,
                     );
-                    self.report_inference_conflicts("function", &full_name, conflicts, span);
-                    (subs, true)
+                    let inferred_type_args_valid =
+                        self.report_inference_conflicts("function", &full_name, conflicts, span);
+                    (subs, inferred_type_args_valid)
                 } else {
                     self.explicit_type_arg_substitutions(
                         "function",
@@ -228,8 +229,9 @@ impl TypeChecker {
                         &info.params,
                         &arg_types,
                     );
-                    self.report_inference_conflicts("method", &method_key, conflicts, span);
-                    (subs, true)
+                    let inferred_type_args_valid =
+                        self.report_inference_conflicts("method", &method_key, conflicts, span);
+                    (subs, inferred_type_args_valid)
                 } else {
                     self.explicit_type_arg_substitutions(
                         "method",
@@ -320,13 +322,13 @@ impl TypeChecker {
                             &info.params,
                             &arg_types,
                         );
-                        self.report_inference_conflicts(
+                        let inferred_type_args_valid = self.report_inference_conflicts(
                             "method",
                             &generic_method_key,
                             conflicts,
                             span,
                         );
-                        (subs, true)
+                        (subs, inferred_type_args_valid)
                     } else {
                         self.explicit_type_arg_substitutions(
                             "method",
@@ -434,8 +436,9 @@ impl TypeChecker {
                         &info.params,
                         &arg_types,
                     );
-                    self.report_inference_conflicts("function", method, conflicts, span);
-                    (subs, true)
+                    let inferred_type_args_valid =
+                        self.report_inference_conflicts("function", method, conflicts, span);
+                    (subs, inferred_type_args_valid)
                 } else {
                     self.explicit_type_arg_substitutions(
                         "function",

--- a/src/typechecker/expressions/call_validation.rs
+++ b/src/typechecker/expressions/call_validation.rs
@@ -98,7 +98,8 @@ impl TypeChecker {
         callee: &str,
         conflicts: Vec<InferenceConflict>,
         span: Span,
-    ) {
+    ) -> bool {
+        let valid = conflicts.is_empty();
         for conflict in conflicts {
             self.diagnostics.push(Diagnostic::error(
                 "E5000",
@@ -113,6 +114,7 @@ impl TypeChecker {
                 span,
             ));
         }
+        valid
     }
 
     pub(super) fn explicit_type_arg_substitutions(

--- a/src/typechecker/monomorphize_inference.rs
+++ b/src/typechecker/monomorphize_inference.rs
@@ -47,8 +47,8 @@ impl TypeChecker {
         param_types: &[(String, AstType)],
         arg_types: &[Type],
     ) -> (HashMap<String, Type>, Vec<InferenceConflict>) {
-        let (mut map, mut conflicts) =
-            self.infer_type_args_with_conflicts(type_params, param_types, arg_types);
+        let mut map = HashMap::new();
+        let mut conflicts = Vec::new();
         if let (Some(receiver_name), Some(receiver_ty)) = (
             super::method_signature_receiver_name(method_name),
             arg_types.first(),
@@ -60,6 +60,9 @@ impl TypeChecker {
                 &mut map,
                 &mut conflicts,
             );
+        }
+        for ((_name, param_ty), arg_ty) in param_types.iter().zip(arg_types.iter()) {
+            self.match_type_param(param_ty, arg_ty, type_params, &mut map, &mut conflicts);
         }
         (map, conflicts)
     }

--- a/tests/generic_diagnostics/inference_conflicts.rs
+++ b/tests/generic_diagnostics/inference_conflicts.rs
@@ -149,6 +149,45 @@ main = () i32 {
 }
 
 #[test]
+fn generic_result_enum_method_inference_conflict_from_receiver_is_error() {
+    let errors = typecheck_errors(
+        r#"
+Result<T, E>:
+    Ok(T),
+    Err(E)
+
+Result.unwrap_or<T, E> = (self: Self, fallback: T) T {
+    self ?
+        | Ok(value) { value }
+        | Err(_) { fallback }
+}
+
+main = () i32 {
+    value = Result<i32, str>.Ok(1)
+    value.unwrap_or("bad")
+}
+"#,
+    );
+
+    assert!(
+        errors.iter().any(|d| d.message.contains(
+            "conflicting inferred type argument `T` for generic method `Result.unwrap_or`: inferred `i32` and `str`"
+        )),
+        "expected generic Result enum method receiver inference conflict diagnostic, got {errors:?}"
+    );
+    assert!(
+        errors.iter().all(|d| !d.message.contains("argument 1")),
+        "generic Result enum method inference conflict should not also report argument mismatch, got {errors:?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .all(|d| !d.message.contains("return type mismatch")),
+        "generic Result enum method inference conflict should not also report return mismatch, got {errors:?}"
+    );
+}
+
+#[test]
 fn generic_method_inference_conflict_through_function_type_is_error() {
     let errors = typecheck_errors(
         r#"


### PR DESCRIPTION
## Summary
- Treat generic inference conflicts as invalid inferred type-argument sets, so signature, bounds, return, and specialization checks do not run on conflicted substitutions.
- Seed generic method inference from the concrete receiver before ordinary parameters, which makes receiver-vs-argument conflict diagnostics stable.
- Add a `Result.unwrap_or<T, E>` regression test that forbids argument/return mismatch followups after the inference conflict.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --test generic_diagnostics generic_result_enum_method_inference_conflict_from_receiver_is_error`
- `cargo test --test generic_diagnostics inference_conflicts`
- `cargo test --lib`
- `cargo test --tests`