### PR TITLE
[codex] Split CLI compile helpers

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2695,6 +2695,9 @@ and do not assume Phase 4 is ready without evidence.
   targeted rejection for legacy generic `emit-json build.zen` modes. Library
   execution, package/link semantics, and other broader graph semantics still
   need explicit deterministic semantics before promotion.
+- CLI compile helpers are now split into `src/cli/compile.rs`; this is an
+  internal cleanup preserving the same build/emit behavior and keeping tracked
+  Rust source files under the cleanup threshold.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2465,6 +2465,10 @@ checked-in docs, tests, and commits only.
   with shared dependency ordering and existing non-executed source-validation
   ordering preserved, covered by `cargo test --test integration
   library_execution_gates`.
+- CLI C emission and binary compilation helpers now live in
+  `src/cli/compile.rs`, keeping the root CLI module focused on command
+  dispatch, graph loading, and frontend diagnostics while preserving existing
+  build/emit integration coverage.
 
 ## Current Phase
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,9 @@
 use std::collections::BTreeSet;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process;
 
 mod build_graph_execution;
+mod compile;
 mod diagnostics;
 mod usage;
 
@@ -10,10 +11,9 @@ use build_graph_execution::{
     executable_build_targets, single_executable_build_target, test_build_targets,
     validate_build_graph_sources,
 };
+use compile::{compile_file_to_binary, compile_file_to_c_source, typed_program_to_c_source};
 use diagnostics::{print_diagnostic, print_errors};
 use usage::print_usage;
-use zen::codegen::c::CBackend;
-use zen::codegen::Backend;
 use zen::error::FileTable;
 use zen::module_system::ModuleSystem;
 use zen::typechecker::TypeChecker;
@@ -388,79 +388,6 @@ fn cmd_build_graph(path_str: &str) {
             Some(&target.out_dir),
             Some(&target.name),
         );
-    }
-}
-
-fn compile_file_to_c_source(path: &Path) -> String {
-    let path_str = path.to_str().unwrap_or_else(|| {
-        eprintln!("error: non-utf8 source path: {}", path.display());
-        process::exit(1);
-    });
-    let typed = graph_frontend(path_str);
-    typed_program_to_c_source(&typed)
-}
-
-fn typed_program_to_c_source(typed: &zen::ast::typed::TypedProgram) -> String {
-    let backend = CBackend;
-    match backend.generate(typed) {
-        Ok(c_source) => c_source,
-        Err(e) => {
-            eprintln!("codegen error: {}", e);
-            process::exit(1);
-        }
-    }
-}
-
-fn compile_file_to_binary(
-    path_str: &str,
-    output_dir: Option<&Path>,
-    output_name: Option<&str>,
-) -> PathBuf {
-    let c_source = compile_file_to_c_source(Path::new(path_str));
-
-    // Determine output paths
-    let stem = Path::new(path_str)
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or("out");
-    let output_stem = output_name.unwrap_or(stem);
-    let c_path = output_dir
-        .map(|dir| dir.join(format!("{output_stem}.c")))
-        .unwrap_or_else(|| Path::new(&format!("{output_stem}.c")).to_path_buf());
-    let bin_path = output_dir
-        .map(|dir| dir.join(output_stem))
-        .unwrap_or_else(|| Path::new(output_stem).to_path_buf());
-
-    // Write C source
-    if let Err(e) = std::fs::write(&c_path, &c_source) {
-        eprintln!("error writing {}: {}", c_path.display(), e);
-        process::exit(1);
-    }
-    println!("  emitted {}", c_path.display());
-
-    // Compile with cc
-    let cc = std::env::var("CC").unwrap_or_else(|_| "cc".into());
-    let status = process::Command::new(&cc)
-        .arg(&c_path)
-        .arg("-o")
-        .arg(&bin_path)
-        .arg("-lm")
-        .status();
-
-    match status {
-        Ok(s) if s.success() => {
-            println!("  compiled → {}", bin_path.display());
-            bin_path
-        }
-        Ok(s) => {
-            eprintln!("  {} exited with {}", cc, s);
-            process::exit(1);
-        }
-        Err(e) => {
-            eprintln!("  failed to run {}: {}", cc, e);
-            eprintln!("  (C source saved to {})", c_path.display());
-            process::exit(1);
-        }
     }
 }
 

--- a/src/cli/compile.rs
+++ b/src/cli/compile.rs
@@ -1,0 +1,75 @@
+use std::path::{Path, PathBuf};
+use std::process;
+
+use zen::codegen::c::CBackend;
+use zen::codegen::Backend;
+
+pub(super) fn compile_file_to_c_source(path: &Path) -> String {
+    let path_str = path.to_str().unwrap_or_else(|| {
+        eprintln!("error: non-utf8 source path: {}", path.display());
+        process::exit(1);
+    });
+    let typed = super::graph_frontend(path_str);
+    typed_program_to_c_source(&typed)
+}
+
+pub(super) fn typed_program_to_c_source(typed: &zen::ast::typed::TypedProgram) -> String {
+    let backend = CBackend;
+    match backend.generate(typed) {
+        Ok(c_source) => c_source,
+        Err(e) => {
+            eprintln!("codegen error: {}", e);
+            process::exit(1);
+        }
+    }
+}
+
+pub(super) fn compile_file_to_binary(
+    path_str: &str,
+    output_dir: Option<&Path>,
+    output_name: Option<&str>,
+) -> PathBuf {
+    let c_source = compile_file_to_c_source(Path::new(path_str));
+
+    let stem = Path::new(path_str)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("out");
+    let output_stem = output_name.unwrap_or(stem);
+    let c_path = output_dir
+        .map(|dir| dir.join(format!("{output_stem}.c")))
+        .unwrap_or_else(|| Path::new(&format!("{output_stem}.c")).to_path_buf());
+    let bin_path = output_dir
+        .map(|dir| dir.join(output_stem))
+        .unwrap_or_else(|| Path::new(output_stem).to_path_buf());
+
+    if let Err(e) = std::fs::write(&c_path, &c_source) {
+        eprintln!("error writing {}: {}", c_path.display(), e);
+        process::exit(1);
+    }
+    println!("  emitted {}", c_path.display());
+
+    let cc = std::env::var("CC").unwrap_or_else(|_| "cc".into());
+    let status = process::Command::new(&cc)
+        .arg(&c_path)
+        .arg("-o")
+        .arg(&bin_path)
+        .arg("-lm")
+        .status();
+
+    match status {
+        Ok(s) if s.success() => {
+            println!("  compiled → {}", bin_path.display());
+            bin_path
+        }
+        Ok(s) => {
+            eprintln!("  {} exited with {}", cc, s);
+            process::exit(1);
+        }
+        Err(e) => {
+            eprintln!("  failed to run {}: {}", cc, e);
+            eprintln!("  (C source saved to {})", c_path.display());
+            process::exit(1);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Move CLI C emission and binary compilation helpers into `src/cli/compile.rs`.
- Keep `src/cli.rs` focused on command dispatch, graph loading, and frontend diagnostics.
- Update phase/audit docs for the cleanup.

## Validation
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`