### PR TITLE
Split CLI JSON emission

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2698,6 +2698,9 @@ and do not assume Phase 4 is ready without evidence.
 - CLI compile helpers are now split into `src/cli/compile.rs`; this is an
   internal cleanup preserving the same build/emit behavior and keeping tracked
   Rust source files under the cleanup threshold.
+- CLI JSON emit handlers are now split into `src/cli/json_emit.rs`,
+  preserving frontend and build-graph JSON integration coverage while keeping
+  JSON output paths separate from root command dispatch.
 - Imported behavior association dependency seeding is now split into
   `src/typechecker/resolver_validation/imports_behavior_dependencies.rs`,
   preserving imported behavior inheritance and impl coverage while keeping the

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2524,6 +2524,9 @@ checked-in docs, tests, and commits only.
   `src/cli/compile.rs`, keeping the root CLI module focused on command
   dispatch, graph loading, and frontend diagnostics while preserving existing
   build/emit integration coverage.
+- CLI JSON emission handlers now live in `src/cli/json_emit.rs`, keeping AST,
+  symbol, typed, diagnostic, and build-graph JSON output together while
+  preserving the existing frontend and build-graph JSON integration coverage.
 - Resolver validation now keeps imported behavior association dependency
   seeding in `src/typechecker/resolver_validation/imports_behavior_dependencies.rs`,
   separate from imported callable/type dependency seeding while preserving

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,6 +5,7 @@ use std::process;
 mod build_graph_execution;
 mod compile;
 mod diagnostics;
+mod json_emit;
 mod usage;
 
 use build_graph_execution::{
@@ -13,6 +14,10 @@ use build_graph_execution::{
 };
 use compile::{compile_file_to_binary, compile_file_to_c_source, typed_program_to_c_source};
 use diagnostics::{print_diagnostic, print_errors};
+use json_emit::{
+    cmd_emit_json_ast, cmd_emit_json_build_graph, cmd_emit_json_diagnostics, cmd_emit_json_symbols,
+    cmd_emit_json_typed,
+};
 use usage::print_usage;
 use zen::error::FileTable;
 use zen::module_system::ModuleSystem;
@@ -168,96 +173,6 @@ fn graph_frontend(path_str: &str) -> zen::ast::typed::TypedProgram {
                 .filter(|d| d.severity == zen::error::Severity::Error)
                 .count();
             eprintln!("  {} error(s)", errors);
-            process::exit(1);
-        }
-    }
-}
-
-fn cmd_emit_json_ast(path_str: &str) {
-    reject_build_zen_for_emit_json_mode(path_str);
-    let (graph, _files) = load_module_graph(path_str);
-    match zen::ir_json::ast_graph_to_json(&graph) {
-        Ok(json) => println!("{json}"),
-        Err(e) => {
-            eprintln!("json emit error: {}", e);
-            process::exit(1);
-        }
-    }
-}
-
-fn cmd_emit_json_symbols(path_str: &str) {
-    reject_build_zen_for_emit_json_mode(path_str);
-    let (graph, _files) = load_module_graph(path_str);
-    match zen::ir_json::symbols_graph_to_json(&graph) {
-        Ok(json) => println!("{json}"),
-        Err(e) => {
-            eprintln!("json emit error: {}", e);
-            process::exit(1);
-        }
-    }
-}
-
-fn cmd_emit_json_typed(path_str: &str) {
-    reject_build_zen_for_emit_json_mode(path_str);
-    let typed = graph_frontend(path_str);
-    match zen::ir_json::typed_program_to_json(&typed) {
-        Ok(json) => println!("{json}"),
-        Err(e) => {
-            eprintln!("json emit error: {}", e);
-            process::exit(1);
-        }
-    }
-}
-
-fn cmd_emit_json_diagnostics(path_str: &str) {
-    reject_build_zen_for_emit_json_mode(path_str);
-
-    let path = Path::new(path_str);
-    if !path.exists() {
-        eprintln!("error: file not found: {}", path_str);
-        process::exit(1);
-    }
-
-    let mut files = FileTable::new();
-    let mut module_system = ModuleSystem::new();
-    let mut diagnostics = match module_system.load_module_graph(path, &mut files) {
-        Ok(graph) => {
-            let mut checker = TypeChecker::new();
-            match checker.check_module_graph_entry(&graph) {
-                Ok(_) => checker.diagnostics().to_vec(),
-                Err(diags) => diags,
-            }
-        }
-        Err(errs) => errs.into_iter().map(Into::into).collect(),
-    };
-
-    diagnostics.sort_by_key(|diagnostic| {
-        diagnostic
-            .span
-            .map(|span| (span.file_id, span.start, span.end))
-            .unwrap_or((u32::MAX, u32::MAX, u32::MAX))
-    });
-
-    let has_errors = diagnostics.iter().any(|diagnostic| diagnostic.is_error());
-    match zen::ir_json::diagnostics_to_json(&diagnostics, &files) {
-        Ok(json) => println!("{json}"),
-        Err(e) => {
-            eprintln!("json emit error: {}", e);
-            process::exit(1);
-        }
-    }
-
-    if has_errors {
-        process::exit(1);
-    }
-}
-
-fn cmd_emit_json_build_graph(path_str: &str) {
-    let graph = load_build_graph(path_str);
-    match graph.canonical_json() {
-        Ok(json) => println!("{json}"),
-        Err(err) => {
-            eprintln!("json emit error: {}", err);
             process::exit(1);
         }
     }

--- a/src/cli/json_emit.rs
+++ b/src/cli/json_emit.rs
@@ -1,0 +1,96 @@
+use std::path::Path;
+use std::process;
+
+use zen::error::FileTable;
+use zen::module_system::ModuleSystem;
+use zen::typechecker::TypeChecker;
+
+pub(super) fn cmd_emit_json_ast(path_str: &str) {
+    super::reject_build_zen_for_emit_json_mode(path_str);
+    let (graph, _files) = super::load_module_graph(path_str);
+    match zen::ir_json::ast_graph_to_json(&graph) {
+        Ok(json) => println!("{json}"),
+        Err(e) => {
+            eprintln!("json emit error: {}", e);
+            process::exit(1);
+        }
+    }
+}
+
+pub(super) fn cmd_emit_json_symbols(path_str: &str) {
+    super::reject_build_zen_for_emit_json_mode(path_str);
+    let (graph, _files) = super::load_module_graph(path_str);
+    match zen::ir_json::symbols_graph_to_json(&graph) {
+        Ok(json) => println!("{json}"),
+        Err(e) => {
+            eprintln!("json emit error: {}", e);
+            process::exit(1);
+        }
+    }
+}
+
+pub(super) fn cmd_emit_json_typed(path_str: &str) {
+    super::reject_build_zen_for_emit_json_mode(path_str);
+    let typed = super::graph_frontend(path_str);
+    match zen::ir_json::typed_program_to_json(&typed) {
+        Ok(json) => println!("{json}"),
+        Err(e) => {
+            eprintln!("json emit error: {}", e);
+            process::exit(1);
+        }
+    }
+}
+
+pub(super) fn cmd_emit_json_diagnostics(path_str: &str) {
+    super::reject_build_zen_for_emit_json_mode(path_str);
+
+    let path = Path::new(path_str);
+    if !path.exists() {
+        eprintln!("error: file not found: {}", path_str);
+        process::exit(1);
+    }
+
+    let mut files = FileTable::new();
+    let mut module_system = ModuleSystem::new();
+    let mut diagnostics = match module_system.load_module_graph(path, &mut files) {
+        Ok(graph) => {
+            let mut checker = TypeChecker::new();
+            match checker.check_module_graph_entry(&graph) {
+                Ok(_) => checker.diagnostics().to_vec(),
+                Err(diags) => diags,
+            }
+        }
+        Err(errs) => errs.into_iter().map(Into::into).collect(),
+    };
+
+    diagnostics.sort_by_key(|diagnostic| {
+        diagnostic
+            .span
+            .map(|span| (span.file_id, span.start, span.end))
+            .unwrap_or((u32::MAX, u32::MAX, u32::MAX))
+    });
+
+    let has_errors = diagnostics.iter().any(|diagnostic| diagnostic.is_error());
+    match zen::ir_json::diagnostics_to_json(&diagnostics, &files) {
+        Ok(json) => println!("{json}"),
+        Err(e) => {
+            eprintln!("json emit error: {}", e);
+            process::exit(1);
+        }
+    }
+
+    if has_errors {
+        process::exit(1);
+    }
+}
+
+pub(super) fn cmd_emit_json_build_graph(path_str: &str) {
+    let graph = super::load_build_graph(path_str);
+    match graph.canonical_json() {
+        Ok(json) => println!("{json}"),
+        Err(err) => {
+            eprintln!("json emit error: {}", err);
+            process::exit(1);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move `emit-json` command handlers into `src/cli/json_emit.rs`
- keep root CLI focused on dispatch, graph loading, and build/run commands
- record the cleanup in phase docs and audit notes

## Validation
- `cargo fmt --check`
- `cargo test --test integration cli_build::frontend_json`
- `cargo test --test integration cli_build::build_graph_json`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`