### PR TITLE
Split lexer string tests

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2710,6 +2710,9 @@ and do not assume Phase 4 is ready without evidence.
   `src/typechecker/resolver_validation_support/expected_type_parameters.rs`,
   preserving expected-symbol and resolver metadata validation descriptor
   coverage while keeping expected symbol constructors smaller.
+- Lexer string literal and interpolation tests now live in
+  `src/lexer/tests/string_literals.rs`, preserving literal escape and
+  interpolation coverage while keeping the parent lexer test module smaller.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -297,6 +297,9 @@ checked-in docs, tests, and commits only.
   coverage separate.
 - Lexer unit tests now live beside the lexer implementation in a dedicated test
   module, keeping the public lexer API and character-span helpers compact.
+- Lexer string literal and interpolation tests now live in a focused child
+  module, keeping the parent lexer test module centered on token categories and
+  syntax smoke coverage.
 - Parser block, closure, and argument-list helpers now live in a dedicated
   parser module, keeping atom parsing focused on prefix expression dispatch.
 - Typechecker monomorphization template dependency install/restore now lives in

--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod string_literals;
+
 /// Tokenise and return just token variants, filtering out Newline/EOF.
 fn toks(src: &str) -> Vec<Token> {
     tokenize(src, 0)
@@ -85,100 +87,6 @@ fn hex_binary_octal() {
             Token::IntLiteral(0b1010),
             Token::IntLiteral(0o777),
             Token::IntLiteral(0xDEAD),
-        ]
-    );
-}
-
-#[test]
-fn plain_string() {
-    assert_eq!(
-        toks(r#""hello world""#),
-        vec![Token::StringLiteral("hello world".into())]
-    );
-}
-
-#[test]
-fn escape_sequences() {
-    assert_eq!(
-        toks(r#""\n\t\\\"""#),
-        vec![Token::StringLiteral("\n\t\\\"".into())]
-    );
-}
-
-#[test]
-fn hex_escape() {
-    assert_eq!(toks(r#""\x41""#), vec![Token::StringLiteral("A".into())]);
-}
-
-#[test]
-fn null_escape() {
-    assert_eq!(toks(r#""\0""#), vec![Token::StringLiteral("\0".into())]);
-}
-
-#[test]
-fn escaped_dollar_no_interpolation() {
-    assert_eq!(
-        toks(r#""\${not interpolated}""#),
-        vec![Token::StringLiteral("${not interpolated}".into())]
-    );
-}
-
-#[test]
-fn string_interpolation_simple() {
-    assert_eq!(
-        toks(r#""hello ${name}!""#),
-        vec![
-            Token::StringChunk("hello ".into()),
-            Token::InterpolationStart,
-            Token::Identifier("name".into()),
-            Token::InterpolationEnd,
-            Token::StringChunk("!".into()),
-        ]
-    );
-}
-
-#[test]
-fn string_interpolation_expr() {
-    assert_eq!(
-        toks(r#""result = ${a + b}""#),
-        vec![
-            Token::StringChunk("result = ".into()),
-            Token::InterpolationStart,
-            Token::Identifier("a".into()),
-            Token::Plus,
-            Token::Identifier("b".into()),
-            Token::InterpolationEnd,
-        ]
-    );
-}
-
-#[test]
-fn string_interpolation_call() {
-    assert_eq!(
-        toks(r#""${f(x)}""#),
-        vec![
-            Token::InterpolationStart,
-            Token::Identifier("f".into()),
-            Token::LParen,
-            Token::Identifier("x".into()),
-            Token::RParen,
-            Token::InterpolationEnd,
-        ]
-    );
-}
-
-#[test]
-fn string_interpolation_multiple() {
-    assert_eq!(
-        toks(r#""${a} and ${b}""#),
-        vec![
-            Token::InterpolationStart,
-            Token::Identifier("a".into()),
-            Token::InterpolationEnd,
-            Token::StringChunk(" and ".into()),
-            Token::InterpolationStart,
-            Token::Identifier("b".into()),
-            Token::InterpolationEnd,
         ]
     );
 }

--- a/src/lexer/tests/string_literals.rs
+++ b/src/lexer/tests/string_literals.rs
@@ -1,0 +1,96 @@
+use super::toks;
+use crate::lexer::Token;
+
+#[test]
+fn plain_string() {
+    assert_eq!(
+        toks(r#""hello world""#),
+        vec![Token::StringLiteral("hello world".into())]
+    );
+}
+
+#[test]
+fn escape_sequences() {
+    assert_eq!(
+        toks(r#""\n\t\\\"""#),
+        vec![Token::StringLiteral("\n\t\\\"".into())]
+    );
+}
+
+#[test]
+fn hex_escape() {
+    assert_eq!(toks(r#""\x41""#), vec![Token::StringLiteral("A".into())]);
+}
+
+#[test]
+fn null_escape() {
+    assert_eq!(toks(r#""\0""#), vec![Token::StringLiteral("\0".into())]);
+}
+
+#[test]
+fn escaped_dollar_no_interpolation() {
+    assert_eq!(
+        toks(r#""\${not interpolated}""#),
+        vec![Token::StringLiteral("${not interpolated}".into())]
+    );
+}
+
+#[test]
+fn string_interpolation_simple() {
+    assert_eq!(
+        toks(r#""hello ${name}!""#),
+        vec![
+            Token::StringChunk("hello ".into()),
+            Token::InterpolationStart,
+            Token::Identifier("name".into()),
+            Token::InterpolationEnd,
+            Token::StringChunk("!".into()),
+        ]
+    );
+}
+
+#[test]
+fn string_interpolation_expr() {
+    assert_eq!(
+        toks(r#""result = ${a + b}""#),
+        vec![
+            Token::StringChunk("result = ".into()),
+            Token::InterpolationStart,
+            Token::Identifier("a".into()),
+            Token::Plus,
+            Token::Identifier("b".into()),
+            Token::InterpolationEnd,
+        ]
+    );
+}
+
+#[test]
+fn string_interpolation_call() {
+    assert_eq!(
+        toks(r#""${f(x)}""#),
+        vec![
+            Token::InterpolationStart,
+            Token::Identifier("f".into()),
+            Token::LParen,
+            Token::Identifier("x".into()),
+            Token::RParen,
+            Token::InterpolationEnd,
+        ]
+    );
+}
+
+#[test]
+fn string_interpolation_multiple() {
+    assert_eq!(
+        toks(r#""${a} and ${b}""#),
+        vec![
+            Token::InterpolationStart,
+            Token::Identifier("a".into()),
+            Token::InterpolationEnd,
+            Token::StringChunk(" and ".into()),
+            Token::InterpolationStart,
+            Token::Identifier("b".into()),
+            Token::InterpolationEnd,
+        ]
+    );
+}


### PR DESCRIPTION
## Summary
- Move lexer string literal and interpolation tests into `src/lexer/tests/string_literals.rs`
- Keep parent lexer tests focused on broad token categories and syntax smoke coverage
- Update phase plan and completion audit evidence

## Verification
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`