### PR TITLE
[codex] Harden generic struct constructor arity diagnostics

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -1994,6 +1994,7 @@ and do not assume Phase 4 is ready without evidence.
 - AST type declaration collection now uses named struct and enum tasks before
   replaying generic-bound validation and type registration, covered by
   `cargo test ast_type_declaration_tasks_collect_structs_and_enums`,
+  `cargo test generic_struct_constructor_without_type_args_is_error`,
   `cargo test generic_enum_type_arg_arity_is_error`,
   `cargo test generic_enum_constructor_without_type_args_is_error`, and
   `cargo test check_program_with_symbols_uses_resolver_type_metadata_for_type_refs`.
@@ -2094,6 +2095,7 @@ and do not assume Phase 4 is ready without evidence.
 - AST type declaration collection now uses a shared type-task push helper
   before replaying generic-bound validation and type registration, covered by
   `cargo test ast_type_declaration_tasks_collect_structs_and_enums`,
+  `cargo test generic_struct_constructor_without_type_args_is_error`,
   `cargo test generic_enum_type_arg_arity_is_error`, and
   `cargo test generic_enum_constructor_without_type_args_is_error`.
 - Behavior declaration collection now uses a shared behavior-task push helper

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -119,6 +119,9 @@ checked-in docs, tests, and commits only.
 - Generic diagnostics now cover generic enum constructor arity failures without
   leaking raw type-parameter payload mismatch followups, including
   `generic_enum_constructor_without_type_args_is_error`.
+- Generic diagnostics now cover generic struct constructor arity failures
+  without leaking raw type-parameter field mismatch followups, including
+  `generic_struct_constructor_without_type_args_is_error`.
 - Generic diagnostics now cover receiver-vs-argument inference conflicts for
   two-parameter `Result<T, E>` enum methods.
 - Generic diagnostics now cover bound failures on `Result<T, E>` enum methods

--- a/src/typechecker/expressions/aggregate_support.rs
+++ b/src/typechecker/expressions/aggregate_support.rs
@@ -73,10 +73,26 @@ impl TypeChecker {
         span: Span,
     ) -> Result<TypedExpression, Diagnostic> {
         let struct_info = self.structs.get(name).cloned();
+        let type_arg_count = struct_info.as_ref().map(|info| info.type_params.len());
+        let type_args_valid = type_arg_count.is_none_or(|expected| expected == type_args.len());
+
         let (type_name, ty, field_defs) = if type_args.is_empty() {
-            let ty = self.resolve_type(&AstType::Named(name.to_string()));
+            let ty = if let Some(expected) = type_arg_count.filter(|expected| *expected > 0) {
+                self.diagnostics.push(Diagnostic::error(
+                    "E5001",
+                    format!(
+                        "generic struct `{}` expects {} type arguments, found 0",
+                        name, expected
+                    ),
+                    span,
+                ));
+                Type::Unknown
+            } else {
+                self.resolve_type(&AstType::Named(name.to_string()))
+            };
             let field_defs = struct_info
                 .as_ref()
+                .filter(|_| type_args_valid)
                 .map(|info| {
                     info.fields
                         .iter()
@@ -98,7 +114,7 @@ impl TypeChecker {
         };
         let mut typed_fields = Vec::new();
         let mut provided = std::collections::HashSet::new();
-        let default_substitutions = if type_args.is_empty() {
+        let default_substitutions = if type_args.is_empty() || !type_args_valid {
             None
         } else {
             struct_info.as_ref().and_then(|info| {
@@ -140,7 +156,7 @@ impl TypeChecker {
                         typed.span,
                     ));
                 }
-            } else if struct_info.is_some() {
+            } else if struct_info.is_some() && type_args_valid {
                 self.diagnostics.push(Diagnostic::error(
                     "E3035",
                     format!("unknown field `{}` for struct `{}`", field_name, name),
@@ -151,7 +167,7 @@ impl TypeChecker {
             typed_fields.push((field_name.clone(), typed));
         }
 
-        if let Some(info) = &struct_info {
+        if let Some(info) = &struct_info.filter(|_| type_args_valid) {
             for (field_name, _) in &info.fields {
                 if !provided.contains(field_name.as_str()) {
                     if let Some(default) = info.field_defaults.get(field_name) {

--- a/tests/docs_truth/phase_audit.rs
+++ b/tests/docs_truth/phase_audit.rs
@@ -95,6 +95,7 @@ fn phase_plan_records_recovered_progress_and_next_slice() {
         "resolver_callable_declaration_metadata_tasks_collect_callable_work",
         "resolver_behavior_impl_block_declaration_tasks_collect_only_behavior_impls",
         "resolver_type_reference_validation_tasks_collect_only_type_reference_work",
+        "generic_struct_constructor_without_type_args_is_error",
         "generic_enum_constructor_without_type_args_is_error",
     ] {
         assert!(
@@ -191,6 +192,7 @@ fn completion_audit_records_recovery_objective_evidence_and_gaps() {
         "resolver_callable_declaration_metadata_tasks_collect_callable_work",
         "resolver_behavior_impl_block_declaration_tasks_collect_only_behavior_impls",
         "resolver_type_reference_validation_tasks_collect_only_type_reference_work",
+        "generic_struct_constructor_without_type_args_is_error",
         "generic_enum_constructor_without_type_args_is_error",
     ] {
         assert!(

--- a/tests/generic_diagnostics/annotations.rs
+++ b/tests/generic_diagnostics/annotations.rs
@@ -221,6 +221,41 @@ main = () i32 {
             .contains("generic struct `Box` expects 1 type arguments, found 2")),
         "expected generic struct arity diagnostic, got {errors:?}"
     );
+    assert!(
+        errors
+            .iter()
+            .all(|d| !d.message.contains("field `value` for struct `Box`")),
+        "malformed generic struct constructor should not also report field mismatch, got {errors:?}"
+    );
+}
+
+#[test]
+fn generic_struct_constructor_without_type_args_is_error() {
+    let errors = typecheck_errors(
+        r#"
+Box<T>: {
+    value: T
+}
+
+main = () i32 {
+    box = Box { value: 1 }
+    box.value
+}
+"#,
+    );
+
+    assert!(
+        errors.iter().any(|d| d
+            .message
+            .contains("generic struct `Box` expects 1 type arguments, found 0")),
+        "expected unspecialized generic struct constructor diagnostic, got {errors:?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .all(|d| !d.message.contains("field `value` for struct `Box`")),
+        "malformed generic struct constructor should not also report field mismatch, got {errors:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add a failing-first generic struct constructor diagnostic case for `Box { ... }` without type arguments.
- Report `E5001` for generic struct constructors missing type arguments and suppress misleading raw type-parameter field mismatch followups.
- Extend existing generic struct constructor arity coverage and record the evidence in phase/audit docs plus docs-truth checks.

## Validation

- `cargo fmt --check`
- `cargo test --test generic_diagnostics generic_struct`
- `cargo test --test generic_diagnostics`
- `cargo test --test docs_truth phase_audit`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`