### PR TITLE
Split CLI build graph targets

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2743,6 +2743,9 @@ and do not assume Phase 4 is ready without evidence.
 - CLI check and emit command bodies now live in
   `src/cli/check_emit_commands.rs`, preserving source validation and C emission
   behavior while keeping root CLI dispatch smaller.
+- CLI build graph target structs and graph-target conversion helpers now live
+  in `src/cli/build_graph_targets.rs`, preserving executable/test target
+  behavior while keeping graph execution ordering and validation smaller.
 - `Self` expression and statement validation traversal now lives in
   `src/typechecker/self_type_validation/expressions.rs`, preserving the same
   context diagnostics while keeping declaration task collection and type

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2576,6 +2576,9 @@ checked-in docs, tests, and commits only.
   `src/cli/check_emit_commands.rs`, keeping validation/emission entrypoints
   separate from root argument dispatch while preserving check and C emission
   behavior.
+- CLI build graph target structs and graph-target conversion helpers now live
+  in `src/cli/build_graph_targets.rs`, keeping target data construction
+  separate from graph execution ordering and validation.
 
 ## Current Phase
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,6 +3,7 @@ use std::process;
 
 mod build_graph_execution;
 mod build_graph_loading;
+mod build_graph_targets;
 mod check_emit_commands;
 mod compile;
 mod diagnostics;
@@ -16,6 +17,9 @@ use build_graph_execution::{
     test_build_targets, validate_build_graph_sources,
 };
 use build_graph_loading::load_build_graph;
+use build_graph_targets::{
+    executable_build_target, test_build_target, BuildGraphExecutableTarget, BuildGraphTestTarget,
+};
 use check_emit_commands::{cmd_check, cmd_emit};
 use compile::{compile_file_to_binary, compile_file_to_c_source, typed_program_to_c_source};
 use diagnostics::{print_diagnostic, print_errors};

--- a/src/cli/build_graph_execution.rs
+++ b/src/cli/build_graph_execution.rs
@@ -2,19 +2,9 @@ use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::process;
 
-pub(super) struct BuildGraphExecutableTarget {
-    pub(super) name: String,
-    pub(super) root_source_file: String,
-    pub(super) root_path: PathBuf,
-    pub(super) out_dir: PathBuf,
-}
-
-pub(super) struct BuildGraphTestTarget {
-    pub(super) name: String,
-    pub(super) root_source_file: String,
-    pub(super) root_path: PathBuf,
-    pub(super) out_dir: PathBuf,
-}
+use super::{
+    executable_build_target, test_build_target, BuildGraphExecutableTarget, BuildGraphTestTarget,
+};
 
 struct BuildGraphExecutionContext {
     graph: zen::build_graph::BuildGraph,
@@ -238,58 +228,4 @@ fn validate_non_executed_target_sources(
         });
         super::graph_frontend(source_path);
     }
-}
-
-fn test_build_target(
-    base_dir: &Path,
-    target: &zen::build_graph::BuildTarget,
-) -> Option<BuildGraphTestTarget> {
-    let zen::build_graph::BuildTargetKind::Test { root_source_file } = target.kind() else {
-        return None;
-    };
-    let root_path = base_dir.join(root_source_file);
-    if !root_path.exists() {
-        eprintln!(
-            "build graph target `{}` root source not found: {}",
-            target.name(),
-            root_source_file
-        );
-        process::exit(1);
-    }
-
-    Some(BuildGraphTestTarget {
-        name: target.name().to_string(),
-        root_source_file: root_source_file.clone(),
-        root_path,
-        out_dir: base_dir.join("build").join("tests"),
-    })
-}
-
-fn executable_build_target(
-    base_dir: &Path,
-    target: &zen::build_graph::BuildTarget,
-) -> Option<BuildGraphExecutableTarget> {
-    let zen::build_graph::BuildTargetKind::Executable {
-        root_source_file,
-        out_dir,
-    } = target.kind()
-    else {
-        return None;
-    };
-    let root_path = base_dir.join(root_source_file);
-    if !root_path.exists() {
-        eprintln!(
-            "build graph target `{}` root source not found: {}",
-            target.name(),
-            root_source_file
-        );
-        process::exit(1);
-    }
-
-    Some(BuildGraphExecutableTarget {
-        name: target.name().to_string(),
-        root_source_file: root_source_file.clone(),
-        root_path,
-        out_dir: base_dir.join(out_dir),
-    })
 }

--- a/src/cli/build_graph_targets.rs
+++ b/src/cli/build_graph_targets.rs
@@ -1,0 +1,70 @@
+use std::path::{Path, PathBuf};
+use std::process;
+
+pub(super) struct BuildGraphExecutableTarget {
+    pub(super) name: String,
+    pub(super) root_source_file: String,
+    pub(super) root_path: PathBuf,
+    pub(super) out_dir: PathBuf,
+}
+
+pub(super) struct BuildGraphTestTarget {
+    pub(super) name: String,
+    pub(super) root_source_file: String,
+    pub(super) root_path: PathBuf,
+    pub(super) out_dir: PathBuf,
+}
+
+pub(super) fn test_build_target(
+    base_dir: &Path,
+    target: &zen::build_graph::BuildTarget,
+) -> Option<BuildGraphTestTarget> {
+    let zen::build_graph::BuildTargetKind::Test { root_source_file } = target.kind() else {
+        return None;
+    };
+    let root_path = base_dir.join(root_source_file);
+    if !root_path.exists() {
+        eprintln!(
+            "build graph target `{}` root source not found: {}",
+            target.name(),
+            root_source_file
+        );
+        process::exit(1);
+    }
+
+    Some(BuildGraphTestTarget {
+        name: target.name().to_string(),
+        root_source_file: root_source_file.clone(),
+        root_path,
+        out_dir: base_dir.join("build").join("tests"),
+    })
+}
+
+pub(super) fn executable_build_target(
+    base_dir: &Path,
+    target: &zen::build_graph::BuildTarget,
+) -> Option<BuildGraphExecutableTarget> {
+    let zen::build_graph::BuildTargetKind::Executable {
+        root_source_file,
+        out_dir,
+    } = target.kind()
+    else {
+        return None;
+    };
+    let root_path = base_dir.join(root_source_file);
+    if !root_path.exists() {
+        eprintln!(
+            "build graph target `{}` root source not found: {}",
+            target.name(),
+            root_source_file
+        );
+        process::exit(1);
+    }
+
+    Some(BuildGraphExecutableTarget {
+        name: target.name().to_string(),
+        root_source_file: root_source_file.clone(),
+        root_path,
+        out_dir: base_dir.join(out_dir),
+    })
+}


### PR DESCRIPTION
## Summary
- move CLI build graph executable/test target structs into `src/cli/build_graph_targets.rs`
- move graph target conversion and root source validation helpers with those structs
- record the cleanup in phase docs and audit notes

## Validation
- `cargo test --test integration build_command_build_zen_compiles_multiple_executable_targets`
- `cargo test --test integration test_command_build_zen_runs_test_targets`
- `cargo test --test integration emit_command_build_zen_outputs_target_c_source`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`