### PR TITLE
[codex] Bundle AST semantic validation replay

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2523,6 +2523,9 @@ and do not assume Phase 4 is ready without evidence.
 - AST declaration collection now replays the full collection task bundle through
   one helper, covered by
   `cargo test --lib ast_declaration_collection_bundle_replays_collection_passes`.
+- AST declaration semantic validation now replays its full validation task
+  bundle through one helper, covered by
+  `cargo test --lib ast_declaration_semantic_bundle_replays_validation_passes`.
 
 ## Unresolved Gaps
 

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2087,6 +2087,8 @@ checked-in docs, tests, and commits only.
 - AST declaration semantic validation now builds behavior-association,
   type-reference, and struct field-default validation task lists in one
   declaration pass before replaying the existing validation order.
+- AST declaration semantic validation now replays that full validation task
+  bundle through one helper instead of unpacking sub-slices at the entrypoint.
 - AST pre-collection validation now builds `Self`-context and behavior-extends
   validation tasks in one declaration pass before replaying the existing
   validation order.

--- a/src/typechecker/semantic_validation.rs
+++ b/src/typechecker/semantic_validation.rs
@@ -15,7 +15,15 @@ impl TypeChecker {
         }
 
         let tasks = Self::collect_ast_declaration_validation_tasks(decls);
-        self.validate_behavior_association_tasks(&tasks.behavior_associations, symbols);
+        self.validate_ast_declaration_semantics_from_tasks(&tasks, symbols);
+    }
+
+    pub(super) fn validate_ast_declaration_semantics_from_tasks(
+        &mut self,
+        tasks: &AstDeclarationValidationTasks<'_>,
+        symbols: Option<&SymbolTable>,
+    ) {
+        self.validate_behavior_association_tasks(tasks, symbols);
         self.validate_ast_type_reference_tasks(&tasks.type_references);
         self.validate_ast_struct_field_default_tasks(&tasks.struct_field_defaults);
     }

--- a/src/typechecker/tests/declaration_validation.rs
+++ b/src/typechecker/tests/declaration_validation.rs
@@ -359,3 +359,53 @@ main = () i32 { 1 }
     assert_eq!(tasks.type_references.len(), 5);
     assert_eq!(tasks.struct_field_defaults.len(), 1);
 }
+
+#[test]
+fn ast_declaration_semantic_bundle_replays_validation_passes() {
+    let program = parse_program(
+        r#"
+Point: { x: i32 = "bad" }
+
+Json: behavior {
+    encode: (Self) str
+}
+
+Point.implements(Json) {
+    encode = (self: Point) str { "point" }
+}
+
+Point.requires(MissingBehavior)
+
+main = (value: MissingType) i32 { 1 }
+"#,
+    );
+    let tasks = TypeChecker::collect_ast_declaration_validation_tasks(&program.declarations);
+    let mut checker = TypeChecker::new();
+    checker.collect_declarations(&program.declarations);
+
+    checker.validate_ast_declaration_semantics_from_tasks(&tasks, None);
+
+    assert!(
+        checker
+            .diagnostics()
+            .iter()
+            .any(|d| d.message.contains("undefined behavior `MissingBehavior`")),
+        "expected behavior association diagnostics, got {:?}",
+        checker.diagnostics()
+    );
+    assert!(
+        checker
+            .diagnostics()
+            .iter()
+            .any(|d| d.message.contains("unknown type symbol 'MissingType'")),
+        "expected type reference diagnostics, got {:?}",
+        checker.diagnostics()
+    );
+    assert!(
+        checker.diagnostics().iter().any(|d| d
+            .message
+            .contains("field `x` default expects `i32`, found `str`")),
+        "expected field default diagnostics, got {:?}",
+        checker.diagnostics()
+    );
+}


### PR DESCRIPTION
## Summary
- replay AST declaration semantic validation through a single task-bundle helper
- add focused coverage for behavior association, type reference, and field default validation from the bundle
- record the cleanup in phase/audit docs

## Verification
- `cargo test --lib ast_declaration_semantic_bundle_replays_validation_passes`
- `cargo test --lib declaration_validation`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`