### PR TITLE
Reject builtin call type arguments

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2778,6 +2778,10 @@ and do not assume Phase 4 is ready without evidence.
   checking in `src/typechecker/expressions/method_call_support/module_calls.rs`,
   preserving module-call diagnostics and multi-file fixture coverage while
   keeping generic receiver/method/UFC resolution separate.
+- Direct module-qualified calls now reject explicit type arguments on
+  non-generic functions, covered by
+  `builtin_function_explicit_type_args_are_error`, so
+  `@builtin.panic<i32>(...)` cannot silently discard malformed type arguments.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -164,6 +164,9 @@ checked-in docs, tests, and commits only.
 - Typechecker method-call support now keeps module-qualified import calls in a
   focused child module, keeping generic receiver/method/UFC resolution
   separate from import dispatch and module-call diagnostics.
+- Direct module-qualified calls such as `@builtin.panic<i32>(...)` now reject
+  explicit type arguments instead of silently accepting them, while preserving
+  the dedicated cast type-argument path.
 - Generic enum method specialization coverage now includes an imported
   `Result<T, E>` fixture with generated-C assertions for the concrete method.
 - Resolver-backed callable type-reference validation now shares the collected

--- a/src/typechecker/expressions/call_support.rs
+++ b/src/typechecker/expressions/call_support.rs
@@ -106,12 +106,15 @@ impl TypeChecker {
                 name.to_string()
             };
             if let Some(info) = self.methods.get(&full_name).cloned() {
+                self.reject_direct_module_call_type_args("method", &full_name, type_args, span);
                 self.check_call_signature("method", &full_name, &info.params, &typed_args, &span);
                 (full_name.clone(), self.resolve_type(&info.return_type))
             } else if let Some(info) = self.functions.get(&mangled).cloned() {
+                self.reject_direct_module_call_type_args("function", &full_name, type_args, span);
                 self.check_call_signature("function", &mangled, &info.params, &typed_args, &span);
                 (full_name.clone(), self.resolve_type(&info.return_type))
             } else {
+                self.reject_direct_module_call_type_args("function", &full_name, type_args, span);
                 let m = module.as_deref().unwrap_or("");
                 self.diagnostics.push(Diagnostic::warning(
                     "W3041",
@@ -137,5 +140,26 @@ impl TypeChecker {
             ty: ret_type,
             span,
         })
+    }
+
+    fn reject_direct_module_call_type_args(
+        &mut self,
+        kind: &str,
+        name: &str,
+        type_args: &[AstType],
+        span: Span,
+    ) {
+        if type_args.is_empty() {
+            return;
+        }
+
+        self.diagnostics.push(Diagnostic::error(
+            "E5001",
+            format!(
+                "non-generic {} `{}` does not accept type arguments",
+                kind, name
+            ),
+            span,
+        ));
     }
 }

--- a/tests/generic_diagnostics/method_type_args.rs
+++ b/tests/generic_diagnostics/method_type_args.rs
@@ -49,6 +49,25 @@ main = () i32 {
 }
 
 #[test]
+fn builtin_function_explicit_type_args_are_error() {
+    let errors = typecheck_errors(
+        r#"
+main = () i32 {
+    @builtin.panic<i32>("bad")
+    0
+}
+"#,
+    );
+
+    assert!(
+        errors.iter().any(|d| d
+            .message
+            .contains("non-generic function `@builtin.panic` does not accept type arguments")),
+        "expected builtin function type-argument diagnostic, got {errors:?}"
+    );
+}
+
+#[test]
 fn generic_method_explicit_type_arg_arity_is_error() {
     let errors = typecheck_errors(
         r#"


### PR DESCRIPTION
## Summary
- reject explicit type arguments on direct module-qualified builtin calls such as `@builtin.panic<i32>(...)`
- preserve the special `cast` type-argument form while preventing other module fallback calls from silently discarding malformed type arguments
- record the diagnostic hardening in the phase plan and completion audit

## Validation
- `cargo test --test generic_diagnostics builtin_function_explicit_type_args_are_error` (failed before the fix, passed after)
- `cargo fmt --check`
- `cargo test --test generic_diagnostics method_type_args`
- `cargo test --lib parser::tests::declarations`
- `cargo test --lib parser::tests::expressions`
- `cargo test --test integration single_file_fixtures`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`