### PR TITLE
[codex] Report emit graph ambiguity before source validation

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2341,6 +2341,9 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration test_command_build_zen_rejects_missing_graph_only_library_source`,
   and
   `cargo test --test integration emit_command_build_zen_rejects_missing_graph_only_library_source`.
+- Single-target `zen emit build.zen` rejects multi-executable ambiguity before
+  per-executable source validation, covered by
+  `cargo test --test integration emit_command_build_zen_reports_multi_target_ambiguity_before_missing_executable_source`.
 - Dependency-ordered build execution still stops before execution when graph
   lowering detects undeclared host effects, covered by
   `cargo test --test integration build_command_build_zen_rejects_undeclared_host_effects_before_dependency_execution`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2153,7 +2153,9 @@ checked-in docs, tests, and commits only.
   undeclared host effects through
   `emit_command_build_zen_rejects_undeclared_host_effects`. It validates
   graph-only library exports before emission through
-  `emit_command_build_zen_rejects_missing_graph_only_library_source`.
+  `emit_command_build_zen_rejects_missing_graph_only_library_source`, while
+  `emit_command_build_zen_reports_multi_target_ambiguity_before_missing_executable_source`
+  keeps multi-executable ambiguity ahead of per-executable source checks.
 - Direct `zen build.zen` now aliases the same constrained deterministic graph
   build path as `zen build build.zen`, covered by
   `direct_file_command_build_zen_routes_through_deterministic_graph`, and

--- a/src/cli/build_graph_execution.rs
+++ b/src/cli/build_graph_execution.rs
@@ -35,16 +35,36 @@ impl BuildGraphExecutionKind {
 }
 
 pub(super) fn single_executable_build_target(path_str: &str) -> BuildGraphExecutableTarget {
-    let mut targets = collect_executable_build_targets(path_str);
-    if targets.len() != 1 {
+    let graph = super::load_build_graph(path_str);
+    validate_executed_dependency_targets(&graph, BuildGraphExecutionKind::Executable);
+    let build_path = Path::new(path_str);
+    let base_dir = build_path.parent().unwrap_or_else(|| Path::new("."));
+    validate_non_executed_target_sources(base_dir, &graph, BuildGraphExecutionKind::Executable);
+    let ordered_targets = match graph.targets_in_dependency_order() {
+        Ok(targets) => targets,
+        Err(err) => {
+            eprintln!("build graph error: {}", err);
+            process::exit(1);
+        }
+    };
+    let executable_targets: Vec<_> = ordered_targets
+        .into_iter()
+        .filter(|target| {
+            matches!(
+                target.kind(),
+                zen::build_graph::BuildTargetKind::Executable { .. }
+            )
+        })
+        .collect();
+    if executable_targets.len() != 1 {
         eprintln!(
             "build graph C emission supports exactly one target, found {}",
-            targets.len()
+            executable_targets.len()
         );
         process::exit(1);
     }
 
-    targets.pop().expect("one target")
+    executable_build_target(base_dir, executable_targets[0]).expect("one executable target")
 }
 
 pub(super) fn test_build_targets(path_str: &str) -> Vec<BuildGraphTestTarget> {

--- a/tests/integration/cli_build/emit_direct.rs
+++ b/tests/integration/cli_build/emit_direct.rs
@@ -104,6 +104,57 @@ main = () i32 {
 }
 
 #[test]
+fn emit_command_build_zen_reports_multi_target_ambiguity_before_missing_executable_source() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    b.add(Executable { name: "tool", main: "missing_tool.zen", out_dir: "build/tool/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen emit build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen emit build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("build graph C emission supports exactly one target, found 2"),
+        "expected single-target emit diagnostic before source validation, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("missing_tool.zen"),
+        "emit should reject ambiguous executable graphs before per-target source validation, stderr={stderr}"
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "zen emit build.zen should not create build outputs when graph emission is ambiguous"
+    );
+}
+
+#[test]
 fn emit_command_build_zen_rejects_graph_without_executable_targets() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(


### PR DESCRIPTION
## Summary
- Count executable graph targets for `zen emit build.zen` before materializing target roots.
- Preserve graph-only library source validation and existing single-target root-source diagnostics.
- Add a regression for a multi-executable graph where an extra executable source is missing.
- Update the phase and audit docs with the new coverage.

## Validation
- `cargo test --test integration emit_command_build_zen_reports_multi_target_ambiguity_before_missing_executable_source`
- `cargo test --test integration cli_build::emit_direct`
- `cargo test --test integration missing_graph_only_library_source`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`