### PR TITLE
[codex] Cover test graph file read effects

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2373,6 +2373,11 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration build_command_build_zen_rejects_gated_test_dependencies`
   and
   `cargo test --test integration test_command_build_zen_rejects_gated_executable_dependencies`.
+- Normal test graph execution accepts declared deterministic file-read effects
+  and rejects undeclared file reads before test execution, covered by
+  `cargo test --test integration test_command_build_zen_accepts_declared_file_read_effects`
+  and
+  `cargo test --test integration test_command_build_zen_rejects_undeclared_file_read_effects_before_execution`.
 - Build/test/emit graph execution validates non-executed graph-only library
   exports before compiling or running selected targets, covered by
   `cargo test --test integration build_command_build_zen_rejects_missing_graph_only_library_source`,

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2213,6 +2213,10 @@ checked-in docs, tests, and commits only.
   `test_command_build_zen_rejects_missing_graph_only_library_source` and
   typechecks them before execution through
   `test_command_build_zen_rejects_graph_only_library_type_errors`.
+  Declared deterministic file-read effects are accepted on the normal test
+  path through `test_command_build_zen_accepts_declared_file_read_effects`,
+  while undeclared file reads reject before test execution through
+  `test_command_build_zen_rejects_undeclared_file_read_effects_before_execution`.
 - Normal `zen emit build.zen` emits generated C for the single executable graph
   target without compiling a binary, covered by
   `emit_command_build_zen_outputs_target_c_source`, rejects ambiguous

--- a/tests/integration/cli_build/graph_validation_test_command_host_effects.rs
+++ b/tests/integration/cli_build/graph_validation_test_command_host_effects.rs
@@ -96,3 +96,95 @@ main = () i32 {
         "test command should not start after graph validation fails"
     );
 }
+
+#[test]
+fn test_command_build_zen_accepts_declared_file_read_effects() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("test.targets") ?
+        | .Ok(contents) { contents }
+        | .Err { "default" }
+    b.add(Test { name: "unit", root: "test.zen" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(tmp.path().join("test.targets"), "unit\n").expect("write manifest");
+    std::fs::write(
+        tmp.path().join("test.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write test.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["test", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen test build.zen");
+
+    assert!(
+        output.status.success(),
+        "zen test build.zen failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let bin_path = tmp.path().join("build").join("tests").join("unit");
+    assert!(
+        bin_path.exists(),
+        "expected {} to exist",
+        bin_path.display()
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("test unit passed"),
+        "expected test pass output, stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn test_command_build_zen_rejects_undeclared_file_read_effects_before_execution() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("test.targets")
+    b.add(Test { name: "unit", root: "test.zen" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["test", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen test build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen test build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("undeclared host effect: read file `test.targets`"),
+        "expected undeclared file read diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "test command should not start after graph validation fails"
+    );
+}


### PR DESCRIPTION
## Summary
- add normal `zen test build.zen` coverage for declared deterministic `b.os.read_file(...)` effects
- add the matching undeclared file-read rejection before test execution starts
- record the new positive/negative graph evidence in the phase plan and completion audit

## Verification
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `cargo test --test docs_truth`
- `cargo test --test integration file_read_effects`
- `cargo test --test integration test_command_build_zen_accepts_declared_file_read_effects`
- `cargo test --test integration test_command_build_zen_rejects_undeclared_file_read_effects_before_execution`