### PR TITLE
[codex] Cover imported generic function arity diagnostics

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -1838,6 +1838,10 @@ and do not assume Phase 4 is ready without evidence.
   same hard diagnostic and suppress inference/argument followups through the
   module graph, covered by
   `integration::imported_generic_enum_method_explicit_type_arg_arity_is_error`.
+- Imported generic function explicit type-argument arity failures use the same
+  hard diagnostic and suppress inference/argument followups through the module
+  graph, covered by
+  `integration::imported_generic_function_explicit_type_arg_arity_is_error`.
 - Malformed nested generic type annotations inside explicit function and
   method call type arguments now also skip dependent signature checks, covered
   by `generic_diagnostics::generic_function_type_arg_annotation_arity_is_error`

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -129,6 +129,9 @@ checked-in docs, tests, and commits only.
 - Imported generic enum methods now cover the same explicit type-argument arity
   failure through the module graph, preserving the hard method diagnostic
   without inference or argument-mismatch followups.
+- Imported generic functions now cover the same explicit type-argument arity
+  failure through the module graph, preserving the hard function diagnostic
+  without inference or argument-mismatch followups.
 - Generic diagnostics now cover generic enum constructor arity failures without
   leaking raw type-parameter payload mismatch followups, including
   `generic_enum_constructor_without_type_args_is_error`.

--- a/tests/integration/frontend_diagnostics.rs
+++ b/tests/integration/frontend_diagnostics.rs
@@ -130,6 +130,55 @@ main = () i32 {
 }
 
 #[test]
+fn imported_generic_function_explicit_type_arg_arity_is_error() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let helpers_path = tmp.path().join("helpers.zen");
+    std::fs::write(
+        &helpers_path,
+        r#"
+pub take_second<T, U> = (value: U) U {
+    value
+}
+"#,
+    )
+    .expect("write helpers module");
+
+    let main_path = tmp.path().join("main.zen");
+    std::fs::write(
+        &main_path,
+        r#"
+{ take_second } = helpers
+
+main = () i32 {
+    take_second<i32>(1)
+}
+"#,
+    )
+    .expect("write entry module");
+
+    let panic = std::panic::catch_unwind(|| compile_to_c(&main_path))
+        .expect_err("compile_to_c should reject imported generic function arity errors");
+    let message = panic
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| panic.downcast_ref::<&str>().copied())
+        .unwrap_or("<non-string panic>");
+
+    assert!(
+        message.contains("generic function `take_second` expects 2 type arguments, found 1"),
+        "expected imported generic function arity diagnostic, panic={message}"
+    );
+    assert!(
+        !message.contains("cannot infer type argument"),
+        "imported generic function arity failure should not also report inference, panic={message}"
+    );
+    assert!(
+        !message.contains("argument 1"),
+        "imported generic function arity failure should not also report argument mismatch, panic={message}"
+    );
+}
+
+#[test]
 fn imported_behavior_extends_requires_parent_methods() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let traits_path = tmp.path().join("traits.zen");


### PR DESCRIPTION
## Summary
- add module-graph coverage for imported generic function explicit type-argument arity errors
- assert the hard arity diagnostic suppresses inference and argument mismatch followups
- record the Phase 5 diagnostic coverage in phase/audit docs

## Verification
- `cargo test --test docs_truth`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`