### PR TITLE
[codex] Add multi-file Result enum method coverage

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -122,6 +122,8 @@ checked-in docs, tests, and commits only.
   without specializing failed method bodies into followup errors.
 - Generic diagnostics now also guard plain generic function and method
   inference conflicts against argument/return mismatch followups.
+- Generic enum method specialization coverage now includes an imported
+  `Result<T, E>` fixture with generated-C assertions for the concrete method.
 - Resolver-backed callable type-reference validation now shares the collected
   signature/body validation helper after function, top-level method, and
   `Type.impl` method dispatch restore the resolver-owned callable key, with

--- a/tests/integration/generic_specializations.rs
+++ b/tests/integration/generic_specializations.rs
@@ -26,6 +26,7 @@ fn generic_specializations_emit_each_generated_c_definition_once() {
         "multi_file_generic_imported_transitive_dependency/main.zen",
         "multi_file_generic_imported_type_dependency/main.zen",
         "multi_file_generic_imported_worklist_chain/main.zen",
+        "multi_file_generic_result_enum_method/main.zen",
         "multi_file_imported_generic_function_return_enum_dependency/main.zen",
         "multi_file_type_impl_return_enum_dependency/main.zen",
         "multi_file_type_method_nested_result_dependency/main.zen",
@@ -237,6 +238,19 @@ fn generic_specializations_do_not_emit_unspecialized_c_symbols() {
     assert!(!c_source.contains("Option_T"));
     assert!(!c_source.contains("T Option_unwrap_or"));
     assert!(!c_source.contains("Option_unwrap_or(some"));
+
+    let c_source = compile_to_c_with_generated_call_check(
+        &test_dir().join("multi_file_generic_result_enum_method/main.zen"),
+    );
+    assert!(c_source.contains("typedef struct Result_i32_str Result_i32_str;"));
+    assert!(c_source
+        .contains("int32_t Result_unwrap_or_i32_str(Result_i32_str self, int32_t fallback)"));
+    assert!(c_source.contains("Result_unwrap_or_i32_str(ok, 0LL)"));
+    assert!(c_source.contains("Result_unwrap_or_i32_str(err, 144LL)"));
+    assert_c_call_resolves_to_definition(&c_source, "Result_unwrap_or_i32_str");
+    assert!(!c_source.contains("Result_T"));
+    assert!(!c_source.contains("T Result_unwrap_or"));
+    assert!(!c_source.contains("Result_unwrap_or(err"));
 
     let c_source = compile_to_c_with_generated_call_check(
         &test_dir().join("multi_file_generic_imported_type_dependency/main.zen"),

--- a/tests/integration/multi_file_fixtures.rs
+++ b/tests/integration/multi_file_fixtures.rs
@@ -43,6 +43,13 @@ fn test_multi_file_generic_enum_method_imports() {
 }
 
 #[test]
+fn test_multi_file_generic_result_enum_method_imports() {
+    let zen_path = test_dir().join("multi_file_generic_result_enum_method/main.zen");
+    let actual = compile_and_run(&zen_path);
+    assert_eq!(actual, "55\n144\n");
+}
+
+#[test]
 fn test_multi_file_type_impl_imports() {
     let zen_path = test_dir().join("multi_file_type_impl/main.zen");
     let actual = compile_and_run(&zen_path);

--- a/tests/zen/multi_file_generic_result_enum_method/main.zen
+++ b/tests/zen/multi_file_generic_result_enum_method/main.zen
@@ -1,0 +1,10 @@
+{ io } = std
+{ Result } = result
+
+main = () i32 {
+    ok = Result<i32, str>.Ok(55)
+    err = Result<i32, str>.Err("bad")
+    io.println("${ok.unwrap_or(0)}")
+    io.println("${err.unwrap_or(144)}")
+    0
+}

--- a/tests/zen/multi_file_generic_result_enum_method/result.zen
+++ b/tests/zen/multi_file_generic_result_enum_method/result.zen
@@ -1,0 +1,9 @@
+pub Result<T, E>:
+    Ok(T),
+    Err(E)
+
+pub Result.unwrap_or<T, E> = (self: Self, fallback: T) T {
+    self ?
+        | Ok(value) { value }
+        | Err(_) { fallback }
+}


### PR DESCRIPTION
## Summary
- Add a multi-file fixture for an imported `Result<T, E>` enum method.
- Assert runtime output for imported `unwrap_or` calls.
- Add generated-C checks for the concrete `Result_unwrap_or_i32_str` specialization and duplicate-definition coverage.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --test integration multi_file_fixtures::test_multi_file_generic_result_enum_method_imports`
- `cargo test --test integration generic_specializations::generic_specializations_do_not_emit_unspecialized_c_symbols`
- `cargo test --test integration generic_specializations::generic_specializations_emit_each_generated_c_definition_once`
- `cargo test --lib`
- `cargo test --tests`