### PR TITLE
[codex] Cover test graph library validation

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2401,7 +2401,10 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration build_command_build_zen_accepts_valid_graph_only_library_sources`,
   `cargo test --test integration build_command_build_zen_rejects_graph_only_library_type_errors`,
   `cargo test --test integration build_command_build_zen_rejects_undeclared_host_effects_before_library_typechecking`,
+  `cargo test --test integration test_command_build_zen_accepts_valid_graph_only_library_sources`,
   `cargo test --test integration test_command_build_zen_rejects_graph_only_library_type_errors`,
+  `cargo test --test integration test_command_build_zen_rejects_undeclared_host_effects_before_library_typechecking`,
+  `cargo test --test integration emit_command_build_zen_accepts_valid_graph_only_library_sources`,
   and
   `cargo test --test integration emit_command_build_zen_rejects_graph_only_library_type_errors`.
 - `zen check build.zen` typechecks graph target sources after deterministic

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2239,9 +2239,14 @@ checked-in docs, tests, and commits only.
   test-target dependencies on gated executable targets through
   `test_command_build_zen_rejects_gated_executable_dependencies`. It validates
   graph-only library exports before execution through
-  `test_command_build_zen_rejects_missing_graph_only_library_source` and
+  `test_command_build_zen_rejects_missing_graph_only_library_source`,
+  accepts valid graph-only library exports through
+  `test_command_build_zen_accepts_valid_graph_only_library_sources`, and
   typechecks them before execution through
-  `test_command_build_zen_rejects_graph_only_library_type_errors`.
+  `test_command_build_zen_rejects_graph_only_library_type_errors`. It also
+  preserves host-effect validation before graph-only library typechecking
+  through
+  `test_command_build_zen_rejects_undeclared_host_effects_before_library_typechecking`.
   Declared deterministic file-read effects are accepted on the normal test
   path through `test_command_build_zen_accepts_declared_file_read_effects`,
   while undeclared file reads reject before test execution through

--- a/tests/integration/cli_build/graph_validation_test_command_host_effects.rs
+++ b/tests/integration/cli_build/graph_validation_test_command_host_effects.rs
@@ -98,6 +98,67 @@ main = () i32 {
 }
 
 #[test]
+fn test_command_build_zen_rejects_undeclared_host_effects_before_library_typechecking() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    std_path = b.os.env("ZEN_STD")
+    b.add(Test { name: "unit", root: "test.zen" })
+    b.add(Library { name: "core", exports: ["lib.zen"] })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("test.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write test.zen");
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    true
+}
+"#,
+    )
+    .expect("write lib.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["test", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen test build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen test build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("undeclared host effect: read env `ZEN_STD`"),
+        "expected undeclared host effect diagnostic, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("return type mismatch"),
+        "host-effect validation should run before graph-only library typechecking, stderr={stderr}"
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "test command should not start after graph validation fails"
+    );
+}
+
+#[test]
 fn test_command_build_zen_accepts_declared_file_read_effects() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(

--- a/tests/integration/cli_build/graph_validation_test_command_validation.rs
+++ b/tests/integration/cli_build/graph_validation_test_command_validation.rs
@@ -153,6 +153,62 @@ main = () i32 {
 }
 
 #[test]
+fn test_command_build_zen_accepts_valid_graph_only_library_sources() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Test { name: "unit", root: "test.zen" })
+    b.add(Library { name: "core", exports: ["lib.zen"] })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("test.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write test.zen");
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    1
+}
+"#,
+    )
+    .expect("write lib.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["test", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen test build.zen");
+
+    assert!(
+        output.status.success(),
+        "zen test build.zen failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        tmp.path().join("build").join("tests").join("unit").exists(),
+        "expected test binary output to exist"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("test unit passed"),
+        "expected test pass output, stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
 fn test_command_build_zen_rejects_graph_only_library_type_errors() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(


### PR DESCRIPTION
## Summary
- add `zen test build.zen` coverage for valid graph-only library exports
- add host-effect ordering coverage before graph-only library typechecking
- record the coverage in phase/audit docs

## Verification
- `cargo test --test docs_truth`
- `cargo test --test integration test_command_build_zen`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`