### PR TITLE
[codex] Cover library-only build graph check validation

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2428,6 +2428,9 @@ and do not assume Phase 4 is ready without evidence.
 - `zen check build.zen` typechecks graph target sources after deterministic
   graph/source validation and before reporting the graph summary, covered by
   `cargo test --test integration check_command_build_zen_typechecks_target_sources`.
+  Library-only graphs are valid on this non-executing validation path, covered
+  by
+  `cargo test --test integration check_command_build_zen_accepts_library_only_graph_validation`.
   Undeclared host effects still reject before target source typechecking,
   covered by
   `cargo test --test integration check_command_build_zen_rejects_undeclared_host_effects_before_target_typechecking`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2367,9 +2367,10 @@ Continue the smallest behavior-association and resolver/typechecker hardening
 slices. Phase 3 C codegen is sufficient for the current tested fixtures, but
 Phase 4 build-driver work still has constrained `build.zen` semantics: normal
 `zen build build.zen` and direct `zen build.zen` execute multiple executable
-graph targets, `zen test build.zen` executes multiple test graph targets,
-`zen check build.zen` validates executable, test, and library targets in the
-  graph and typechecks target sources without compiling them, `zen emit build.zen`
+  graph targets, `zen test build.zen` executes multiple test graph targets,
+  `zen check build.zen` validates executable, test, and library targets in the
+  graph, accepts library-only validation, and typechecks target sources without
+  compiling them, `zen emit build.zen`
   emits target C for a single executable graph target, and build/test/emit
   validate and typecheck graph-only library target sources while build/test/emit
   execution rejects dependencies on gated non-selected target kinds and library

--- a/tests/integration/cli_build/graph_validation.rs
+++ b/tests/integration/cli_build/graph_validation.rs
@@ -43,6 +43,52 @@ main = () i32 {
 }
 
 #[test]
+fn check_command_build_zen_accepts_library_only_graph_validation() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Library { name: "core", exports: ["lib.zen"] })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    1
+}
+"#,
+    )
+    .expect("write lib.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["check", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen check build.zen");
+
+    assert!(
+        output.status.success(),
+        "zen check build.zen failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("1 build targets"),
+        "expected build graph check summary, stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "zen check build.zen should validate library-only graphs without creating build outputs"
+    );
+}
+
+#[test]
 fn check_command_build_zen_typechecks_target_sources() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(


### PR DESCRIPTION
## Summary
- add positive `zen check build.zen` coverage for library-only build graphs
- assert check validates without creating build outputs
- update phase/audit docs to distinguish library-only validation from gated library execution

## Verification
- `cargo test --test integration check_command_build_zen_accepts_library_only_graph_validation -- --nocapture`
- `cargo test --test docs_truth`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`