### PR TITLE
Split CLI build graph loading

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2734,6 +2734,9 @@ and do not assume Phase 4 is ready without evidence.
 - CLI module-graph loading and frontend typechecking now live in
   `src/cli/frontend.rs`, preserving check, emit, JSON, build, and run command
   frontend behavior while keeping root CLI dispatch smaller.
+- CLI build graph loading and deterministic `build.zen` lowering now live in
+  `src/cli/build_graph_loading.rs`, preserving build graph JSON/check behavior
+  while keeping root CLI dispatch smaller.
 - `Self` expression and statement validation traversal now lives in
   `src/typechecker/self_type_validation/expressions.rs`, preserving the same
   context diagnostics while keeping declaration task collection and type

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2566,6 +2566,9 @@ checked-in docs, tests, and commits only.
 - CLI module-graph loading and frontend typechecking now live in
   `src/cli/frontend.rs`, sharing the same frontend path across check, emit,
   JSON, build, and run commands while keeping root CLI dispatch smaller.
+- CLI build graph loading and deterministic `build.zen` lowering now live in
+  `src/cli/build_graph_loading.rs`, keeping parse/lower diagnostics together
+  while root CLI remains focused on command routing.
 
 ## Current Phase
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 use std::process;
 
 mod build_graph_execution;
+mod build_graph_loading;
 mod compile;
 mod diagnostics;
 mod frontend;
@@ -12,6 +13,7 @@ use build_graph_execution::{
     check_build_graph_sources, executable_build_targets, single_executable_build_target,
     test_build_targets, validate_build_graph_sources,
 };
+use build_graph_loading::load_build_graph;
 use compile::{compile_file_to_binary, compile_file_to_c_source, typed_program_to_c_source};
 use diagnostics::{print_diagnostic, print_errors};
 use frontend::{graph_frontend, load_module_graph};
@@ -20,7 +22,6 @@ use json_emit::{
     cmd_emit_json_typed,
 };
 use usage::print_usage;
-use zen::error::FileTable;
 
 pub fn main() {
     let args: Vec<String> = std::env::args().collect();
@@ -112,52 +113,6 @@ fn cmd_check(path_str: &str) {
         typed.functions.len(),
         typed.types.len()
     );
-}
-
-fn load_build_graph(path_str: &str) -> zen::build_graph::BuildGraph {
-    let path = Path::new(path_str);
-    if !path.exists() {
-        eprintln!("error: file not found: {}", path_str);
-        process::exit(1);
-    }
-    if !is_build_zen_path(path_str) {
-        eprintln!("error: emit-json build-graph expects a build.zen file");
-        process::exit(1);
-    }
-
-    let source = match std::fs::read_to_string(path) {
-        Ok(source) => source,
-        Err(err) => {
-            eprintln!("error reading {}: {}", path_str, err);
-            process::exit(1);
-        }
-    };
-
-    let mut files = FileTable::new();
-    let file_id = files.add_file(path_str.to_string(), source.clone());
-    let tokens = match zen::lexer::tokenize(&source, file_id) {
-        Ok(tokens) => tokens,
-        Err(err) => {
-            print_errors(&[err], &files);
-            process::exit(1);
-        }
-    };
-    let program = match zen::parser::parse(tokens, file_id) {
-        Ok(program) => program,
-        Err(errs) => {
-            print_errors(&errs, &files);
-            process::exit(1);
-        }
-    };
-    let graph = match zen::build_graph::BuildGraph::from_build_program(&program) {
-        Ok(graph) => graph,
-        Err(err) => {
-            eprintln!("build graph error: {}", err);
-            process::exit(1);
-        }
-    };
-
-    graph
 }
 
 fn cmd_emit(path_str: &str) {

--- a/src/cli/build_graph_loading.rs
+++ b/src/cli/build_graph_loading.rs
@@ -1,0 +1,48 @@
+use std::path::Path;
+use std::process;
+
+use zen::error::FileTable;
+
+pub(super) fn load_build_graph(path_str: &str) -> zen::build_graph::BuildGraph {
+    let path = Path::new(path_str);
+    if !path.exists() {
+        eprintln!("error: file not found: {}", path_str);
+        process::exit(1);
+    }
+    if !super::is_build_zen_path(path_str) {
+        eprintln!("error: emit-json build-graph expects a build.zen file");
+        process::exit(1);
+    }
+
+    let source = match std::fs::read_to_string(path) {
+        Ok(source) => source,
+        Err(err) => {
+            eprintln!("error reading {}: {}", path_str, err);
+            process::exit(1);
+        }
+    };
+
+    let mut files = FileTable::new();
+    let file_id = files.add_file(path_str.to_string(), source.clone());
+    let tokens = match zen::lexer::tokenize(&source, file_id) {
+        Ok(tokens) => tokens,
+        Err(err) => {
+            super::print_errors(&[err], &files);
+            process::exit(1);
+        }
+    };
+    let program = match zen::parser::parse(tokens, file_id) {
+        Ok(program) => program,
+        Err(errs) => {
+            super::print_errors(&errs, &files);
+            process::exit(1);
+        }
+    };
+    match zen::build_graph::BuildGraph::from_build_program(&program) {
+        Ok(graph) => graph,
+        Err(err) => {
+            eprintln!("build graph error: {}", err);
+            process::exit(1);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move deterministic `build.zen` parse/lower loading into `src/cli/build_graph_loading.rs`
- keep root CLI focused on command routing and command-specific execution
- record the cleanup in phase docs and audit notes

## Validation
- `cargo test --test integration emit_json_build_graph_outputs_project_build_graph`
- `cargo test --test integration emit_json_build_graph_rejects_undeclared_host_effects`
- `cargo test --test integration check_command_validates_build_zen_graph`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`