### PR TITLE
Split CLI frontend helpers

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2731,6 +2731,9 @@ and do not assume Phase 4 is ready without evidence.
 - Build graph check-source typechecking now lives in
   `src/cli/build_graph_execution.rs`, preserving `zen check build.zen` source
   diagnostics while keeping build graph validation helpers together.
+- CLI module-graph loading and frontend typechecking now live in
+  `src/cli/frontend.rs`, preserving check, emit, JSON, build, and run command
+  frontend behavior while keeping root CLI dispatch smaller.
 - `Self` expression and statement validation traversal now lives in
   `src/typechecker/self_type_validation/expressions.rs`, preserving the same
   context diagnostics while keeping declaration task collection and type

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2563,6 +2563,9 @@ checked-in docs, tests, and commits only.
 - Build graph check-source typechecking now lives beside source validation in
   `src/cli/build_graph_execution.rs`, keeping the root CLI module focused on
   command routing while preserving `zen check build.zen` source diagnostics.
+- CLI module-graph loading and frontend typechecking now live in
+  `src/cli/frontend.rs`, sharing the same frontend path across check, emit,
+  JSON, build, and run commands while keeping root CLI dispatch smaller.
 
 ## Current Phase
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,6 +4,7 @@ use std::process;
 mod build_graph_execution;
 mod compile;
 mod diagnostics;
+mod frontend;
 mod json_emit;
 mod usage;
 
@@ -13,14 +14,13 @@ use build_graph_execution::{
 };
 use compile::{compile_file_to_binary, compile_file_to_c_source, typed_program_to_c_source};
 use diagnostics::{print_diagnostic, print_errors};
+use frontend::{graph_frontend, load_module_graph};
 use json_emit::{
     cmd_emit_json_ast, cmd_emit_json_build_graph, cmd_emit_json_diagnostics, cmd_emit_json_symbols,
     cmd_emit_json_typed,
 };
 use usage::print_usage;
 use zen::error::FileTable;
-use zen::module_system::ModuleSystem;
-use zen::typechecker::TypeChecker;
 
 pub fn main() {
     let args: Vec<String> = std::env::args().collect();
@@ -112,52 +112,6 @@ fn cmd_check(path_str: &str) {
         typed.functions.len(),
         typed.types.len()
     );
-}
-
-fn load_module_graph(path_str: &str) -> (zen::module_system::ResolvedModuleGraph, FileTable) {
-    let path = Path::new(path_str);
-    if !path.exists() {
-        eprintln!("error: file not found: {}", path_str);
-        process::exit(1);
-    }
-
-    let mut files = FileTable::new();
-    let mut module_system = ModuleSystem::new();
-
-    let graph = match module_system.load_module_graph(path, &mut files) {
-        Ok(graph) => graph,
-        Err(errs) => {
-            print_errors(&errs, &files);
-            process::exit(1);
-        }
-    };
-
-    (graph, files)
-}
-
-fn graph_frontend(path_str: &str) -> zen::ast::typed::TypedProgram {
-    let (graph, files) = load_module_graph(path_str);
-
-    let mut checker = TypeChecker::new();
-    match checker.check_module_graph_entry(&graph) {
-        Ok(typed) => {
-            for diag in checker.diagnostics() {
-                print_diagnostic(diag, &files);
-            }
-            typed
-        }
-        Err(diags) => {
-            for diag in &diags {
-                print_diagnostic(diag, &files);
-            }
-            let errors = diags
-                .iter()
-                .filter(|d| d.severity == zen::error::Severity::Error)
-                .count();
-            eprintln!("  {} error(s)", errors);
-            process::exit(1);
-        }
-    }
 }
 
 fn load_build_graph(path_str: &str) -> zen::build_graph::BuildGraph {

--- a/src/cli/frontend.rs
+++ b/src/cli/frontend.rs
@@ -1,0 +1,54 @@
+use std::path::Path;
+use std::process;
+
+use zen::error::FileTable;
+use zen::module_system::ModuleSystem;
+use zen::typechecker::TypeChecker;
+
+pub(super) fn load_module_graph(
+    path_str: &str,
+) -> (zen::module_system::ResolvedModuleGraph, FileTable) {
+    let path = Path::new(path_str);
+    if !path.exists() {
+        eprintln!("error: file not found: {}", path_str);
+        process::exit(1);
+    }
+
+    let mut files = FileTable::new();
+    let mut module_system = ModuleSystem::new();
+
+    let graph = match module_system.load_module_graph(path, &mut files) {
+        Ok(graph) => graph,
+        Err(errs) => {
+            super::print_errors(&errs, &files);
+            process::exit(1);
+        }
+    };
+
+    (graph, files)
+}
+
+pub(super) fn graph_frontend(path_str: &str) -> zen::ast::typed::TypedProgram {
+    let (graph, files) = load_module_graph(path_str);
+
+    let mut checker = TypeChecker::new();
+    match checker.check_module_graph_entry(&graph) {
+        Ok(typed) => {
+            for diag in checker.diagnostics() {
+                super::print_diagnostic(diag, &files);
+            }
+            typed
+        }
+        Err(diags) => {
+            for diag in &diags {
+                super::print_diagnostic(diag, &files);
+            }
+            let errors = diags
+                .iter()
+                .filter(|d| d.severity == zen::error::Severity::Error)
+                .count();
+            eprintln!("  {} error(s)", errors);
+            process::exit(1);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move CLI module graph loading and frontend typechecking into `src/cli/frontend.rs`
- keep root CLI focused on command routing and build graph loading
- record the cleanup in phase docs and audit notes

## Validation
- `cargo test --test integration check_command_validates_build_zen_graph`
- `cargo test --test integration emit_json_ast_command_outputs_resolved_module_graph`
- `cargo test --test integration emit_json_typed_command_outputs_checked_program`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`