### PR TITLE
[codex] Own build target kind support list

### DIFF
--- a/src/build_graph/lowering.rs
+++ b/src/build_graph/lowering.rs
@@ -32,6 +32,7 @@ enum BuildTargetDslIdent {
 }
 
 impl BuildTargetDslKind {
+    const ALL: [Self; 3] = [Self::Executable, Self::Test, Self::Library];
     const EXECUTABLE: &'static str = "Executable";
     const TEST: &'static str = "Test";
     const LIBRARY: &'static str = "Library";
@@ -42,6 +43,20 @@ impl BuildTargetDslKind {
             Self::Test => Self::TEST,
             Self::Library => Self::LIBRARY,
         }
+    }
+
+    fn supported_display_list() -> String {
+        let names = Self::ALL
+            .iter()
+            .map(|kind| format!("`{kind}`"))
+            .collect::<Vec<_>>();
+        let Some((last, rest)) = names.split_last() else {
+            return String::new();
+        };
+        if rest.is_empty() {
+            return last.clone();
+        }
+        format!("{}, and {last}", rest.join(", "))
     }
 }
 
@@ -334,7 +349,8 @@ fn build_target_from_builder_add(
         Ok(BuildTargetDslKind::Library) => library_target_from_fields(fields),
         Err(()) => {
             return Err(BuildGraphError::UnsupportedBuildScript(format!(
-                "unsupported build target kind `{name}`; supported target kinds are `Executable`, `Test`, and `Library`"
+                "unsupported build target kind `{name}`; supported target kinds are {}",
+                BuildTargetDslKind::supported_display_list()
             )));
         }
     };

--- a/src/build_graph/lowering_tests.rs
+++ b/src/build_graph/lowering_tests.rs
@@ -12,6 +12,10 @@ fn build_target_dsl_kind_owns_source_spelling() {
     assert_eq!(BuildTargetDslKind::Executable.to_string(), "Executable");
     assert_eq!(BuildTargetDslKind::Test.to_string(), "Test");
     assert_eq!(BuildTargetDslKind::Library.to_string(), "Library");
+    assert_eq!(
+        BuildTargetDslKind::supported_display_list(),
+        "`Executable`, `Test`, and `Library`"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- make `BuildTargetDslKind` own the supported target-kind diagnostic list
- use that enum-owned list when rejecting unsupported build target kinds
- cover the supported-list spelling with the existing DSL-kind ownership test

## Verification
- `cargo test --lib build_target_dsl_kind_owns_source_spelling -- --nocapture` fails before implementation
- `cargo test --lib build_target_dsl_kind_owns_source_spelling -- --nocapture`
- `cargo test --test build_graph unsupported_package -- --nocapture`
- `cargo test --test integration unsupported_package -- --nocapture`
- `cargo test --test docs_truth`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`