### PR TITLE
Use semantic tasks for resolver defaults

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -1974,13 +1974,14 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test collect_declarations_with_symbols_uses_distinct_restored_requires_type_args`,
   and
   `cargo test collect_declarations_with_symbols_does_not_validate_stale_requires_after_target_restore`.
-- Resolver-backed struct field default validation now reuses collected type
-  metadata tasks instead of rescanning declarations during semantic replay,
+- Resolver-backed struct field default validation now uses dedicated semantic
+  validation tasks instead of carrying unused resolver metadata while replaying
+  standalone default checks,
   covered by
-  `cargo test resolver_struct_field_defaults_validate_from_type_metadata_tasks`.
+  `cargo test resolver_struct_field_defaults_validate_from_semantic_tasks`.
   The fallback resolver-backed struct field default validation path also uses
-  the shared metadata task collector, covered by
-  `cargo test resolver_backed_struct_field_defaults_reuse_metadata_tasks`.
+  the focused semantic task collector, covered by
+  `cargo test resolver_backed_struct_field_defaults_use_semantic_tasks`.
 - Resolver-backed generic type-reference validation now reuses type-reference
   tasks from the declaration metadata pass instead of rescanning declarations
   during semantic replay, covered by
@@ -2075,13 +2076,12 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test resolver_type_reference_validation_tasks_collect_only_type_reference_work`
   and
   `cargo test collect_declarations_with_symbols_uses_resolver_type_metadata_for_type_refs`.
-- Resolver-backed struct field-default validation now uses a narrow type
-  declaration metadata task collector instead of collecting the full resolver
-  metadata task bundle when only type default replay is needed, covered by
-  `cargo test resolver_type_declaration_metadata_tasks_collect_only_type_work`,
-  `cargo test resolver_backed_struct_field_defaults_reuse_metadata_tasks`,
-  and
-  `cargo test resolver_struct_field_defaults_validate_from_type_metadata_tasks`.
+- Resolver-backed struct field-default validation now uses the dedicated
+  semantic task collector instead of collecting the full resolver metadata
+  task bundle when only default replay is needed, covered by
+  `cargo test resolver_declaration_semantic_tasks_collect_only_semantic_work`,
+  `cargo test resolver_backed_struct_field_defaults_use_semantic_tasks`, and
+  `cargo test resolver_struct_field_defaults_validate_from_semantic_tasks`.
 - Resolver-backed behavior declaration metadata now uses a narrow behavior
   metadata task collector shared by the full resolver metadata collector,
   covered by

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1915,8 +1915,9 @@ checked-in docs, tests, and commits only.
 - Resolver-backed behavior requires semantic validation now reuses collected
   requires tasks from the declaration metadata pass instead of rebuilding
   requires tasks during semantic replay.
-- Resolver-backed struct field default validation now reuses collected type
-  metadata tasks instead of rescanning declarations during semantic replay.
+- Resolver-backed struct field default validation now uses dedicated semantic
+  validation tasks instead of carrying unused resolver metadata while replaying
+  standalone default checks.
 - Resolver-backed generic type-reference validation now reuses type-reference
   tasks from the declaration metadata pass instead of rescanning declarations
   during semantic replay.

--- a/src/typechecker/semantic_validation.rs
+++ b/src/typechecker/semantic_validation.rs
@@ -205,8 +205,8 @@ impl TypeChecker {
         symbols: Option<&SymbolTable>,
     ) {
         if self.resolver_backed_collection {
-            let tasks = Self::collect_resolver_declaration_metadata_tasks(decls);
-            self.validate_resolver_struct_field_default_tasks(&tasks, symbols);
+            let tasks = Self::collect_resolver_declaration_semantic_validation_tasks(decls);
+            self.validate_resolver_struct_field_default_task_list(&tasks.struct_defaults, symbols);
             return;
         }
 

--- a/src/typechecker/tests/resolver_collection/type_metadata.rs
+++ b/src/typechecker/tests/resolver_collection/type_metadata.rs
@@ -98,7 +98,7 @@ Point: { x: i32 = true }
 }
 
 #[test]
-fn resolver_struct_field_defaults_validate_from_type_metadata_tasks() {
+fn resolver_struct_field_defaults_validate_from_semantic_tasks() {
     let program = parse_program(
         r#"
 Point: { x: i32 = true }
@@ -107,17 +107,20 @@ Point: { x: i32 = true }
     let symbols = crate::resolver::Resolver::new()
         .resolve_program(&program)
         .expect("resolver succeeds");
-    let tasks = TypeChecker::collect_resolver_declaration_metadata_tasks(&program.declarations);
+    let tasks =
+        TypeChecker::collect_resolver_declaration_semantic_validation_tasks(&program.declarations);
     let mut stale_declarations = program.declarations.clone();
     if let Declaration::Struct { fields, .. } = &mut stale_declarations[0] {
         fields.clear();
     }
     let mut tc = TypeChecker::new();
     tc.with_resolver_backed_collection(|checker| checker.collect_declarations(&stale_declarations));
-    tc.collect_resolver_declaration_metadata(&symbols, &tasks);
+    let metadata_tasks =
+        TypeChecker::collect_resolver_declaration_metadata_tasks(&program.declarations);
+    tc.collect_resolver_declaration_metadata(&symbols, &metadata_tasks);
 
     tc.with_resolver_backed_collection(|checker| {
-        checker.validate_resolver_struct_field_default_tasks(&tasks, Some(&symbols));
+        checker.validate_resolver_declaration_semantics_from_semantic_tasks(&tasks, Some(&symbols));
     });
 
     assert!(
@@ -127,13 +130,13 @@ Point: { x: i32 = true }
                     .message
                     .contains("field `x` default expects `i32`, found `bool`")
         }),
-        "resolver-backed default validation should use precollected type tasks: {:?}",
+        "resolver-backed default validation should use semantic validation tasks: {:?}",
         tc.diagnostics
     );
 }
 
 #[test]
-fn resolver_backed_struct_field_defaults_reuse_metadata_tasks() {
+fn resolver_backed_struct_field_defaults_use_semantic_tasks() {
     let program = parse_program(
         r#"
 Point: { x: i32 = true }
@@ -162,13 +165,13 @@ Point: { x: i32 = true }
                     .message
                     .contains("field `x` default expects `i32`, found `bool`")
         }),
-        "resolver-backed default validation should reuse shared metadata tasks: {:?}",
+        "resolver-backed default validation should use focused semantic tasks: {:?}",
         tc.diagnostics
     );
 }
 
 #[test]
-fn resolver_backed_semantic_validation_reuses_metadata_tasks() {
+fn resolver_backed_semantic_validation_uses_semantic_tasks() {
     let program = parse_program(
         r#"
 Point: { x: i32 = true }
@@ -195,7 +198,7 @@ Point: { x: i32 = true }
                     .message
                     .contains("field `x` default expects `i32`, found `bool`")
         }),
-        "resolver-backed semantic validation should reuse resolver metadata tasks: {:?}",
+        "resolver-backed semantic validation should use resolver semantic tasks: {:?}",
         tc.diagnostics
     );
 }


### PR DESCRIPTION
## Summary
- Route resolver-backed struct field-default validation through the dedicated semantic task bundle
- Rename focused tests/docs to describe the semantic task path instead of the older metadata-task path
- Preserve resolver-restored default validation behavior

## Verification
- `cargo fmt --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`