### PR TITLE
Split expression simple forms

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2761,6 +2761,11 @@ and do not assume Phase 4 is ready without evidence.
   walking in `src/typechecker/generic_type_reference_walker/expressions.rs`,
   preserving generic annotation diagnostics while keeping type argument arity
   and bound checks smaller.
+- Expression checking now keeps identifier, block, return, cast,
+  interpolation, defer, and closure forms in
+  `src/typechecker/expressions/simple_forms.rs`, preserving core semantic,
+  single-file fixture, and generic diagnostic coverage while leaving the root
+  expression checker closer to dispatch.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -340,6 +340,9 @@ checked-in docs, tests, and commits only.
 - Generic type reference validation now keeps expression and statement walking
   in a focused child module, leaving generic type argument arity and bound
   checks smaller.
+- Expression checking now keeps identifier, block, return, cast, interpolation,
+  defer, and closure forms in a focused child module, leaving the root
+  expression checker closer to dispatch.
 - Generic diagnostic integration coverage now keeps nested/function/container
   annotation arity tests in a focused module, separate from direct generic
   call, method, local, and declaration annotation arity cases.

--- a/src/typechecker/expressions.rs
+++ b/src/typechecker/expressions.rs
@@ -8,6 +8,7 @@ mod call_validation;
 mod control_flow_support;
 mod function_checking;
 mod method_call_support;
+mod simple_forms;
 
 use crate::ast::expressions::StringPart;
 use crate::ast::typed::*;
@@ -45,45 +46,7 @@ impl TypeChecker {
                 span: *span,
             }),
 
-            Expression::Identifier { name, span } => {
-                if name == "true" {
-                    return Ok(TypedExpression {
-                        kind: TypedExprKind::BoolLiteral(true),
-                        ty: Type::Bool,
-                        span: *span,
-                    });
-                }
-                if name == "false" {
-                    return Ok(TypedExpression {
-                        kind: TypedExprKind::BoolLiteral(false),
-                        ty: Type::Bool,
-                        span: *span,
-                    });
-                }
-                let ty = match self.lookup_var(name) {
-                    Some(t) => t,
-                    None => {
-                        // Not a variable — only warn if it's not a known type, enum, function, or import
-                        if !self.structs.contains_key(name.as_str())
-                            && !self.enums.contains_key(name.as_str())
-                            && !self.functions.contains_key(name.as_str())
-                            && !self.is_import(name)
-                        {
-                            self.diagnostics.push(Diagnostic::error(
-                                "E3040",
-                                format!("undefined variable `{}`", name),
-                                *span,
-                            ));
-                        }
-                        Type::Unknown
-                    }
-                };
-                Ok(TypedExpression {
-                    kind: TypedExprKind::Variable(name.clone()),
-                    ty,
-                    span: *span,
-                })
-            }
+            Expression::Identifier { name, span } => self.check_identifier_expr(name, *span),
 
             Expression::BinaryOp {
                 op,
@@ -150,59 +113,9 @@ impl TypeChecker {
                 statements,
                 expr,
                 span,
-            } => {
-                self.push_scope();
-                let mut typed_stmts = Vec::new();
-                for stmt in statements {
-                    typed_stmts.push(self.check_statement(stmt)?);
-                }
-                let typed_expr = match expr {
-                    Some(e) => Some(Box::new(self.check_expr(e)?)),
-                    None => None,
-                };
-                let ty = typed_expr
-                    .as_ref()
-                    .map(|e| e.ty.clone())
-                    .unwrap_or(Type::Void);
-                self.pop_scope();
-                Ok(TypedExpression {
-                    kind: TypedExprKind::Block(TypedBlock {
-                        statements: typed_stmts,
-                        expr: typed_expr,
-                        ty: ty.clone(),
-                        span: *span,
-                    }),
-                    ty,
-                    span: *span,
-                })
-            }
+            } => self.check_block_expr(statements, expr, *span),
 
-            Expression::Return { value, span } => {
-                let typed_val = match value {
-                    Some(v) => Some(Box::new(self.check_expr(v)?)),
-                    None => None,
-                };
-                // Check return type compatibility
-                if let Some(ref expected) = self.current_return_type {
-                    let actual = typed_val.as_ref().map(|v| &v.ty).unwrap_or(&Type::Void);
-                    if !self.types_compatible(expected, actual) {
-                        self.diagnostics.push(Diagnostic::error(
-                            "E3030",
-                            format!(
-                                "return type mismatch: expected `{}`, found `{}`",
-                                expected.display_name(),
-                                actual.display_name()
-                            ),
-                            *span,
-                        ));
-                    }
-                }
-                Ok(TypedExpression {
-                    kind: TypedExprKind::Return(typed_val),
-                    ty: Type::Never,
-                    span: *span,
-                })
-            }
+            Expression::Return { value, span } => self.check_return_expr(value, *span),
 
             Expression::Break { span } => Ok(TypedExpression {
                 kind: TypedExprKind::Break,
@@ -258,57 +171,13 @@ impl TypeChecker {
                 expr,
                 target_type,
                 span,
-            } => {
-                let typed_expr = self.check_expr(expr)?;
-                let from_type = typed_expr.ty.clone();
-                let to_type = self.resolve_type(target_type);
-                Ok(TypedExpression {
-                    kind: TypedExprKind::Cast {
-                        expr: Box::new(typed_expr),
-                        from_type,
-                        to_type: to_type.clone(),
-                    },
-                    ty: to_type,
-                    span: *span,
-                })
-            }
+            } => self.check_cast_expr(expr, target_type, *span),
 
             Expression::StringInterpolation { parts, span } => {
-                let mut typed_parts = Vec::new();
-                for part in parts {
-                    match part {
-                        StringPart::Literal(s) => {
-                            typed_parts.push(TypedStringPart::Literal(s.clone()));
-                        }
-                        StringPart::Expr(e) => {
-                            let typed = self.check_expr(e)?;
-                            typed_parts.push(TypedStringPart::Expr(typed));
-                        }
-                    }
-                }
-                Ok(TypedExpression {
-                    kind: TypedExprKind::StringInterpolation { parts: typed_parts },
-                    ty: Type::Str,
-                    span: *span,
-                })
+                self.check_string_interpolation_expr(parts, *span)
             }
 
-            Expression::Defer { expr, span } => {
-                // Type-check the deferred expression and collect it
-                let typed_expr = self.check_expr(expr)?;
-                self.pending_defers.push(typed_expr);
-                // Defer itself doesn't produce a value
-                Ok(TypedExpression {
-                    kind: TypedExprKind::Block(TypedBlock {
-                        statements: Vec::new(),
-                        expr: None,
-                        ty: Type::Void,
-                        span: *span,
-                    }),
-                    ty: Type::Void,
-                    span: *span,
-                })
-            }
+            Expression::Defer { expr, span } => self.check_defer_expr(expr, *span),
 
             Expression::IndexAccess {
                 object,
@@ -318,70 +187,10 @@ impl TypeChecker {
 
             Expression::Closure {
                 params,
-                return_type: _return_type,
+                return_type,
                 body,
                 span,
-            } => {
-                // Collect variables visible before entering closure scope
-                let outer_vars: std::collections::HashMap<String, Type> = self
-                    .scopes
-                    .iter()
-                    .flat_map(|s| s.vars.iter())
-                    .map(|(k, v)| (k.clone(), v.ty.clone()))
-                    .collect();
-
-                self.push_scope();
-                let mut param_types = Vec::new();
-                let mut param_names: std::collections::HashSet<String> =
-                    std::collections::HashSet::new();
-                for p in params {
-                    let ty = self.resolve_type(&p.ty);
-                    self.define_var_with_mutability(&p.name, ty.clone(), p.mutable);
-                    param_types.push(ty);
-                    param_names.insert(p.name.clone());
-                }
-                let typed_body = self.check_expr(body)?;
-                self.pop_scope();
-
-                let ret_type = if let Some(rt) = _return_type {
-                    self.resolve_type(rt)
-                } else {
-                    typed_body.ty.clone()
-                };
-
-                // Capture analysis: find variables in body that come from outer scopes
-                let mut captures = Vec::new();
-                let mut seen = std::collections::HashSet::new();
-                collect_captures(
-                    &typed_body,
-                    &param_names,
-                    &outer_vars,
-                    &mut captures,
-                    &mut seen,
-                );
-
-                let fn_name = format!("__closure_{}_{}", span.start, span.end);
-                let env_type = if captures.is_empty() {
-                    String::new()
-                } else {
-                    format!("__env_{}_{}", span.start, span.end)
-                };
-
-                let fn_type = Type::Function {
-                    params: param_types,
-                    ret: Box::new(ret_type),
-                };
-
-                Ok(TypedExpression {
-                    kind: TypedExprKind::Closure {
-                        fn_name,
-                        env_type,
-                        captures,
-                    },
-                    ty: fn_type,
-                    span: *span,
-                })
-            }
+            } => self.check_closure_expr(params, return_type, body, *span),
 
             Expression::UnaryOp { op, operand, span } => {
                 let typed = self.check_expr(operand)?;

--- a/src/typechecker/expressions/simple_forms.rs
+++ b/src/typechecker/expressions/simple_forms.rs
@@ -1,0 +1,244 @@
+use super::*;
+
+impl TypeChecker {
+    pub(super) fn check_identifier_expr(
+        &mut self,
+        name: &str,
+        span: Span,
+    ) -> Result<TypedExpression, Diagnostic> {
+        if name == "true" {
+            return Ok(TypedExpression {
+                kind: TypedExprKind::BoolLiteral(true),
+                ty: Type::Bool,
+                span,
+            });
+        }
+        if name == "false" {
+            return Ok(TypedExpression {
+                kind: TypedExprKind::BoolLiteral(false),
+                ty: Type::Bool,
+                span,
+            });
+        }
+
+        let ty = match self.lookup_var(name) {
+            Some(t) => t,
+            None => {
+                if !self.structs.contains_key(name)
+                    && !self.enums.contains_key(name)
+                    && !self.functions.contains_key(name)
+                    && !self.is_import(name)
+                {
+                    self.diagnostics.push(Diagnostic::error(
+                        "E3040",
+                        format!("undefined variable `{}`", name),
+                        span,
+                    ));
+                }
+                Type::Unknown
+            }
+        };
+
+        Ok(TypedExpression {
+            kind: TypedExprKind::Variable(name.to_owned()),
+            ty,
+            span,
+        })
+    }
+
+    pub(super) fn check_block_expr(
+        &mut self,
+        statements: &[crate::ast::Statement],
+        expr: &Option<Box<Expression>>,
+        span: Span,
+    ) -> Result<TypedExpression, Diagnostic> {
+        self.push_scope();
+        let mut typed_stmts = Vec::new();
+        for stmt in statements {
+            typed_stmts.push(self.check_statement(stmt)?);
+        }
+        let typed_expr = match expr {
+            Some(e) => Some(Box::new(self.check_expr(e)?)),
+            None => None,
+        };
+        let ty = typed_expr
+            .as_ref()
+            .map(|e| e.ty.clone())
+            .unwrap_or(Type::Void);
+        self.pop_scope();
+
+        Ok(TypedExpression {
+            kind: TypedExprKind::Block(TypedBlock {
+                statements: typed_stmts,
+                expr: typed_expr,
+                ty: ty.clone(),
+                span,
+            }),
+            ty,
+            span,
+        })
+    }
+
+    pub(super) fn check_return_expr(
+        &mut self,
+        value: &Option<Box<Expression>>,
+        span: Span,
+    ) -> Result<TypedExpression, Diagnostic> {
+        let typed_val = match value {
+            Some(v) => Some(Box::new(self.check_expr(v)?)),
+            None => None,
+        };
+
+        if let Some(ref expected) = self.current_return_type {
+            let actual = typed_val.as_ref().map(|v| &v.ty).unwrap_or(&Type::Void);
+            if !self.types_compatible(expected, actual) {
+                self.diagnostics.push(Diagnostic::error(
+                    "E3030",
+                    format!(
+                        "return type mismatch: expected `{}`, found `{}`",
+                        expected.display_name(),
+                        actual.display_name()
+                    ),
+                    span,
+                ));
+            }
+        }
+
+        Ok(TypedExpression {
+            kind: TypedExprKind::Return(typed_val),
+            ty: Type::Never,
+            span,
+        })
+    }
+
+    pub(super) fn check_cast_expr(
+        &mut self,
+        expr: &Expression,
+        target_type: &AstType,
+        span: Span,
+    ) -> Result<TypedExpression, Diagnostic> {
+        let typed_expr = self.check_expr(expr)?;
+        let from_type = typed_expr.ty.clone();
+        let to_type = self.resolve_type(target_type);
+
+        Ok(TypedExpression {
+            kind: TypedExprKind::Cast {
+                expr: Box::new(typed_expr),
+                from_type,
+                to_type: to_type.clone(),
+            },
+            ty: to_type,
+            span,
+        })
+    }
+
+    pub(super) fn check_string_interpolation_expr(
+        &mut self,
+        parts: &[StringPart],
+        span: Span,
+    ) -> Result<TypedExpression, Diagnostic> {
+        let mut typed_parts = Vec::new();
+        for part in parts {
+            match part {
+                StringPart::Literal(s) => {
+                    typed_parts.push(TypedStringPart::Literal(s.clone()));
+                }
+                StringPart::Expr(e) => {
+                    let typed = self.check_expr(e)?;
+                    typed_parts.push(TypedStringPart::Expr(typed));
+                }
+            }
+        }
+
+        Ok(TypedExpression {
+            kind: TypedExprKind::StringInterpolation { parts: typed_parts },
+            ty: Type::Str,
+            span,
+        })
+    }
+
+    pub(super) fn check_defer_expr(
+        &mut self,
+        expr: &Expression,
+        span: Span,
+    ) -> Result<TypedExpression, Diagnostic> {
+        let typed_expr = self.check_expr(expr)?;
+        self.pending_defers.push(typed_expr);
+
+        Ok(TypedExpression {
+            kind: TypedExprKind::Block(TypedBlock {
+                statements: Vec::new(),
+                expr: None,
+                ty: Type::Void,
+                span,
+            }),
+            ty: Type::Void,
+            span,
+        })
+    }
+
+    pub(super) fn check_closure_expr(
+        &mut self,
+        params: &[Param],
+        return_type: &Option<AstType>,
+        body: &Expression,
+        span: Span,
+    ) -> Result<TypedExpression, Diagnostic> {
+        let outer_vars: std::collections::HashMap<String, Type> = self
+            .scopes
+            .iter()
+            .flat_map(|s| s.vars.iter())
+            .map(|(k, v)| (k.clone(), v.ty.clone()))
+            .collect();
+
+        self.push_scope();
+        let mut param_types = Vec::new();
+        let mut param_names = std::collections::HashSet::new();
+        for param in params {
+            let ty = self.resolve_type(&param.ty);
+            self.define_var_with_mutability(&param.name, ty.clone(), param.mutable);
+            param_types.push(ty);
+            param_names.insert(param.name.clone());
+        }
+        let typed_body = self.check_expr(body)?;
+        self.pop_scope();
+
+        let ret_type = if let Some(return_type) = return_type {
+            self.resolve_type(return_type)
+        } else {
+            typed_body.ty.clone()
+        };
+
+        let mut captures = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+        collect_captures(
+            &typed_body,
+            &param_names,
+            &outer_vars,
+            &mut captures,
+            &mut seen,
+        );
+
+        let fn_name = format!("__closure_{}_{}", span.start, span.end);
+        let env_type = if captures.is_empty() {
+            String::new()
+        } else {
+            format!("__env_{}_{}", span.start, span.end)
+        };
+
+        let fn_type = Type::Function {
+            params: param_types,
+            ret: Box::new(ret_type),
+        };
+
+        Ok(TypedExpression {
+            kind: TypedExprKind::Closure {
+                fn_name,
+                env_type,
+                captures,
+            },
+            ty: fn_type,
+            span,
+        })
+    }
+}


### PR DESCRIPTION
## Summary
- move identifier, block, return, cast, interpolation, defer, and closure expression checking into `src/typechecker/expressions/simple_forms.rs`
- keep `src/typechecker/expressions.rs` closer to expression dispatch
- record the cleanup in the phase plan and completion audit

## Validation
- `cargo fmt --check`
- `cargo test --lib typechecker::tests::core_semantics`
- `cargo test --test integration single_file_fixtures`
- `cargo test --test generic_diagnostics`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`