### PR TITLE
[codex] Harden non-generic annotation type argument diagnostics

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -1997,6 +1997,8 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test generic_struct_constructor_without_type_args_is_error`,
   `cargo test nongeneric_struct_constructor_type_args_are_error`,
   `cargo test nongeneric_enum_constructor_type_args_are_error`,
+  `cargo test nongeneric_struct_annotation_type_args_are_error`,
+  `cargo test nongeneric_enum_annotation_type_args_are_error`,
   `cargo test generic_enum_type_arg_arity_is_error`,
   `cargo test generic_enum_constructor_without_type_args_is_error`, and
   `cargo test check_program_with_symbols_uses_resolver_type_metadata_for_type_refs`.
@@ -2100,6 +2102,8 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test generic_struct_constructor_without_type_args_is_error`,
   `cargo test nongeneric_struct_constructor_type_args_are_error`,
   `cargo test nongeneric_enum_constructor_type_args_are_error`,
+  `cargo test nongeneric_struct_annotation_type_args_are_error`,
+  `cargo test nongeneric_enum_annotation_type_args_are_error`,
   `cargo test generic_enum_type_arg_arity_is_error`, and
   `cargo test generic_enum_constructor_without_type_args_is_error`.
 - Behavior declaration collection now uses a shared behavior-task push helper

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -126,6 +126,10 @@ checked-in docs, tests, and commits only.
   receive type arguments, including
   `nongeneric_struct_constructor_type_args_are_error` and
   `nongeneric_enum_constructor_type_args_are_error`.
+- Generic diagnostics now cover non-generic struct and enum annotations that
+  receive type arguments, including
+  `nongeneric_struct_annotation_type_args_are_error` and
+  `nongeneric_enum_annotation_type_args_are_error`.
 - Generic diagnostics now cover receiver-vs-argument inference conflicts for
   two-parameter `Result<T, E>` enum methods.
 - Generic diagnostics now cover bound failures on `Result<T, E>` enum methods

--- a/src/typechecker/generic_type_reference_walker.rs
+++ b/src/typechecker/generic_type_reference_walker.rs
@@ -142,6 +142,18 @@ impl TypeChecker {
                         return;
                     };
 
+                if type_params.is_empty() && !type_args.is_empty() {
+                    self.diagnostics.push(Diagnostic::error(
+                        "E5002",
+                        format!(
+                            "non-generic {} `{}` does not accept type arguments",
+                            kind, name
+                        ),
+                        span,
+                    ));
+                    return;
+                }
+
                 if type_params.len() != type_args.len() {
                     self.diagnostics.push(Diagnostic::error(
                         "E5001",

--- a/tests/docs_truth/phase_audit.rs
+++ b/tests/docs_truth/phase_audit.rs
@@ -98,6 +98,8 @@ fn phase_plan_records_recovered_progress_and_next_slice() {
         "generic_struct_constructor_without_type_args_is_error",
         "nongeneric_struct_constructor_type_args_are_error",
         "nongeneric_enum_constructor_type_args_are_error",
+        "nongeneric_struct_annotation_type_args_are_error",
+        "nongeneric_enum_annotation_type_args_are_error",
         "generic_enum_constructor_without_type_args_is_error",
     ] {
         assert!(
@@ -197,6 +199,8 @@ fn completion_audit_records_recovery_objective_evidence_and_gaps() {
         "generic_struct_constructor_without_type_args_is_error",
         "nongeneric_struct_constructor_type_args_are_error",
         "nongeneric_enum_constructor_type_args_are_error",
+        "nongeneric_struct_annotation_type_args_are_error",
+        "nongeneric_enum_annotation_type_args_are_error",
         "generic_enum_constructor_without_type_args_is_error",
     ] {
         assert!(

--- a/tests/generic_diagnostics/annotations.rs
+++ b/tests/generic_diagnostics/annotations.rs
@@ -419,6 +419,62 @@ read = (value: Option<i32, str>) i32 {
 }
 
 #[test]
+fn nongeneric_struct_annotation_type_args_are_error() {
+    let errors = typecheck_errors(
+        r#"
+Point: {
+    x: i32
+}
+
+read = (point: Point<i32>) i32 {
+    0
+}
+"#,
+    );
+
+    assert!(
+        errors.iter().any(|d| d
+            .message
+            .contains("non-generic struct `Point` does not accept type arguments")),
+        "expected non-generic struct annotation type-argument diagnostic, got {errors:?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .all(|d| !d.message.contains("generic struct `Point` expects 0")),
+        "non-generic struct annotation should not use generic arity wording, got {errors:?}"
+    );
+}
+
+#[test]
+fn nongeneric_enum_annotation_type_args_are_error() {
+    let errors = typecheck_errors(
+        r#"
+Status:
+    Ready,
+    Done(i32)
+
+read = (value: Status<i32>) i32 {
+    0
+}
+"#,
+    );
+
+    assert!(
+        errors.iter().any(|d| d
+            .message
+            .contains("non-generic enum `Status` does not accept type arguments")),
+        "expected non-generic enum annotation type-argument diagnostic, got {errors:?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .all(|d| !d.message.contains("generic enum `Status` expects 0")),
+        "non-generic enum annotation should not use generic arity wording, got {errors:?}"
+    );
+}
+
+#[test]
 fn generic_struct_annotation_without_type_args_is_error() {
     let errors = typecheck_errors(
         r#"


### PR DESCRIPTION
## Summary
- Add diagnostics coverage for non-generic struct and enum annotations with explicit type arguments.
- Report `E5002` non-generic annotation type-argument errors instead of `generic ... expects 0` wording.
- Record the new evidence in phase/audit docs and docs-truth checks.

## Local Gates
- `cargo fmt --check`
- `cargo test --test generic_diagnostics annotation_type_args_are_error`
- `cargo test --test generic_diagnostics`
- `cargo test --test docs_truth phase_audit`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`