### PR TITLE
[codex] Cover emit build graph gated dependencies

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2445,6 +2445,11 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration emit_command_build_zen_accepts_declared_file_read_effects`
   and
   `cargo test --test integration emit_command_build_zen_rejects_undeclared_file_read_effects`.
+- Single-target `zen emit build.zen` rejects selected executable dependencies
+  on gated library and test targets before C emission, covered by
+  `cargo test --test integration emit_command_build_zen_rejects_gated_library_dependencies`
+  and
+  `cargo test --test integration emit_command_build_zen_rejects_gated_test_dependencies`.
 - Single-target `zen emit build.zen` validates and typechecks graph-only
   library exports before emission, covered by
   `cargo test --test integration emit_command_build_zen_accepts_valid_graph_only_library_sources`,

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2281,6 +2281,10 @@ checked-in docs, tests, and commits only.
   `emit_command_build_zen_rejects_multiple_executable_targets`, and rejects
   undeclared host effects through
   `emit_command_build_zen_rejects_undeclared_host_effects`. It validates
+  selected executable dependencies before emission through
+  `emit_command_build_zen_rejects_gated_library_dependencies` and
+  `emit_command_build_zen_rejects_gated_test_dependencies`, preserving gated
+  library/test execution boundaries on the emit path. It validates
   graph-only library exports before emission through
   `emit_command_build_zen_rejects_missing_graph_only_library_source`,
   accepts valid graph-only library exports through
@@ -2365,9 +2369,9 @@ graph targets, `zen test build.zen` executes multiple test graph targets,
 `zen check build.zen` validates executable, test, and library targets in the
 graph and typechecks target sources without compiling them, `zen emit build.zen`
 emits target C for a single executable graph target, and build/test/emit
-validate and typecheck graph-only library target sources while build/test
-execution rejects dependencies on gated library targets and library execution
-remains gated. Legacy generic JSON emitters reject
+validate and typecheck graph-only library target sources while build/test/emit
+execution rejects dependencies on gated non-selected target kinds and library
+execution remains gated. Legacy generic JSON emitters reject
 `build.zen` and point to
 `emit-json build-graph`.
 

--- a/tests/integration/cli_build/emit_direct_validation.rs
+++ b/tests/integration/cli_build/emit_direct_validation.rs
@@ -226,6 +226,96 @@ main = () i32 {
 }
 
 #[test]
+fn emit_command_build_zen_rejects_gated_library_dependencies() {
+    assert_emit_rejects_gated_dependency(
+        r#"b.add(Library { name: "core", exports: ["lib.zen"] })"#,
+        "core",
+        "lib.zen",
+        "library",
+    );
+}
+
+#[test]
+fn emit_command_build_zen_rejects_gated_test_dependencies() {
+    assert_emit_rejects_gated_dependency(
+        r#"b.add(Test { name: "unit", root: "test.zen" })"#,
+        "unit",
+        "test.zen",
+        "test",
+    );
+}
+
+fn assert_emit_rejects_gated_dependency(
+    gated_target_decl: &str,
+    gated_target_name: &str,
+    gated_source_name: &str,
+    gated_target_kind: &str,
+) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
+    {gated_target_decl}
+    b.add(Executable {{
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["{gated_target_name}"],
+    }})
+    .Ok(b.config())
+}}
+"#,
+        ),
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join(gated_source_name),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write gated target source");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen emit build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen emit build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains(&format!(
+                "build graph target `app` depends on gated {gated_target_kind} target `{gated_target_name}`"
+            )),
+        "expected gated dependency diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "zen emit build.zen should not create build outputs after gated dependency validation fails"
+    );
+}
+
+#[test]
 fn emit_command_build_zen_rejects_missing_graph_only_library_source() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(


### PR DESCRIPTION
## Summary
- add single-target `zen emit build.zen` coverage for dependencies on gated library and test targets
- assert emit stops before creating build outputs when those dependencies are rejected
- update phase/audit docs to record the emit-path gated dependency boundary

## Verification
- `cargo test --test integration emit_command_build_zen_rejects_gated -- --nocapture`
- `cargo test --test docs_truth`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`