### PR TITLE
[codex] Typecheck graph-only library sources before execution

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2356,6 +2356,14 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration test_command_build_zen_rejects_missing_graph_only_library_source`,
   and
   `cargo test --test integration emit_command_build_zen_rejects_missing_graph_only_library_source`.
+  Graph-only library exports are also typechecked before build/test/emit
+  execution starts, covered by
+  `cargo test --test integration build_command_build_zen_accepts_valid_graph_only_library_sources`,
+  `cargo test --test integration build_command_build_zen_rejects_graph_only_library_type_errors`,
+  `cargo test --test integration build_command_build_zen_rejects_undeclared_host_effects_before_library_typechecking`,
+  `cargo test --test integration test_command_build_zen_rejects_graph_only_library_type_errors`,
+  and
+  `cargo test --test integration emit_command_build_zen_rejects_graph_only_library_type_errors`.
 - `zen check build.zen` typechecks graph target sources after deterministic
   graph/source validation and before reporting the graph summary, covered by
   `cargo test --test integration check_command_build_zen_typechecks_target_sources`.
@@ -2408,12 +2416,14 @@ and do not assume Phase 4 is ready without evidence.
   `zen build build.zen` and direct `zen build.zen`, dependency-ordered
   executable target execution for normal `zen build build.zen`, normal
   `zen test build.zen` test-target execution, normal `zen check build.zen`
-  graph/source validation plus target source typechecking, test and library
-  target graph lowering/emission, and single-target normal `zen emit build.zen`,
-  while build/test execution rejects dependencies on gated library targets and
-  legacy generic `emit-json` build.zen modes have a targeted rejection. Library
-  execution, package/link semantics, and other broader graph semantics still
-  need explicit deterministic semantics before promotion.
+  graph/source validation plus target source typechecking, graph-only library
+  source validation and typechecking before build/test/emit execution, test and
+  library target graph lowering/emission, and single-target normal
+  `zen emit build.zen`, while build/test execution rejects dependencies on
+  gated library targets and legacy generic `emit-json` build.zen modes have a
+  targeted rejection. Library execution, package/link semantics, and other
+  broader graph semantics still need explicit deterministic semantics before
+  promotion.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2124,7 +2124,15 @@ checked-in docs, tests, and commits only.
   reject executable-target dependencies on gated test targets through
   `build_command_build_zen_rejects_gated_test_dependencies`. They reject
   graph-only library exports with missing sources through
-  `build_command_build_zen_rejects_missing_graph_only_library_source`, and
+  `build_command_build_zen_rejects_missing_graph_only_library_source`, accept
+  valid graph-only library exports through
+  `build_command_build_zen_accepts_valid_graph_only_library_sources`, and
+  typecheck graph-only library exports before compiling executable targets
+  through `build_command_build_zen_rejects_graph_only_library_type_errors`.
+  They preserve host-effect validation before graph-only library typechecking
+  through
+  `build_command_build_zen_rejects_undeclared_host_effects_before_library_typechecking`,
+  and reject
   undeclared host effects before dependency-ordered execution through
   `build_command_build_zen_rejects_undeclared_host_effects_before_dependency_execution`.
   The normal build path also rejects undeclared host effects before
@@ -2163,7 +2171,9 @@ checked-in docs, tests, and commits only.
   test-target dependencies on gated executable targets through
   `test_command_build_zen_rejects_gated_executable_dependencies`. It validates
   graph-only library exports before execution through
-  `test_command_build_zen_rejects_missing_graph_only_library_source`.
+  `test_command_build_zen_rejects_missing_graph_only_library_source` and
+  typechecks them before execution through
+  `test_command_build_zen_rejects_graph_only_library_type_errors`.
 - Normal `zen emit build.zen` emits generated C for the single executable graph
   target without compiling a binary, covered by
   `emit_command_build_zen_outputs_target_c_source`, rejects ambiguous
@@ -2173,7 +2183,9 @@ checked-in docs, tests, and commits only.
   undeclared host effects through
   `emit_command_build_zen_rejects_undeclared_host_effects`. It validates
   graph-only library exports before emission through
-  `emit_command_build_zen_rejects_missing_graph_only_library_source`, while
+  `emit_command_build_zen_rejects_missing_graph_only_library_source` and
+  typechecks them before emission through
+  `emit_command_build_zen_rejects_graph_only_library_type_errors`, while
   `emit_command_build_zen_reports_multi_target_ambiguity_before_missing_executable_source`
   keeps multi-executable ambiguity ahead of per-executable source checks.
 - Direct `zen build.zen` now aliases the same constrained deterministic graph
@@ -2229,9 +2241,10 @@ Phase 4 build-driver work still has constrained `build.zen` semantics: normal
 graph targets, `zen test build.zen` executes multiple test graph targets,
 `zen check build.zen` validates executable, test, and library targets in the
 graph and typechecks target sources without compiling them, `zen emit build.zen`
-emits target C for a single executable graph target, and build/test execution
-rejects dependencies on gated library targets while library execution remains
-gated. Legacy generic JSON emitters reject
+emits target C for a single executable graph target, and build/test/emit
+validate and typecheck graph-only library target sources while build/test
+execution rejects dependencies on gated library targets and library execution
+remains gated. Legacy generic JSON emitters reject
 `build.zen` and point to
 `emit-json build-graph`.
 

--- a/src/cli/build_graph_execution.rs
+++ b/src/cli/build_graph_execution.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::process;
 
@@ -173,13 +173,15 @@ fn validate_non_executed_target_sources(
     graph: &zen::build_graph::BuildGraph,
     execution_kind: BuildGraphExecutionKind,
 ) {
+    let mut checked_sources = BTreeSet::new();
     for target in graph
         .targets()
         .iter()
         .filter(|target| !execution_kind.includes(target.kind()))
     {
         for source in target.sources() {
-            if !base_dir.join(source).exists() {
+            let source_path = base_dir.join(source);
+            if !source_path.exists() {
                 eprintln!(
                     "build graph target `{}` source not found: {}",
                     target.name(),
@@ -187,7 +189,16 @@ fn validate_non_executed_target_sources(
                 );
                 process::exit(1);
             }
+            checked_sources.insert(source_path);
         }
+    }
+
+    for source_path in checked_sources {
+        let source_path = source_path.to_str().unwrap_or_else(|| {
+            eprintln!("error: non-utf8 source path: {}", source_path.display());
+            process::exit(1);
+        });
+        super::graph_frontend(source_path);
     }
 }
 

--- a/tests/integration/cli_build/build_command.rs
+++ b/tests/integration/cli_build/build_command.rs
@@ -209,6 +209,175 @@ main = () i32 {
 }
 
 #[test]
+fn build_command_build_zen_accepts_valid_graph_only_library_sources() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    b.add(Library { name: "core", exports: ["lib.zen"] })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    1
+}
+"#,
+    )
+    .expect("write lib.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build build.zen");
+
+    assert!(
+        output.status.success(),
+        "zen build build.zen failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        tmp.path().join("build").join("app").join("app").exists(),
+        "expected executable output to exist"
+    );
+}
+
+#[test]
+fn build_command_build_zen_rejects_graph_only_library_type_errors() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    b.add(Library { name: "core", exports: ["lib.zen"] })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    true
+}
+"#,
+    )
+    .expect("write lib.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen build build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("return type mismatch: expected `i32`, found `bool`"),
+        "expected graph-only library type diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "build command should not start after graph-only library typechecking fails"
+    );
+}
+
+#[test]
+fn build_command_build_zen_rejects_undeclared_host_effects_before_library_typechecking() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    std_path = b.os.env("ZEN_STD")
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    b.add(Library { name: "core", exports: ["lib.zen"] })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    true
+}
+"#,
+    )
+    .expect("write lib.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen build build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("undeclared host effect: read env `ZEN_STD`"),
+        "expected undeclared host effect diagnostic, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("return type mismatch"),
+        "host-effect validation should run before graph-only library typechecking, stderr={stderr}"
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "build command should not start after graph validation fails"
+    );
+}
+
+#[test]
 fn build_command_build_zen_rejects_gated_test_dependencies() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(

--- a/tests/integration/cli_build/emit_direct.rs
+++ b/tests/integration/cli_build/emit_direct.rs
@@ -250,6 +250,63 @@ main = () i32 {
 }
 
 #[test]
+fn emit_command_build_zen_rejects_graph_only_library_type_errors() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    b.add(Library { name: "core", exports: ["lib.zen"] })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    true
+}
+"#,
+    )
+    .expect("write lib.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen emit build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen emit build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("return type mismatch: expected `i32`, found `bool`"),
+        "expected graph-only library type diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "zen emit build.zen should not create build outputs after graph-only library typechecking fails"
+    );
+}
+
+#[test]
 fn emit_command_build_zen_rejects_undeclared_host_effects() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(

--- a/tests/integration/cli_build/graph_validation_test_command.rs
+++ b/tests/integration/cli_build/graph_validation_test_command.rs
@@ -432,6 +432,63 @@ main = () i32 {
 }
 
 #[test]
+fn test_command_build_zen_rejects_graph_only_library_type_errors() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Test { name: "unit", root: "test.zen" })
+    b.add(Library { name: "core", exports: ["lib.zen"] })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("test.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write test.zen");
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    true
+}
+"#,
+    )
+    .expect("write lib.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["test", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen test build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen test build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("return type mismatch: expected `i32`, found `bool`"),
+        "expected graph-only library type diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "test command should not start after graph-only library typechecking fails"
+    );
+}
+
+#[test]
 fn test_command_build_zen_rejects_gated_executable_dependencies() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(


### PR DESCRIPTION
## Summary
- typecheck non-executed graph-only target sources before build/test/emit starts selected target execution
- add build-command coverage for valid graph-only libraries, type errors, and host-effect precedence
- add test/emit coverage for graph-only library type errors
- record the new build-driver evidence in the phase plan and completion audit

## Verification
- `cargo test --test integration build_command_build_zen_rejects_graph_only_library_type_errors`
- `cargo test --test integration test_command_build_zen_rejects_graph_only_library_type_errors`
- `cargo test --test integration emit_command_build_zen_rejects_graph_only_library_type_errors`
- `cargo test --test docs_truth`
- `cargo test --test integration cli_build::`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`