### PR TITLE
[codex] Guard generic inference conflict followups

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -120,6 +120,8 @@ checked-in docs, tests, and commits only.
   two-parameter `Result<T, E>` enum methods.
 - Generic diagnostics now cover bound failures on `Result<T, E>` enum methods
   without specializing failed method bodies into followup errors.
+- Generic diagnostics now also guard plain generic function and method
+  inference conflicts against argument/return mismatch followups.
 - Resolver-backed callable type-reference validation now shares the collected
   signature/body validation helper after function, top-level method, and
   `Type.impl` method dispatch restore the resolver-owned callable key, with

--- a/tests/generic_diagnostics/inference_conflicts.rs
+++ b/tests/generic_diagnostics/inference_conflicts.rs
@@ -21,6 +21,16 @@ main = () i32 {
         )),
         "expected generic function inference conflict diagnostic, got {errors:?}"
     );
+    assert!(
+        errors.iter().all(|d| !d.message.contains("argument 2")),
+        "generic function inference conflict should not also report argument mismatch, got {errors:?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .all(|d| !d.message.contains("return type mismatch")),
+        "generic function inference conflict should not also report return mismatch, got {errors:?}"
+    );
 }
 
 #[test]
@@ -118,6 +128,16 @@ main = () i32 {
             "conflicting inferred type argument `T` for generic method `Box.choose`: inferred `i32` and `str`"
         )),
         "expected generic method inference conflict diagnostic, got {errors:?}"
+    );
+    assert!(
+        errors.iter().all(|d| !d.message.contains("argument 2")),
+        "generic method inference conflict should not also report argument mismatch, got {errors:?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .all(|d| !d.message.contains("return type mismatch")),
+        "generic method inference conflict should not also report return mismatch, got {errors:?}"
     );
 }
 


### PR DESCRIPTION
## Summary
- Add followup-noise guards for plain generic function inference conflicts.
- Add followup-noise guards for plain generic method inference conflicts.
- Record the expanded diagnostic coverage in the phase plan.

## Validation
- `cargo test --test generic_diagnostics inference_conflicts`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`