### PR TITLE
[codex] Split expression function checking

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2384,6 +2384,13 @@ and do not assume Phase 4 is ready without evidence.
   `call_support.rs` to direct function-call handling while preserving generic
   method and UFC coverage through `cargo test --lib generic_method` and the
   `single_file_fixtures::test_generic_method*` integration filters.
+- Expression function checking now lives in
+  `src/typechecker/expressions/function_checking.rs`, reducing
+  `expressions.rs` below the 500-line cleanup threshold while preserving
+  return/fallthrough and defer behavior through
+  `cargo test --lib return_type_mismatch_error`,
+  `cargo test --lib non_void_function_without_return_is_error`, and
+  `cargo test --test integration runtime_fixtures::test_defer_early_return`.
 
 ## Unresolved Gaps
 

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2210,6 +2210,10 @@ checked-in docs, tests, and commits only.
   `src/typechecker/expressions/method_call_support.rs`, keeping direct
   function-call checking separate from method, generic-method, and UFC
   resolution while preserving generic method fixture coverage.
+- Expression function checking now lives in
+  `src/typechecker/expressions/function_checking.rs`, keeping
+  `src/typechecker/expressions.rs` focused on expression dispatch while
+  preserving return/fallthrough and defer coverage.
 
 ## Current Phase
 

--- a/src/typechecker/expressions.rs
+++ b/src/typechecker/expressions.rs
@@ -5,6 +5,7 @@ mod aggregate_support;
 mod call_support;
 mod call_validation;
 mod control_flow_support;
+mod function_checking;
 mod method_call_support;
 
 use crate::ast::expressions::StringPart;
@@ -17,90 +18,6 @@ use super::monomorphize_inference::InferenceConflict;
 use super::{BehaviorBound, TypeChecker};
 
 impl TypeChecker {
-    pub(crate) fn check_function(
-        &mut self,
-        name: &str,
-        params: &[Param],
-        return_type: &Option<AstType>,
-        body: &Expression,
-        _span: &Span,
-    ) -> Result<TypedFunction, Diagnostic> {
-        let ret_type = return_type
-            .as_ref()
-            .map(|t| self.resolve_type(t))
-            .unwrap_or(Type::Void);
-
-        self.current_return_type = Some(ret_type.clone());
-
-        // Push function scope with params
-        self.push_scope();
-        let mut typed_params = Vec::new();
-        for p in params {
-            let ty = self.resolve_type(&p.ty);
-            self.define_var(&p.name, ty.clone());
-            typed_params.push(TypedParam {
-                name: p.name.clone(),
-                ty,
-                span: p.span,
-            });
-        }
-
-        let typed_body = self.check_expr(body)?;
-        let body_block = match typed_body.kind {
-            TypedExprKind::Block(block) => block,
-            _ => TypedBlock {
-                ty: typed_body.ty.clone(),
-                span: typed_body.span,
-                statements: Vec::new(),
-                expr: Some(Box::new(typed_body)),
-            },
-        };
-
-        self.pop_scope();
-        self.current_return_type = None;
-
-        if ret_type != Type::Void && ret_type != Type::Never {
-            if let Some(expr) = &body_block.expr {
-                if expr.ty != Type::Never && !self.types_compatible(&ret_type, &expr.ty) {
-                    return Err(Diagnostic::error(
-                        "E3030",
-                        format!(
-                            "return type mismatch: expected `{}`, found `{}`",
-                            ret_type.display_name(),
-                            expr.ty.display_name()
-                        ),
-                        expr.span,
-                    ));
-                }
-            }
-
-            if !self.block_satisfies_return(&body_block, &ret_type) {
-                return Err(Diagnostic::error(
-                    "E3031",
-                    format!(
-                        "function `{}` must return `{}` on all non-error paths",
-                        name,
-                        ret_type.display_name()
-                    ),
-                    *_span,
-                ));
-            }
-        }
-
-        // Collect defers accumulated during this function's body (LIFO order)
-        let mut defers: Vec<TypedExpression> = self.pending_defers.drain(..).collect();
-        defers.reverse();
-
-        Ok(TypedFunction {
-            name: name.to_string(),
-            params: typed_params,
-            return_type: ret_type,
-            body: body_block,
-            defers,
-            span: *_span,
-        })
-    }
-
     pub(crate) fn check_expr(&mut self, expr: &Expression) -> Result<TypedExpression, Diagnostic> {
         match expr {
             Expression::IntLiteral { value, span } => Ok(TypedExpression {

--- a/src/typechecker/expressions/function_checking.rs
+++ b/src/typechecker/expressions/function_checking.rs
@@ -1,0 +1,85 @@
+use super::*;
+
+impl TypeChecker {
+    pub(crate) fn check_function(
+        &mut self,
+        name: &str,
+        params: &[Param],
+        return_type: &Option<AstType>,
+        body: &Expression,
+        span: &Span,
+    ) -> Result<TypedFunction, Diagnostic> {
+        let ret_type = return_type
+            .as_ref()
+            .map(|ty| self.resolve_type(ty))
+            .unwrap_or(Type::Void);
+
+        self.current_return_type = Some(ret_type.clone());
+
+        self.push_scope();
+        let mut typed_params = Vec::new();
+        for param in params {
+            let ty = self.resolve_type(&param.ty);
+            self.define_var(&param.name, ty.clone());
+            typed_params.push(TypedParam {
+                name: param.name.clone(),
+                ty,
+                span: param.span,
+            });
+        }
+
+        let typed_body = self.check_expr(body)?;
+        let body_block = match typed_body.kind {
+            TypedExprKind::Block(block) => block,
+            _ => TypedBlock {
+                ty: typed_body.ty.clone(),
+                span: typed_body.span,
+                statements: Vec::new(),
+                expr: Some(Box::new(typed_body)),
+            },
+        };
+
+        self.pop_scope();
+        self.current_return_type = None;
+
+        if ret_type != Type::Void && ret_type != Type::Never {
+            if let Some(expr) = &body_block.expr {
+                if expr.ty != Type::Never && !self.types_compatible(&ret_type, &expr.ty) {
+                    return Err(Diagnostic::error(
+                        "E3030",
+                        format!(
+                            "return type mismatch: expected `{}`, found `{}`",
+                            ret_type.display_name(),
+                            expr.ty.display_name()
+                        ),
+                        expr.span,
+                    ));
+                }
+            }
+
+            if !self.block_satisfies_return(&body_block, &ret_type) {
+                return Err(Diagnostic::error(
+                    "E3031",
+                    format!(
+                        "function `{}` must return `{}` on all non-error paths",
+                        name,
+                        ret_type.display_name()
+                    ),
+                    *span,
+                ));
+            }
+        }
+
+        let mut defers: Vec<TypedExpression> = self.pending_defers.drain(..).collect();
+        defers.reverse();
+
+        Ok(TypedFunction {
+            name: name.to_string(),
+            params: typed_params,
+            return_type: ret_type,
+            body: body_block,
+            defers,
+            span: *span,
+        })
+    }
+}


### PR DESCRIPTION
## Summary

- Move `check_function` into `src/typechecker/expressions/function_checking.rs`.
- Keep `src/typechecker/expressions.rs` focused on expression dispatch and reduce it below the cleanup threshold.
- Update the phase plan and completion audit with the split evidence.

## Validation

- `cargo test --lib return_type_mismatch_error`
- `cargo test --lib non_void_function_without_return_is_error`
- `cargo test --test integration runtime_fixtures::test_defer_early_return`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`