### PR TITLE
[codex] Split CLI diagnostic rendering

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2369,6 +2369,11 @@ and do not assume Phase 4 is ready without evidence.
   to typechecker state/orchestration while retaining focused resolver metadata
   restoration coverage such as
   `cargo test --lib resolver_behavior_methods_from_metadata_preserves_defaults_by_resolver_order`.
+- `src/cli.rs` no longer owns diagnostic rendering directly. Compile-error and
+  diagnostic printing helpers live in `src/cli/diagnostics.rs`, reducing the
+  root CLI module below the 500-line cleanup threshold while preserving
+  command diagnostic coverage through
+  `cargo test --test integration cli_build::diagnostics`.
 
 ## Unresolved Gaps
 

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2200,6 +2200,9 @@ checked-in docs, tests, and commits only.
   live in `src/typechecker/resolver_metadata_collection.rs`, keeping
   `src/typechecker/mod.rs` focused on state and orchestration while preserving
   the existing resolver metadata restoration tests.
+- CLI diagnostic rendering now lives in `src/cli/diagnostics.rs`, keeping the
+  root `src/cli.rs` module focused on command dispatch and execution while
+  preserving the existing CLI diagnostic integration tests.
 
 ## Current Phase
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,11 +2,13 @@ use std::path::{Path, PathBuf};
 use std::process;
 
 mod build_graph_execution;
+mod diagnostics;
 
 use build_graph_execution::{
     executable_build_targets, single_executable_build_target, test_build_targets,
     validate_build_graph_sources,
 };
+use diagnostics::{print_diagnostic, print_errors};
 use zen::codegen::c::CBackend;
 use zen::codegen::Backend;
 use zen::error::FileTable;
@@ -469,46 +471,5 @@ fn reject_build_zen_for_emit_json_mode(path_str: &str) {
             "error: this emit-json mode does not support build.zen; use `emit-json build-graph`"
         );
         process::exit(1);
-    }
-}
-
-fn print_errors(errs: &[zen::error::CompileError], files: &FileTable) {
-    for err in errs {
-        let diag: zen::error::Diagnostic = err.clone().into();
-        print_diagnostic(&diag, files);
-    }
-}
-
-fn print_diagnostic(diag: &zen::error::Diagnostic, files: &FileTable) {
-    let severity = match diag.severity {
-        zen::error::Severity::Error => "error",
-        zen::error::Severity::Warning => "warning",
-        zen::error::Severity::Info => "info",
-        zen::error::Severity::Hint => "hint",
-    };
-
-    if let Some(span) = diag.span {
-        let path = files.get_path(span.file_id).unwrap_or("<unknown>");
-        if let Some((line, col)) = files.line_col(span.file_id, span.start) {
-            eprintln!(
-                "{}:{}:{}: {}: {}",
-                path,
-                line + 1,
-                col + 1,
-                severity,
-                diag.message
-            );
-        } else {
-            eprintln!("{}: {}: {}", path, severity, diag.message);
-        }
-    } else {
-        eprintln!("{}: {}", severity, diag.message);
-    }
-
-    for label in &diag.labels {
-        let path = files.get_path(label.span.file_id).unwrap_or("<unknown>");
-        if let Some((line, col)) = files.line_col(label.span.file_id, label.span.start) {
-            eprintln!("  --> {}:{}:{}: {}", path, line + 1, col + 1, label.message);
-        }
     }
 }

--- a/src/cli/diagnostics.rs
+++ b/src/cli/diagnostics.rs
@@ -1,0 +1,42 @@
+use zen::error::{CompileError, Diagnostic, FileTable, Severity};
+
+pub(super) fn print_errors(errs: &[CompileError], files: &FileTable) {
+    for err in errs {
+        let diag: Diagnostic = err.clone().into();
+        print_diagnostic(&diag, files);
+    }
+}
+
+pub(super) fn print_diagnostic(diag: &Diagnostic, files: &FileTable) {
+    let severity = match diag.severity {
+        Severity::Error => "error",
+        Severity::Warning => "warning",
+        Severity::Info => "info",
+        Severity::Hint => "hint",
+    };
+
+    if let Some(span) = diag.span {
+        let path = files.get_path(span.file_id).unwrap_or("<unknown>");
+        if let Some((line, col)) = files.line_col(span.file_id, span.start) {
+            eprintln!(
+                "{}:{}:{}: {}: {}",
+                path,
+                line + 1,
+                col + 1,
+                severity,
+                diag.message
+            );
+        } else {
+            eprintln!("{}: {}: {}", path, severity, diag.message);
+        }
+    } else {
+        eprintln!("{}: {}", severity, diag.message);
+    }
+
+    for label in &diag.labels {
+        let path = files.get_path(label.span.file_id).unwrap_or("<unknown>");
+        if let Some((line, col)) = files.line_col(label.span.file_id, label.span.start) {
+            eprintln!("  --> {}:{}:{}: {}", path, line + 1, col + 1, label.message);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Move CLI compile-error and diagnostic rendering helpers from `src/cli.rs` into `src/cli/diagnostics.rs`.
- Keep the root CLI module focused on command dispatch and execution; `src/cli.rs` is now below the 500-line cleanup threshold.
- Update the phase plan and completion audit with the cleanup evidence.

## Validation

- `cargo test --test integration cli_build::diagnostics`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`