### PR TITLE
Split C runtime helper emission

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2766,6 +2766,10 @@ and do not assume Phase 4 is ready without evidence.
   `src/typechecker/expressions/simple_forms.rs`, preserving core semantic,
   single-file fixture, and generic diagnostic coverage while leaving the root
   expression checker closer to dispatch.
+- C codegen now keeps runtime and stdlib stand-in helper emission in
+  `src/codegen/c/types/runtime_helpers.rs`, preserving codegen unit coverage
+  and runtime fixture execution while leaving C type/program/function emission
+  smaller.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -343,6 +343,8 @@ checked-in docs, tests, and commits only.
 - Expression checking now keeps identifier, block, return, cast, interpolation,
   defer, and closure forms in a focused child module, leaving the root
   expression checker closer to dispatch.
+- C codegen now keeps runtime and stdlib stand-in helper emission in a focused
+  child module, leaving C type/program/function emission smaller.
 - Generic diagnostic integration coverage now keeps nested/function/container
   annotation arity tests in a focused module, separate from direct generic
   call, method, local, and declaration annotation arity cases.

--- a/src/codegen/c/types.rs
+++ b/src/codegen/c/types.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod runtime_helpers;
+
 impl CEmitter {
     // ── Type mapping ──────────────────────────────────────────
 
@@ -123,78 +125,6 @@ impl CEmitter {
             self.dedent();
             self.line("}");
         }
-    }
-
-    fn emit_runtime_types(&mut self) {
-        self.line("/* Runtime types */");
-        self.line("typedef struct { const char* ptr; size_t len; } zen_str;");
-        self.line("typedef struct { char* ptr; size_t len; size_t cap; } zen_string;");
-        self.blank();
-
-        // String helpers
-        self.line("static zen_str zen_str_from_literal(const char* s) {");
-        self.indent();
-        self.line("return (zen_str){ .ptr = s, .len = strlen(s) };");
-        self.dedent();
-        self.line("}");
-        self.blank();
-
-        // Printf helper for zen_str
-        self.line("static void zen_str_print(zen_str s) {");
-        self.indent();
-        self.line("fwrite(s.ptr, 1, s.len, stdout);");
-        self.dedent();
-        self.line("}");
-        self.blank();
-
-        // Int to string helper
-        self.line("static zen_str zen_i64_to_str(int64_t v, char* buf, size_t bufsz) {");
-        self.indent();
-        self.line("int n = snprintf(buf, bufsz, \"%lld\", (long long)v);");
-        self.line("return (zen_str){ .ptr = buf, .len = (size_t)(n > 0 ? n : 0) };");
-        self.dedent();
-        self.line("}");
-        self.blank();
-
-        // Float to string helper
-        self.line("static zen_str zen_f64_to_str(double v, char* buf, size_t bufsz) {");
-        self.indent();
-        self.line("int n = snprintf(buf, bufsz, \"%g\", v);");
-        self.line("return (zen_str){ .ptr = buf, .len = (size_t)(n > 0 ? n : 0) };");
-        self.dedent();
-        self.line("}");
-        self.blank();
-
-        // String concatenation helper (stack-based for now)
-        self.line("static zen_str zen_str_concat(zen_str a, zen_str b, char* buf, size_t bufsz) {");
-        self.indent();
-        self.line("size_t total = a.len + b.len;");
-        self.line("if (total > bufsz - 1) total = bufsz - 1;");
-        self.line("memcpy(buf, a.ptr, a.len < total ? a.len : total);");
-        self.line("if (a.len < total) memcpy(buf + a.len, b.ptr, total - a.len);");
-        self.line("buf[total] = '\\0';");
-        self.line("return (zen_str){ .ptr = buf, .len = total };");
-        self.dedent();
-        self.line("}");
-        self.blank();
-    }
-
-    fn emit_io_helpers(&mut self) {
-        self.line("/* I/O helpers (stdlib stand-in) */");
-        self.line("static void io_println(zen_str s) {");
-        self.indent();
-        self.line("fwrite(s.ptr, 1, s.len, stdout);");
-        self.line("fputc('\\n', stdout);");
-        self.dedent();
-        self.line("}");
-        self.blank();
-
-        self.line("static void io_print(zen_str s) {");
-        self.indent();
-        self.line("fwrite(s.ptr, 1, s.len, stdout);");
-        self.dedent();
-        self.line("}");
-        self.blank();
     }
 
     // ── Type definitions ──────────────────────────────────────

--- a/src/codegen/c/types/runtime_helpers.rs
+++ b/src/codegen/c/types/runtime_helpers.rs
@@ -1,0 +1,86 @@
+use super::*;
+
+impl CEmitter {
+    pub(super) fn emit_runtime_types(&mut self) {
+        self.line("/* Runtime types */");
+        self.line("typedef struct { const char* ptr; size_t len; } zen_str;");
+        self.line("typedef struct { char* ptr; size_t len; size_t cap; } zen_string;");
+        self.blank();
+
+        self.emit_string_literal_helper();
+        self.emit_string_print_helper();
+        self.emit_int_string_helper();
+        self.emit_float_string_helper();
+        self.emit_string_concat_helper();
+    }
+
+    pub(super) fn emit_io_helpers(&mut self) {
+        self.line("/* I/O helpers (stdlib stand-in) */");
+        self.line("static void io_println(zen_str s) {");
+        self.indent();
+        self.line("fwrite(s.ptr, 1, s.len, stdout);");
+        self.line("fputc('\\n', stdout);");
+        self.dedent();
+        self.line("}");
+        self.blank();
+
+        self.line("static void io_print(zen_str s) {");
+        self.indent();
+        self.line("fwrite(s.ptr, 1, s.len, stdout);");
+        self.dedent();
+        self.line("}");
+        self.blank();
+    }
+
+    fn emit_string_literal_helper(&mut self) {
+        self.line("static zen_str zen_str_from_literal(const char* s) {");
+        self.indent();
+        self.line("return (zen_str){ .ptr = s, .len = strlen(s) };");
+        self.dedent();
+        self.line("}");
+        self.blank();
+    }
+
+    fn emit_string_print_helper(&mut self) {
+        self.line("static void zen_str_print(zen_str s) {");
+        self.indent();
+        self.line("fwrite(s.ptr, 1, s.len, stdout);");
+        self.dedent();
+        self.line("}");
+        self.blank();
+    }
+
+    fn emit_int_string_helper(&mut self) {
+        self.line("static zen_str zen_i64_to_str(int64_t v, char* buf, size_t bufsz) {");
+        self.indent();
+        self.line("int n = snprintf(buf, bufsz, \"%lld\", (long long)v);");
+        self.line("return (zen_str){ .ptr = buf, .len = (size_t)(n > 0 ? n : 0) };");
+        self.dedent();
+        self.line("}");
+        self.blank();
+    }
+
+    fn emit_float_string_helper(&mut self) {
+        self.line("static zen_str zen_f64_to_str(double v, char* buf, size_t bufsz) {");
+        self.indent();
+        self.line("int n = snprintf(buf, bufsz, \"%g\", v);");
+        self.line("return (zen_str){ .ptr = buf, .len = (size_t)(n > 0 ? n : 0) };");
+        self.dedent();
+        self.line("}");
+        self.blank();
+    }
+
+    fn emit_string_concat_helper(&mut self) {
+        self.line("static zen_str zen_str_concat(zen_str a, zen_str b, char* buf, size_t bufsz) {");
+        self.indent();
+        self.line("size_t total = a.len + b.len;");
+        self.line("if (total > bufsz - 1) total = bufsz - 1;");
+        self.line("memcpy(buf, a.ptr, a.len < total ? a.len : total);");
+        self.line("if (a.len < total) memcpy(buf + a.len, b.ptr, total - a.len);");
+        self.line("buf[total] = '\\0';");
+        self.line("return (zen_str){ .ptr = buf, .len = total };");
+        self.dedent();
+        self.line("}");
+        self.blank();
+    }
+}


### PR DESCRIPTION
## Summary
- move C runtime and stdlib stand-in helper emission into `src/codegen/c/types/runtime_helpers.rs`
- keep `src/codegen/c/types.rs` focused on C type mapping, program emission, type definitions, functions, and globals
- record the cleanup in the phase plan and completion audit

## Validation
- `cargo fmt --check`
- `cargo test --lib codegen::c::tests`
- `cargo test --test integration runtime_fixtures`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`