### PR TITLE
Split build graph target lowering

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2749,6 +2749,9 @@ and do not assume Phase 4 is ready without evidence.
 - CLI build graph source existence and typechecking helpers now live in
   `src/cli/build_graph_sources.rs`, preserving source validation behavior while
   keeping graph execution ordering and dependency gating smaller.
+- Build graph lowering target extraction now lives in
+  `src/build_graph/lowering/targets.rs`, preserving deterministic target
+  lowering coverage while keeping build-script expression traversal smaller.
 - `Self` expression and statement validation traversal now lives in
   `src/typechecker/self_type_validation/expressions.rs`, preserving the same
   context diagnostics while keeping declaration task collection and type

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2582,6 +2582,10 @@ checked-in docs, tests, and commits only.
 - CLI build graph source existence and typechecking helpers now live in
   `src/cli/build_graph_sources.rs`, keeping source validation separate from
   execution target ordering and dependency gating.
+- Build graph lowering target extraction now lives in
+  `src/build_graph/lowering/targets.rs`, keeping `b.add(...)` target
+  recognition and field extraction separate from build-script expression
+  traversal.
 
 ## Current Phase
 

--- a/src/build_graph/lowering.rs
+++ b/src/build_graph/lowering.rs
@@ -2,8 +2,13 @@ use crate::ast::{Declaration, Expression, MatchArm, Program, Statement};
 
 #[path = "lowering/dsl.rs"]
 mod dsl;
+#[path = "lowering/targets.rs"]
+mod targets;
 
-use dsl::{BuildTargetDslIdent, BuildTargetDslKind, BuildTargetField};
+use dsl::BuildTargetDslIdent;
+#[cfg(test)]
+use dsl::{BuildTargetDslKind, BuildTargetField};
+use targets::build_target_from_builder_add;
 
 impl BuildGraph {
     pub fn from_build_program(program: &Program) -> Result<Self, BuildGraphError> {
@@ -185,147 +190,6 @@ impl BuildProgramLowering {
             }
         }
     }
-}
-
-fn build_target_from_builder_add(
-    expr: &Expression,
-) -> Result<Option<BuildTargetInput>, BuildGraphError> {
-    let Expression::MethodCall {
-        receiver,
-        method,
-        args,
-        ..
-    } = expr
-    else {
-        return Ok(None);
-    };
-    if method != BuildTargetDslIdent::Add.as_str()
-        || !matches!(
-            receiver.as_ref(),
-            Expression::Identifier { name, .. } if name == BuildTargetDslIdent::Builder.as_str()
-        )
-    {
-        return Ok(None);
-    }
-    let [arg] = args.as_slice() else {
-        return Ok(None);
-    };
-    let Expression::StructLiteral { name, fields, .. } = arg else {
-        return Ok(None);
-    };
-    let target = match name.parse::<BuildTargetDslKind>() {
-        Ok(BuildTargetDslKind::Executable) => executable_target_from_fields(fields),
-        Ok(BuildTargetDslKind::Test) => test_target_from_fields(fields),
-        Ok(BuildTargetDslKind::Library) => library_target_from_fields(fields),
-        Err(()) => {
-            return Err(BuildGraphError::UnsupportedBuildScript(format!(
-                "unsupported build target kind `{name}`; supported target kinds are {}",
-                BuildTargetDslKind::supported_display_list()
-            )));
-        }
-    };
-    Ok(target)
-}
-
-fn executable_target_from_fields(fields: &[(String, Expression)]) -> Option<BuildTargetInput> {
-    let target_name = string_field(fields, BuildTargetField::Name)?;
-    let root_source_file = string_field(fields, BuildTargetField::Main)
-        .or_else(|| string_field(fields, BuildTargetField::RootSourceFile))?;
-    let out_dir = string_field(fields, BuildTargetField::OutDir)?;
-    let dependencies =
-        string_array_field(fields, BuildTargetField::Dependencies).unwrap_or_default();
-    let features = string_array_field(fields, BuildTargetField::Features).unwrap_or_default();
-
-    Some(BuildTargetInput {
-        name: target_name,
-        kind: BuildTargetKind::Executable {
-            root_source_file: root_source_file.clone(),
-            out_dir,
-        },
-        sources: vec![root_source_file],
-        dependencies,
-        features,
-    })
-}
-
-fn test_target_from_fields(fields: &[(String, Expression)]) -> Option<BuildTargetInput> {
-    let root_source_file = string_field(fields, BuildTargetField::Root)
-        .or_else(|| string_field(fields, BuildTargetField::RootSourceFile))?;
-    let target_name =
-        string_field(fields, BuildTargetField::Name).unwrap_or_else(|| target_name_from_root(&root_source_file));
-    let dependencies =
-        string_array_field(fields, BuildTargetField::Dependencies).unwrap_or_default();
-    let features = string_array_field(fields, BuildTargetField::Features).unwrap_or_default();
-
-    Some(BuildTargetInput {
-        name: target_name,
-        kind: BuildTargetKind::Test {
-            root_source_file: root_source_file.clone(),
-        },
-        sources: vec![root_source_file],
-        dependencies,
-        features,
-    })
-}
-
-fn library_target_from_fields(fields: &[(String, Expression)]) -> Option<BuildTargetInput> {
-    let target_name = string_field(fields, BuildTargetField::Name)?;
-    let exports = string_array_field(fields, BuildTargetField::Exports)?;
-    let dependencies =
-        string_array_field(fields, BuildTargetField::Dependencies).unwrap_or_default();
-    let features = string_array_field(fields, BuildTargetField::Features).unwrap_or_default();
-    if exports.is_empty() {
-        return None;
-    }
-
-    Some(BuildTargetInput {
-        name: target_name,
-        kind: BuildTargetKind::Library {
-            exports: exports.clone(),
-        },
-        sources: exports,
-        dependencies,
-        features,
-    })
-}
-
-fn target_name_from_root(root: &str) -> String {
-    std::path::Path::new(root)
-        .file_stem()
-        .and_then(|stem| stem.to_str())
-        .filter(|stem| !stem.is_empty())
-        .unwrap_or("test")
-        .to_string()
-}
-
-fn string_field(fields: &[(String, Expression)], field_name: BuildTargetField) -> Option<String> {
-    fields.iter().find_map(|(name, value)| {
-        (name == field_name.as_str()).then(|| match value {
-            Expression::StringLiteral { value, .. } => Some(value.clone()),
-            _ => None,
-        })?
-    })
-}
-
-fn string_array_field(
-    fields: &[(String, Expression)],
-    field_name: BuildTargetField,
-) -> Option<Vec<String>> {
-    fields.iter().find_map(|(name, value)| {
-        if name != field_name.as_str() {
-            return None;
-        }
-        let Expression::ArrayLiteral { elements, .. } = value else {
-            return None;
-        };
-        elements
-            .iter()
-            .map(|element| match element {
-                Expression::StringLiteral { value, .. } => Some(value.clone()),
-                _ => None,
-            })
-            .collect()
-    })
 }
 
 fn declared_host_effect(expr: &Expression) -> Option<HostEffect> {

--- a/src/build_graph/lowering/targets.rs
+++ b/src/build_graph/lowering/targets.rs
@@ -1,0 +1,145 @@
+use crate::ast::Expression;
+
+use super::dsl::{BuildTargetDslIdent, BuildTargetDslKind, BuildTargetField};
+use super::{BuildGraphError, BuildTargetInput, BuildTargetKind};
+
+pub(super) fn build_target_from_builder_add(
+    expr: &Expression,
+) -> Result<Option<BuildTargetInput>, BuildGraphError> {
+    let Expression::MethodCall {
+        receiver,
+        method,
+        args,
+        ..
+    } = expr
+    else {
+        return Ok(None);
+    };
+    if method != BuildTargetDslIdent::Add.as_str()
+        || !matches!(
+            receiver.as_ref(),
+            Expression::Identifier { name, .. } if name == BuildTargetDslIdent::Builder.as_str()
+        )
+    {
+        return Ok(None);
+    }
+    let [arg] = args.as_slice() else {
+        return Ok(None);
+    };
+    let Expression::StructLiteral { name, fields, .. } = arg else {
+        return Ok(None);
+    };
+    let target = match name.parse::<BuildTargetDslKind>() {
+        Ok(BuildTargetDslKind::Executable) => executable_target_from_fields(fields),
+        Ok(BuildTargetDslKind::Test) => test_target_from_fields(fields),
+        Ok(BuildTargetDslKind::Library) => library_target_from_fields(fields),
+        Err(()) => {
+            return Err(BuildGraphError::UnsupportedBuildScript(format!(
+                "unsupported build target kind `{name}`; supported target kinds are {}",
+                BuildTargetDslKind::supported_display_list()
+            )));
+        }
+    };
+    Ok(target)
+}
+
+fn executable_target_from_fields(fields: &[(String, Expression)]) -> Option<BuildTargetInput> {
+    let target_name = string_field(fields, BuildTargetField::Name)?;
+    let root_source_file = string_field(fields, BuildTargetField::Main)
+        .or_else(|| string_field(fields, BuildTargetField::RootSourceFile))?;
+    let out_dir = string_field(fields, BuildTargetField::OutDir)?;
+    let dependencies =
+        string_array_field(fields, BuildTargetField::Dependencies).unwrap_or_default();
+    let features = string_array_field(fields, BuildTargetField::Features).unwrap_or_default();
+
+    Some(BuildTargetInput {
+        name: target_name,
+        kind: BuildTargetKind::Executable {
+            root_source_file: root_source_file.clone(),
+            out_dir,
+        },
+        sources: vec![root_source_file],
+        dependencies,
+        features,
+    })
+}
+
+fn test_target_from_fields(fields: &[(String, Expression)]) -> Option<BuildTargetInput> {
+    let root_source_file = string_field(fields, BuildTargetField::Root)
+        .or_else(|| string_field(fields, BuildTargetField::RootSourceFile))?;
+    let target_name = string_field(fields, BuildTargetField::Name)
+        .unwrap_or_else(|| target_name_from_root(&root_source_file));
+    let dependencies =
+        string_array_field(fields, BuildTargetField::Dependencies).unwrap_or_default();
+    let features = string_array_field(fields, BuildTargetField::Features).unwrap_or_default();
+
+    Some(BuildTargetInput {
+        name: target_name,
+        kind: BuildTargetKind::Test {
+            root_source_file: root_source_file.clone(),
+        },
+        sources: vec![root_source_file],
+        dependencies,
+        features,
+    })
+}
+
+fn library_target_from_fields(fields: &[(String, Expression)]) -> Option<BuildTargetInput> {
+    let target_name = string_field(fields, BuildTargetField::Name)?;
+    let exports = string_array_field(fields, BuildTargetField::Exports)?;
+    let dependencies =
+        string_array_field(fields, BuildTargetField::Dependencies).unwrap_or_default();
+    let features = string_array_field(fields, BuildTargetField::Features).unwrap_or_default();
+    if exports.is_empty() {
+        return None;
+    }
+
+    Some(BuildTargetInput {
+        name: target_name,
+        kind: BuildTargetKind::Library {
+            exports: exports.clone(),
+        },
+        sources: exports,
+        dependencies,
+        features,
+    })
+}
+
+fn target_name_from_root(root: &str) -> String {
+    std::path::Path::new(root)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .filter(|stem| !stem.is_empty())
+        .unwrap_or("test")
+        .to_string()
+}
+
+fn string_field(fields: &[(String, Expression)], field_name: BuildTargetField) -> Option<String> {
+    fields.iter().find_map(|(name, value)| {
+        (name == field_name.as_str()).then(|| match value {
+            Expression::StringLiteral { value, .. } => Some(value.clone()),
+            _ => None,
+        })?
+    })
+}
+
+fn string_array_field(
+    fields: &[(String, Expression)],
+    field_name: BuildTargetField,
+) -> Option<Vec<String>> {
+    fields.iter().find_map(|(name, value)| {
+        if name != field_name.as_str() {
+            return None;
+        }
+        let Expression::ArrayLiteral { elements, .. } = value else {
+            return None;
+        };
+        elements
+            .iter()
+            .map(|element| match element {
+                Expression::StringLiteral { value, .. } => Some(value.clone()),
+                _ => None,
+            })
+            .collect()
+    })
+}


### PR DESCRIPTION
## Summary
- move `b.add(...)` target recognition and field extraction into `src/build_graph/lowering/targets.rs`
- keep build-script traversal and host-effect collection in the main lowering file
- record the cleanup in phase docs and audit notes

## Validation
- `cargo test --lib build_graph`
- `cargo test --test build_graph`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`