### PR TITLE
[codex] Cover imported generic method arity diagnostics

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -1834,6 +1834,10 @@ and do not assume Phase 4 is ready without evidence.
   `generic_diagnostics::generic_function_explicit_type_arg_arity_does_not_emit_argument_followup`
   and
   `generic_diagnostics::generic_method_explicit_type_arg_arity_does_not_emit_argument_followup`.
+- Imported generic enum method explicit type-argument arity failures use the
+  same hard diagnostic and suppress inference/argument followups through the
+  module graph, covered by
+  `integration::imported_generic_enum_method_explicit_type_arg_arity_is_error`.
 - Malformed nested generic type annotations inside explicit function and
   method call type arguments now also skip dependent signature checks, covered
   by `generic_diagnostics::generic_function_type_arg_annotation_arity_is_error`

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -126,6 +126,9 @@ checked-in docs, tests, and commits only.
   uniqueness and call/definition assertions.
 - Generic diagnostics now cover explicit type-argument arity failures for
   two-parameter `Result<T, E>` enum methods without noisy followup diagnostics.
+- Imported generic enum methods now cover the same explicit type-argument arity
+  failure through the module graph, preserving the hard method diagnostic
+  without inference or argument-mismatch followups.
 - Generic diagnostics now cover generic enum constructor arity failures without
   leaking raw type-parameter payload mismatch followups, including
   `generic_enum_constructor_without_type_args_is_error`.

--- a/tests/integration/frontend_diagnostics.rs
+++ b/tests/integration/frontend_diagnostics.rs
@@ -74,6 +74,62 @@ main = () i32 {
 }
 
 #[test]
+fn imported_generic_enum_method_explicit_type_arg_arity_is_error() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let result_path = tmp.path().join("result.zen");
+    std::fs::write(
+        &result_path,
+        r#"
+pub Result<T, E>:
+    Ok(T),
+    Err(E)
+
+pub Result.unwrap_or<T, E> = (self: Self, fallback: T) T {
+    self ?
+        | Ok(value) { value }
+        | Err(_) { fallback }
+}
+"#,
+    )
+    .expect("write result module");
+
+    let main_path = tmp.path().join("main.zen");
+    std::fs::write(
+        &main_path,
+        r#"
+{ Result } = result
+
+main = () i32 {
+    value = Result<i32, str>.Ok(1)
+    value.unwrap_or<i32>(0)
+}
+"#,
+    )
+    .expect("write entry module");
+
+    let panic = std::panic::catch_unwind(|| compile_to_c(&main_path))
+        .expect_err("compile_to_c should reject imported generic method arity errors");
+    let message = panic
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| panic.downcast_ref::<&str>().copied())
+        .unwrap_or("<non-string panic>");
+
+    assert!(
+        message.contains("generic method `Result.unwrap_or` expects 2 type arguments, found 1"),
+        "expected imported generic method arity diagnostic, panic={message}"
+    );
+    assert!(
+        !message.contains("cannot infer type argument"),
+        "imported generic method arity failure should not also report inference, panic={message}"
+    );
+    assert!(
+        !message.contains("argument 2"),
+        "imported generic method arity failure should not also report argument mismatch, panic={message}"
+    );
+}
+
+#[test]
 fn imported_behavior_extends_requires_parent_methods() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let traits_path = tmp.path().join("traits.zen");


### PR DESCRIPTION
## Summary
- add module-graph coverage for imported generic enum method explicit type-argument arity errors
- assert the hard arity diagnostic suppresses inference and argument mismatch followups
- record the Phase 5 diagnostic coverage in phase/audit docs

## Verification
- `cargo test --test integration imported_generic_enum_method_explicit_type_arg_arity_is_error -- --nocapture`
- `cargo test --test docs_truth`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`