### PR TITLE
[codex] Cover build graph file reads on build command

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2359,6 +2359,11 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test build_graph build_graph_orders_targets_before_dependents`
   and
   `cargo test --test integration build_command_build_zen_compiles_executable_dependencies_first`.
+- Normal build graph execution accepts declared deterministic file-read effects
+  and rejects undeclared file reads before target execution, covered by
+  `cargo test --test integration build_command_build_zen_accepts_declared_file_read_effects`
+  and
+  `cargo test --test integration build_command_build_zen_rejects_undeclared_file_read_effects_before_execution`.
 - Build/test graph execution rejects dependencies on gated library targets,
   covered by
   `cargo test --test integration build_command_build_zen_rejects_gated_library_dependencies`

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2175,6 +2175,10 @@ checked-in docs, tests, and commits only.
   `build_command_multi_target_build_zen_rejects_undeclared_host_effects`. The
   single-target rejection remains covered by
   `build_command_build_zen_rejects_undeclared_host_effects`.
+  Declared deterministic file-read effects are accepted on the normal build
+  path through `build_command_build_zen_accepts_declared_file_read_effects`,
+  while undeclared file reads reject before target execution through
+  `build_command_build_zen_rejects_undeclared_file_read_effects_before_execution`.
 - Normal `zen check build.zen` validates the same constrained deterministic
   graph without compiling targets, covered by
   `check_command_validates_build_zen_graph`. It typechecks graph target

--- a/tests/integration/cli_build/build_command_host_effects.rs
+++ b/tests/integration/cli_build/build_command_host_effects.rs
@@ -113,3 +113,96 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
         String::from_utf8_lossy(&output.stderr)
     );
 }
+
+#[test]
+fn build_command_build_zen_accepts_declared_file_read_effects() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets") ?
+        | .Ok(contents) { contents }
+        | .Err { "default" }
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(tmp.path().join("build.targets"), "myapp\n").expect("write manifest");
+    std::fs::write(
+        tmp.path().join("main.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write main.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build build.zen");
+
+    assert!(
+        output.status.success(),
+        "zen build build.zen failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let bin_path = tmp.path().join("build").join("myapp");
+    assert!(
+        bin_path.exists(),
+        "expected {} to exist",
+        bin_path.display()
+    );
+    let run = Command::new(&bin_path).output().expect("run built binary");
+    assert!(
+        run.status.success(),
+        "built binary exited with {}",
+        run.status
+    );
+}
+
+#[test]
+fn build_command_build_zen_rejects_undeclared_file_read_effects_before_execution() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets")
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen build build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("undeclared host effect: read file `build.targets`"),
+        "expected undeclared file read diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "build should not start after graph validation fails"
+    );
+}


### PR DESCRIPTION
## Summary
- add normal `zen build build.zen` coverage for declared deterministic `b.os.read_file(...)` effects
- add the matching undeclared file-read rejection before target execution starts
- record the new positive/negative graph evidence in the phase plan and completion audit

## Verification
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `cargo test --test docs_truth`
- `cargo test --test integration file_read_effects`
- `cargo test --test integration build_command_build_zen_accepts_declared_file_read_effects`
- `cargo test --test integration build_command_build_zen_rejects_undeclared_file_read_effects_before_execution`