### PR TITLE
[codex] Split check graph host effect tests

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -279,6 +279,10 @@ and do not assume Phase 4 is ready without evidence.
   dependency cases into
   `tests/integration/generic_specializations/multifile_generated_c.rs`,
   preserving generated-call coverage while reducing the root integration file.
+- Check-command build graph validation now splits host-effect ordering and
+  declared-effect tests into
+  `tests/integration/cli_build/graph_validation_host_effects.rs`, leaving
+  target source and library graph validation in the root graph-validation file.
 - Resolver-backed behavior impl metadata now builds restored impl-block tasks
   once and reuses them for both impl method signature restoration and omitted
   default-method synthesis, preserving the signature-before-defaults ordering.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -403,6 +403,9 @@ checked-in docs, tests, and commits only.
 - Generic specialization generated-C assertions now keep multi-file import and
   dependency cases in a focused integration module, separating them from
   single-file generic specialization emission assertions.
+- Check-command build graph validation tests now keep host-effect ordering and
+  declared-effect cases in a focused integration module, separating them from
+  target source and library graph validation cases.
 - Resolver-backed behavior impl metadata now builds restored impl-block tasks
   once and reuses them for both impl method signature restoration and omitted
   default-method synthesis. Impl-block declaration collection now also uses a

--- a/tests/integration/cli_build.rs
+++ b/tests/integration/cli_build.rs
@@ -32,6 +32,8 @@ mod emit_direct_validation;
 mod frontend_json;
 #[path = "cli_build/graph_validation.rs"]
 mod graph_validation;
+#[path = "cli_build/graph_validation_host_effects.rs"]
+mod graph_validation_host_effects;
 #[path = "cli_build/graph_validation_test_command.rs"]
 mod graph_validation_test_command;
 #[path = "cli_build/graph_validation_test_command_host_effects.rs"]

--- a/tests/integration/cli_build/graph_validation_host_effects.rs
+++ b/tests/integration/cli_build/graph_validation_host_effects.rs
@@ -1,12 +1,50 @@
 use std::process::Command;
 
 #[test]
-fn check_command_validates_build_zen_graph() {
+fn check_command_build_zen_rejects_undeclared_host_effects() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(
         tmp.path().join("build.zen"),
         r#"
 build = (b: Builder) Result<BuildConfig, BuildError> {
+    std_path = b.os.env("ZEN_STD")
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["check", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen check build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen check build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("undeclared host effect: read env `ZEN_STD`"),
+        "expected undeclared host effect diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn check_command_build_zen_accepts_declared_env_read_with_fallback() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    std_path = b.os.env("ZEN_STD") ?
+        | .Ok(path) { path }
+        | .Err { "~/.zen/std" }
     b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
     .Ok(b.config())
 }
@@ -43,27 +81,31 @@ main = () i32 {
 }
 
 #[test]
-fn check_command_build_zen_accepts_library_only_graph_validation() {
+fn check_command_build_zen_accepts_declared_file_read_effects() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(
         tmp.path().join("build.zen"),
         r#"
 build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Library { name: "core", exports: ["lib.zen"] })
+    manifest = b.os.read_file("build.targets") ?
+        | .Ok(contents) { contents }
+        | .Err { "default" }
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
     .Ok(b.config())
 }
 "#,
     )
     .expect("write build.zen");
+    std::fs::write(tmp.path().join("build.targets"), "myapp\n").expect("write manifest");
     std::fs::write(
-        tmp.path().join("lib.zen"),
+        tmp.path().join("main.zen"),
         r#"
-value = () i32 {
-    1
+main = () i32 {
+    0
 }
 "#,
     )
-    .expect("write lib.zen");
+    .expect("write main.zen");
 
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
         .args(["check", "build.zen"])
@@ -82,19 +124,92 @@ value = () i32 {
         "expected build graph check summary, stdout={}",
         String::from_utf8_lossy(&output.stdout)
     );
-    assert!(
-        !tmp.path().join("build").exists(),
-        "zen check build.zen should validate library-only graphs without creating build outputs"
-    );
 }
 
 #[test]
-fn check_command_build_zen_typechecks_target_sources() {
+fn check_command_build_zen_rejects_undeclared_file_read_effects_before_source_validation() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(
         tmp.path().join("build.zen"),
         r#"
 build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets")
+    b.add(Executable { name: "myapp", main: "missing.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["check", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen check build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen check build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("undeclared host effect: read file `build.targets`"),
+        "expected undeclared file read diagnostic, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("source not found"),
+        "host-effect validation should run before source validation, stderr={stderr}"
+    );
+}
+
+#[test]
+fn check_command_build_zen_rejects_undeclared_host_effects_before_source_validation() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    std_path = b.os.env("ZEN_STD")
+    b.add(Executable { name: "myapp", main: "missing.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["check", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen check build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen check build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("undeclared host effect: read env `ZEN_STD`"),
+        "expected undeclared host effect diagnostic, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("source not found"),
+        "host-effect validation should run before source validation, stderr={stderr}"
+    );
+}
+
+#[test]
+fn check_command_build_zen_rejects_undeclared_host_effects_before_target_typechecking() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    std_path = b.os.env("ZEN_STD")
     b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
     .Ok(b.config())
 }
@@ -123,112 +238,13 @@ main = () i32 {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+    let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("return type mismatch: expected `i32`, found `bool`"),
-        "expected target source type diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-}
-
-#[test]
-fn check_command_build_zen_rejects_missing_executable_source() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable { name: "myapp", main: "missing.zen", out_dir: "build/" })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["check", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen check build.zen");
-
-    assert!(
-        !output.status.success(),
-        "zen check build.zen unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
+        stderr.contains("undeclared host effect: read env `ZEN_STD`"),
+        "expected undeclared host effect diagnostic, stderr={stderr}"
     );
     assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("build graph target `myapp` source not found: missing.zen"),
-        "expected missing source diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-}
-
-#[test]
-fn check_command_build_zen_rejects_missing_test_source() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Test { name: "unit", root: "missing_test.zen" })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["check", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen check build.zen");
-
-    assert!(
-        !output.status.success(),
-        "zen check build.zen unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("build graph target `unit` source not found: missing_test.zen"),
-        "expected missing source diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-}
-
-#[test]
-fn check_command_build_zen_rejects_missing_library_source() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Library { name: "core", exports: ["missing_lib.zen"] })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["check", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen check build.zen");
-
-    assert!(
-        !output.status.success(),
-        "zen check build.zen unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("build graph target `core` source not found: missing_lib.zen"),
-        "expected missing source diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
+        !stderr.contains("return type mismatch"),
+        "host-effect validation should run before target typechecking, stderr={stderr}"
     );
 }


### PR DESCRIPTION
## Summary
- Move check-command build graph host-effect validation cases into `graph_validation_host_effects.rs`.
- Keep target source and library graph validation cases in the root graph validation module.
- Update phase plan and completion audit with the new split.

## Validation
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`