### PR TITLE
Reject module call type arguments

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2770,6 +2770,10 @@ and do not assume Phase 4 is ready without evidence.
   `src/codegen/c/types/runtime_helpers.rs`, preserving codegen unit coverage
   and runtime fixture execution while leaving C type/program/function emission
   smaller.
+- Module-qualified calls now reject explicit type arguments on non-generic
+  functions, covered by
+  `module_function_explicit_type_args_are_error`, so `io.println<i32>(...)`
+  cannot silently discard malformed type arguments.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -158,6 +158,9 @@ checked-in docs, tests, and commits only.
   without specializing failed method bodies into followup errors.
 - Generic diagnostics now also guard plain generic function and method
   inference conflicts against argument/return mismatch followups.
+- Generic diagnostics now reject explicit type arguments on non-generic
+  module-qualified calls such as `io.println<i32>(...)`, so import/module call
+  syntax no longer silently drops malformed type arguments.
 - Generic enum method specialization coverage now includes an imported
   `Result<T, E>` fixture with generated-C assertions for the concrete method.
 - Resolver-backed callable type-reference validation now shares the collected

--- a/src/typechecker/expressions/method_call_support.rs
+++ b/src/typechecker/expressions/method_call_support.rs
@@ -24,6 +24,12 @@ impl TypeChecker {
                 let mangled = format!("{}_{}", recv_name, method);
                 // Try to look up the return type
                 let ret_type = if let Some(info) = self.functions.get(&mangled).cloned() {
+                    self.reject_module_call_type_args(
+                        "function",
+                        &format!("{}.{}", recv_name, method),
+                        type_args,
+                        span,
+                    );
                     self.check_call_signature(
                         "function",
                         &mangled,
@@ -35,6 +41,7 @@ impl TypeChecker {
                 } else {
                     let method_key = Self::method_key(recv_name, method);
                     if let Some(info) = self.methods.get(&method_key).cloned() {
+                        self.reject_module_call_type_args("method", &method_key, type_args, span);
                         self.check_call_signature(
                             "method",
                             &method_key,
@@ -44,6 +51,12 @@ impl TypeChecker {
                         );
                         self.resolve_type(&info.return_type)
                     } else if self.is_root_std_runtime_call(recv_name, method) {
+                        self.reject_module_call_type_args(
+                            "function",
+                            &format!("{}.{}", recv_name, method),
+                            type_args,
+                            span,
+                        );
                         Type::Void
                     } else {
                         self.diagnostics.push(Diagnostic::error(
@@ -364,5 +377,26 @@ impl TypeChecker {
         } else {
             self.unknown_method_expr(&type_name, method, typed_args, span)
         }
+    }
+
+    fn reject_module_call_type_args(
+        &mut self,
+        kind: &str,
+        name: &str,
+        type_args: &[AstType],
+        span: Span,
+    ) {
+        if type_args.is_empty() {
+            return;
+        }
+
+        self.diagnostics.push(Diagnostic::error(
+            "E5001",
+            format!(
+                "non-generic {} `{}` does not accept type arguments",
+                kind, name
+            ),
+            span,
+        ));
     }
 }

--- a/tests/generic_diagnostics/method_type_args.rs
+++ b/tests/generic_diagnostics/method_type_args.rs
@@ -28,6 +28,27 @@ main = () i32 {
 }
 
 #[test]
+fn module_function_explicit_type_args_are_error() {
+    let errors = typecheck_errors(
+        r#"
+{ io } = std
+
+main = () i32 {
+    io.println<i32>("bad")
+    0
+}
+"#,
+    );
+
+    assert!(
+        errors.iter().any(|d| d
+            .message
+            .contains("non-generic function `io.println` does not accept type arguments")),
+        "expected module function type-argument diagnostic, got {errors:?}"
+    );
+}
+
+#[test]
 fn generic_method_explicit_type_arg_arity_is_error() {
     let errors = typecheck_errors(
         r#"


### PR DESCRIPTION
## Summary
- reject explicit type arguments on non-generic module-qualified calls such as `io.println<i32>(...)`
- add generic diagnostic coverage proving module calls no longer silently discard malformed type arguments
- record the diagnostic hardening in the phase plan and completion audit

## Validation
- `cargo test --test generic_diagnostics module_function_explicit_type_args_are_error` (failed before the fix, passed after)
- `cargo fmt --check`
- `cargo test --test generic_diagnostics method_type_args`
- `cargo test --test integration multi_file_fixtures`
- `cargo test --test integration single_file_fixtures`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`