### PR TITLE
[codex] Preserve emit graph ambiguity ordering

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2373,6 +2373,9 @@ and do not assume Phase 4 is ready without evidence.
 - Single-target `zen emit build.zen` rejects multi-executable ambiguity before
   per-executable source validation, covered by
   `cargo test --test integration emit_command_build_zen_reports_multi_target_ambiguity_before_missing_executable_source`.
+  It also rejects multi-executable ambiguity before graph-only library
+  typechecking, covered by
+  `cargo test --test integration emit_command_build_zen_reports_multi_target_ambiguity_before_graph_only_library_typechecking`.
 - Dependency-ordered build execution still stops before execution when graph
   lowering detects undeclared host effects, covered by
   `cargo test --test integration build_command_build_zen_rejects_undeclared_host_effects_before_dependency_execution`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2187,7 +2187,10 @@ checked-in docs, tests, and commits only.
   typechecks them before emission through
   `emit_command_build_zen_rejects_graph_only_library_type_errors`, while
   `emit_command_build_zen_reports_multi_target_ambiguity_before_missing_executable_source`
-  keeps multi-executable ambiguity ahead of per-executable source checks.
+  and
+  `emit_command_build_zen_reports_multi_target_ambiguity_before_graph_only_library_typechecking`
+  keep multi-executable ambiguity ahead of per-executable and graph-only
+  library source checks.
 - Direct `zen build.zen` now aliases the same constrained deterministic graph
   build path as `zen build build.zen`, covered by
   `direct_file_command_build_zen_routes_through_deterministic_graph`, and

--- a/src/cli/build_graph_execution.rs
+++ b/src/cli/build_graph_execution.rs
@@ -39,7 +39,6 @@ pub(super) fn single_executable_build_target(path_str: &str) -> BuildGraphExecut
     validate_executed_dependency_targets(&graph, BuildGraphExecutionKind::Executable);
     let build_path = Path::new(path_str);
     let base_dir = build_path.parent().unwrap_or_else(|| Path::new("."));
-    validate_non_executed_target_sources(base_dir, &graph, BuildGraphExecutionKind::Executable);
     let ordered_targets = match graph.targets_in_dependency_order() {
         Ok(targets) => targets,
         Err(err) => {
@@ -64,6 +63,7 @@ pub(super) fn single_executable_build_target(path_str: &str) -> BuildGraphExecut
         process::exit(1);
     }
 
+    validate_non_executed_target_sources(base_dir, &graph, BuildGraphExecutionKind::Executable);
     executable_build_target(base_dir, executable_targets[0]).expect("one executable target")
 }
 

--- a/tests/integration/cli_build/emit_direct.rs
+++ b/tests/integration/cli_build/emit_direct.rs
@@ -155,6 +155,76 @@ main = () i32 {
 }
 
 #[test]
+fn emit_command_build_zen_reports_multi_target_ambiguity_before_graph_only_library_typechecking() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    b.add(Executable { name: "tool", main: "tool.zen", out_dir: "build/tool/" })
+    b.add(Library { name: "core", exports: ["lib.zen"] })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+    std::fs::write(
+        tmp.path().join("tool.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write tool.zen");
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    true
+}
+"#,
+    )
+    .expect("write lib.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen emit build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen emit build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("build graph C emission supports exactly one target, found 2"),
+        "expected single-target emit diagnostic before graph-only library typechecking, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("return type mismatch"),
+        "emit should reject ambiguous executable graphs before graph-only library typechecking, stderr={stderr}"
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "zen emit build.zen should not create build outputs when graph emission is ambiguous"
+    );
+}
+
+#[test]
 fn emit_command_build_zen_rejects_graph_without_executable_targets() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(


### PR DESCRIPTION
## Summary

- Report `zen emit build.zen` multi-executable ambiguity before graph-only library source typechecking.
- Keep graph-only source validation and typechecking for the single-executable emit path.
- Update phase and audit docs with regression coverage for the diagnostic ordering.

## Validation

- `cargo test --test integration emit_command_build_zen_reports_multi_target_ambiguity_before_graph_only_library_typechecking`
- `cargo test --test integration emit_command_build_zen_reports_multi_target_ambiguity_before_missing_executable_source`
- `cargo test --test integration emit_command_build_zen_rejects_graph_only_library_type_errors`
- `cargo test --test integration emit_command_build_zen_rejects_missing_graph_only_library_source`
- `cargo test --test docs_truth`
- `cargo test --test integration cli_build::emit_direct`
- `cargo fmt --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`