### PR TITLE
[codex] Split CLI usage rendering

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -269,6 +269,9 @@ and do not assume Phase 4 is ready without evidence.
 - Resolver replay declaration-validation tests now split semantic-bundle
   coverage into a focused submodule, keeping the anti-slop file-size guard
   below threshold while preserving the resolver replay coverage.
+- CLI usage rendering now lives in `src/cli/usage.rs`, reducing the command
+  dispatcher file size while preserving the existing usage text and command
+  behavior.
 - Resolver-backed behavior impl metadata now builds restored impl-block tasks
   once and reuses them for both impl method signature restoration and omitted
   default-method synthesis, preserving the signature-before-defaults ordering.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -395,6 +395,8 @@ checked-in docs, tests, and commits only.
 - Resolver replay declaration-validation tests now keep semantic-bundle replay
   coverage in a focused submodule, preserving the file-size guard while keeping
   metadata replay helper tests separate from semantic replay coverage.
+- CLI usage rendering now lives in a focused helper module, keeping the command
+  dispatcher away from the file-size guard without changing command behavior.
 - Resolver-backed behavior impl metadata now builds restored impl-block tasks
   once and reuses them for both impl method signature restoration and omitted
   default-method synthesis. Impl-block declaration collection now also uses a

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,12 +4,14 @@ use std::process;
 
 mod build_graph_execution;
 mod diagnostics;
+mod usage;
 
 use build_graph_execution::{
     executable_build_targets, single_executable_build_target, test_build_targets,
     validate_build_graph_sources,
 };
 use diagnostics::{print_diagnostic, print_errors};
+use usage::print_usage;
 use zen::codegen::c::CBackend;
 use zen::codegen::Backend;
 use zen::error::FileTable;
@@ -20,22 +22,7 @@ pub fn main() {
     let args: Vec<String> = std::env::args().collect();
 
     if args.len() < 2 {
-        eprintln!("zen compiler v0.8.0");
-        eprintln!("Usage: zen <command> [args]");
-        eprintln!("Commands:");
-        eprintln!("  check <file>   Parse and typecheck a .zen file");
-        eprintln!("  build <file>   Compile a .zen file to a binary");
-        eprintln!("  test <build.zen>   Compile and run deterministic test targets");
-        eprintln!(
-            "  build-graph <build.zen>   Compile executable targets from deterministic build graph"
-        );
-        eprintln!("  emit  <file>   Emit C source (no compilation)");
-        eprintln!("  emit-json ast <file>   Emit resolved AST JSON");
-        eprintln!("  emit-json symbols <file>   Emit resolver symbol tables JSON");
-        eprintln!("  emit-json typed <file>   Emit checked typed program JSON");
-        eprintln!("  emit-json diagnostics <file>   Emit diagnostics JSON");
-        eprintln!("  emit-json build-graph <build.zen>   Emit deterministic build graph JSON");
-        eprintln!("  <file>         Run a .zen file");
+        print_usage();
         process::exit(1);
     }
 

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -1,0 +1,18 @@
+pub(super) fn print_usage() {
+    eprintln!("zen compiler v0.8.0");
+    eprintln!("Usage: zen <command> [args]");
+    eprintln!("Commands:");
+    eprintln!("  check <file>   Parse and typecheck a .zen file");
+    eprintln!("  build <file>   Compile a .zen file to a binary");
+    eprintln!("  test <build.zen>   Compile and run deterministic test targets");
+    eprintln!(
+        "  build-graph <build.zen>   Compile executable targets from deterministic build graph"
+    );
+    eprintln!("  emit  <file>   Emit C source (no compilation)");
+    eprintln!("  emit-json ast <file>   Emit resolved AST JSON");
+    eprintln!("  emit-json symbols <file>   Emit resolver symbol tables JSON");
+    eprintln!("  emit-json typed <file>   Emit checked typed program JSON");
+    eprintln!("  emit-json diagnostics <file>   Emit diagnostics JSON");
+    eprintln!("  emit-json build-graph <build.zen>   Emit deterministic build graph JSON");
+    eprintln!("  <file>         Run a .zen file");
+}


### PR DESCRIPTION
## Summary

- Move CLI usage rendering into `src/cli/usage.rs`.
- Keep the command dispatcher focused and below the file-size guard.
- Update Phase 2 audit docs with the cleanup evidence.

## Validation

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`