### PR TITLE
[codex] Recognize build graph file read effects

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2282,6 +2282,9 @@ and do not assume Phase 4 is ready without evidence.
 - Build script lowering includes target dependency and feature metadata arrays,
   covered by
   `cargo test --test build_graph build_program_lowering_collects_target_dependencies_and_features`.
+- Build script lowering recognizes declared deterministic file-read effects
+  without allowing undeclared file reads, covered by
+  `cargo test --test build_graph file_reads`.
 - Build script lowering keeps accepted `build.zen` DSL spellings owned by
   focused enums for target kinds, target fields, and builder identifiers,
   covered by `cargo test build_target_dsl --lib` and
@@ -2316,6 +2319,9 @@ and do not assume Phase 4 is ready without evidence.
   covered by
   `cargo test --test integration emit_json_build_graph_outputs_target_dependencies_and_features`
   and `cargo test --test integration emit_json_build_graph_rejects_undeclared_host_effects_before_target_metadata_lowering`.
+- `emit-json build-graph` emits declared deterministic file-read effects and
+  rejects undeclared file reads through the advertised graph command, covered
+  by `cargo test --test integration file_read_effects`.
 - `emit-json build-graph` rejects unresolved target dependencies through the
   advertised graph-emission path, covered by
   `cargo test --test integration emit_json_build_graph_rejects_unknown_target_dependencies`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2103,7 +2103,11 @@ checked-in docs, tests, and commits only.
   `build_program_lowering_rejects_unknown_target_dependencies` covers
   unresolved target dependency rejection, and
   `build_program_lowering_rejects_undeclared_env_reads` keeps undeclared host
-  effects rejected during lowering.
+  effects rejected during lowering. The constrained deterministic-effect
+  surface also recognizes declared `b.os.read_file("...")` effects, covered by
+  `build_program_lowering_accepts_declared_file_reads`, while
+  `build_program_lowering_rejects_undeclared_file_reads` keeps undeclared file
+  reads rejected before graph promotion.
 - `emit-json build-graph <build.zen>` now exposes the constrained graph-emission
   path without enabling normal build execution. `emit_json_build_graph_outputs_project_build_graph`
   covers the positive CLI path, `emit_json_build_graph_outputs_library_target`
@@ -2115,6 +2119,10 @@ checked-in docs, tests, and commits only.
   and `emit_json_build_graph_rejects_undeclared_host_effects_before_library_target_lowering`
   and `emit_json_build_graph_rejects_undeclared_host_effects_before_target_metadata_lowering`
   cover negative host-effect paths through the advertised compiler command.
+  `emit_json_build_graph_outputs_declared_file_read_effects` and
+  `emit_json_build_graph_rejects_undeclared_file_read_effects` cover the
+  matching positive and negative deterministic file-read effect pair through
+  that same graph-emission command.
   `emit_json_build_graph_rejects_unknown_target_dependencies` covers unresolved
   target dependency rejection through the same graph-emission path, and
   `emit_json_build_graph_rejects_self_target_dependencies` covers

--- a/src/build_graph/lowering.rs
+++ b/src/build_graph/lowering.rs
@@ -28,6 +28,7 @@ enum BuildTargetDslIdent {
     Build,
     Env,
     Os,
+    ReadFile,
 }
 
 impl BuildTargetDslKind {
@@ -80,6 +81,7 @@ impl BuildTargetDslIdent {
     const BUILD: &'static str = "build";
     const ENV: &'static str = "env";
     const OS: &'static str = "os";
+    const READ_FILE: &'static str = "read_file";
 
     fn as_str(self) -> &'static str {
         match self {
@@ -88,6 +90,7 @@ impl BuildTargetDslIdent {
             Self::Build => Self::BUILD,
             Self::Env => Self::ENV,
             Self::Os => Self::OS,
+            Self::ReadFile => Self::READ_FILE,
         }
     }
 }
@@ -155,10 +158,10 @@ impl BuildProgramLowering {
     }
 
     fn collect_expr(&mut self, expr: &Expression) {
-        if let Some(effect) = env_read_effect(expr) {
+        if let Some(effect) = host_effect(expr) {
             self.used_host_effects.push(effect);
         }
-        if let Some(effect) = declared_env_read_effect(expr) {
+        if let Some(effect) = declared_host_effect(expr) {
             self.declared_host_effects.push(effect);
         }
         if let Some(target) = build_target_from_builder_add(expr) {
@@ -421,7 +424,7 @@ fn string_array_field(
     })
 }
 
-fn declared_env_read_effect(expr: &Expression) -> Option<HostEffect> {
+fn declared_host_effect(expr: &Expression) -> Option<HostEffect> {
     let Expression::Match {
         scrutinee, arms, ..
     } = expr
@@ -434,10 +437,10 @@ fn declared_env_read_effect(expr: &Expression) -> Option<HostEffect> {
             crate::ast::Pattern::Enum { variant, .. } if variant == "Err"
         )
     });
-    has_fallback.then(|| env_read_effect(scrutinee)).flatten()
+    has_fallback.then(|| host_effect(scrutinee)).flatten()
 }
 
-fn env_read_effect(expr: &Expression) -> Option<HostEffect> {
+fn host_effect(expr: &Expression) -> Option<HostEffect> {
     let Expression::MethodCall {
         receiver,
         method,
@@ -447,13 +450,21 @@ fn env_read_effect(expr: &Expression) -> Option<HostEffect> {
     else {
         return None;
     };
-    if method != BuildTargetDslIdent::Env.as_str() || !is_builder_os(receiver) {
+    if !is_builder_os(receiver) {
         return None;
     }
-    let [Expression::StringLiteral { value, .. }] = args.as_slice() else {
+    let [Expression::StringLiteral { value: argument, .. }] = args.as_slice() else {
         return None;
     };
-    Some(HostEffect::ReadEnv(value.clone()))
+    match method.as_str() {
+        method if method == BuildTargetDslIdent::Env.as_str() => {
+            Some(HostEffect::ReadEnv(argument.clone()))
+        }
+        method if method == BuildTargetDslIdent::ReadFile.as_str() => {
+            Some(HostEffect::ReadFile(argument.clone()))
+        }
+        _ => None,
+    }
 }
 
 fn is_builder_os(expr: &Expression) -> bool {

--- a/src/build_graph/lowering_tests.rs
+++ b/src/build_graph/lowering_tests.rs
@@ -40,5 +40,6 @@ fn build_target_dsl_ident_owns_source_spelling() {
     assert_eq!(BuildTargetDslIdent::Build.as_str(), "build");
     assert_eq!(BuildTargetDslIdent::Env.as_str(), "env");
     assert_eq!(BuildTargetDslIdent::Os.as_str(), "os");
+    assert_eq!(BuildTargetDslIdent::ReadFile.as_str(), "read_file");
     assert_eq!(BuildTargetDslIdent::Builder.to_string(), "b");
 }

--- a/tests/build_graph.rs
+++ b/tests/build_graph.rs
@@ -393,3 +393,47 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
         "undeclared host effect: read env `ZEN_STD`"
     );
 }
+
+#[test]
+fn build_program_lowering_accepts_declared_file_reads() {
+    let program = parse_program(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets") ?
+        | .Ok(contents) { contents }
+        | .Err { "default" }
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    );
+
+    let graph = BuildGraph::from_build_program(&program).expect("lower build graph");
+    let json = graph.canonical_json().expect("build graph json");
+
+    assert!(
+        json.contains(r#""kind":"read_file","value":"build.targets""#),
+        "expected read-file host effect in graph json, json={json}"
+    );
+}
+
+#[test]
+fn build_program_lowering_rejects_undeclared_file_reads() {
+    let program = parse_program(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets")
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    );
+
+    let err = BuildGraph::from_build_program(&program)
+        .expect_err("undeclared build.zen file read should fail");
+
+    assert_eq!(
+        err.to_string(),
+        "undeclared host effect: read file `build.targets`"
+    );
+}

--- a/tests/integration/cli_build/build_graph_json.rs
+++ b/tests/integration/cli_build/build_graph_json.rs
@@ -59,6 +59,78 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
 }
 
 #[test]
+fn emit_json_build_graph_outputs_declared_file_read_effects() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let build_path = tmp.path().join("build.zen");
+    std::fs::write(
+        &build_path,
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets") ?
+        | .Ok(contents) { contents }
+        | .Err { "default" }
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "build-graph", build_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json build-graph");
+
+    assert!(
+        output.status.success(),
+        "emit-json build-graph failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("build graph json");
+    assert_eq!(json["declared_host_effects"][0]["kind"], "read_file");
+    assert_eq!(json["declared_host_effects"][0]["value"], "build.targets");
+    assert_eq!(json["used_host_effects"][0]["kind"], "read_file");
+    assert_eq!(json["used_host_effects"][0]["value"], "build.targets");
+}
+
+#[test]
+fn emit_json_build_graph_rejects_undeclared_file_read_effects() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let build_path = tmp.path().join("build.zen");
+    std::fs::write(
+        &build_path,
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets")
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "build-graph", build_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json build-graph");
+
+    assert!(
+        !output.status.success(),
+        "emit-json build-graph unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("undeclared host effect: read file `build.targets`"),
+        "expected undeclared file-read effect diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn emit_json_build_graph_rejects_undeclared_host_effects_before_test_target_lowering() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let build_path = tmp.path().join("build.zen");


### PR DESCRIPTION
## Summary
- recognize constrained deterministic `b.os.read_file("...")` host effects in `build.zen` lowering
- reject undeclared file reads and emit declared `read_file` effects in build graph JSON
- record the positive/negative graph evidence in the phase plan and completion audit

## Verification
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `cargo test --test docs_truth`
- `cargo test --test build_graph file_reads`
- `cargo test --test integration file_read_effects`
- `cargo test build_target_dsl_ident_owns_source_spelling --lib`