### PR TITLE
Centralize build graph check sources

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2728,6 +2728,9 @@ and do not assume Phase 4 is ready without evidence.
   keeping typed AST node definitions smaller.
 - Parser import declarations now live in `src/parser/import_declarations.rs`,
   preserving parser import coverage while keeping declaration dispatch smaller.
+- Build graph check-source typechecking now lives in
+  `src/cli/build_graph_execution.rs`, preserving `zen check build.zen` source
+  diagnostics while keeping build graph validation helpers together.
 - `Self` expression and statement validation traversal now lives in
   `src/typechecker/self_type_validation/expressions.rs`, preserving the same
   context diagnostics while keeping declaration task collection and type

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2560,6 +2560,9 @@ checked-in docs, tests, and commits only.
 - Parser import declarations now live in `src/parser/import_declarations.rs`,
   keeping module-path parsing separate from generic/function/type declaration
   dispatch while preserving parser import coverage.
+- Build graph check-source typechecking now lives beside source validation in
+  `src/cli/build_graph_execution.rs`, keeping the root CLI module focused on
+  command routing while preserving `zen check build.zen` source diagnostics.
 
 ## Current Phase
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeSet;
 use std::path::Path;
 use std::process;
 
@@ -9,8 +8,8 @@ mod json_emit;
 mod usage;
 
 use build_graph_execution::{
-    executable_build_targets, single_executable_build_target, test_build_targets,
-    validate_build_graph_sources,
+    check_build_graph_sources, executable_build_targets, single_executable_build_target,
+    test_build_targets, validate_build_graph_sources,
 };
 use compile::{compile_file_to_binary, compile_file_to_c_source, typed_program_to_c_source};
 use diagnostics::{print_diagnostic, print_errors};
@@ -113,23 +112,6 @@ fn cmd_check(path_str: &str) {
         typed.functions.len(),
         typed.types.len()
     );
-}
-
-fn check_build_graph_sources(base_dir: &Path, graph: &zen::build_graph::BuildGraph) {
-    let mut source_paths = BTreeSet::new();
-    for target in graph.targets() {
-        for source in target.sources() {
-            source_paths.insert(base_dir.join(source));
-        }
-    }
-
-    for source_path in source_paths {
-        let source_path = source_path.to_str().unwrap_or_else(|| {
-            eprintln!("error: non-utf8 source path: {}", source_path.display());
-            process::exit(1);
-        });
-        graph_frontend(source_path);
-    }
 }
 
 fn load_module_graph(path_str: &str) -> (zen::module_system::ResolvedModuleGraph, FileTable) {

--- a/src/cli/build_graph_execution.rs
+++ b/src/cli/build_graph_execution.rs
@@ -189,6 +189,23 @@ pub(super) fn validate_build_graph_sources(base_dir: &Path, graph: &zen::build_g
     }
 }
 
+pub(super) fn check_build_graph_sources(base_dir: &Path, graph: &zen::build_graph::BuildGraph) {
+    let mut source_paths = BTreeSet::new();
+    for target in graph.targets() {
+        for source in target.sources() {
+            source_paths.insert(base_dir.join(source));
+        }
+    }
+
+    for source_path in source_paths {
+        let source_path = source_path.to_str().unwrap_or_else(|| {
+            eprintln!("error: non-utf8 source path: {}", source_path.display());
+            process::exit(1);
+        });
+        super::graph_frontend(source_path);
+    }
+}
+
 fn validate_non_executed_target_sources(
     base_dir: &Path,
     graph: &zen::build_graph::BuildGraph,


### PR DESCRIPTION
## Summary
- move `zen check build.zen` source typechecking into the build graph execution helper module
- keep root CLI focused on command routing and frontend dispatch
- record the cleanup in phase docs and audit notes

## Validation
- `cargo test --test integration check_command_build_zen_typechecks_target_sources`
- `cargo test --test integration check_command_build_zen_rejects_missing_executable_source`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`