### PR TITLE
[codex] Cover library-only build graph gates

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2458,6 +2458,14 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration emit_command_build_zen_rejects_graph_only_library_type_errors`,
   and
   `cargo test --test integration emit_command_build_zen_rejects_undeclared_host_effects_before_library_typechecking`.
+- Library-only build graphs remain non-executable across the current execution
+  entrypoints, covered by
+  `cargo test --test integration build_command_build_zen_rejects_library_only_graph_execution`,
+  `cargo test --test integration direct_file_command_build_zen_rejects_library_only_graph_execution`,
+  `cargo test --test integration build_graph_command_rejects_library_only_graph_execution`,
+  `cargo test --test integration emit_command_build_zen_rejects_library_only_graph_execution`,
+  and
+  `cargo test --test integration test_command_build_zen_rejects_library_only_graph_execution`.
 - Direct `zen build.zen` accepts declared deterministic file-read effects and
   rejects undeclared file reads before execution, covered by
   `cargo test --test integration direct_file_command_build_zen_accepts_declared_file_read_effects`

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2369,13 +2369,14 @@ Phase 4 build-driver work still has constrained `build.zen` semantics: normal
 `zen build build.zen` and direct `zen build.zen` execute multiple executable
 graph targets, `zen test build.zen` executes multiple test graph targets,
 `zen check build.zen` validates executable, test, and library targets in the
-graph and typechecks target sources without compiling them, `zen emit build.zen`
-emits target C for a single executable graph target, and build/test/emit
-validate and typecheck graph-only library target sources while build/test/emit
-execution rejects dependencies on gated non-selected target kinds and library
-execution remains gated. Legacy generic JSON emitters reject
-`build.zen` and point to
-`emit-json build-graph`.
+  graph and typechecks target sources without compiling them, `zen emit build.zen`
+  emits target C for a single executable graph target, and build/test/emit
+  validate and typecheck graph-only library target sources while build/test/emit
+  execution rejects dependencies on gated non-selected target kinds and library
+  execution remains explicitly gated by library-only graph rejection coverage.
+  Legacy generic JSON emitters reject
+  `build.zen` and point to
+  `emit-json build-graph`.
 
 Do not promote gated v1 features until the relevant positive and negative tests
 exist and pass through the same compiler path advertised in `docs/V1_SPEC.md`.

--- a/tests/integration/cli_build.rs
+++ b/tests/integration/cli_build.rs
@@ -38,3 +38,5 @@ mod legacy_graph_command;
 mod legacy_graph_command_host_effects;
 #[path = "cli_build/legacy_graph_command_validation.rs"]
 mod legacy_graph_command_validation;
+#[path = "cli_build/library_execution_gates.rs"]
+mod library_execution_gates;

--- a/tests/integration/cli_build/library_execution_gates.rs
+++ b/tests/integration/cli_build/library_execution_gates.rs
@@ -1,0 +1,86 @@
+use std::process::Command;
+
+#[test]
+fn build_command_build_zen_rejects_library_only_graph_execution() {
+    assert_library_only_graph_is_rejected(
+        &["build", "build.zen"],
+        "build graph execution requires at least one executable target",
+    );
+}
+
+#[test]
+fn direct_file_command_build_zen_rejects_library_only_graph_execution() {
+    assert_library_only_graph_is_rejected(
+        &["build.zen"],
+        "build graph execution requires at least one executable target",
+    );
+}
+
+#[test]
+fn build_graph_command_rejects_library_only_graph_execution() {
+    assert_library_only_graph_is_rejected(
+        &["build-graph", "build.zen"],
+        "build graph execution requires at least one executable target",
+    );
+}
+
+#[test]
+fn emit_command_build_zen_rejects_library_only_graph_execution() {
+    assert_library_only_graph_is_rejected(
+        &["emit", "build.zen"],
+        "build graph C emission supports exactly one target, found 0",
+    );
+}
+
+#[test]
+fn test_command_build_zen_rejects_library_only_graph_execution() {
+    assert_library_only_graph_is_rejected(
+        &["test", "build.zen"],
+        "build graph test execution requires at least one test target",
+    );
+}
+
+fn assert_library_only_graph_is_rejected(args: &[&str], expected_stderr: &str) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Library { name: "core", exports: ["lib.zen"] })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    1
+}
+"#,
+    )
+    .expect("write lib.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(args)
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen command");
+
+    assert!(
+        !output.status.success(),
+        "zen {args:?} unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains(expected_stderr),
+        "expected library-only graph diagnostic `{expected_stderr}`, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "zen {args:?} should not create build outputs for a library-only graph"
+    );
+}


### PR DESCRIPTION
## Summary
- add explicit library-only build graph rejection coverage for build, direct build.zen, legacy build-graph, emit, and test entrypoints
- assert library-only graphs do not create build outputs on execution paths
- update phase/audit docs to record library execution as directly gated by tests

## Verification
- `cargo test --test integration library_only_graph_execution -- --nocapture`
- `cargo test --test docs_truth`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`