### PR TITLE
[codex] Bundle resolver association replay tasks

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2517,6 +2517,9 @@ and do not assume Phase 4 is ready without evidence.
   `src/module_system/tests/graph_loading.rs`, reducing
   `src/module_system/tests.rs` from 503 to 333 lines while preserving coverage
   through `cargo test --lib module_system::tests`.
+- Resolver behavior-association list replay now selects from the resolver
+  declaration task bundle internally, covered by
+  `cargo test --lib resolver_behavior_association_list_tasks_select_from_declaration_bundle`.
 
 ## Unresolved Gaps
 

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2075,6 +2075,9 @@ checked-in docs, tests, and commits only.
 - Stripped resolver import validation now receives the full resolver
   validation replay task bundle and reads the import-validation flag
   internally, completing the current resolver replay call-site bundle shape.
+- Resolver behavior-association list replay now selects type and behavior
+  association entries from the resolver declaration task bundle internally,
+  reducing another declaration replay sub-slice handoff.
 - AST behavior extends validation now receives the full behavior-association
   task bundle and selects `.extends` entries internally, removing another
   association sub-slice handoff.

--- a/src/typechecker/resolver_validation/replay_tasks.rs
+++ b/src/typechecker/resolver_validation/replay_tasks.rs
@@ -13,23 +13,34 @@ impl TypeChecker {
     ) -> ResolverValidationReplayTasks<'a> {
         let declaration_tasks =
             Self::collect_resolver_validation_replay_declaration_tasks(program, symbols);
-        let mut tasks = ResolverValidationReplayTasks {
-            expected_symbols: declaration_tasks.expected_symbols,
-            behavior_associations: ResolverBehaviorAssociationListTasks::default(),
-        };
+        let behavior_associations =
+            Self::collect_resolver_behavior_association_list_tasks_from_declaration_tasks(
+                &declaration_tasks,
+            );
 
-        for source in declaration_tasks.type_declarations {
+        ResolverValidationReplayTasks {
+            expected_symbols: declaration_tasks.expected_symbols,
+            behavior_associations,
+        }
+    }
+
+    pub(super) fn collect_resolver_behavior_association_list_tasks_from_declaration_tasks<'a>(
+        declaration_tasks: &ResolverValidationReplayDeclarationTasks<'a>,
+    ) -> ResolverBehaviorAssociationListTasks<'a> {
+        let mut tasks = ResolverBehaviorAssociationListTasks::default();
+
+        for source in &declaration_tasks.type_declarations {
             Self::push_resolver_type_behavior_association_list_task(
                 source,
                 &declaration_tasks.expected_associations,
-                &mut tasks.behavior_associations.type_associations,
+                &mut tasks.type_associations,
             );
         }
-        for source in declaration_tasks.behavior_declarations {
+        for source in &declaration_tasks.behavior_declarations {
             Self::push_resolver_behavior_parent_list_task(
                 source,
                 &declaration_tasks.expected_parents,
-                &mut tasks.behavior_associations.behavior_parents,
+                &mut tasks.behavior_parents,
             );
         }
 
@@ -37,7 +48,7 @@ impl TypeChecker {
     }
 
     fn push_resolver_type_behavior_association_list_task<'a>(
-        source: ResolverValidationBehaviorAssociationSource<'a>,
+        source: &ResolverValidationBehaviorAssociationSource<'a>,
         expected: &ExpectedBehaviorAssociations,
         tasks: &mut Vec<ResolverTypeBehaviorAssociationListTask<'a>>,
     ) {
@@ -51,7 +62,7 @@ impl TypeChecker {
     }
 
     fn push_resolver_behavior_parent_list_task<'a>(
-        source: ResolverValidationBehaviorAssociationSource<'a>,
+        source: &ResolverValidationBehaviorAssociationSource<'a>,
         expected: &ExpectedBehaviorEdges,
         tasks: &mut Vec<ResolverBehaviorParentListTask<'a>>,
     ) {

--- a/src/typechecker/tests/resolver_validation/replay_tasks.rs
+++ b/src/typechecker/tests/resolver_validation/replay_tasks.rs
@@ -135,6 +135,59 @@ Point.requires(Json<str>)
 }
 
 #[test]
+fn resolver_behavior_association_list_tasks_select_from_declaration_bundle() {
+    let program = parse_program(
+        r#"
+Point: { x: i32 }
+
+Json<T>: behavior {
+    encode: (Self) T
+}
+
+Pretty<T>: behavior {
+    pretty: (Self) str
+}
+
+Pretty.extends(Json<T>)
+
+Point.implements(Json<str>) {
+    encode = (value: Point) str { "point" }
+}
+
+Point.requires(Json<str>)
+"#,
+    );
+    let symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+
+    let declaration_tasks =
+        TypeChecker::collect_resolver_validation_replay_declaration_tasks(&program, &symbols);
+    let association_tasks =
+        TypeChecker::collect_resolver_behavior_association_list_tasks_from_declaration_tasks(
+            &declaration_tasks,
+        );
+
+    assert_eq!(association_tasks.type_associations.len(), 1);
+    assert_eq!(association_tasks.type_associations[0].name, "Point");
+    assert_eq!(
+        association_tasks.type_associations[0].impl_edges[0].display,
+        "Json<str>"
+    );
+    assert_eq!(
+        association_tasks.type_associations[0].required_edges[0].display,
+        "Json<str>"
+    );
+    assert_eq!(association_tasks.behavior_parents.len(), 2);
+    let pretty_task = association_tasks
+        .behavior_parents
+        .iter()
+        .find(|task| task.name == "Pretty")
+        .expect("Pretty parent association task");
+    assert_eq!(pretty_task.parent_edges[0].display, "Json<T>");
+}
+
+#[test]
 fn resolver_type_reference_validation_tasks_collect_only_type_reference_work() {
     let program = parse_program(
         r#"


### PR DESCRIPTION
## Summary
- collect resolver behavior-association list replay from the declaration task bundle
- add focused resolver replay coverage for the bundled helper
- record the Phase 2 cleanup in phase/audit docs

## Verification
- `cargo test --lib resolver_behavior_association_list_tasks_select_from_declaration_bundle`
- `cargo test --lib resolver_validation::replay_tasks`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`