### PR TITLE
[codex] Cover imported result enum multi specialization

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -95,6 +95,14 @@ and do not assume Phase 4 is ready without evidence.
   and `integration::generated_c_call_definition_scan_reports_missing_generated_calls`,
   proving `Result<Option<T>, str>` specialization does not leave undefined
   generated C calls.
+- Imported generic `Result<T, E>` enum methods now cover multiple concrete
+  instantiations in the importing module through
+  `tests/zen/multi_file_generic_result_enum_multi_specialization/main.zen`,
+  `integration::test_multi_file_generic_result_enum_multi_specialization_imports`,
+  and `integration::generic_specializations_do_not_emit_unspecialized_c_symbols`,
+  proving both `Result_unwrap_or_i32_str` and `Result_unwrap_or_bool_str`
+  resolve to emitted definitions exactly once without unspecialized `Result_T`
+  symbols.
   Imported public generic non-behavior `Type.impl` method templates that use
   source-module imported generic types and methods are covered by
   `tests/zen/multi_file_type_impl_imported_type_dependency/main.zen` and

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -54,6 +54,11 @@ checked-in docs, tests, and commits only.
   `tests/zen/multi_file_type_method_nested_result_dependency/main.zen`,
   proving `Result<Option<T>, str>` return specialization through an imported
   public method without undefined generated C calls.
+- Imported generic `Result<T, E>` enum methods now cover multiple concrete
+  instantiations from the importing module through
+  `tests/zen/multi_file_generic_result_enum_multi_specialization/main.zen`,
+  preserving `Result_unwrap_or_i32_str` and `Result_unwrap_or_bool_str`
+  call/definition pairs without unspecialized `Result_T` symbols.
 - Resolver method symbols carry full value-signature metadata, including
   generic type-parameter names and bounds, and typechecker setup validates
   method signature handoff drift before method bodies are checked.

--- a/tests/integration/generic_specializations.rs
+++ b/tests/integration/generic_specializations.rs
@@ -29,6 +29,7 @@ fn generic_specializations_emit_each_generated_c_definition_once() {
         "multi_file_generic_imported_type_dependency/main.zen",
         "multi_file_generic_imported_worklist_chain/main.zen",
         "multi_file_generic_result_enum_method/main.zen",
+        "multi_file_generic_result_enum_multi_specialization/main.zen",
         "multi_file_imported_generic_function_return_enum_dependency/main.zen",
         "multi_file_type_impl_return_enum_dependency/main.zen",
         "multi_file_type_method_nested_result_dependency/main.zen",
@@ -291,6 +292,28 @@ fn generic_specializations_do_not_emit_unspecialized_c_symbols() {
     assert!(c_source.contains("Result_unwrap_or_i32_str(ok, 0LL)"));
     assert!(c_source.contains("Result_unwrap_or_i32_str(err, 144LL)"));
     assert_c_call_resolves_to_definition(&c_source, "Result_unwrap_or_i32_str");
+    assert!(!c_source.contains("Result_T"));
+    assert!(!c_source.contains("T Result_unwrap_or"));
+    assert!(!c_source.contains("Result_unwrap_or(err"));
+
+    let c_source = compile_to_c_with_generated_call_check(
+        &test_dir().join("multi_file_generic_result_enum_multi_specialization/main.zen"),
+    );
+    assert!(c_source.contains("typedef struct Result_i32_str Result_i32_str;"));
+    assert!(c_source.contains("typedef struct Result_bool_str Result_bool_str;"));
+    assert!(c_source
+        .contains("int32_t Result_unwrap_or_i32_str(Result_i32_str self, int32_t fallback)"));
+    assert!(
+        c_source.contains("bool Result_unwrap_or_bool_str(Result_bool_str self, bool fallback)")
+    );
+    assert!(c_source.contains("Result_unwrap_or_i32_str(ok_int, 0LL)"));
+    assert!(c_source.contains("Result_unwrap_or_i32_str(err_int, 144LL)"));
+    assert!(c_source.contains("Result_unwrap_or_bool_str(ok_bool, true)"));
+    assert!(c_source.contains("Result_unwrap_or_bool_str(err_bool, true)"));
+    assert_c_call_resolves_to_definition(&c_source, "Result_unwrap_or_i32_str");
+    assert_c_call_resolves_to_definition(&c_source, "Result_unwrap_or_bool_str");
+    assert_c_function_definition_count(&c_source, "Result_unwrap_or_i32_str", 1);
+    assert_c_function_definition_count(&c_source, "Result_unwrap_or_bool_str", 1);
     assert!(!c_source.contains("Result_T"));
     assert!(!c_source.contains("T Result_unwrap_or"));
     assert!(!c_source.contains("Result_unwrap_or(err"));

--- a/tests/integration/multi_file_fixtures.rs
+++ b/tests/integration/multi_file_fixtures.rs
@@ -50,6 +50,13 @@ fn test_multi_file_generic_result_enum_method_imports() {
 }
 
 #[test]
+fn test_multi_file_generic_result_enum_multi_specialization_imports() {
+    let zen_path = test_dir().join("multi_file_generic_result_enum_multi_specialization/main.zen");
+    let actual = compile_and_run(&zen_path);
+    assert_eq!(actual, "55\n144\nfalse\ntrue\n");
+}
+
+#[test]
 fn test_multi_file_type_impl_imports() {
     let zen_path = test_dir().join("multi_file_type_impl/main.zen");
     let actual = compile_and_run(&zen_path);

--- a/tests/zen/multi_file_generic_result_enum_multi_specialization/main.zen
+++ b/tests/zen/multi_file_generic_result_enum_multi_specialization/main.zen
@@ -1,0 +1,15 @@
+{ io } = std
+{ Result } = result
+
+main = () i32 {
+    ok_int = Result<i32, str>.Ok(55)
+    err_int = Result<i32, str>.Err("bad")
+    ok_bool = Result<bool, str>.Ok(false)
+    err_bool = Result<bool, str>.Err("nope")
+
+    io.println("${ok_int.unwrap_or(0)}")
+    io.println("${err_int.unwrap_or(144)}")
+    io.println("${ok_bool.unwrap_or(true)}")
+    io.println("${err_bool.unwrap_or(true)}")
+    0
+}

--- a/tests/zen/multi_file_generic_result_enum_multi_specialization/result.zen
+++ b/tests/zen/multi_file_generic_result_enum_multi_specialization/result.zen
@@ -1,0 +1,9 @@
+pub Result<T, E>:
+    Ok(T),
+    Err(E)
+
+pub Result.unwrap_or<T, E> = (self: Self, fallback: T) T {
+    self ?
+        | Ok(value) { value }
+        | Err(_) { fallback }
+}


### PR DESCRIPTION
## Summary
- add a multi-file `Result<T, E>` enum-method fixture with both i32 and bool instantiations
- assert generated C emits and calls both concrete imported method specializations once
- record the Phase 5 coverage in phase/audit docs

## Verification
- `cargo test --test integration multi_file_generic_result_enum_multi_specialization -- --nocapture`
- `cargo test --test integration generic_specializations -- --nocapture`
- `cargo test --test docs_truth`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`