### PR TITLE
[codex] Cover legacy build graph gated dependencies

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2390,13 +2390,15 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration build_command_build_zen_accepts_declared_file_read_effects`
   and
   `cargo test --test integration build_command_build_zen_rejects_undeclared_file_read_effects_before_execution`.
-- Build/test graph execution rejects dependencies on gated library targets,
+- Build/test/legacy graph execution rejects dependencies on gated library targets,
   covered by
-  `cargo test --test integration build_command_build_zen_rejects_gated_library_dependencies`
+  `cargo test --test integration build_command_build_zen_rejects_gated_library_dependencies`,
+  `cargo test --test integration build_graph_command_rejects_gated_library_dependencies`,
   and
   `cargo test --test integration test_command_build_zen_rejects_gated_library_dependencies`.
   Cross-mode execution gating is also covered by
-  `cargo test --test integration build_command_build_zen_rejects_gated_test_dependencies`
+  `cargo test --test integration build_command_build_zen_rejects_gated_test_dependencies`,
+  `cargo test --test integration build_graph_command_rejects_gated_test_dependencies`,
   and
   `cargo test --test integration test_command_build_zen_rejects_gated_executable_dependencies`.
 - Normal test graph execution accepts declared deterministic file-read effects

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2184,7 +2184,9 @@ checked-in docs, tests, and commits only.
   graph-only library typechecking before execution starts, and
   `build_graph_command_rejects_undeclared_host_effects_before_library_typechecking`
   preserves deterministic host-effect validation before graph-only library
-  typechecking, and
+  typechecking. `build_graph_command_rejects_gated_library_dependencies` and
+  `build_graph_command_rejects_gated_test_dependencies` cover rejected
+  executable dependencies on gated library/test targets, and
   `build_graph_command_rejects_missing_root_source` covers a target execution
   failure before normal `zen build build.zen` is ungated.
   Declared deterministic file-read effects are accepted through

--- a/tests/integration/cli_build/legacy_graph_command_validation.rs
+++ b/tests/integration/cli_build/legacy_graph_command_validation.rs
@@ -48,6 +48,95 @@ main = () i32 {
 }
 
 #[test]
+fn build_graph_command_rejects_gated_library_dependencies() {
+    assert_build_graph_rejects_gated_dependency(
+        r#"b.add(Library { name: "core", exports: ["lib.zen"] })"#,
+        "core",
+        "lib.zen",
+        "library",
+    );
+}
+
+#[test]
+fn build_graph_command_rejects_gated_test_dependencies() {
+    assert_build_graph_rejects_gated_dependency(
+        r#"b.add(Test { name: "unit", root: "test.zen" })"#,
+        "unit",
+        "test.zen",
+        "test",
+    );
+}
+
+fn assert_build_graph_rejects_gated_dependency(
+    gated_target_decl: &str,
+    gated_target_name: &str,
+    gated_source_name: &str,
+    gated_target_kind: &str,
+) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
+    {gated_target_decl}
+    b.add(Executable {{
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["{gated_target_name}"],
+    }})
+    .Ok(b.config())
+}}
+"#,
+        ),
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join(gated_source_name),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write gated target source");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build-graph", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build-graph");
+
+    assert!(
+        !output.status.success(),
+        "zen build-graph unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains(&format!(
+            "build graph target `app` depends on gated {gated_target_kind} target `{gated_target_name}`"
+        )),
+        "expected gated dependency diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "build-graph command should not start after gated dependency validation fails"
+    );
+}
+
+#[test]
 fn build_graph_command_rejects_missing_graph_only_library_source() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(


### PR DESCRIPTION
## Summary
- add legacy `zen build-graph build.zen` coverage for dependencies on gated library and test targets
- assert the command stops before creating build outputs when gated dependencies are rejected
- update phase/audit docs to record legacy command coverage in the gated dependency matrix

## Verification
- `cargo test --test integration build_graph_command_rejects_gated -- --nocapture`
- `cargo test --test docs_truth`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`