### PR TITLE
Split CLI check and emit commands

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2740,6 +2740,9 @@ and do not assume Phase 4 is ready without evidence.
 - CLI build, test, direct-file, and legacy build-graph execution commands now
   live in `src/cli/execution_commands.rs`, preserving executable/test graph
   execution behavior while keeping root CLI dispatch smaller.
+- CLI check and emit command bodies now live in
+  `src/cli/check_emit_commands.rs`, preserving source validation and C emission
+  behavior while keeping root CLI dispatch smaller.
 - `Self` expression and statement validation traversal now lives in
   `src/typechecker/self_type_validation/expressions.rs`, preserving the same
   context diagnostics while keeping declaration task collection and type

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2572,6 +2572,10 @@ checked-in docs, tests, and commits only.
 - CLI build, test, direct-file, and legacy build-graph execution commands now
   live in `src/cli/execution_commands.rs`, keeping command execution separate
   from root CLI dispatch while preserving graph execution behavior.
+- CLI check and emit command bodies now live in
+  `src/cli/check_emit_commands.rs`, keeping validation/emission entrypoints
+  separate from root argument dispatch while preserving check and C emission
+  behavior.
 
 ## Current Phase
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,6 +3,7 @@ use std::process;
 
 mod build_graph_execution;
 mod build_graph_loading;
+mod check_emit_commands;
 mod compile;
 mod diagnostics;
 mod execution_commands;
@@ -15,6 +16,7 @@ use build_graph_execution::{
     test_build_targets, validate_build_graph_sources,
 };
 use build_graph_loading::load_build_graph;
+use check_emit_commands::{cmd_check, cmd_emit};
 use compile::{compile_file_to_binary, compile_file_to_c_source, typed_program_to_c_source};
 use diagnostics::{print_diagnostic, print_errors};
 use execution_commands::{cmd_build, cmd_build_graph, cmd_run_file, cmd_test};
@@ -96,36 +98,6 @@ pub fn main() {
             process::exit(1);
         }
     }
-}
-
-fn cmd_check(path_str: &str) {
-    if is_build_zen_path(path_str) {
-        let graph = load_build_graph(path_str);
-        let build_path = Path::new(path_str);
-        let base_dir = build_path.parent().unwrap_or_else(|| Path::new("."));
-        validate_build_graph_sources(base_dir, &graph);
-        check_build_graph_sources(base_dir, &graph);
-        println!("  {} build targets — ok", graph.targets().len());
-        return;
-    }
-
-    let typed = graph_frontend(path_str);
-    println!(
-        "  {} functions, {} types — ok",
-        typed.functions.len(),
-        typed.types.len()
-    );
-}
-
-fn cmd_emit(path_str: &str) {
-    if is_build_zen_path(path_str) {
-        let target = single_executable_build_target(path_str);
-        print!("{}", compile_file_to_c_source(&target.root_path));
-        return;
-    }
-
-    let typed = graph_frontend(path_str);
-    print!("{}", typed_program_to_c_source(&typed));
 }
 
 fn is_build_zen_path(path_str: &str) -> bool {

--- a/src/cli/check_emit_commands.rs
+++ b/src/cli/check_emit_commands.rs
@@ -1,0 +1,31 @@
+use std::path::Path;
+
+pub(super) fn cmd_check(path_str: &str) {
+    if super::is_build_zen_path(path_str) {
+        let graph = super::load_build_graph(path_str);
+        let build_path = Path::new(path_str);
+        let base_dir = build_path.parent().unwrap_or_else(|| Path::new("."));
+        super::validate_build_graph_sources(base_dir, &graph);
+        super::check_build_graph_sources(base_dir, &graph);
+        println!("  {} build targets — ok", graph.targets().len());
+        return;
+    }
+
+    let typed = super::graph_frontend(path_str);
+    println!(
+        "  {} functions, {} types — ok",
+        typed.functions.len(),
+        typed.types.len()
+    );
+}
+
+pub(super) fn cmd_emit(path_str: &str) {
+    if super::is_build_zen_path(path_str) {
+        let target = super::single_executable_build_target(path_str);
+        print!("{}", super::compile_file_to_c_source(&target.root_path));
+        return;
+    }
+
+    let typed = super::graph_frontend(path_str);
+    print!("{}", super::typed_program_to_c_source(&typed));
+}


### PR DESCRIPTION
## Summary
- move check and emit command bodies into `src/cli/check_emit_commands.rs`
- keep root CLI focused on argument dispatch and shared path predicates
- record the cleanup in phase docs and audit notes

## Validation
- `cargo test --test integration check_command_validates_build_zen_graph`
- `cargo test --test integration check_command_runs_resolver_diagnostics`
- `cargo test --test integration emit_command_build_zen_outputs_target_c_source`
- `cargo test --test integration emit_command_reports_imported_module_type_diagnostics`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`