### PR TITLE
[codex] Own build target kind diagnostics

### DIFF
--- a/src/build_graph.rs
+++ b/src/build_graph.rs
@@ -34,6 +34,22 @@ pub enum BuildTargetKind {
     },
 }
 
+impl BuildTargetKind {
+    pub fn diagnostic_name(&self) -> &'static str {
+        match self {
+            Self::Executable { .. } => "executable",
+            Self::Test { .. } => "test",
+            Self::Library { .. } => "library",
+        }
+    }
+}
+
+impl fmt::Display for BuildTargetKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.diagnostic_name())
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(tag = "kind", content = "value", rename_all = "snake_case")]
 pub enum HostEffect {

--- a/src/cli/build_graph_execution.rs
+++ b/src/cli/build_graph_execution.rs
@@ -145,7 +145,7 @@ fn validate_executed_dependency_targets(
             eprintln!(
                 "build graph target `{}` depends on gated {} target `{}`",
                 target.name(),
-                build_target_kind_name(dependency_target.kind()),
+                dependency_target.kind(),
                 dependency_target.name()
             );
             process::exit(1);
@@ -199,14 +199,6 @@ fn validate_non_executed_target_sources(
             process::exit(1);
         });
         super::graph_frontend(source_path);
-    }
-}
-
-fn build_target_kind_name(kind: &zen::build_graph::BuildTargetKind) -> &'static str {
-    match kind {
-        zen::build_graph::BuildTargetKind::Executable { .. } => "executable",
-        zen::build_graph::BuildTargetKind::Test { .. } => "test",
-        zen::build_graph::BuildTargetKind::Library { .. } => "library",
     }
 }
 

--- a/tests/build_graph.rs
+++ b/tests/build_graph.rs
@@ -23,6 +23,32 @@ fn executable_target(name: &str, sources: &[&str]) -> BuildTargetInput {
 }
 
 #[test]
+fn build_target_kind_owns_diagnostic_spelling() {
+    assert_eq!(
+        BuildTargetKind::Executable {
+            root_source_file: "src/main.zen".to_string(),
+            out_dir: "build".to_string(),
+        }
+        .to_string(),
+        "executable"
+    );
+    assert_eq!(
+        BuildTargetKind::Test {
+            root_source_file: "tests/main.zen".to_string(),
+        }
+        .to_string(),
+        "test"
+    );
+    assert_eq!(
+        BuildTargetKind::Library {
+            exports: vec!["src/lib.zen".to_string()],
+        }
+        .to_string(),
+        "library"
+    );
+}
+
+#[test]
 fn deterministic_build_graph_creates_one_executable_target() {
     let first = BuildGraph::from_input(BuildGraphInput {
         targets: vec![executable_target(


### PR DESCRIPTION
## Summary
- add `BuildTargetKind` diagnostic/display spelling for executable, test, and library target kinds
- use the enum display in gated dependency diagnostics instead of a local CLI match helper
- add focused coverage that target-kind diagnostic strings are owned by the enum

## Verification
- `cargo test --test build_graph build_target_kind_owns_diagnostic_spelling -- --nocapture` fails before implementation
- `cargo test --test build_graph build_target_kind_owns_diagnostic_spelling -- --nocapture`
- `cargo test --test integration build_command_build_zen_rejects_gated_library_dependencies -- --nocapture`
- `cargo test --test integration test_command_build_zen_rejects_gated_executable_dependencies -- --nocapture`
- `cargo test --test docs_truth`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`