### PR TITLE
[codex] Harden non-generic behavior type argument diagnostics

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -1999,6 +1999,10 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test nongeneric_enum_constructor_type_args_are_error`,
   `cargo test nongeneric_struct_annotation_type_args_are_error`,
   `cargo test nongeneric_enum_annotation_type_args_are_error`,
+  `cargo test behavior_impl_nongeneric_behavior_type_args_are_error`,
+  `cargo test behavior_requires_nongeneric_behavior_type_args_are_error`,
+  `cargo test behavior_extends_nongeneric_parent_type_args_are_error`,
+  `cargo test generic_bound_nongeneric_behavior_type_args_are_error`,
   `cargo test generic_enum_type_arg_arity_is_error`,
   `cargo test generic_enum_constructor_without_type_args_is_error`, and
   `cargo test check_program_with_symbols_uses_resolver_type_metadata_for_type_refs`.
@@ -2104,6 +2108,10 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test nongeneric_enum_constructor_type_args_are_error`,
   `cargo test nongeneric_struct_annotation_type_args_are_error`,
   `cargo test nongeneric_enum_annotation_type_args_are_error`,
+  `cargo test behavior_impl_nongeneric_behavior_type_args_are_error`,
+  `cargo test behavior_requires_nongeneric_behavior_type_args_are_error`,
+  `cargo test behavior_extends_nongeneric_parent_type_args_are_error`,
+  `cargo test generic_bound_nongeneric_behavior_type_args_are_error`,
   `cargo test generic_enum_type_arg_arity_is_error`, and
   `cargo test generic_enum_constructor_without_type_args_is_error`.
 - Behavior declaration collection now uses a shared behavior-task push helper

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -130,6 +130,12 @@ checked-in docs, tests, and commits only.
   receive type arguments, including
   `nongeneric_struct_annotation_type_args_are_error` and
   `nongeneric_enum_annotation_type_args_are_error`.
+- Generic diagnostics now cover non-generic behavior references that receive
+  type arguments across impls, requires, extends, and generic bounds, including
+  `behavior_impl_nongeneric_behavior_type_args_are_error`,
+  `behavior_requires_nongeneric_behavior_type_args_are_error`,
+  `behavior_extends_nongeneric_parent_type_args_are_error`, and
+  `generic_bound_nongeneric_behavior_type_args_are_error`.
 - Generic diagnostics now cover receiver-vs-argument inference conflicts for
   two-parameter `Result<T, E>` enum methods.
 - Generic diagnostics now cover bound failures on `Result<T, E>` enum methods

--- a/src/typechecker/generic_bound_validation.rs
+++ b/src/typechecker/generic_bound_validation.rs
@@ -20,6 +20,17 @@ impl TypeChecker {
                         .map(|info| info.type_params.len())
                         .unwrap_or(0);
                     let found = param.constraint_type_args.len();
+                    if expected == 0 && found > 0 {
+                        self.diagnostics.push(Diagnostic::error(
+                            "E5002",
+                            format!(
+                                "non-generic behavior `{}` does not accept type arguments",
+                                bound
+                            ),
+                            param.span,
+                        ));
+                        continue;
+                    }
                     if expected != found {
                         self.diagnostics.push(Diagnostic::error(
                             "E6012",

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -456,6 +456,18 @@ impl TypeChecker {
             return None;
         };
 
+        if info.type_params.is_empty() && !type_args.is_empty() {
+            self.diagnostics.push(Diagnostic::error(
+                "E5002",
+                format!(
+                    "non-generic behavior `{}` does not accept type arguments",
+                    behavior
+                ),
+                span,
+            ));
+            return None;
+        }
+
         if info.type_params.len() != type_args.len() {
             self.diagnostics.push(Diagnostic::error(
                 "E5001",

--- a/src/typechecker/tests/generic_behaviors/extends.rs
+++ b/src/typechecker/tests/generic_behaviors/extends.rs
@@ -331,6 +331,39 @@ PrettyJson.extends(Json)
 }
 
 #[test]
+fn behavior_extends_nongeneric_parent_type_args_are_error() {
+    let program = parse_program(
+        r#"
+Json: behavior {
+    encode: (Self) str
+}
+
+PrettyJson: behavior {
+    pretty: (Self) str
+}
+
+PrettyJson.extends(Json<i32>)
+"#,
+    );
+
+    let errors = TypeChecker::new()
+        .check_program(&program)
+        .expect_err("non-generic behavior extends parent with type arguments should fail");
+    assert!(
+        errors.iter().any(|d| d
+            .message
+            .contains("non-generic behavior `Json` does not accept type arguments")),
+        "expected non-generic behavior extends parent type-argument diagnostic, got {errors:?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .all(|d| !d.message.contains("generic behavior `Json` expects 0")),
+        "non-generic behavior extends parent should not use generic arity wording, got {errors:?}"
+    );
+}
+
+#[test]
 fn behavior_extends_conflicting_method_signature_is_error() {
     let program = parse_program(
         r#"

--- a/src/typechecker/tests/generic_behaviors/generic_function_diagnostics.rs
+++ b/src/typechecker/tests/generic_behaviors/generic_function_diagnostics.rs
@@ -134,3 +134,39 @@ main = () i32 {
         "expected generic behavior bound arity diagnostic, got {errors:?}"
     );
 }
+
+#[test]
+fn generic_bound_nongeneric_behavior_type_args_are_error() {
+    let program = parse_program(
+        r#"
+Json: behavior {
+    to_json: (Self) str
+}
+
+encode<T: Json<i32>> = (value: T) str {
+    "encoded"
+}
+
+main = () i32 {
+    0
+}
+"#,
+    );
+
+    let mut tc = TypeChecker::new();
+    let errors = tc
+        .check_program(&program)
+        .expect_err("non-generic behavior bound with type arguments should fail");
+    assert!(
+        errors.iter().any(|d| d
+            .message
+            .contains("non-generic behavior `Json` does not accept type arguments")),
+        "expected non-generic behavior bound type-argument diagnostic, got {errors:?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .all(|d| !d.message.contains("generic behavior `Json` expects 0")),
+        "non-generic behavior bound should not use generic arity wording, got {errors:?}"
+    );
+}

--- a/src/typechecker/tests/generic_behaviors/impls_and_requires.rs
+++ b/src/typechecker/tests/generic_behaviors/impls_and_requires.rs
@@ -128,6 +128,39 @@ Point.implements(Json) {
 }
 
 #[test]
+fn behavior_impl_nongeneric_behavior_type_args_are_error() {
+    let program = parse_program(
+        r#"
+Point: { x: i32 }
+
+Json: behavior {
+    encode: (Self) str
+}
+
+Point.implements(Json<i32>) {
+    encode = (value: Point) str { "point" }
+}
+"#,
+    );
+
+    let errors = TypeChecker::new()
+        .check_program(&program)
+        .expect_err("non-generic behavior impl with type arguments should fail");
+    assert!(
+        errors.iter().any(|d| d
+            .message
+            .contains("non-generic behavior `Json` does not accept type arguments")),
+        "expected non-generic behavior impl type-argument diagnostic, got {errors:?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .all(|d| !d.message.contains("generic behavior `Json` expects 0")),
+        "non-generic behavior impl should not use generic arity wording, got {errors:?}"
+    );
+}
+
+#[test]
 fn behavior_impl_generic_behavior_with_type_args_passes_requires() {
     let program = parse_program(
         r#"
@@ -232,6 +265,37 @@ Point.requires(Json<i32, str>)
             .message
             .contains("generic behavior `Json` expects 1 type arguments, found 2")),
         "expected generic behavior requires arity diagnostic, got {errors:?}"
+    );
+}
+
+#[test]
+fn behavior_requires_nongeneric_behavior_type_args_are_error() {
+    let program = parse_program(
+        r#"
+Point: { x: i32 }
+
+Json: behavior {
+    encode: (Self) str
+}
+
+Point.requires(Json<i32>)
+"#,
+    );
+
+    let errors = TypeChecker::new()
+        .check_program(&program)
+        .expect_err("non-generic behavior requires with type arguments should fail");
+    assert!(
+        errors.iter().any(|d| d
+            .message
+            .contains("non-generic behavior `Json` does not accept type arguments")),
+        "expected non-generic behavior requires type-argument diagnostic, got {errors:?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .all(|d| !d.message.contains("generic behavior `Json` expects 0")),
+        "non-generic behavior requires should not use generic arity wording, got {errors:?}"
     );
 }
 

--- a/tests/docs_truth/phase_audit.rs
+++ b/tests/docs_truth/phase_audit.rs
@@ -100,6 +100,10 @@ fn phase_plan_records_recovered_progress_and_next_slice() {
         "nongeneric_enum_constructor_type_args_are_error",
         "nongeneric_struct_annotation_type_args_are_error",
         "nongeneric_enum_annotation_type_args_are_error",
+        "behavior_impl_nongeneric_behavior_type_args_are_error",
+        "behavior_requires_nongeneric_behavior_type_args_are_error",
+        "behavior_extends_nongeneric_parent_type_args_are_error",
+        "generic_bound_nongeneric_behavior_type_args_are_error",
         "generic_enum_constructor_without_type_args_is_error",
     ] {
         assert!(
@@ -201,6 +205,10 @@ fn completion_audit_records_recovery_objective_evidence_and_gaps() {
         "nongeneric_enum_constructor_type_args_are_error",
         "nongeneric_struct_annotation_type_args_are_error",
         "nongeneric_enum_annotation_type_args_are_error",
+        "behavior_impl_nongeneric_behavior_type_args_are_error",
+        "behavior_requires_nongeneric_behavior_type_args_are_error",
+        "behavior_extends_nongeneric_parent_type_args_are_error",
+        "generic_bound_nongeneric_behavior_type_args_are_error",
         "generic_enum_constructor_without_type_args_is_error",
     ] {
         assert!(


### PR DESCRIPTION
## Summary
- Add failing-first coverage for non-generic behavior references with explicit type arguments across impls, requires, extends, and generic bounds.
- Report `E5002` non-generic behavior type-argument diagnostics instead of `generic behavior ... expects 0` wording.
- Record the new evidence in phase/audit docs and docs-truth checks.

## Local Gates
- `cargo fmt --check`
- `cargo test --lib nongeneric_behavior_type_args_are_error`
- `cargo test --lib behavior_extends_nongeneric_parent_type_args_are_error`
- `cargo test --test docs_truth phase_audit`
- `cargo test --lib generic_behaviors`
- `cargo test --test generic_diagnostics`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`