### PR TITLE
Split CLI build graph sources

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2746,6 +2746,9 @@ and do not assume Phase 4 is ready without evidence.
 - CLI build graph target structs and graph-target conversion helpers now live
   in `src/cli/build_graph_targets.rs`, preserving executable/test target
   behavior while keeping graph execution ordering and validation smaller.
+- CLI build graph source existence and typechecking helpers now live in
+  `src/cli/build_graph_sources.rs`, preserving source validation behavior while
+  keeping graph execution ordering and dependency gating smaller.
 - `Self` expression and statement validation traversal now lives in
   `src/typechecker/self_type_validation/expressions.rs`, preserving the same
   context diagnostics while keeping declaration task collection and type

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2579,6 +2579,9 @@ checked-in docs, tests, and commits only.
 - CLI build graph target structs and graph-target conversion helpers now live
   in `src/cli/build_graph_targets.rs`, keeping target data construction
   separate from graph execution ordering and validation.
+- CLI build graph source existence and typechecking helpers now live in
+  `src/cli/build_graph_sources.rs`, keeping source validation separate from
+  execution target ordering and dependency gating.
 
 ## Current Phase
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,6 +3,7 @@ use std::process;
 
 mod build_graph_execution;
 mod build_graph_loading;
+mod build_graph_sources;
 mod build_graph_targets;
 mod check_emit_commands;
 mod compile;
@@ -13,10 +14,13 @@ mod json_emit;
 mod usage;
 
 use build_graph_execution::{
-    check_build_graph_sources, executable_build_targets, single_executable_build_target,
-    test_build_targets, validate_build_graph_sources,
+    executable_build_targets, single_executable_build_target, test_build_targets,
+    BuildGraphExecutionKind,
 };
 use build_graph_loading::load_build_graph;
+use build_graph_sources::{
+    check_build_graph_sources, validate_build_graph_sources, validate_non_executed_target_sources,
+};
 use build_graph_targets::{
     executable_build_target, test_build_target, BuildGraphExecutableTarget, BuildGraphTestTarget,
 };

--- a/src/cli/build_graph_execution.rs
+++ b/src/cli/build_graph_execution.rs
@@ -1,9 +1,10 @@
-use std::collections::{BTreeSet, HashMap};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process;
 
 use super::{
-    executable_build_target, test_build_target, BuildGraphExecutableTarget, BuildGraphTestTarget,
+    executable_build_target, test_build_target, validate_non_executed_target_sources,
+    BuildGraphExecutableTarget, BuildGraphTestTarget,
 };
 
 struct BuildGraphExecutionContext {
@@ -12,13 +13,13 @@ struct BuildGraphExecutionContext {
 }
 
 #[derive(Clone, Copy)]
-enum BuildGraphExecutionKind {
+pub(super) enum BuildGraphExecutionKind {
     Executable,
     Test,
 }
 
 impl BuildGraphExecutionKind {
-    fn includes(self, kind: &zen::build_graph::BuildTargetKind) -> bool {
+    pub(super) fn includes(self, kind: &zen::build_graph::BuildTargetKind) -> bool {
         matches!(
             (self, kind),
             (
@@ -161,71 +162,5 @@ fn validate_executed_dependency_targets(
             );
             process::exit(1);
         }
-    }
-}
-
-pub(super) fn validate_build_graph_sources(base_dir: &Path, graph: &zen::build_graph::BuildGraph) {
-    for target in graph.targets() {
-        for source in target.sources() {
-            if !base_dir.join(source).exists() {
-                eprintln!(
-                    "build graph target `{}` source not found: {}",
-                    target.name(),
-                    source
-                );
-                process::exit(1);
-            }
-        }
-    }
-}
-
-pub(super) fn check_build_graph_sources(base_dir: &Path, graph: &zen::build_graph::BuildGraph) {
-    let mut source_paths = BTreeSet::new();
-    for target in graph.targets() {
-        for source in target.sources() {
-            source_paths.insert(base_dir.join(source));
-        }
-    }
-
-    for source_path in source_paths {
-        let source_path = source_path.to_str().unwrap_or_else(|| {
-            eprintln!("error: non-utf8 source path: {}", source_path.display());
-            process::exit(1);
-        });
-        super::graph_frontend(source_path);
-    }
-}
-
-fn validate_non_executed_target_sources(
-    base_dir: &Path,
-    graph: &zen::build_graph::BuildGraph,
-    execution_kind: BuildGraphExecutionKind,
-) {
-    let mut checked_sources = BTreeSet::new();
-    for target in graph
-        .targets()
-        .iter()
-        .filter(|target| !execution_kind.includes(target.kind()))
-    {
-        for source in target.sources() {
-            let source_path = base_dir.join(source);
-            if !source_path.exists() {
-                eprintln!(
-                    "build graph target `{}` source not found: {}",
-                    target.name(),
-                    source
-                );
-                process::exit(1);
-            }
-            checked_sources.insert(source_path);
-        }
-    }
-
-    for source_path in checked_sources {
-        let source_path = source_path.to_str().unwrap_or_else(|| {
-            eprintln!("error: non-utf8 source path: {}", source_path.display());
-            process::exit(1);
-        });
-        super::graph_frontend(source_path);
     }
 }

--- a/src/cli/build_graph_sources.rs
+++ b/src/cli/build_graph_sources.rs
@@ -1,0 +1,69 @@
+use std::collections::BTreeSet;
+use std::path::Path;
+use std::process;
+
+use super::BuildGraphExecutionKind;
+
+pub(super) fn validate_build_graph_sources(base_dir: &Path, graph: &zen::build_graph::BuildGraph) {
+    for target in graph.targets() {
+        for source in target.sources() {
+            if !base_dir.join(source).exists() {
+                eprintln!(
+                    "build graph target `{}` source not found: {}",
+                    target.name(),
+                    source
+                );
+                process::exit(1);
+            }
+        }
+    }
+}
+
+pub(super) fn check_build_graph_sources(base_dir: &Path, graph: &zen::build_graph::BuildGraph) {
+    let mut source_paths = BTreeSet::new();
+    for target in graph.targets() {
+        for source in target.sources() {
+            source_paths.insert(base_dir.join(source));
+        }
+    }
+
+    check_source_paths(source_paths);
+}
+
+pub(super) fn validate_non_executed_target_sources(
+    base_dir: &Path,
+    graph: &zen::build_graph::BuildGraph,
+    execution_kind: BuildGraphExecutionKind,
+) {
+    let mut checked_sources = BTreeSet::new();
+    for target in graph
+        .targets()
+        .iter()
+        .filter(|target| !execution_kind.includes(target.kind()))
+    {
+        for source in target.sources() {
+            let source_path = base_dir.join(source);
+            if !source_path.exists() {
+                eprintln!(
+                    "build graph target `{}` source not found: {}",
+                    target.name(),
+                    source
+                );
+                process::exit(1);
+            }
+            checked_sources.insert(source_path);
+        }
+    }
+
+    check_source_paths(checked_sources);
+}
+
+fn check_source_paths(source_paths: BTreeSet<std::path::PathBuf>) {
+    for source_path in source_paths {
+        let source_path = source_path.to_str().unwrap_or_else(|| {
+            eprintln!("error: non-utf8 source path: {}", source_path.display());
+            process::exit(1);
+        });
+        super::graph_frontend(source_path);
+    }
+}


### PR DESCRIPTION
## Summary
- move build graph source existence and typechecking helpers into `src/cli/build_graph_sources.rs`
- keep graph execution ordering and dependency gating separate from source validation
- record the cleanup in phase docs and audit notes

## Validation
- `cargo test --test integration check_command_build_zen_rejects_missing_library_source`
- `cargo test --test integration emit_command_build_zen_rejects_missing_graph_only_library_source`
- `cargo test --test integration emit_command_build_zen_reports_multi_target_ambiguity_before_graph_only_library_typechecking`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`