### PR TITLE
Split direct emit gated dependency tests

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2717,6 +2717,10 @@ and do not assume Phase 4 is ready without evidence.
   `src/typechecker/self_type_validation/expressions.rs`, preserving the same
   context diagnostics while keeping declaration task collection and type
   reference validation separate.
+- Direct `zen emit build.zen` gated dependency validation tests now live in
+  `tests/integration/cli_build/emit_direct_validation/gated_dependencies.rs`,
+  preserving the gated dependency diagnostic coverage while keeping direct emit
+  graph validation cases grouped by failure mode.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -308,6 +308,9 @@ checked-in docs, tests, and commits only.
 - Typechecker `Self` expression and statement traversal now lives in a focused
   validation child module, leaving declaration task and type-reference
   validation separate.
+- Direct `zen emit build.zen` gated dependency tests now live in a focused
+  child module, keeping direct emit graph validation tests grouped by failure
+  mode.
 - Generic diagnostic integration coverage now keeps nested/function/container
   annotation arity tests in a focused module, separate from direct generic
   call, method, local, and declaration annotation arity cases.

--- a/tests/integration/cli_build/emit_direct_validation.rs
+++ b/tests/integration/cli_build/emit_direct_validation.rs
@@ -1,5 +1,8 @@
 use std::process::Command;
 
+#[path = "emit_direct_validation/gated_dependencies.rs"]
+mod gated_dependencies;
+
 #[test]
 fn emit_command_build_zen_rejects_multiple_executable_targets() {
     let tmp = tempfile::tempdir().expect("create temp dir");
@@ -222,86 +225,6 @@ main = () i32 {
     assert!(
         !tmp.path().join("build").exists(),
         "zen emit build.zen should not create build outputs for a test-only graph"
-    );
-}
-
-#[test]
-fn emit_command_build_zen_rejects_gated_test_dependencies() {
-    assert_emit_rejects_gated_dependency(
-        r#"b.add(Test { name: "unit", root: "test.zen" })"#,
-        "unit",
-        "test.zen",
-        "test",
-    );
-}
-
-fn assert_emit_rejects_gated_dependency(
-    gated_target_decl: &str,
-    gated_target_name: &str,
-    gated_source_name: &str,
-    gated_target_kind: &str,
-) {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        format!(
-            r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {{
-    {gated_target_decl}
-    b.add(Executable {{
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        dependencies: ["{gated_target_name}"],
-    }})
-    .Ok(b.config())
-}}
-"#,
-        ),
-    )
-    .expect("write build.zen");
-    std::fs::write(
-        tmp.path().join(gated_source_name),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write gated target source");
-    std::fs::write(
-        tmp.path().join("app.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write app.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen emit build.zen");
-
-    assert!(
-        !output.status.success(),
-        "zen emit build.zen unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains(&format!(
-                "build graph target `app` depends on gated {gated_target_kind} target `{gated_target_name}`"
-            )),
-        "expected gated dependency diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        !tmp.path().join("build").exists(),
-        "zen emit build.zen should not create build outputs after gated dependency validation fails"
     );
 }
 

--- a/tests/integration/cli_build/emit_direct_validation/gated_dependencies.rs
+++ b/tests/integration/cli_build/emit_direct_validation/gated_dependencies.rs
@@ -1,0 +1,80 @@
+use std::process::Command;
+
+#[test]
+fn emit_command_build_zen_rejects_gated_test_dependencies() {
+    assert_emit_rejects_gated_dependency(
+        r#"b.add(Test { name: "unit", root: "test.zen" })"#,
+        "unit",
+        "test.zen",
+        "test",
+    );
+}
+
+fn assert_emit_rejects_gated_dependency(
+    gated_target_decl: &str,
+    gated_target_name: &str,
+    gated_source_name: &str,
+    gated_target_kind: &str,
+) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
+    {gated_target_decl}
+    b.add(Executable {{
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["{gated_target_name}"],
+    }})
+    .Ok(b.config())
+}}
+"#,
+        ),
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join(gated_source_name),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write gated target source");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen emit build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen emit build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains(&format!(
+            "build graph target `app` depends on gated {gated_target_kind} target `{gated_target_name}`"
+        )),
+        "expected gated dependency diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "zen emit build.zen should not create build outputs after gated dependency validation fails"
+    );
+}


### PR DESCRIPTION
## Summary
- Move direct `zen emit build.zen` gated dependency validation coverage into `tests/integration/cli_build/emit_direct_validation/gated_dependencies.rs`
- Keep the parent direct emit validation module focused on target-count and graph-only library validation cases
- Update phase plan and completion audit evidence

## Verification
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`