### PR TITLE
[codex] Split expected type parameter metadata

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2706,6 +2706,10 @@ and do not assume Phase 4 is ready without evidence.
   `src/typechecker/expressions/aggregate_constructors.rs`, preserving focused
   struct literal, enum variant, and generic enum coverage while keeping
   member/array/index access support separate.
+- Expected resolver type-parameter metadata helpers now live in
+  `src/typechecker/resolver_validation_support/expected_type_parameters.rs`,
+  preserving expected-symbol and resolver metadata validation descriptor
+  coverage while keeping expected symbol constructors smaller.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2477,6 +2477,11 @@ checked-in docs, tests, and commits only.
   `src/typechecker/expressions/aggregate_constructors.rs`, leaving
   `aggregate_support.rs` focused on member, array, and index access while
   preserving struct literal, enum variant, and generic enum fixture coverage.
+- Resolver validation support now keeps expected type-parameter metadata and
+  validation descriptors in
+  `src/typechecker/resolver_validation_support/expected_type_parameters.rs`,
+  separate from expected symbol-shape constructors while preserving resolver
+  metadata descriptor tests.
 
 ## Current Phase
 

--- a/src/typechecker/resolver_validation_support.rs
+++ b/src/typechecker/resolver_validation_support.rs
@@ -1,4 +1,5 @@
 include!("resolver_validation_support/replay_tasks.rs");
+include!("resolver_validation_support/expected_type_parameters.rs");
 include!("resolver_validation_support/expected_symbols.rs");
 include!("resolver_validation_support/absence_entries.rs");
 include!("resolver_validation_support/absence_diagnostics.rs");

--- a/src/typechecker/resolver_validation_support/expected_symbols.rs
+++ b/src/typechecker/resolver_validation_support/expected_symbols.rs
@@ -344,64 +344,6 @@ impl ExpectedLocalSymbol {
     }
 }
 
-struct ExpectedTypeParameter {
-    name: String,
-    bound: Option<ExpectedTypeParameterBound>,
-}
-
-impl ExpectedTypeParameter {
-    fn new(type_param: &ast::TypeParam) -> Self {
-        Self {
-            name: type_param.name.clone(),
-            bound: ExpectedTypeParameterBound::new(type_param),
-        }
-    }
-}
-
-struct ExpectedTypeParameterBound {
-    display: TypeParameterBoundMetadata,
-    reference: TypeParameterBoundRefMetadata,
-}
-
-impl ExpectedTypeParameterBound {
-    fn new(type_param: &ast::TypeParam) -> Option<Self> {
-        let behavior = type_param.constraint.as_ref()?;
-        let display = type_param_bound_display(type_param)?;
-        Some(Self {
-            display: (type_param.name.clone(), display),
-            reference: TypeParameterBoundRefMetadata {
-                type_parameter: type_param.name.clone(),
-                behavior: behavior.clone(),
-                type_args: type_param.constraint_type_args.clone(),
-            },
-        })
-    }
-}
-
-struct ExpectedTypeParameterMetadata {
-    count: usize,
-    names: Vec<String>,
-    bounds: Vec<TypeParameterBoundMetadata>,
-    bound_refs: Vec<TypeParameterBoundRefMetadata>,
-}
-
-impl ExpectedTypeParameterMetadata {
-    fn from_parameters(parameters: &[ExpectedTypeParameter]) -> Self {
-        Self {
-            count: parameters.len(),
-            names: parameters.iter().map(|param| param.name.clone()).collect(),
-            bounds: parameters
-                .iter()
-                .filter_map(|param| param.bound.as_ref().map(|bound| bound.display.clone()))
-                .collect(),
-            bound_refs: parameters
-                .iter()
-                .filter_map(|param| param.bound.as_ref().map(|bound| bound.reference.clone()))
-                .collect(),
-        }
-    }
-}
-
 struct ExpectedTypeLikeSymbol {
     type_params: Vec<ExpectedTypeParameter>,
     is_public: Option<bool>,
@@ -413,64 +355,5 @@ impl ExpectedTypeLikeSymbol {
             type_params: expected_type_parameter_metadata(type_params),
             is_public,
         }
-    }
-}
-
-#[derive(Clone, Copy)]
-struct TypeParameterValidation {
-    count_code: &'static str,
-    name_code: &'static str,
-    bound_code: &'static str,
-    bound_ref_code: &'static str,
-}
-
-impl TypeParameterValidation {
-    fn type_like_resolver_codes() -> Self {
-        Self {
-            count_code: "E0213",
-            name_code: "E0346",
-            bound_code: "E0222",
-            bound_ref_code: "E0350",
-        }
-    }
-
-    fn value_resolver_codes() -> Self {
-        Self {
-            count_code: "E0220",
-            name_code: "E0347",
-            bound_code: "E0221",
-            bound_ref_code: "E0351",
-        }
-    }
-
-    fn count_validation(self) -> CountValidation {
-        CountValidation {
-            label: "type parameter count",
-            code: self.count_code,
-        }
-    }
-
-    fn name_message(self, symbol_kind: &str, name: &str, actual: &str, expected: &str) -> String {
-        format!(
-            "resolver {symbol_kind} symbol '{name}' has type parameter names '{actual}', expected '{expected}'"
-        )
-    }
-
-    fn bound_message(self, symbol_kind: &str, name: &str, actual: &str, expected: &str) -> String {
-        format!(
-            "resolver {symbol_kind} symbol '{name}' has type parameter bounds '{actual}', expected '{expected}'"
-        )
-    }
-
-    fn bound_ref_message(
-        self,
-        symbol_kind: &str,
-        name: &str,
-        actual: &str,
-        expected: &str,
-    ) -> String {
-        format!(
-            "resolver {symbol_kind} symbol '{name}' has type parameter bound refs '{actual}', expected '{expected}'"
-        )
     }
 }

--- a/src/typechecker/resolver_validation_support/expected_type_parameters.rs
+++ b/src/typechecker/resolver_validation_support/expected_type_parameters.rs
@@ -1,0 +1,116 @@
+struct ExpectedTypeParameter {
+    name: String,
+    bound: Option<ExpectedTypeParameterBound>,
+}
+
+impl ExpectedTypeParameter {
+    fn new(type_param: &ast::TypeParam) -> Self {
+        Self {
+            name: type_param.name.clone(),
+            bound: ExpectedTypeParameterBound::new(type_param),
+        }
+    }
+}
+
+struct ExpectedTypeParameterBound {
+    display: TypeParameterBoundMetadata,
+    reference: TypeParameterBoundRefMetadata,
+}
+
+impl ExpectedTypeParameterBound {
+    fn new(type_param: &ast::TypeParam) -> Option<Self> {
+        let behavior = type_param.constraint.as_ref()?;
+        let display = type_param_bound_display(type_param)?;
+        Some(Self {
+            display: (type_param.name.clone(), display),
+            reference: TypeParameterBoundRefMetadata {
+                type_parameter: type_param.name.clone(),
+                behavior: behavior.clone(),
+                type_args: type_param.constraint_type_args.clone(),
+            },
+        })
+    }
+}
+
+struct ExpectedTypeParameterMetadata {
+    count: usize,
+    names: Vec<String>,
+    bounds: Vec<TypeParameterBoundMetadata>,
+    bound_refs: Vec<TypeParameterBoundRefMetadata>,
+}
+
+impl ExpectedTypeParameterMetadata {
+    fn from_parameters(parameters: &[ExpectedTypeParameter]) -> Self {
+        Self {
+            count: parameters.len(),
+            names: parameters.iter().map(|param| param.name.clone()).collect(),
+            bounds: parameters
+                .iter()
+                .filter_map(|param| param.bound.as_ref().map(|bound| bound.display.clone()))
+                .collect(),
+            bound_refs: parameters
+                .iter()
+                .filter_map(|param| param.bound.as_ref().map(|bound| bound.reference.clone()))
+                .collect(),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct TypeParameterValidation {
+    count_code: &'static str,
+    name_code: &'static str,
+    bound_code: &'static str,
+    bound_ref_code: &'static str,
+}
+
+impl TypeParameterValidation {
+    fn type_like_resolver_codes() -> Self {
+        Self {
+            count_code: "E0213",
+            name_code: "E0346",
+            bound_code: "E0222",
+            bound_ref_code: "E0350",
+        }
+    }
+
+    fn value_resolver_codes() -> Self {
+        Self {
+            count_code: "E0220",
+            name_code: "E0347",
+            bound_code: "E0221",
+            bound_ref_code: "E0351",
+        }
+    }
+
+    fn count_validation(self) -> CountValidation {
+        CountValidation {
+            label: "type parameter count",
+            code: self.count_code,
+        }
+    }
+
+    fn name_message(self, symbol_kind: &str, name: &str, actual: &str, expected: &str) -> String {
+        format!(
+            "resolver {symbol_kind} symbol '{name}' has type parameter names '{actual}', expected '{expected}'"
+        )
+    }
+
+    fn bound_message(self, symbol_kind: &str, name: &str, actual: &str, expected: &str) -> String {
+        format!(
+            "resolver {symbol_kind} symbol '{name}' has type parameter bounds '{actual}', expected '{expected}'"
+        )
+    }
+
+    fn bound_ref_message(
+        self,
+        symbol_kind: &str,
+        name: &str,
+        actual: &str,
+        expected: &str,
+    ) -> String {
+        format!(
+            "resolver {symbol_kind} symbol '{name}' has type parameter bound refs '{actual}', expected '{expected}'"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Move expected resolver type-parameter metadata and validation descriptors into `expected_type_parameters.rs`.
- Keep expected symbol-shape constructors in `expected_symbols.rs`.
- Update phase/audit docs for the split.

## Validation
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`