### PR TITLE
[codex] Cover legacy graph library typechecking

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2355,8 +2355,13 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration build_graph_command_accepts_declared_file_read_effects`
   and
   `cargo test --test integration build_graph_command_rejects_undeclared_file_read_effects_before_execution`.
-  Graph-only library export source validation before execution is covered by
-  `cargo test --test integration build_graph_command_rejects_missing_graph_only_library_source`.
+  Graph-only library export source validation and typechecking before
+  execution are covered by
+  `cargo test --test integration build_graph_command_rejects_missing_graph_only_library_source`,
+  `cargo test --test integration build_graph_command_accepts_valid_graph_only_library_sources`,
+  `cargo test --test integration build_graph_command_rejects_graph_only_library_type_errors`,
+  and
+  `cargo test --test integration build_graph_command_rejects_undeclared_host_effects_before_library_typechecking`.
   Test-only graphs are rejected before execution starts, covered by
   `cargo test --test integration build_graph_command_rejects_graph_without_executable_targets`.
 - Executable build graph targets now execute dependencies before dependents,

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2145,7 +2145,14 @@ checked-in docs, tests, and commits only.
   `build_graph_command_rejects_graph_without_executable_targets` covers
   test-only graph rejection before execution starts,
   `build_graph_command_rejects_missing_graph_only_library_source` covers
-  graph-only library export validation before execution starts, and
+  graph-only library export validation before execution starts,
+  `build_graph_command_accepts_valid_graph_only_library_sources` covers valid
+  graph-only library source validation before executable target execution,
+  `build_graph_command_rejects_graph_only_library_type_errors` covers
+  graph-only library typechecking before execution starts, and
+  `build_graph_command_rejects_undeclared_host_effects_before_library_typechecking`
+  preserves deterministic host-effect validation before graph-only library
+  typechecking, and
   `build_graph_command_rejects_missing_root_source` covers a target execution
   failure before normal `zen build build.zen` is ungated.
   Declared deterministic file-read effects are accepted through

--- a/tests/integration/cli_build/legacy_graph_command.rs
+++ b/tests/integration/cli_build/legacy_graph_command.rs
@@ -350,6 +350,114 @@ main = () i32 {
 }
 
 #[test]
+fn build_graph_command_accepts_valid_graph_only_library_sources() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    b.add(Library { name: "core", exports: ["lib.zen"] })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    1
+}
+"#,
+    )
+    .expect("write lib.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build-graph", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build-graph");
+
+    assert!(
+        output.status.success(),
+        "zen build-graph failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        tmp.path().join("build").join("app").join("app").exists(),
+        "expected executable output to exist"
+    );
+}
+
+#[test]
+fn build_graph_command_rejects_graph_only_library_type_errors() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    b.add(Library { name: "core", exports: ["lib.zen"] })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    true
+}
+"#,
+    )
+    .expect("write lib.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build-graph", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build-graph");
+
+    assert!(
+        !output.status.success(),
+        "zen build-graph unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("return type mismatch: expected `i32`, found `bool`"),
+        "expected graph-only library type diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "build-graph command should not start after graph-only library typechecking fails"
+    );
+}
+
+#[test]
 fn build_graph_command_rejects_missing_root_source() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(

--- a/tests/integration/cli_build/legacy_graph_command_host_effects.rs
+++ b/tests/integration/cli_build/legacy_graph_command_host_effects.rs
@@ -89,6 +89,67 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
 }
 
 #[test]
+fn build_graph_command_rejects_undeclared_host_effects_before_library_typechecking() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    std_path = b.os.env("ZEN_STD")
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    b.add(Library { name: "core", exports: ["lib.zen"] })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    true
+}
+"#,
+    )
+    .expect("write lib.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build-graph", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build-graph");
+
+    assert!(
+        !output.status.success(),
+        "zen build-graph unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("undeclared host effect: read env `ZEN_STD`"),
+        "expected undeclared host effect diagnostic, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("return type mismatch"),
+        "host-effect validation should run before graph-only library typechecking, stderr={stderr}"
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "build-graph command should not start after graph validation fails"
+    );
+}
+
+#[test]
 fn build_graph_command_accepts_declared_file_read_effects() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(


### PR DESCRIPTION
## Summary
- add legacy `build-graph` coverage for valid graph-only library sources
- add legacy `build-graph` coverage for graph-only library type errors before execution
- add host-effect ordering coverage before graph-only library typechecking
- record the coverage in the phase plan and completion audit

## Verification
- `cargo test --test docs_truth`
- `cargo test --test integration build_graph_command`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`