### PR TITLE
[codex] Harden non-generic constructor type argument diagnostics

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -1995,6 +1995,8 @@ and do not assume Phase 4 is ready without evidence.
   replaying generic-bound validation and type registration, covered by
   `cargo test ast_type_declaration_tasks_collect_structs_and_enums`,
   `cargo test generic_struct_constructor_without_type_args_is_error`,
+  `cargo test nongeneric_struct_constructor_type_args_are_error`,
+  `cargo test nongeneric_enum_constructor_type_args_are_error`,
   `cargo test generic_enum_type_arg_arity_is_error`,
   `cargo test generic_enum_constructor_without_type_args_is_error`, and
   `cargo test check_program_with_symbols_uses_resolver_type_metadata_for_type_refs`.
@@ -2096,6 +2098,8 @@ and do not assume Phase 4 is ready without evidence.
   before replaying generic-bound validation and type registration, covered by
   `cargo test ast_type_declaration_tasks_collect_structs_and_enums`,
   `cargo test generic_struct_constructor_without_type_args_is_error`,
+  `cargo test nongeneric_struct_constructor_type_args_are_error`,
+  `cargo test nongeneric_enum_constructor_type_args_are_error`,
   `cargo test generic_enum_type_arg_arity_is_error`, and
   `cargo test generic_enum_constructor_without_type_args_is_error`.
 - Behavior declaration collection now uses a shared behavior-task push helper

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -122,6 +122,10 @@ checked-in docs, tests, and commits only.
 - Generic diagnostics now cover generic struct constructor arity failures
   without leaking raw type-parameter field mismatch followups, including
   `generic_struct_constructor_without_type_args_is_error`.
+- Generic diagnostics now cover non-generic struct and enum constructors that
+  receive type arguments, including
+  `nongeneric_struct_constructor_type_args_are_error` and
+  `nongeneric_enum_constructor_type_args_are_error`.
 - Generic diagnostics now cover receiver-vs-argument inference conflicts for
   two-parameter `Result<T, E>` enum methods.
 - Generic diagnostics now cover bound failures on `Result<T, E>` enum methods

--- a/src/typechecker/expressions/aggregate_support.rs
+++ b/src/typechecker/expressions/aggregate_support.rs
@@ -75,6 +75,29 @@ impl TypeChecker {
         let struct_info = self.structs.get(name).cloned();
         let type_arg_count = struct_info.as_ref().map(|info| info.type_params.len());
         let type_args_valid = type_arg_count.is_none_or(|expected| expected == type_args.len());
+        if !type_args.is_empty() && type_arg_count == Some(0) {
+            self.diagnostics.push(Diagnostic::error(
+                "E5002",
+                format!(
+                    "non-generic struct `{}` does not accept type arguments",
+                    name
+                ),
+                span,
+            ));
+        } else if let Some(expected) = type_arg_count.filter(|expected| {
+            !type_args.is_empty() && *expected > 0 && *expected != type_args.len()
+        }) {
+            self.diagnostics.push(Diagnostic::error(
+                "E5001",
+                format!(
+                    "generic struct `{}` expects {} type arguments, found {}",
+                    name,
+                    expected,
+                    type_args.len()
+                ),
+                span,
+            ));
+        }
 
         let (type_name, ty, field_defs) = if type_args.is_empty() {
             let ty = if let Some(expected) = type_arg_count.filter(|expected| *expected > 0) {
@@ -105,11 +128,19 @@ impl TypeChecker {
             (name.to_string(), ty, field_defs)
         } else {
             let type_name = self.mangle_generic_type_name(name, type_args);
-            let ty = self.resolve_type(&AstType::Generic {
-                name: name.to_string(),
-                type_args: type_args.to_vec(),
-            });
-            let field_defs = self.specialize_generic_struct(name, type_args, span);
+            let ty = if type_args_valid {
+                self.resolve_type(&AstType::Generic {
+                    name: name.to_string(),
+                    type_args: type_args.to_vec(),
+                })
+            } else {
+                Type::Unknown
+            };
+            let field_defs = if type_args_valid {
+                self.specialize_generic_struct(name, type_args, span)
+            } else {
+                std::collections::HashMap::new()
+            };
             (type_name, ty, field_defs)
         };
         let mut typed_fields = Vec::new();
@@ -240,6 +271,29 @@ impl TypeChecker {
         let enum_info = self.enums.get(enum_name).cloned();
         let type_arg_count = enum_info.as_ref().map(|info| info.type_params.len());
         let type_args_valid = type_arg_count.is_none_or(|expected| expected == type_args.len());
+        if !type_args.is_empty() && type_arg_count == Some(0) {
+            self.diagnostics.push(Diagnostic::error(
+                "E5002",
+                format!(
+                    "non-generic enum `{}` does not accept type arguments",
+                    enum_name
+                ),
+                span,
+            ));
+        } else if let Some(expected) = type_arg_count.filter(|expected| {
+            !type_args.is_empty() && *expected > 0 && *expected != type_args.len()
+        }) {
+            self.diagnostics.push(Diagnostic::error(
+                "E5001",
+                format!(
+                    "generic enum `{}` expects {} type arguments, found {}",
+                    enum_name,
+                    expected,
+                    type_args.len()
+                ),
+                span,
+            ));
+        }
 
         let (type_name, ty, variant_defs) = if type_args.is_empty() {
             let ty = self.resolve_type(&AstType::Named(enum_name.to_string()));
@@ -271,11 +325,19 @@ impl TypeChecker {
             (enum_name.to_string(), ty, variant_defs)
         } else {
             let type_name = self.mangle_generic_type_name(enum_name, type_args);
-            let ty = self.resolve_type(&AstType::Generic {
-                name: enum_name.to_string(),
-                type_args: type_args.to_vec(),
-            });
-            let variant_defs = self.specialize_generic_enum(enum_name, type_args, span);
+            let ty = if type_args_valid {
+                self.resolve_type(&AstType::Generic {
+                    name: enum_name.to_string(),
+                    type_args: type_args.to_vec(),
+                })
+            } else {
+                Type::Unknown
+            };
+            let variant_defs = if type_args_valid {
+                self.specialize_generic_enum(enum_name, type_args, span)
+            } else {
+                std::collections::HashMap::new()
+            };
             (type_name, ty, variant_defs)
         };
         if self.enums.contains_key(enum_name) && type_args_valid {
@@ -330,7 +392,7 @@ impl TypeChecker {
                     ));
                 }
             }
-        } else {
+        } else if !self.enums.contains_key(enum_name) {
             self.diagnostics.push(Diagnostic::error(
                 "E3064",
                 format!("undefined enum `{}`", enum_name),

--- a/tests/docs_truth/phase_audit.rs
+++ b/tests/docs_truth/phase_audit.rs
@@ -96,6 +96,8 @@ fn phase_plan_records_recovered_progress_and_next_slice() {
         "resolver_behavior_impl_block_declaration_tasks_collect_only_behavior_impls",
         "resolver_type_reference_validation_tasks_collect_only_type_reference_work",
         "generic_struct_constructor_without_type_args_is_error",
+        "nongeneric_struct_constructor_type_args_are_error",
+        "nongeneric_enum_constructor_type_args_are_error",
         "generic_enum_constructor_without_type_args_is_error",
     ] {
         assert!(
@@ -193,6 +195,8 @@ fn completion_audit_records_recovery_objective_evidence_and_gaps() {
         "resolver_behavior_impl_block_declaration_tasks_collect_only_behavior_impls",
         "resolver_type_reference_validation_tasks_collect_only_type_reference_work",
         "generic_struct_constructor_without_type_args_is_error",
+        "nongeneric_struct_constructor_type_args_are_error",
+        "nongeneric_enum_constructor_type_args_are_error",
         "generic_enum_constructor_without_type_args_is_error",
     ] {
         assert!(

--- a/tests/generic_diagnostics/annotations.rs
+++ b/tests/generic_diagnostics/annotations.rs
@@ -259,6 +259,35 @@ main = () i32 {
 }
 
 #[test]
+fn nongeneric_struct_constructor_type_args_are_error() {
+    let errors = typecheck_errors(
+        r#"
+Point: {
+    x: i32
+}
+
+main = () i32 {
+    point = Point<i32> { x: 1 }
+    point.x
+}
+"#,
+    );
+
+    assert!(
+        errors.iter().any(|d| d
+            .message
+            .contains("non-generic struct `Point` does not accept type arguments")),
+        "expected non-generic struct constructor type-argument diagnostic, got {errors:?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .all(|d| !d.message.contains("field `x` for struct `Point`")),
+        "malformed non-generic struct constructor should not also report field mismatch, got {errors:?}"
+    );
+}
+
+#[test]
 fn generic_enum_type_arg_arity_is_error() {
     let errors = typecheck_errors(
         r#"
@@ -313,6 +342,35 @@ main = () i32 {
             .iter()
             .all(|d| !d.message.contains("payload for enum variant")),
         "malformed generic enum constructor should not also report payload mismatch, got {errors:?}"
+    );
+}
+
+#[test]
+fn nongeneric_enum_constructor_type_args_are_error() {
+    let errors = typecheck_errors(
+        r#"
+Status:
+    Ready,
+    Done(i32)
+
+main = () i32 {
+    value = Status<i32>.Done(1)
+    0
+}
+"#,
+    );
+
+    assert!(
+        errors.iter().any(|d| d
+            .message
+            .contains("non-generic enum `Status` does not accept type arguments")),
+        "expected non-generic enum constructor type-argument diagnostic, got {errors:?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .all(|d| !d.message.contains("payload for enum variant")),
+        "malformed non-generic enum constructor should not also report payload mismatch, got {errors:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Add failing-first diagnostics for `Point<i32> { ... }` and `Status<i32>.Done(...)` on non-generic types.
- Report clear `E5002` non-generic constructor type-argument errors and suppress misleading field/payload/undefined-enum followups.
- Preserve existing generic constructor arity diagnostics and record the new evidence in phase/audit docs plus docs-truth checks.

## Validation

- `cargo fmt --check`
- `cargo test --test generic_diagnostics nongeneric_`
- `cargo test --test generic_diagnostics`
- `cargo test --test docs_truth phase_audit`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`