### PR TITLE
[codex] Replay resolver semantic collection bundle

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -262,6 +262,10 @@ and do not assume Phase 4 is ready without evidence.
   and behavior metadata tasks in one declaration dispatch, then replays the
   same callable/type/behavior restoration order as before, shrinking duplicate
   resolver-backed declaration walks without changing restoration ordering.
+- Declaration collection replay now records resolver semantic validation tasks
+  beside AST collection and resolver metadata tasks in the same declaration
+  pass, and resolver-backed semantic validation consumes that dedicated
+  semantic task bundle instead of replaying from metadata tasks.
 - Resolver-backed behavior impl metadata now builds restored impl-block tasks
   once and reuses them for both impl method signature restoration and omitted
   default-method synthesis, preserving the signature-before-defaults ordering.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -387,6 +387,11 @@ checked-in docs, tests, and commits only.
   collector instead of maintaining a second declaration match, and
   resolver-backed struct field default validation reuses the same collected
   type tasks on the fallback semantic path.
+- Declaration collection replay now also records resolver semantic validation
+  tasks in the same declaration pass as AST collection and resolver metadata,
+  so resolver-backed semantic validation replays dedicated behavior, type-ref,
+  and struct-default task lists instead of treating metadata tasks as a
+  semantic-validation bundle.
 - Resolver-backed behavior impl metadata now builds restored impl-block tasks
   once and reuses them for both impl method signature restoration and omitted
   default-method synthesis. Impl-block declaration collection now also uses a

--- a/src/typechecker/declaration_collection.rs
+++ b/src/typechecker/declaration_collection.rs
@@ -42,7 +42,11 @@ impl TypeChecker {
         self.with_resolver_backed_collection(|checker| {
             checker.collect_ast_declarations_from_tasks(&tasks.ast);
         });
-        self.collect_resolver_declarations_from_tasks(&tasks.resolver, symbols);
+        self.collect_resolver_declarations_from_tasks(
+            &tasks.resolver,
+            &tasks.resolver_semantics,
+            symbols,
+        );
     }
 
     pub(super) fn collect_resolver_declaration_metadata(

--- a/src/typechecker/declaration_collection_resolver_semantic_tasks.rs
+++ b/src/typechecker/declaration_collection_resolver_semantic_tasks.rs
@@ -11,7 +11,7 @@ impl TypeChecker {
         tasks
     }
 
-    fn push_resolver_declaration_semantic_validation_tasks<'a>(
+    pub(super) fn push_resolver_declaration_semantic_validation_tasks<'a>(
         decl: &'a Declaration,
         tasks: &mut ResolverDeclarationSemanticValidationTasks<'a>,
     ) {

--- a/src/typechecker/declaration_collection_resolver_tasks.rs
+++ b/src/typechecker/declaration_collection_resolver_tasks.rs
@@ -8,6 +8,10 @@ impl TypeChecker {
         for decl in decls {
             Self::push_ast_declaration_collection_tasks(decl, &mut tasks.ast);
             Self::push_resolver_declaration_metadata_tasks(decl, &mut tasks.resolver);
+            Self::push_resolver_declaration_semantic_validation_tasks(
+                decl,
+                &mut tasks.resolver_semantics,
+            );
         }
         tasks
     }

--- a/src/typechecker/declaration_tasks.rs
+++ b/src/typechecker/declaration_tasks.rs
@@ -100,6 +100,7 @@ struct AstDeclarationCollectionTasks<'a> {
 struct DeclarationCollectionReplayTasks<'a> {
     ast: AstDeclarationCollectionTasks<'a>,
     resolver: ResolverDeclarationMetadataTasks<'a>,
+    resolver_semantics: ResolverDeclarationSemanticValidationTasks<'a>,
 }
 
 struct AstStructFieldDefaultValidationTask<'a> {

--- a/src/typechecker/generic_type_validation.rs
+++ b/src/typechecker/generic_type_validation.rs
@@ -198,14 +198,6 @@ impl TypeChecker {
         self.validate_generic_expr_type_references(body, &scoped);
     }
 
-    pub(super) fn validate_resolver_type_reference_tasks(
-        &mut self,
-        tasks: &ResolverDeclarationMetadataTasks<'_>,
-        symbols: Option<&SymbolTable>,
-    ) {
-        self.validate_resolver_type_reference_task_list(&tasks.type_references, symbols);
-    }
-
     pub(super) fn validate_resolver_type_reference_task_list(
         &mut self,
         tasks: &[ResolverTypeReferenceValidationTask<'_>],

--- a/src/typechecker/resolver_backed_collection.rs
+++ b/src/typechecker/resolver_backed_collection.rs
@@ -4,11 +4,12 @@ impl TypeChecker {
     pub(super) fn collect_resolver_declarations_from_tasks(
         &mut self,
         tasks: &ResolverDeclarationMetadataTasks<'_>,
+        semantic_tasks: &ResolverDeclarationSemanticValidationTasks<'_>,
         symbols: &SymbolTable,
     ) {
         self.collect_resolver_declaration_metadata(symbols, tasks);
         self.collect_resolver_behavior_impl_metadata(tasks, symbols);
-        self.validate_resolver_collected_declaration_semantics(symbols, tasks);
+        self.validate_resolver_collected_declaration_semantics(symbols, semantic_tasks);
         self.clear_resolver_behavior_ref_state();
         self.refresh_resolver_type_behavior_impls(tasks, symbols);
     }
@@ -48,10 +49,11 @@ impl TypeChecker {
     pub(super) fn validate_resolver_collected_declaration_semantics(
         &mut self,
         symbols: &SymbolTable,
-        tasks: &ResolverDeclarationMetadataTasks<'_>,
+        tasks: &ResolverDeclarationSemanticValidationTasks<'_>,
     ) {
         self.with_resolver_backed_collection(|checker| {
-            checker.validate_resolver_declaration_semantics_from_tasks(tasks, Some(symbols));
+            checker
+                .validate_resolver_declaration_semantics_from_semantic_tasks(tasks, Some(symbols));
         });
     }
 

--- a/src/typechecker/semantic_validation.rs
+++ b/src/typechecker/semantic_validation.rs
@@ -26,16 +26,6 @@ impl TypeChecker {
         self.validate_ast_struct_field_default_tasks(&tasks.struct_field_defaults);
     }
 
-    pub(super) fn validate_resolver_declaration_semantics_from_tasks(
-        &mut self,
-        tasks: &ResolverDeclarationMetadataTasks<'_>,
-        symbols: Option<&SymbolTable>,
-    ) {
-        self.validate_behavior_association_tasks(tasks, symbols);
-        self.validate_resolver_type_reference_tasks(tasks, symbols);
-        self.validate_resolver_struct_field_default_tasks(tasks, symbols);
-    }
-
     pub(super) fn validate_resolver_declaration_semantics_from_semantic_tasks(
         &mut self,
         tasks: &ResolverDeclarationSemanticValidationTasks<'_>,
@@ -267,18 +257,6 @@ impl TypeChecker {
         for (field_name, expected) in &info.fields {
             if let Some(default) = info.field_defaults.get(field_name) {
                 self.validate_struct_field_default(field_name, expected, default);
-            }
-        }
-    }
-
-    pub(super) fn validate_resolver_struct_field_default_tasks(
-        &mut self,
-        tasks: &ResolverDeclarationMetadataTasks<'_>,
-        symbols: Option<&SymbolTable>,
-    ) {
-        for task in &tasks.types {
-            if let ResolverTypeDeclarationMetadataTask::Struct { name, span, .. } = task {
-                self.validate_resolver_struct_field_defaults(symbols, name, *span);
             }
         }
     }

--- a/src/typechecker/tests/declaration_validation/resolver_replay.rs
+++ b/src/typechecker/tests/declaration_validation/resolver_replay.rs
@@ -258,7 +258,10 @@ main = (value: Point) i32 { 1 }
     let symbols = crate::resolver::Resolver::new()
         .resolve_program(&program)
         .expect("resolver succeeds");
-    let tasks = TypeChecker::collect_resolver_declaration_metadata_tasks(&program.declarations);
+    let metadata_tasks =
+        TypeChecker::collect_resolver_declaration_metadata_tasks(&program.declarations);
+    let semantic_tasks =
+        TypeChecker::collect_resolver_declaration_semantic_validation_tasks(&program.declarations);
     let mut stale_declarations = program.declarations.clone();
     if let Declaration::Requires { behavior, .. } = &mut stale_declarations[3] {
         *behavior = "MissingBehavior".to_string();
@@ -270,9 +273,12 @@ main = (value: Point) i32 { 1 }
     checker.with_resolver_backed_collection(|checker| {
         checker.collect_declarations(&stale_declarations)
     });
-    checker.collect_resolver_declaration_metadata(&symbols, &tasks);
+    checker.collect_resolver_declaration_metadata(&symbols, &metadata_tasks);
 
-    checker.validate_resolver_declaration_semantics_from_tasks(&tasks, Some(&symbols));
+    checker.validate_resolver_declaration_semantics_from_semantic_tasks(
+        &semantic_tasks,
+        Some(&symbols),
+    );
 
     assert!(
         checker
@@ -321,7 +327,7 @@ main = (value: Point) i32 { 1 }
     let symbols = crate::resolver::Resolver::new()
         .resolve_program(&program)
         .expect("resolver succeeds");
-    let tasks = TypeChecker::collect_resolver_declaration_metadata_tasks(&program.declarations);
+    let tasks = TypeChecker::collect_declaration_collection_replay_tasks(&program.declarations);
     let mut stale_declarations = program.declarations.clone();
     if let Declaration::Requires { behavior, .. } = &mut stale_declarations[3] {
         *behavior = "MissingBehavior".to_string();
@@ -334,7 +340,11 @@ main = (value: Point) i32 { 1 }
         checker.collect_declarations(&stale_declarations)
     });
 
-    checker.collect_resolver_declarations_from_tasks(&tasks, &symbols);
+    checker.collect_resolver_declarations_from_tasks(
+        &tasks.resolver,
+        &tasks.resolver_semantics,
+        &symbols,
+    );
 
     assert!(
         checker
@@ -402,6 +412,20 @@ main = () i32 { 1 }
     assert_eq!(tasks.resolver.behavior_associations.impls.len(), 1);
     assert_eq!(tasks.resolver.behavior_associations.requires.len(), 1);
     assert_eq!(tasks.resolver.type_references.len(), 4);
+    assert_eq!(
+        tasks.resolver_semantics.behavior_associations.impls.len(),
+        1
+    );
+    assert_eq!(
+        tasks
+            .resolver_semantics
+            .behavior_associations
+            .requires
+            .len(),
+        1
+    );
+    assert_eq!(tasks.resolver_semantics.struct_defaults.len(), 1);
+    assert_eq!(tasks.resolver_semantics.type_references.len(), 4);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add resolver semantic validation tasks to the declaration collection replay bundle.
- Route resolver-backed semantic validation through the dedicated semantic task bundle instead of metadata tasks.
- Remove now-unused metadata-based semantic/type-reference helper paths and update Phase 2 audit docs.

## Validation

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`