### PR TITLE
[codex] Typecheck build graph sources on check

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2356,6 +2356,12 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration test_command_build_zen_rejects_missing_graph_only_library_source`,
   and
   `cargo test --test integration emit_command_build_zen_rejects_missing_graph_only_library_source`.
+- `zen check build.zen` typechecks graph target sources after deterministic
+  graph/source validation and before reporting the graph summary, covered by
+  `cargo test --test integration check_command_build_zen_typechecks_target_sources`.
+  Undeclared host effects still reject before target source typechecking,
+  covered by
+  `cargo test --test integration check_command_build_zen_rejects_undeclared_host_effects_before_target_typechecking`.
 - Single-target `zen emit build.zen` rejects multi-executable ambiguity before
   per-executable source validation, covered by
   `cargo test --test integration emit_command_build_zen_reports_multi_target_ambiguity_before_missing_executable_source`.
@@ -2401,13 +2407,13 @@ and do not assume Phase 4 is ready without evidence.
   graph emission, multi-executable target execution for normal
   `zen build build.zen` and direct `zen build.zen`, dependency-ordered
   executable target execution for normal `zen build build.zen`, normal
-  `zen test build.zen` test-target execution, normal `zen check build.zen`,
-  test and library target graph lowering/emission, and single-target normal
-  `zen emit build.zen`, while build/test execution rejects dependencies on
-  gated library targets and legacy generic `emit-json` build.zen modes have a
-  targeted rejection. Library execution, package/link semantics, and other
-  broader graph semantics still need explicit deterministic semantics before
-  promotion.
+  `zen test build.zen` test-target execution, normal `zen check build.zen`
+  graph/source validation plus target source typechecking, test and library
+  target graph lowering/emission, and single-target normal `zen emit build.zen`,
+  while build/test execution rejects dependencies on gated library targets and
+  legacy generic `emit-json` build.zen modes have a targeted rejection. Library
+  execution, package/link semantics, and other broader graph semantics still
+  need explicit deterministic semantics before promotion.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2134,13 +2134,18 @@ checked-in docs, tests, and commits only.
   `build_command_build_zen_rejects_undeclared_host_effects`.
 - Normal `zen check build.zen` validates the same constrained deterministic
   graph without compiling targets, covered by
-  `check_command_validates_build_zen_graph`. It rejects missing executable,
-  test, and library sources through
+  `check_command_validates_build_zen_graph`. It typechecks graph target
+  sources without compiling them through
+  `check_command_build_zen_typechecks_target_sources`. It rejects missing
+  executable, test, and library sources through
   `check_command_build_zen_rejects_missing_executable_source`,
   `check_command_build_zen_rejects_missing_test_source`, and
   `check_command_build_zen_rejects_missing_library_source`, and rejects
   undeclared host effects before source validation through
   `check_command_build_zen_rejects_undeclared_host_effects_before_source_validation`.
+  It also rejects undeclared host effects before target source typechecking
+  through
+  `check_command_build_zen_rejects_undeclared_host_effects_before_target_typechecking`.
   The single-target host-effect rejection remains covered by
   `check_command_build_zen_rejects_undeclared_host_effects`.
 - Normal `zen test build.zen` compiles and runs test graph targets, covered by
@@ -2223,9 +2228,10 @@ Phase 4 build-driver work still has constrained `build.zen` semantics: normal
 `zen build build.zen` and direct `zen build.zen` execute multiple executable
 graph targets, `zen test build.zen` executes multiple test graph targets,
 `zen check build.zen` validates executable, test, and library targets in the
-graph, `zen emit build.zen` emits target C for a single executable graph target,
-and build/test execution rejects dependencies on gated library targets while
-library execution remains gated. Legacy generic JSON emitters reject
+graph and typechecks target sources without compiling them, `zen emit build.zen`
+emits target C for a single executable graph target, and build/test execution
+rejects dependencies on gated library targets while library execution remains
+gated. Legacy generic JSON emitters reject
 `build.zen` and point to
 `emit-json build-graph`.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::process;
 
@@ -109,6 +110,7 @@ fn cmd_check(path_str: &str) {
         let build_path = Path::new(path_str);
         let base_dir = build_path.parent().unwrap_or_else(|| Path::new("."));
         validate_build_graph_sources(base_dir, &graph);
+        check_build_graph_sources(base_dir, &graph);
         println!("  {} build targets — ok", graph.targets().len());
         return;
     }
@@ -119,6 +121,23 @@ fn cmd_check(path_str: &str) {
         typed.functions.len(),
         typed.types.len()
     );
+}
+
+fn check_build_graph_sources(base_dir: &Path, graph: &zen::build_graph::BuildGraph) {
+    let mut source_paths = BTreeSet::new();
+    for target in graph.targets() {
+        for source in target.sources() {
+            source_paths.insert(base_dir.join(source));
+        }
+    }
+
+    for source_path in source_paths {
+        let source_path = source_path.to_str().unwrap_or_else(|| {
+            eprintln!("error: non-utf8 source path: {}", source_path.display());
+            process::exit(1);
+        });
+        graph_frontend(source_path);
+    }
 }
 
 fn load_module_graph(path_str: &str) -> (zen::module_system::ResolvedModuleGraph, FileTable) {

--- a/tests/integration/cli_build/graph_validation.rs
+++ b/tests/integration/cli_build/graph_validation.rs
@@ -43,6 +43,49 @@ main = () i32 {
 }
 
 #[test]
+fn check_command_build_zen_typechecks_target_sources() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("main.zen"),
+        r#"
+main = () i32 {
+    true
+}
+"#,
+    )
+    .expect("write main.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["check", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen check build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen check build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("return type mismatch: expected `i32`, found `bool`"),
+        "expected target source type diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn check_command_build_zen_rejects_missing_executable_source() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(
@@ -259,5 +302,52 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
     assert!(
         !stderr.contains("source not found"),
         "host-effect validation should run before source validation, stderr={stderr}"
+    );
+}
+
+#[test]
+fn check_command_build_zen_rejects_undeclared_host_effects_before_target_typechecking() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    std_path = b.os.env("ZEN_STD")
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("main.zen"),
+        r#"
+main = () i32 {
+    true
+}
+"#,
+    )
+    .expect("write main.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["check", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen check build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen check build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("undeclared host effect: read env `ZEN_STD`"),
+        "expected undeclared host effect diagnostic, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("return type mismatch"),
+        "host-effect validation should run before target typechecking, stderr={stderr}"
     );
 }


### PR DESCRIPTION
## Summary
- make `zen check build.zen` typecheck all graph target sources after deterministic graph/source validation
- keep undeclared host-effect rejection ahead of target source typechecking
- record the new build-driver evidence in the phase plan and completion audit

## Verification
- `cargo test --test integration check_command_build_zen_typechecks_target_sources`
- `cargo test --test integration check_command_build_zen_rejects_undeclared_host_effects_before_target_typechecking`
- `cargo test --test integration cli_build::graph_validation`
- `cargo test --test docs_truth`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`