### PR TITLE
[codex] Cover emit graph file read effects

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2411,6 +2411,11 @@ and do not assume Phase 4 is ready without evidence.
   It also rejects multi-executable ambiguity before graph-only library
   typechecking, covered by
   `cargo test --test integration emit_command_build_zen_reports_multi_target_ambiguity_before_graph_only_library_typechecking`.
+- Single-target `zen emit build.zen` accepts declared deterministic file-read
+  effects and rejects undeclared file reads before C emission, covered by
+  `cargo test --test integration emit_command_build_zen_accepts_declared_file_read_effects`
+  and
+  `cargo test --test integration emit_command_build_zen_rejects_undeclared_file_read_effects`.
 - Dependency-ordered build execution still stops before execution when graph
   lowering detects undeclared host effects, covered by
   `cargo test --test integration build_command_build_zen_rejects_undeclared_host_effects_before_dependency_execution`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2238,6 +2238,10 @@ checked-in docs, tests, and commits only.
   `emit_command_build_zen_reports_multi_target_ambiguity_before_graph_only_library_typechecking`
   keep multi-executable ambiguity ahead of per-executable and graph-only
   library source checks.
+  Declared deterministic file-read effects are accepted through
+  `emit_command_build_zen_accepts_declared_file_read_effects`, while
+  undeclared file reads reject before C emission through
+  `emit_command_build_zen_rejects_undeclared_file_read_effects`.
 - Direct `zen build.zen` now aliases the same constrained deterministic graph
   build path as `zen build build.zen`, covered by
   `direct_file_command_build_zen_routes_through_deterministic_graph`, and

--- a/tests/integration/cli_build.rs
+++ b/tests/integration/cli_build.rs
@@ -14,6 +14,8 @@ mod diagnostics;
 mod direct_build_graph_execution;
 #[path = "cli_build/emit_direct.rs"]
 mod emit_direct;
+#[path = "cli_build/emit_direct_host_effects.rs"]
+mod emit_direct_host_effects;
 #[path = "cli_build/frontend_json.rs"]
 mod frontend_json;
 #[path = "cli_build/graph_validation.rs"]

--- a/tests/integration/cli_build/emit_direct.rs
+++ b/tests/integration/cli_build/emit_direct.rs
@@ -375,38 +375,3 @@ value = () i32 {
         "zen emit build.zen should not create build outputs after graph-only library typechecking fails"
     );
 }
-
-#[test]
-fn emit_command_build_zen_rejects_undeclared_host_effects() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    std_path = b.os.env("ZEN_STD")
-    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen emit build.zen");
-
-    assert!(
-        !output.status.success(),
-        "zen emit build.zen unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("undeclared host effect: read env `ZEN_STD`"),
-        "expected undeclared host effect diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-}

--- a/tests/integration/cli_build/emit_direct_host_effects.rs
+++ b/tests/integration/cli_build/emit_direct_host_effects.rs
@@ -1,0 +1,126 @@
+use std::process::Command;
+
+#[test]
+fn emit_command_build_zen_rejects_undeclared_host_effects() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    std_path = b.os.env("ZEN_STD")
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen emit build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen emit build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("undeclared host effect: read env `ZEN_STD`"),
+        "expected undeclared host effect diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn emit_command_build_zen_accepts_declared_file_read_effects() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets") ?
+        | .Ok(contents) { contents }
+        | .Err { "default" }
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(tmp.path().join("build.targets"), "myapp\n").expect("write manifest");
+    std::fs::write(
+        tmp.path().join("main.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write main.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen emit build.zen");
+
+    assert!(
+        output.status.success(),
+        "zen emit build.zen failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let c_source = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        c_source.contains("int32_t zen_main(void)"),
+        "expected target C source, stdout={c_source}"
+    );
+    assert!(
+        !tmp.path().join("build").join("myapp").exists(),
+        "zen emit build.zen should not compile the target binary"
+    );
+}
+
+#[test]
+fn emit_command_build_zen_rejects_undeclared_file_read_effects() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets")
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen emit build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen emit build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("undeclared host effect: read file `build.targets`"),
+        "expected undeclared file read diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "emit should not write C source after graph validation fails, stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}


### PR DESCRIPTION
## Summary
- add `zen emit build.zen` coverage for declared deterministic `b.os.read_file(...)` effects
- add the matching undeclared file-read rejection before C emission
- split emit host-effect integration tests into a focused module to keep `emit_direct.rs` below the cleanup threshold
- record the new positive/negative graph evidence in the phase plan and completion audit

## Verification
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `cargo test --test docs_truth`
- `cargo test --test integration file_read_effects`
- `cargo test --test integration emit_command_build_zen_accepts_declared_file_read_effects`
- `cargo test --test integration emit_command_build_zen_rejects_undeclared_file_read_effects`