### PR TITLE
[codex] Validate graph-only library sources before execution

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2315,6 +2315,8 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration build_graph_command_rejects_undeclared_host_effects`
   and
   `cargo test --test integration build_graph_command_multi_target_rejects_undeclared_host_effects`.
+  Graph-only library export source validation before execution is covered by
+  `cargo test --test integration build_graph_command_rejects_missing_graph_only_library_source`.
   Test-only graphs are rejected before execution starts, covered by
   `cargo test --test integration build_graph_command_rejects_graph_without_executable_targets`.
 - Executable build graph targets now execute dependencies before dependents,
@@ -2331,6 +2333,14 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration build_command_build_zen_rejects_gated_test_dependencies`
   and
   `cargo test --test integration test_command_build_zen_rejects_gated_executable_dependencies`.
+- Build/test/emit graph execution validates non-executed graph-only library
+  exports before compiling or running selected targets, covered by
+  `cargo test --test integration build_command_build_zen_rejects_missing_graph_only_library_source`,
+  `cargo test --test integration direct_file_command_build_zen_rejects_missing_graph_only_library_source`,
+  `cargo test --test integration build_graph_command_rejects_missing_graph_only_library_source`,
+  `cargo test --test integration test_command_build_zen_rejects_missing_graph_only_library_source`,
+  and
+  `cargo test --test integration emit_command_build_zen_rejects_missing_graph_only_library_source`.
 - Dependency-ordered build execution still stops before execution when graph
   lowering detects undeclared host effects, covered by
   `cargo test --test integration build_command_build_zen_rejects_undeclared_host_effects_before_dependency_execution`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2089,7 +2089,9 @@ checked-in docs, tests, and commits only.
   and `build_graph_command_multi_target_rejects_undeclared_host_effects` cover
   deterministic host-effect rejection before execution starts,
   `build_graph_command_rejects_graph_without_executable_targets` covers
-  test-only graph rejection before execution starts, and
+  test-only graph rejection before execution starts,
+  `build_graph_command_rejects_missing_graph_only_library_source` covers
+  graph-only library export validation before execution starts, and
   `build_graph_command_rejects_missing_root_source` covers a target execution
   failure before normal `zen build build.zen` is ungated.
 - Normal `zen build build.zen` now routes through the same constrained
@@ -2106,6 +2108,8 @@ checked-in docs, tests, and commits only.
   `build_command_build_zen_rejects_gated_library_dependencies`. They also
   reject executable-target dependencies on gated test targets through
   `build_command_build_zen_rejects_gated_test_dependencies`. They reject
+  graph-only library exports with missing sources through
+  `build_command_build_zen_rejects_missing_graph_only_library_source`, and
   undeclared host effects before dependency-ordered execution through
   `build_command_build_zen_rejects_undeclared_host_effects_before_dependency_execution`.
   The normal build path also rejects undeclared host effects before
@@ -2137,7 +2141,9 @@ checked-in docs, tests, and commits only.
   Test execution also rejects dependencies on gated library targets through
   `test_command_build_zen_rejects_gated_library_dependencies`, and rejects
   test-target dependencies on gated executable targets through
-  `test_command_build_zen_rejects_gated_executable_dependencies`.
+  `test_command_build_zen_rejects_gated_executable_dependencies`. It validates
+  graph-only library exports before execution through
+  `test_command_build_zen_rejects_missing_graph_only_library_source`.
 - Normal `zen emit build.zen` emits generated C for the single executable graph
   target without compiling a binary, covered by
   `emit_command_build_zen_outputs_target_c_source`, rejects ambiguous
@@ -2145,7 +2151,9 @@ checked-in docs, tests, and commits only.
   `emit_command_build_zen_rejects_graph_without_executable_targets` and
   `emit_command_build_zen_rejects_multiple_executable_targets`, and rejects
   undeclared host effects through
-  `emit_command_build_zen_rejects_undeclared_host_effects`.
+  `emit_command_build_zen_rejects_undeclared_host_effects`. It validates
+  graph-only library exports before emission through
+  `emit_command_build_zen_rejects_missing_graph_only_library_source`.
 - Direct `zen build.zen` now aliases the same constrained deterministic graph
   build path as `zen build build.zen`, covered by
   `direct_file_command_build_zen_routes_through_deterministic_graph`, and
@@ -2156,6 +2164,8 @@ checked-in docs, tests, and commits only.
   rejects dependencies on gated library and test targets through
   `direct_file_command_build_zen_rejects_gated_library_dependencies` and
   `direct_file_command_build_zen_rejects_gated_test_dependencies`,
+  rejects graph-only library exports with missing sources through
+  `direct_file_command_build_zen_rejects_missing_graph_only_library_source`,
   rejects test-only graphs before execution starts through
   `direct_file_command_build_zen_rejects_graph_without_executable_targets`,
   and rejects undeclared host effects for single-target and multi-target graphs

--- a/src/cli/build_graph_execution.rs
+++ b/src/cli/build_graph_execution.rs
@@ -52,6 +52,7 @@ pub(super) fn test_build_targets(path_str: &str) -> Vec<BuildGraphTestTarget> {
     validate_executed_dependency_targets(&graph, BuildGraphExecutionKind::Test);
     let build_path = Path::new(path_str);
     let base_dir = build_path.parent().unwrap_or_else(|| Path::new("."));
+    validate_non_executed_target_sources(base_dir, &graph, BuildGraphExecutionKind::Test);
     let ordered_targets = match graph.targets_in_dependency_order() {
         Ok(targets) => targets,
         Err(err) => {
@@ -84,6 +85,7 @@ fn collect_executable_build_targets(path_str: &str) -> Vec<BuildGraphExecutableT
     validate_executed_dependency_targets(&graph, BuildGraphExecutionKind::Executable);
     let build_path = Path::new(path_str);
     let base_dir = build_path.parent().unwrap_or_else(|| Path::new("."));
+    validate_non_executed_target_sources(base_dir, &graph, BuildGraphExecutionKind::Executable);
     let ordered_targets = match graph.targets_in_dependency_order() {
         Ok(targets) => targets,
         Err(err) => {
@@ -133,6 +135,29 @@ fn validate_executed_dependency_targets(
 
 pub(super) fn validate_build_graph_sources(base_dir: &Path, graph: &zen::build_graph::BuildGraph) {
     for target in graph.targets() {
+        for source in target.sources() {
+            if !base_dir.join(source).exists() {
+                eprintln!(
+                    "build graph target `{}` source not found: {}",
+                    target.name(),
+                    source
+                );
+                process::exit(1);
+            }
+        }
+    }
+}
+
+fn validate_non_executed_target_sources(
+    base_dir: &Path,
+    graph: &zen::build_graph::BuildGraph,
+    execution_kind: BuildGraphExecutionKind,
+) {
+    for target in graph
+        .targets()
+        .iter()
+        .filter(|target| !execution_kind.includes(target.kind()))
+    {
         for source in target.sources() {
             if !base_dir.join(source).exists() {
                 eprintln!(

--- a/tests/integration/cli_build/build_command.rs
+++ b/tests/integration/cli_build/build_command.rs
@@ -161,6 +161,54 @@ main = () i32 {
 }
 
 #[test]
+fn build_command_build_zen_rejects_missing_graph_only_library_source() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    b.add(Library { name: "core", exports: ["missing_lib.zen"] })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen build build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("build graph target `core` source not found: missing_lib.zen"),
+        "expected missing graph-only library source diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "build command should not start after graph source validation fails"
+    );
+}
+
+#[test]
 fn build_command_build_zen_rejects_gated_test_dependencies() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(

--- a/tests/integration/cli_build/direct_build_graph_execution.rs
+++ b/tests/integration/cli_build/direct_build_graph_execution.rs
@@ -307,6 +307,54 @@ main = () i32 {
 }
 
 #[test]
+fn direct_file_command_build_zen_rejects_missing_graph_only_library_source() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    b.add(Library { name: "core", exports: ["missing_lib.zen"] })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .arg("build.zen")
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("build graph target `core` source not found: missing_lib.zen"),
+        "expected missing graph-only library source diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "direct build.zen command should not start after graph source validation fails"
+    );
+}
+
+#[test]
 fn direct_file_command_build_zen_rejects_gated_test_dependencies() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(

--- a/tests/integration/cli_build/emit_direct.rs
+++ b/tests/integration/cli_build/emit_direct.rs
@@ -151,6 +151,54 @@ main = () i32 {
 }
 
 #[test]
+fn emit_command_build_zen_rejects_missing_graph_only_library_source() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    b.add(Library { name: "core", exports: ["missing_lib.zen"] })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen emit build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen emit build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("build graph target `core` source not found: missing_lib.zen"),
+        "expected missing graph-only library source diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "zen emit build.zen should not create build outputs after graph source validation fails"
+    );
+}
+
+#[test]
 fn emit_command_build_zen_rejects_undeclared_host_effects() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(

--- a/tests/integration/cli_build/graph_validation_test_command.rs
+++ b/tests/integration/cli_build/graph_validation_test_command.rs
@@ -384,6 +384,54 @@ main = () i32 {
 }
 
 #[test]
+fn test_command_build_zen_rejects_missing_graph_only_library_source() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Test { name: "unit", root: "test.zen" })
+    b.add(Library { name: "core", exports: ["missing_lib.zen"] })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("test.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write test.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["test", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen test build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen test build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("build graph target `core` source not found: missing_lib.zen"),
+        "expected missing graph-only library source diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "test command should not start after graph source validation fails"
+    );
+}
+
+#[test]
 fn test_command_build_zen_rejects_gated_executable_dependencies() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(

--- a/tests/integration/cli_build/legacy_graph_command.rs
+++ b/tests/integration/cli_build/legacy_graph_command.rs
@@ -390,6 +390,54 @@ main = () i32 {
 }
 
 #[test]
+fn build_graph_command_rejects_missing_graph_only_library_source() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    b.add(Library { name: "core", exports: ["missing_lib.zen"] })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build-graph", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build-graph");
+
+    assert!(
+        !output.status.success(),
+        "zen build-graph unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("build graph target `core` source not found: missing_lib.zen"),
+        "expected missing graph-only library source diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "build-graph command should not start after graph source validation fails"
+    );
+}
+
+#[test]
 fn build_graph_command_rejects_missing_root_source() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(


### PR DESCRIPTION
## Summary

- Validate source files for non-executed graph targets before build/test/emit graph execution starts.
- Preserve existing root-source diagnostics for executable and test targets that are actually compiled or run.
- Add regression coverage for graph-only library exports with missing sources across `zen build build.zen`, direct `zen build.zen`, `build-graph`, `zen test build.zen`, and `zen emit build.zen`.
- Record the new build-driver evidence in the phase plan and completion audit.

## Impact

This keeps constrained `build.zen` execution consistent with graph validation: graph-only library targets are still not executed, but missing library export files now stop execution before selected targets are compiled or run.

## Validation

- `cargo test --test integration missing_graph_only_library_source` initially failed before the implementation and passes now.
- `cargo test --test integration build_graph_command_rejects_missing_root_source`
- `cargo test --test integration graph_without`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`