### PR TITLE
[codex] Share resolver replay task collection in tests

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -1249,6 +1249,13 @@ and do not assume Phase 4 is ready without evidence.
   `typechecker::tests::collect_declarations_with_symbols_uses_resolver_behavior_impl_generic_method_template_target_and_name_metadata`.
   AST import seeding now has a named helper pass, removing the residual mixed
   declaration collection loop.
+  Test-facing resolver replay task views now delegate to the same bundled
+  resolver declaration metadata collector as production replay instead of
+  running separate declaration scans, covered by
+  `cargo test resolver_type_declaration_metadata_tasks_collect_only_type_work`,
+  `cargo test resolver_callable_declaration_metadata_tasks_collect_callable_work`,
+  `cargo test resolver_behavior_impl_block_declaration_tasks_collect_only_behavior_impls`,
+  and `cargo test resolver_type_reference_validation_tasks_collect_only_type_reference_work`.
   Resolver-backed function and method signature restoration now shares one
   callable key repair and generic-template rekey helper.
   Resolver-backed semantic validation and final type impl association refresh

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -820,6 +820,13 @@ checked-in docs, tests, and commits only.
   of invoking both and relying on per-pass resolver-backed guards.
   AST import seeding now has a named helper pass, removing the residual mixed
   declaration collection loop.
+  Test-facing resolver replay task views now delegate to the same bundled
+  resolver declaration metadata collector as production replay instead of
+  running separate declaration scans, covered by
+  `resolver_type_declaration_metadata_tasks_collect_only_type_work`,
+  `resolver_callable_declaration_metadata_tasks_collect_callable_work`,
+  `resolver_behavior_impl_block_declaration_tasks_collect_only_behavior_impls`,
+  and `resolver_type_reference_validation_tasks_collect_only_type_reference_work`.
   Resolver-backed function and method signature restoration now shares one
   callable key repair and generic-template rekey helper.
   Resolver-backed semantic validation and final type impl association refresh

--- a/src/typechecker/declaration_collection_resolver_tasks.rs
+++ b/src/typechecker/declaration_collection_resolver_tasks.rs
@@ -57,33 +57,7 @@ impl TypeChecker {
     pub(super) fn collect_resolver_type_declaration_metadata_tasks(
         decls: &[Declaration],
     ) -> Vec<ResolverTypeDeclarationMetadataTask<'_>> {
-        let mut tasks = Vec::new();
-        for decl in decls {
-            Self::push_resolver_type_declaration_metadata_task(decl, &mut tasks);
-        }
-        tasks
-    }
-
-    #[cfg(test)]
-    fn push_resolver_type_declaration_metadata_task<'a>(
-        decl: &'a Declaration,
-        tasks: &mut Vec<ResolverTypeDeclarationMetadataTask<'a>>,
-    ) {
-        match decl {
-            Declaration::Struct {
-                name, fields, span, ..
-            } => {
-                tasks.push(ResolverTypeDeclarationMetadataTask::Struct {
-                    name,
-                    fields,
-                    span: *span,
-                });
-            }
-            Declaration::Enum { name, span, .. } => {
-                tasks.push(ResolverTypeDeclarationMetadataTask::Enum { name, span: *span });
-            }
-            _ => {}
-        }
+        Self::collect_resolver_declaration_metadata_tasks(decls).types
     }
 
     pub(super) fn push_resolver_type_replay_tasks<'a>(
@@ -121,24 +95,7 @@ impl TypeChecker {
     pub(super) fn collect_resolver_behavior_declaration_metadata_tasks(
         decls: &[Declaration],
     ) -> Vec<ResolverBehaviorDeclarationMetadataTask<'_>> {
-        let mut tasks = Vec::new();
-        for decl in decls {
-            Self::push_resolver_behavior_declaration_metadata_task(decl, &mut tasks);
-        }
-        tasks
-    }
-
-    #[cfg(test)]
-    fn push_resolver_behavior_declaration_metadata_task<'a>(
-        decl: &'a Declaration,
-        tasks: &mut Vec<ResolverBehaviorDeclarationMetadataTask<'a>>,
-    ) {
-        if let Declaration::Behavior { name, span, .. } = decl {
-            tasks.push(ResolverBehaviorDeclarationMetadataTask {
-                name: name.as_str(),
-                span: *span,
-            });
-        }
+        Self::collect_resolver_declaration_metadata_tasks(decls).behaviors
     }
 
     pub(super) fn push_resolver_behavior_replay_tasks<'a>(
@@ -191,11 +148,9 @@ impl TypeChecker {
     pub(super) fn collect_resolver_behavior_impl_block_declaration_tasks(
         decls: &[Declaration],
     ) -> Vec<ResolverBehaviorImplBlockDeclarationTask<'_>> {
-        let mut tasks = Vec::new();
-        for decl in decls {
-            Self::push_behavior_impl_block_declaration_task(decl, &mut tasks);
-        }
-        tasks
+        Self::collect_resolver_declaration_metadata_tasks(decls)
+            .behavior_associations
+            .impls
     }
 
     pub(super) fn push_behavior_impl_block_declaration_task<'a>(
@@ -228,45 +183,7 @@ impl TypeChecker {
     pub(super) fn collect_resolver_callable_declaration_metadata_tasks(
         decls: &[Declaration],
     ) -> Vec<ResolverCallableDeclarationMetadataTask<'_>> {
-        let mut tasks = Vec::new();
-        for decl in decls {
-            Self::push_resolver_callable_declaration_metadata_task(decl, &mut tasks);
-        }
-        tasks
-    }
-
-    #[cfg(test)]
-    fn push_resolver_callable_declaration_metadata_task<'a>(
-        decl: &'a Declaration,
-        tasks: &mut Vec<ResolverCallableDeclarationMetadataTask<'a>>,
-    ) {
-        match decl {
-            Declaration::Function { name, span, .. } => {
-                tasks.push(ResolverCallableDeclarationMetadataTask::Function { name, span: *span });
-            }
-            Declaration::Method {
-                type_name,
-                method_name,
-                span,
-                ..
-            } => {
-                tasks.push(ResolverCallableDeclarationMetadataTask::Method {
-                    type_name,
-                    method_name,
-                    span: *span,
-                });
-            }
-            Declaration::ImplBlock {
-                type_name,
-                behavior: None,
-                methods,
-                ..
-            } => {
-                tasks
-                    .push(ResolverCallableDeclarationMetadataTask::TypeImpl { type_name, methods });
-            }
-            _ => {}
-        }
+        Self::collect_resolver_declaration_metadata_tasks(decls).callable
     }
 
     pub(super) fn push_resolver_callable_replay_tasks<'a>(
@@ -327,11 +244,7 @@ impl TypeChecker {
     pub(super) fn collect_resolver_type_reference_validation_tasks(
         decls: &[Declaration],
     ) -> Vec<ResolverTypeReferenceValidationTask<'_>> {
-        let mut tasks = Vec::new();
-        for decl in decls {
-            Self::push_resolver_type_reference_validation_task(decl, &mut tasks);
-        }
-        tasks
+        Self::collect_resolver_declaration_metadata_tasks(decls).type_references
     }
 
     fn push_resolver_type_reference_validation_task<'a>(

--- a/tests/docs_truth/phase_audit.rs
+++ b/tests/docs_truth/phase_audit.rs
@@ -74,6 +74,10 @@ fn phase_plan_records_recovered_progress_and_next_slice() {
         "collect_declarations_with_symbols_uses_resolver_behavior_impl_generic_method_template_target_and_name_metadata",
         "collect_declarations_with_symbols_clears_stale_behavior_impl_generic_method_template_after_key_restore",
         "resolver_declaration_metadata_skips_behavior_impl_methods_until_behavior_impl_pass",
+        "resolver_type_declaration_metadata_tasks_collect_only_type_work",
+        "resolver_callable_declaration_metadata_tasks_collect_callable_work",
+        "resolver_behavior_impl_block_declaration_tasks_collect_only_behavior_impls",
+        "resolver_type_reference_validation_tasks_collect_only_type_reference_work",
     ] {
         assert!(
             plan.contains(required),
@@ -147,6 +151,10 @@ fn completion_audit_records_recovery_objective_evidence_and_gaps() {
         "collect_declarations_with_symbols_uses_resolver_behavior_impl_generic_method_template_target_and_name_metadata",
         "collect_declarations_with_symbols_clears_stale_behavior_impl_generic_method_template_after_key_restore",
         "resolver_declaration_metadata_skips_behavior_impl_methods_until_behavior_impl_pass",
+        "resolver_type_declaration_metadata_tasks_collect_only_type_work",
+        "resolver_callable_declaration_metadata_tasks_collect_callable_work",
+        "resolver_behavior_impl_block_declaration_tasks_collect_only_behavior_impls",
+        "resolver_type_reference_validation_tasks_collect_only_type_reference_work",
     ] {
         assert!(
             audit.contains(required),


### PR DESCRIPTION
## Summary
- Route test-facing resolver replay task views through the production bundled resolver declaration metadata collector.
- Remove duplicate test-only declaration scans for callable, type, behavior, impl, and type-reference task views.
- Record the consolidation in the phase plan, completion audit, and docs-truth gate.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth phase_audit`
- `cargo test resolver_replay`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`