### PR TITLE
[codex] Split build graph JSON host effect tests

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -272,6 +272,9 @@ and do not assume Phase 4 is ready without evidence.
 - CLI usage rendering now lives in `src/cli/usage.rs`, reducing the command
   dispatcher file size while preserving the existing usage text and command
   behavior.
+- Build-graph JSON integration tests now split host-effect JSON coverage into
+  `tests/integration/cli_build/build_graph_json_host_effects.rs`, keeping target
+  metadata/dependency JSON tests separate from effect determinism tests.
 - Resolver-backed behavior impl metadata now builds restored impl-block tasks
   once and reuses them for both impl method signature restoration and omitted
   default-method synthesis, preserving the signature-before-defaults ordering.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -397,6 +397,9 @@ checked-in docs, tests, and commits only.
   metadata replay helper tests separate from semantic replay coverage.
 - CLI usage rendering now lives in a focused helper module, keeping the command
   dispatcher away from the file-size guard without changing command behavior.
+- Build-graph JSON integration tests now keep host-effect JSON coverage in a
+  focused module, separating effect determinism cases from target metadata and
+  dependency JSON assertions.
 - Resolver-backed behavior impl metadata now builds restored impl-block tasks
   once and reuses them for both impl method signature restoration and omitted
   default-method synthesis. Impl-block declaration collection now also uses a

--- a/tests/integration/cli_build.rs
+++ b/tests/integration/cli_build.rs
@@ -10,6 +10,8 @@ mod build_command_validation;
 mod build_graph_json;
 #[path = "cli_build/build_graph_json_declared_env.rs"]
 mod build_graph_json_declared_env;
+#[path = "cli_build/build_graph_json_host_effects.rs"]
+mod build_graph_json_host_effects;
 #[path = "cli_build/declared_env_effects.rs"]
 mod declared_env_effects;
 #[path = "cli_build/diagnostics.rs"]

--- a/tests/integration/cli_build/build_graph_json_host_effects.rs
+++ b/tests/integration/cli_build/build_graph_json_host_effects.rs
@@ -1,37 +1,52 @@
 use std::process::Command;
 
 #[test]
-fn emit_json_build_graph_outputs_project_build_graph() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "build-graph", "examples/project/build.zen"])
-        .output()
-        .expect("run zen emit-json build-graph");
-
-    assert!(
-        output.status.success(),
-        "emit-json build-graph failed: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("build graph json");
-    assert_eq!(json["targets"][0]["name"], "myapp");
-    assert_eq!(json["targets"][0]["kind"]["root_source_file"], "main.zen");
-    assert_eq!(json["targets"][0]["kind"]["out_dir"], "build/");
-    assert_eq!(json["targets"][1]["name"], "test");
-    assert_eq!(json["targets"][1]["kind"]["kind"], "test");
-    assert_eq!(json["targets"][1]["kind"]["root_source_file"], "test.zen");
-}
-
-#[test]
-fn emit_json_build_graph_outputs_library_target() {
+fn emit_json_build_graph_rejects_undeclared_host_effects() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let build_path = tmp.path().join("build.zen");
     std::fs::write(
         &build_path,
         r#"
 build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Library { name: "core", exports: ["src/math.zen", "src/strings.zen"] })
+    std_path = b.os.env("ZEN_STD")
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "build-graph", build_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json build-graph");
+
+    assert!(
+        !output.status.success(),
+        "emit-json build-graph unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("undeclared host effect: read env `ZEN_STD`"),
+        "expected undeclared host effect diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn emit_json_build_graph_outputs_declared_file_read_effects() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let build_path = tmp.path().join("build.zen");
+    std::fs::write(
+        &build_path,
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets") ?
+        | .Ok(contents) { contents }
+        | .Err { "default" }
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
     .Ok(b.config())
 }
 "#,
@@ -51,66 +66,132 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
     );
 
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("build graph json");
-    assert_eq!(json["targets"][0]["name"], "core");
-    assert_eq!(json["targets"][0]["kind"]["kind"], "library");
-    assert_eq!(json["targets"][0]["kind"]["exports"][0], "src/math.zen");
-    assert_eq!(json["targets"][0]["kind"]["exports"][1], "src/strings.zen");
+    assert_eq!(json["declared_host_effects"][0]["kind"], "read_file");
+    assert_eq!(json["declared_host_effects"][0]["value"], "build.targets");
+    assert_eq!(json["used_host_effects"][0]["kind"], "read_file");
+    assert_eq!(json["used_host_effects"][0]["value"], "build.targets");
 }
 
 #[test]
-fn emit_json_build_graph_outputs_target_dependencies_and_features() {
+fn emit_json_build_graph_rejects_undeclared_file_read_effects() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let build_path = tmp.path().join("build.zen");
     std::fs::write(
         &build_path,
         r#"
 build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Library { name: "core", exports: ["src/lib.zen"] })
+    manifest = b.os.read_file("build.targets")
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "build-graph", build_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json build-graph");
+
+    assert!(
+        !output.status.success(),
+        "emit-json build-graph unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("undeclared host effect: read file `build.targets`"),
+        "expected undeclared file-read effect diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn emit_json_build_graph_rejects_undeclared_host_effects_before_test_target_lowering() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let build_path = tmp.path().join("build.zen");
+    std::fs::write(
+        &build_path,
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    std_path = b.os.env("ZEN_STD")
+    b.add(Test { root: "test.zen" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "build-graph", build_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json build-graph");
+
+    assert!(
+        !output.status.success(),
+        "emit-json build-graph unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("undeclared host effect: read env `ZEN_STD`"),
+        "expected undeclared host effect diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn emit_json_build_graph_rejects_undeclared_host_effects_before_library_target_lowering() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let build_path = tmp.path().join("build.zen");
+    std::fs::write(
+        &build_path,
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    std_path = b.os.env("ZEN_STD")
+    b.add(Library { name: "core", exports: ["src/math.zen"] })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "build-graph", build_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json build-graph");
+
+    assert!(
+        !output.status.success(),
+        "emit-json build-graph unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("undeclared host effect: read env `ZEN_STD`"),
+        "expected undeclared host effect diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn emit_json_build_graph_rejects_undeclared_host_effects_before_target_metadata_lowering() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let build_path = tmp.path().join("build.zen");
+    std::fs::write(
+        &build_path,
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    std_path = b.os.env("ZEN_STD")
     b.add(Executable {
         name: "app",
         main: "app.zen",
         out_dir: "build/app/",
         dependencies: ["core"],
-        features: ["lto", "release"],
-    })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "build-graph", build_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json build-graph");
-
-    assert!(
-        output.status.success(),
-        "emit-json build-graph failed: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("build graph json");
-    assert_eq!(json["targets"][0]["name"], "app");
-    assert_eq!(json["targets"][0]["dependencies"][0], "core");
-    assert_eq!(json["targets"][0]["features"][0], "lto");
-    assert_eq!(json["targets"][0]["features"][1], "release");
-}
-
-#[test]
-fn emit_json_build_graph_rejects_unknown_target_dependencies() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let build_path = tmp.path().join("build.zen");
-    std::fs::write(
-        &build_path,
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable {
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        dependencies: ["core"],
+        features: ["release"],
     })
     .Ok(b.config())
 }
@@ -131,140 +212,8 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
     );
     assert!(
         String::from_utf8_lossy(&output.stderr)
-            .contains("build target `app` depends on unknown target `core`"),
-        "expected unknown dependency diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-}
-
-#[test]
-fn emit_json_build_graph_rejects_unsupported_package_targets() {
-    assert_emit_json_build_graph_rejects_unsupported_target_kind("Package");
-}
-
-#[test]
-fn emit_json_build_graph_rejects_unsupported_link_targets() {
-    assert_emit_json_build_graph_rejects_unsupported_target_kind("Link");
-}
-
-fn assert_emit_json_build_graph_rejects_unsupported_target_kind(target_kind: &str) {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let build_path = tmp.path().join("build.zen");
-    std::fs::write(
-        &build_path,
-        format!(
-            r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {{
-    b.add({target_kind} {{ name: "core", root: "src/lib.zen" }})
-    .Ok(b.config())
-}}
-"#,
-        ),
-    )
-    .expect("write build.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "build-graph", build_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json build-graph");
-
-    assert!(
-        !output.status.success(),
-        "emit-json build-graph unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr).contains(
-            &format!(
-                "unsupported build target kind `{target_kind}`; supported target kinds are `Executable`, `Test`, and `Library`"
-            )
-        ),
-        "expected unsupported target diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-}
-
-#[test]
-fn emit_json_build_graph_rejects_self_target_dependencies() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let build_path = tmp.path().join("build.zen");
-    std::fs::write(
-        &build_path,
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable {
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        dependencies: ["app"],
-    })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "build-graph", build_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json build-graph");
-
-    assert!(
-        !output.status.success(),
-        "emit-json build-graph unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("build target `app` cannot depend on itself"),
-        "expected self dependency diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-}
-
-#[test]
-fn emit_json_build_graph_rejects_cyclic_target_dependencies() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let build_path = tmp.path().join("build.zen");
-    std::fs::write(
-        &build_path,
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable {
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        dependencies: ["tool"],
-    })
-    b.add(Executable {
-        name: "tool",
-        main: "tool.zen",
-        out_dir: "build/tool/",
-        dependencies: ["app"],
-    })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "build-graph", build_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json build-graph");
-
-    assert!(
-        !output.status.success(),
-        "emit-json build-graph unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("build target dependency cycle includes `app`"),
-        "expected cyclic dependency diagnostic, stderr={}",
+            .contains("undeclared host effect: read env `ZEN_STD`"),
+        "expected undeclared host effect diagnostic, stderr={}",
         String::from_utf8_lossy(&output.stderr)
     );
 }


### PR DESCRIPTION
## Summary

- Move build-graph JSON host-effect tests into a focused integration module.
- Keep target metadata and dependency JSON assertions in the existing module.
- Update Phase 2 audit docs with the split evidence.

## Validation

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`