### PR TITLE
Split module call checking

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2774,6 +2774,10 @@ and do not assume Phase 4 is ready without evidence.
   functions, covered by
   `module_function_explicit_type_args_are_error`, so `io.println<i32>(...)`
   cannot silently discard malformed type arguments.
+- Typechecker method-call support now keeps module-qualified import call
+  checking in `src/typechecker/expressions/method_call_support/module_calls.rs`,
+  preserving module-call diagnostics and multi-file fixture coverage while
+  keeping generic receiver/method/UFC resolution separate.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -161,6 +161,9 @@ checked-in docs, tests, and commits only.
 - Generic diagnostics now reject explicit type arguments on non-generic
   module-qualified calls such as `io.println<i32>(...)`, so import/module call
   syntax no longer silently drops malformed type arguments.
+- Typechecker method-call support now keeps module-qualified import calls in a
+  focused child module, keeping generic receiver/method/UFC resolution
+  separate from import dispatch and module-call diagnostics.
 - Generic enum method specialization coverage now includes an imported
   `Result<T, E>` fixture with generated-C assertions for the concrete method.
 - Resolver-backed callable type-reference validation now shares the collected

--- a/src/typechecker/expressions/method_call_support.rs
+++ b/src/typechecker/expressions/method_call_support.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod module_calls;
+
 impl TypeChecker {
     pub(super) fn check_method_call_expr(
         &mut self,
@@ -9,73 +11,10 @@ impl TypeChecker {
         args: &[Expression],
         span: Span,
     ) -> Result<TypedExpression, Diagnostic> {
-        // Check if receiver is an imported module name (like `io`)
-        // In that case, this is a module-qualified call: io.println(args)
-        if let Expression::Identifier {
-            name: ref recv_name,
-            ..
-        } = receiver
+        if let Some(module_call) =
+            self.try_module_qualified_method_call(receiver, method, type_args, args, span)
         {
-            if self.is_import(recv_name) {
-                let mut typed_args = Vec::new();
-                for arg in args {
-                    typed_args.push(self.check_expr(arg)?);
-                }
-                let mangled = format!("{}_{}", recv_name, method);
-                // Try to look up the return type
-                let ret_type = if let Some(info) = self.functions.get(&mangled).cloned() {
-                    self.reject_module_call_type_args(
-                        "function",
-                        &format!("{}.{}", recv_name, method),
-                        type_args,
-                        span,
-                    );
-                    self.check_call_signature(
-                        "function",
-                        &mangled,
-                        &info.params,
-                        &typed_args,
-                        &span,
-                    );
-                    self.resolve_type(&info.return_type)
-                } else {
-                    let method_key = Self::method_key(recv_name, method);
-                    if let Some(info) = self.methods.get(&method_key).cloned() {
-                        self.reject_module_call_type_args("method", &method_key, type_args, span);
-                        self.check_call_signature(
-                            "method",
-                            &method_key,
-                            &info.params,
-                            &typed_args,
-                            &span,
-                        );
-                        self.resolve_type(&info.return_type)
-                    } else if self.is_root_std_runtime_call(recv_name, method) {
-                        self.reject_module_call_type_args(
-                            "function",
-                            &format!("{}.{}", recv_name, method),
-                            type_args,
-                            span,
-                        );
-                        Type::Void
-                    } else {
-                        self.diagnostics.push(Diagnostic::error(
-                            "E3023",
-                            format!("undefined module function `{}.{}`", recv_name, method),
-                            span,
-                        ));
-                        Type::Unknown
-                    }
-                };
-                return Ok(TypedExpression {
-                    kind: TypedExprKind::FunctionCall {
-                        function: mangled,
-                        args: typed_args,
-                    },
-                    ty: ret_type,
-                    span,
-                });
-            }
+            return module_call;
         }
 
         let typed_receiver = self.check_expr(receiver)?;
@@ -377,26 +316,5 @@ impl TypeChecker {
         } else {
             self.unknown_method_expr(&type_name, method, typed_args, span)
         }
-    }
-
-    fn reject_module_call_type_args(
-        &mut self,
-        kind: &str,
-        name: &str,
-        type_args: &[AstType],
-        span: Span,
-    ) {
-        if type_args.is_empty() {
-            return;
-        }
-
-        self.diagnostics.push(Diagnostic::error(
-            "E5001",
-            format!(
-                "non-generic {} `{}` does not accept type arguments",
-                kind, name
-            ),
-            span,
-        ));
     }
 }

--- a/src/typechecker/expressions/method_call_support/module_calls.rs
+++ b/src/typechecker/expressions/method_call_support/module_calls.rs
@@ -1,0 +1,115 @@
+use super::*;
+
+impl TypeChecker {
+    pub(super) fn try_module_qualified_method_call(
+        &mut self,
+        receiver: &Expression,
+        method: &str,
+        type_args: &[AstType],
+        args: &[Expression],
+        span: Span,
+    ) -> Option<Result<TypedExpression, Diagnostic>> {
+        let Expression::Identifier {
+            name: recv_name, ..
+        } = receiver
+        else {
+            return None;
+        };
+        if !self.is_import(recv_name) {
+            return None;
+        }
+
+        Some(self.check_module_qualified_method_call(recv_name, method, type_args, args, span))
+    }
+
+    fn check_module_qualified_method_call(
+        &mut self,
+        recv_name: &str,
+        method: &str,
+        type_args: &[AstType],
+        args: &[Expression],
+        span: Span,
+    ) -> Result<TypedExpression, Diagnostic> {
+        let mut typed_args = Vec::new();
+        for arg in args {
+            typed_args.push(self.check_expr(arg)?);
+        }
+
+        let mangled = format!("{}_{}", recv_name, method);
+        let ret_type = if let Some(info) = self.functions.get(&mangled).cloned() {
+            self.reject_module_call_type_args(
+                "function",
+                &format!("{}.{}", recv_name, method),
+                type_args,
+                span,
+            );
+            self.check_call_signature("function", &mangled, &info.params, &typed_args, &span);
+            self.resolve_type(&info.return_type)
+        } else {
+            self.check_module_method_fallback(recv_name, method, type_args, &typed_args, span)
+        };
+
+        Ok(TypedExpression {
+            kind: TypedExprKind::FunctionCall {
+                function: mangled,
+                args: typed_args,
+            },
+            ty: ret_type,
+            span,
+        })
+    }
+
+    fn check_module_method_fallback(
+        &mut self,
+        recv_name: &str,
+        method: &str,
+        type_args: &[AstType],
+        typed_args: &[TypedExpression],
+        span: Span,
+    ) -> Type {
+        let method_key = Self::method_key(recv_name, method);
+        if let Some(info) = self.methods.get(&method_key).cloned() {
+            self.reject_module_call_type_args("method", &method_key, type_args, span);
+            self.check_call_signature("method", &method_key, &info.params, typed_args, &span);
+            return self.resolve_type(&info.return_type);
+        }
+
+        if self.is_root_std_runtime_call(recv_name, method) {
+            self.reject_module_call_type_args(
+                "function",
+                &format!("{}.{}", recv_name, method),
+                type_args,
+                span,
+            );
+            return Type::Void;
+        }
+
+        self.diagnostics.push(Diagnostic::error(
+            "E3023",
+            format!("undefined module function `{}.{}`", recv_name, method),
+            span,
+        ));
+        Type::Unknown
+    }
+
+    fn reject_module_call_type_args(
+        &mut self,
+        kind: &str,
+        name: &str,
+        type_args: &[AstType],
+        span: Span,
+    ) {
+        if type_args.is_empty() {
+            return;
+        }
+
+        self.diagnostics.push(Diagnostic::error(
+            "E5001",
+            format!(
+                "non-generic {} `{}` does not accept type arguments",
+                kind, name
+            ),
+            span,
+        ));
+    }
+}


### PR DESCRIPTION
## Summary
- move module-qualified import call checking into `src/typechecker/expressions/method_call_support/module_calls.rs`
- keep generic receiver/method/UFC resolution separate from import dispatch and module-call diagnostics
- record the cleanup in the phase plan and completion audit

## Validation
- `cargo fmt --check`
- `cargo test --test generic_diagnostics module_function_explicit_type_args_are_error`
- `cargo test --test integration multi_file_fixtures`
- `cargo test --test integration single_file_fixtures`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`