### PR TITLE
[codex] Add Result enum method bound diagnostics

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -118,6 +118,8 @@ checked-in docs, tests, and commits only.
   two-parameter `Result<T, E>` enum methods without noisy followup diagnostics.
 - Generic diagnostics now cover receiver-vs-argument inference conflicts for
   two-parameter `Result<T, E>` enum methods.
+- Generic diagnostics now cover bound failures on `Result<T, E>` enum methods
+  without specializing failed method bodies into followup errors.
 - Resolver-backed callable type-reference validation now shares the collected
   signature/body validation helper after function, top-level method, and
   `Type.impl` method dispatch restore the resolver-owned callable key, with

--- a/tests/generic_diagnostics/bounds.rs
+++ b/tests/generic_diagnostics/bounds.rs
@@ -345,6 +345,50 @@ main = () i32 {
 }
 
 #[test]
+fn generic_result_enum_method_behavior_bound_failure_is_error() {
+    let errors = typecheck_errors(
+        r#"
+Json: behavior {
+    encode: (Self) str
+}
+
+Point: {
+    x: i32
+}
+
+Result<T, E>:
+    Ok(T),
+    Err(E)
+
+Result.map<T, E, U: Json> = (self: Self, fallback: U) U {
+    fallback.encode()
+    fallback
+}
+
+main = () i32 {
+    value = Result<i32, str>.Ok(1)
+    point = Point { x: 1 }
+    bad = value.map(point)
+    0
+}
+"#,
+    );
+
+    assert!(
+        errors.iter().any(|d| d
+            .message
+            .contains("type `Point` does not implement behavior `Json` required by `U`")),
+        "expected generic Result enum method bound diagnostic, got {errors:?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .all(|d| !d.message.contains("has no method `encode`")),
+        "generic Result enum method bound failure should not also specialize body method errors, got {errors:?}"
+    );
+}
+
+#[test]
 fn generic_ufc_function_behavior_bound_failure_is_error() {
     let errors = typecheck_errors(
         r#"


### PR DESCRIPTION
## Summary
- Add generic diagnostic coverage for a `Result<T, E>` enum method with a bounded method type parameter.
- Assert the bound failure names the concrete missing behavior implementation.
- Assert the failed method body is not specialized into noisy `encode` followup errors.

## Validation
- `cargo test --test generic_diagnostics generic_result_enum_method_behavior_bound_failure_is_error`
- `cargo test --test generic_diagnostics bounds`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`