### PR TITLE
[codex] Run CI only for PR readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,8 @@
 name: CI
 
 on:
-  push:
-    branches: [master, rewrite]
   pull_request:
+    branches: [master]
     types: [opened, reopened, ready_for_review]
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- stop running CI on branch pushes to `master` or `rewrite`
- keep CI on PR open/reopen/ready-for-review events, scoped to `master`
- preserve manual `workflow_dispatch`

## Verification
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`