### PR TITLE
Split error file table

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2749,6 +2749,10 @@ and do not assume Phase 4 is ready without evidence.
   `src/typechecker/resolver_validation_support/absence_symbol_descriptors.rs`,
   preserving absence diagnostics while keeping field and variant descriptors
   smaller.
+- Error reporting now keeps `FileTable` and `FileId` source storage in
+  `src/error/file_table.rs`, preserving the public `zen::error::FileTable`
+  API while keeping `src/error.rs` focused on spans, diagnostics, and compile
+  error conversion.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -332,6 +332,9 @@ checked-in docs, tests, and commits only.
 - Resolver absence validation now keeps behavior, mutability, and source
   descriptor tables in a focused support include, separate from field and
   variant descriptor tables.
+- Error reporting now keeps `FileTable` source storage in a focused child
+  module, leaving `error.rs` centered on spans, diagnostics, and compile error
+  conversion.
 - Generic diagnostic integration coverage now keeps nested/function/container
   annotation arity tests in a focused module, separate from direct generic
   call, method, local, and declaration annotation arity cases.

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,81 +2,9 @@ use std::fmt;
 
 use serde::Serialize;
 
-// ── FileId & FileTable ─────────────────────────────────────────────
+mod file_table;
 
-/// Index into the FileTable. 0 is reserved for "no file" / test usage.
-pub type FileId = u32;
-
-/// Maps FileId → (path, source text, line_starts cache).
-pub struct FileTable {
-    files: Vec<SourceFile>,
-}
-
-struct SourceFile {
-    path: String,
-    source: String,
-    /// Byte offsets of each line start (computed on insert, cached).
-    line_starts: Vec<u32>,
-}
-
-impl FileTable {
-    pub fn new() -> Self {
-        Self { files: Vec::new() }
-    }
-
-    /// Add a file and return its FileId.
-    pub fn add_file(&mut self, path: String, source: String) -> FileId {
-        let line_starts = compute_line_starts(&source);
-        let id = self.files.len() as FileId;
-        self.files.push(SourceFile {
-            path,
-            source,
-            line_starts,
-        });
-        id
-    }
-
-    pub fn get_source(&self, file_id: FileId) -> Option<&str> {
-        self.files.get(file_id as usize).map(|f| f.source.as_str())
-    }
-
-    pub fn get_path(&self, file_id: FileId) -> Option<&str> {
-        self.files.get(file_id as usize).map(|f| f.path.as_str())
-    }
-
-    /// Resolve a byte offset to (line, col), both 0-based.
-    /// Returns None if file_id is invalid or offset is out of range.
-    pub fn line_col(&self, file_id: FileId, byte_offset: u32) -> Option<(u32, u32)> {
-        let file = self.files.get(file_id as usize)?;
-        let line = match file.line_starts.binary_search(&byte_offset) {
-            Ok(exact) => exact,
-            Err(insert) => insert.saturating_sub(1),
-        };
-        let col = byte_offset - file.line_starts[line];
-        Some((line as u32, col))
-    }
-
-    pub fn file_count(&self) -> usize {
-        self.files.len()
-    }
-}
-
-impl Default for FileTable {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-/// Compute byte offsets of each line start in `source`.
-fn compute_line_starts(source: &str) -> Vec<u32> {
-    let mut starts = vec![0u32];
-    for (i, b) in source.bytes().enumerate() {
-        if b == b'\n' {
-            starts.push((i + 1) as u32);
-        }
-    }
-    starts
-}
+pub use file_table::{FileId, FileTable};
 
 // ── Span ───────────────────────────────────────────────────────────
 

--- a/src/error/file_table.rs
+++ b/src/error/file_table.rs
@@ -1,0 +1,73 @@
+/// Index into the FileTable. 0 is reserved for "no file" / test usage.
+pub type FileId = u32;
+
+/// Maps FileId -> (path, source text, line_starts cache).
+pub struct FileTable {
+    files: Vec<SourceFile>,
+}
+
+struct SourceFile {
+    path: String,
+    source: String,
+    /// Byte offsets of each line start (computed on insert, cached).
+    line_starts: Vec<u32>,
+}
+
+impl FileTable {
+    pub fn new() -> Self {
+        Self { files: Vec::new() }
+    }
+
+    /// Add a file and return its FileId.
+    pub fn add_file(&mut self, path: String, source: String) -> FileId {
+        let line_starts = compute_line_starts(&source);
+        let id = self.files.len() as FileId;
+        self.files.push(SourceFile {
+            path,
+            source,
+            line_starts,
+        });
+        id
+    }
+
+    pub fn get_source(&self, file_id: FileId) -> Option<&str> {
+        self.files.get(file_id as usize).map(|f| f.source.as_str())
+    }
+
+    pub fn get_path(&self, file_id: FileId) -> Option<&str> {
+        self.files.get(file_id as usize).map(|f| f.path.as_str())
+    }
+
+    /// Resolve a byte offset to (line, col), both 0-based.
+    /// Returns None if file_id is invalid or offset is out of range.
+    pub fn line_col(&self, file_id: FileId, byte_offset: u32) -> Option<(u32, u32)> {
+        let file = self.files.get(file_id as usize)?;
+        let line = match file.line_starts.binary_search(&byte_offset) {
+            Ok(exact) => exact,
+            Err(insert) => insert.saturating_sub(1),
+        };
+        let col = byte_offset - file.line_starts[line];
+        Some((line as u32, col))
+    }
+
+    pub fn file_count(&self) -> usize {
+        self.files.len()
+    }
+}
+
+impl Default for FileTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Compute byte offsets of each line start in `source`.
+fn compute_line_starts(source: &str) -> Vec<u32> {
+    let mut starts = vec![0u32];
+    for (i, b) in source.bytes().enumerate() {
+        if b == b'\n' {
+            starts.push((i + 1) as u32);
+        }
+    }
+    starts
+}


### PR DESCRIPTION
## Summary
- move `FileTable`/`FileId` source storage into `src/error/file_table.rs`
- preserve the public `zen::error::{FileTable, FileId}` API through re-exports
- record the cleanup in the phase plan and completion audit

## Validation
- `cargo fmt --check`
- `cargo test --lib error::tests`
- `cargo test --test integration -- --list`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`