### PR TITLE
[codex] Bundle AST declaration collection replay

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2520,6 +2520,9 @@ and do not assume Phase 4 is ready without evidence.
 - Resolver behavior-association list replay now selects from the resolver
   declaration task bundle internally, covered by
   `cargo test --lib resolver_behavior_association_list_tasks_select_from_declaration_bundle`.
+- AST declaration collection now replays the full collection task bundle through
+  one helper, covered by
+  `cargo test --lib ast_declaration_collection_bundle_replays_collection_passes`.
 
 ## Unresolved Gaps
 

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2089,7 +2089,10 @@ checked-in docs, tests, and commits only.
   declaration pass before replaying the existing validation order.
 - AST pre-collection validation now builds `Self`-context and behavior-extends
   validation tasks in one declaration pass before replaying the existing
-  pre-collection validation order.
+  validation order.
+- AST declaration collection now replays the full collection task bundle from
+  one helper instead of fanning out sub-slices at the entrypoint, preserving
+  behavior/type/callable/impl/import collection order.
 - AST declaration collection now carries pre-collection validation tasks in
   the same declaration task bundle, so behavior declarations are collected and
   pre-collection validations are replayed without a second declaration scan.

--- a/src/typechecker/declaration_collection.rs
+++ b/src/typechecker/declaration_collection.rs
@@ -5,6 +5,13 @@ impl TypeChecker {
 
     pub(super) fn collect_declarations(&mut self, decls: &[Declaration]) {
         let tasks = Self::collect_ast_declaration_collection_tasks(decls);
+        self.collect_ast_declarations_from_tasks(&tasks);
+    }
+
+    pub(super) fn collect_ast_declarations_from_tasks(
+        &mut self,
+        tasks: &AstDeclarationCollectionTasks<'_>,
+    ) {
         self.collect_behavior_declarations_from_tasks(&tasks.behaviors);
         self.validate_ast_precollection_tasks(&tasks.precollection_validations);
         if !self.resolver_backed_collection {

--- a/src/typechecker/tests/declaration_validation.rs
+++ b/src/typechecker/tests/declaration_validation.rs
@@ -153,6 +153,37 @@ make = () Point { Point { x: 1 } }
 }
 
 #[test]
+fn ast_declaration_collection_bundle_replays_collection_passes() {
+    let program = parse_program(
+        r#"
+Point: { x: i32 }
+
+Json: behavior {
+    encode: (Self) str
+}
+
+make = () Point { Point { x: 1 } }
+
+Point.get = (self: Point) i32 { self.x }
+
+Point.impl = {
+    x_value = (self: Point) i32 { self.x }
+}
+"#,
+    );
+    let tasks = TypeChecker::collect_ast_declaration_collection_tasks(&program.declarations);
+    let mut checker = TypeChecker::new();
+
+    checker.collect_ast_declarations_from_tasks(&tasks);
+
+    assert!(checker.structs.contains_key("Point"));
+    assert!(checker.behaviors.contains_key("Json"));
+    assert!(checker.functions.contains_key("make"));
+    assert!(checker.methods.contains_key("Point.get"));
+    assert!(checker.methods.contains_key("Point.x_value"));
+}
+
+#[test]
 fn check_program_rejects_unknown_type_references() {
     let program = parse_program(
         r#"


### PR DESCRIPTION
## Summary
- replay AST declaration collection through a single task-bundle helper
- add focused coverage for behavior/type/callable/impl collection from the bundle
- record the cleanup in phase/audit docs

## Verification
- `cargo test --lib ast_declaration_collection_bundle_replays_collection_passes`
- `cargo test --lib declaration_validation`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`