### PR TITLE
[codex] Harden generic enum constructor arity diagnostics

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -1994,7 +1994,8 @@ and do not assume Phase 4 is ready without evidence.
 - AST type declaration collection now uses named struct and enum tasks before
   replaying generic-bound validation and type registration, covered by
   `cargo test ast_type_declaration_tasks_collect_structs_and_enums`,
-  `cargo test generic_enum_type_arg_arity_is_error`, and
+  `cargo test generic_enum_type_arg_arity_is_error`,
+  `cargo test generic_enum_constructor_without_type_args_is_error`, and
   `cargo test check_program_with_symbols_uses_resolver_type_metadata_for_type_refs`.
 - Behavior declaration collection now uses named behavior tasks before
   replaying AST signature registration or resolver-backed stubs, covered by
@@ -2092,8 +2093,9 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test generic_function_collection`.
 - AST type declaration collection now uses a shared type-task push helper
   before replaying generic-bound validation and type registration, covered by
-  `cargo test ast_type_declaration_tasks_collect_structs_and_enums` and
-  `cargo test generic_enum_type_arg_arity_is_error`.
+  `cargo test ast_type_declaration_tasks_collect_structs_and_enums`,
+  `cargo test generic_enum_type_arg_arity_is_error`, and
+  `cargo test generic_enum_constructor_without_type_args_is_error`.
 - Behavior declaration collection now uses a shared behavior-task push helper
   before replaying signature setup and behavior generic-bound validation,
   covered by `cargo test behavior_declaration_tasks_collect_behavior_signatures`

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -116,6 +116,9 @@ checked-in docs, tests, and commits only.
   fixture with generated-C assertions for the concrete mangled method.
 - Generic diagnostics now cover explicit type-argument arity failures for
   two-parameter `Result<T, E>` enum methods without noisy followup diagnostics.
+- Generic diagnostics now cover generic enum constructor arity failures without
+  leaking raw type-parameter payload mismatch followups, including
+  `generic_enum_constructor_without_type_args_is_error`.
 - Generic diagnostics now cover receiver-vs-argument inference conflicts for
   two-parameter `Result<T, E>` enum methods.
 - Generic diagnostics now cover bound failures on `Result<T, E>` enum methods

--- a/src/typechecker/expressions/aggregate_support.rs
+++ b/src/typechecker/expressions/aggregate_support.rs
@@ -221,11 +221,25 @@ impl TypeChecker {
             Some(p) => Some(Box::new(self.check_expr(p)?)),
             None => None,
         };
+        let enum_info = self.enums.get(enum_name).cloned();
+        let type_arg_count = enum_info.as_ref().map(|info| info.type_params.len());
+        let type_args_valid = type_arg_count.is_none_or(|expected| expected == type_args.len());
+
         let (type_name, ty, variant_defs) = if type_args.is_empty() {
             let ty = self.resolve_type(&AstType::Named(enum_name.to_string()));
-            let variant_defs = self
-                .enums
-                .get(enum_name)
+            if let Some(expected) = type_arg_count.filter(|expected| *expected > 0) {
+                self.diagnostics.push(Diagnostic::error(
+                    "E5001",
+                    format!(
+                        "generic enum `{}` expects {} type arguments, found 0",
+                        enum_name, expected
+                    ),
+                    span,
+                ));
+            }
+            let variant_defs = enum_info
+                .as_ref()
+                .filter(|_| type_args_valid)
                 .map(|info| {
                     info.variants
                         .iter()
@@ -248,7 +262,7 @@ impl TypeChecker {
             let variant_defs = self.specialize_generic_enum(enum_name, type_args, span);
             (type_name, ty, variant_defs)
         };
-        if self.enums.contains_key(enum_name) {
+        if self.enums.contains_key(enum_name) && type_args_valid {
             match variant_defs.get(variant) {
                 Some(expected_payload) => match (expected_payload, &typed_payload) {
                     (Some(expected_ast), Some(actual)) => {

--- a/tests/docs_truth/phase_audit.rs
+++ b/tests/docs_truth/phase_audit.rs
@@ -95,6 +95,7 @@ fn phase_plan_records_recovered_progress_and_next_slice() {
         "resolver_callable_declaration_metadata_tasks_collect_callable_work",
         "resolver_behavior_impl_block_declaration_tasks_collect_only_behavior_impls",
         "resolver_type_reference_validation_tasks_collect_only_type_reference_work",
+        "generic_enum_constructor_without_type_args_is_error",
     ] {
         assert!(
             plan.contains(required),
@@ -190,6 +191,7 @@ fn completion_audit_records_recovery_objective_evidence_and_gaps() {
         "resolver_callable_declaration_metadata_tasks_collect_callable_work",
         "resolver_behavior_impl_block_declaration_tasks_collect_only_behavior_impls",
         "resolver_type_reference_validation_tasks_collect_only_type_reference_work",
+        "generic_enum_constructor_without_type_args_is_error",
     ] {
         assert!(
             audit.contains(required),

--- a/tests/generic_diagnostics/annotations.rs
+++ b/tests/generic_diagnostics/annotations.rs
@@ -244,6 +244,41 @@ main = () i32 {
             .contains("generic enum `Option` expects 1 type arguments, found 2")),
         "expected generic enum arity diagnostic, got {errors:?}"
     );
+    assert!(
+        errors
+            .iter()
+            .all(|d| !d.message.contains("payload for enum variant")),
+        "malformed generic enum constructor should not also report payload mismatch, got {errors:?}"
+    );
+}
+
+#[test]
+fn generic_enum_constructor_without_type_args_is_error() {
+    let errors = typecheck_errors(
+        r#"
+Option<T>:
+    None,
+    Some(T)
+
+main = () i32 {
+    value = Option.Some(1)
+    0
+}
+"#,
+    );
+
+    assert!(
+        errors.iter().any(|d| d
+            .message
+            .contains("generic enum `Option` expects 1 type arguments, found 0")),
+        "expected unspecialized generic enum constructor diagnostic, got {errors:?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .all(|d| !d.message.contains("payload for enum variant")),
+        "malformed generic enum constructor should not also report payload mismatch, got {errors:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add a failing-first generic enum constructor diagnostic case for `Option.Some(...)` without type arguments.
- Report `E5001` for generic enum constructors missing type arguments and suppress misleading raw type-parameter payload mismatch followups.
- Extend existing generic enum constructor arity coverage and record the evidence in phase/audit docs plus docs-truth checks.

## Validation

- `cargo fmt --check`
- `cargo test --test generic_diagnostics generic_enum`
- `cargo test --test generic_diagnostics`
- `cargo test --test docs_truth phase_audit`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`