### PR TITLE
[codex] Cover check graph file read effects

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2400,6 +2400,11 @@ and do not assume Phase 4 is ready without evidence.
   Undeclared host effects still reject before target source typechecking,
   covered by
   `cargo test --test integration check_command_build_zen_rejects_undeclared_host_effects_before_target_typechecking`.
+- `zen check build.zen` accepts declared deterministic file-read effects and
+  rejects undeclared file reads before source validation, covered by
+  `cargo test --test integration check_command_build_zen_accepts_declared_file_read_effects`
+  and
+  `cargo test --test integration check_command_build_zen_rejects_undeclared_file_read_effects_before_source_validation`.
 - Single-target `zen emit build.zen` rejects multi-executable ambiguity before
   per-executable source validation, covered by
   `cargo test --test integration emit_command_build_zen_reports_multi_target_ambiguity_before_missing_executable_source`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2195,6 +2195,10 @@ checked-in docs, tests, and commits only.
   `check_command_build_zen_rejects_undeclared_host_effects_before_target_typechecking`.
   The single-target host-effect rejection remains covered by
   `check_command_build_zen_rejects_undeclared_host_effects`.
+  Declared deterministic file-read effects are accepted through
+  `check_command_build_zen_accepts_declared_file_read_effects`, while
+  undeclared file reads reject before source validation through
+  `check_command_build_zen_rejects_undeclared_file_read_effects_before_source_validation`.
 - Normal `zen test build.zen` compiles and runs test graph targets, covered by
   `test_command_build_zen_runs_test_targets`, compiles and runs multiple test
   graph targets through `test_command_build_zen_runs_multiple_test_targets`,

--- a/tests/integration/cli_build/graph_validation.rs
+++ b/tests/integration/cli_build/graph_validation.rs
@@ -268,6 +268,90 @@ main = () i32 {
 }
 
 #[test]
+fn check_command_build_zen_accepts_declared_file_read_effects() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets") ?
+        | .Ok(contents) { contents }
+        | .Err { "default" }
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(tmp.path().join("build.targets"), "myapp\n").expect("write manifest");
+    std::fs::write(
+        tmp.path().join("main.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write main.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["check", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen check build.zen");
+
+    assert!(
+        output.status.success(),
+        "zen check build.zen failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("1 build targets"),
+        "expected build graph check summary, stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn check_command_build_zen_rejects_undeclared_file_read_effects_before_source_validation() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets")
+    b.add(Executable { name: "myapp", main: "missing.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["check", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen check build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen check build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("undeclared host effect: read file `build.targets`"),
+        "expected undeclared file read diagnostic, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("source not found"),
+        "host-effect validation should run before source validation, stderr={stderr}"
+    );
+}
+
+#[test]
 fn check_command_build_zen_rejects_undeclared_host_effects_before_source_validation() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(


### PR DESCRIPTION
## Summary
- add `zen check build.zen` coverage for declared deterministic `b.os.read_file(...)` effects
- add the matching undeclared file-read rejection before source validation
- record the new positive/negative graph evidence in the phase plan and completion audit

## Verification
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `cargo test --test docs_truth`
- `cargo test --test integration file_read_effects`
- `cargo test --test integration check_command_build_zen_accepts_declared_file_read_effects`
- `cargo test --test integration check_command_build_zen_rejects_undeclared_file_read_effects_before_source_validation`