### PR TITLE
Diagnose unsupported range expressions

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2752,6 +2752,12 @@ and do not assume Phase 4 is ready without evidence.
 - Build graph lowering target extraction now lives in
   `src/build_graph/lowering/targets.rs`, preserving deterministic target
   lowering coverage while keeping build-script expression traversal smaller.
+- Range expressions now produce an explicit gated typechecker diagnostic,
+  covered by parser and typechecker tests
+  `parser::tests::expressions::parse_range_expr` and
+  `typechecker::tests::core_semantics::literals::range_expression_is_rejected_until_range_type_exists`,
+  so parser-accepted range syntax no longer succeeds with an unknown typed
+  placeholder before range semantics exist.
 - `Self` expression and statement validation traversal now lives in
   `src/typechecker/self_type_validation/expressions.rs`, preserving the same
   context diagnostics while keeping declaration task collection and type

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2586,6 +2586,9 @@ checked-in docs, tests, and commits only.
   `src/build_graph/lowering/targets.rs`, keeping `b.add(...)` target
   recognition and field extraction separate from build-script expression
   traversal.
+- Range expressions now produce an explicit gated typechecker diagnostic until
+  a concrete range type is designed, instead of silently carrying an unknown
+  placeholder through function return checking.
 
 ## Current Phase
 

--- a/src/parser/tests/expressions.rs
+++ b/src/parser/tests/expressions.rs
@@ -105,6 +105,24 @@ fn parse_cast_expr() {
 }
 
 #[test]
+fn parse_range_expr() {
+    let prog = parse_ok("f = () i32 {\n    1..=3\n}");
+    let Declaration::Function { body, .. } = &prog.declarations[0] else {
+        panic!("expected Function");
+    };
+    let Expression::Block {
+        expr: Some(expr), ..
+    } = body
+    else {
+        panic!("expected block final expression");
+    };
+    let Expression::Range { inclusive, .. } = expr.as_ref() else {
+        panic!("expected range expression, got {expr:?}");
+    };
+    assert!(*inclusive);
+}
+
+#[test]
 fn parse_loop_expr() {
     let prog = parse_ok(
         r#"f = () void {

--- a/src/typechecker/expressions.rs
+++ b/src/typechecker/expressions.rs
@@ -205,17 +205,16 @@ impl TypeChecker {
                 })
             }
 
-            // TODO: implement Range type
             Expression::Range {
                 start, end, span, ..
             } => {
-                let _typed_start = self.check_expr(start)?;
-                let _typed_end = self.check_expr(end)?;
-                Ok(TypedExpression {
-                    kind: TypedExprKind::Error,
-                    ty: Type::Unknown,
-                    span: *span,
-                })
+                self.check_expr(start)?;
+                self.check_expr(end)?;
+                Err(Diagnostic::error(
+                    "E3053",
+                    "range expressions are not implemented; range typing remains gated",
+                    *span,
+                ))
             }
 
             // TODO: implement char literal type

--- a/src/typechecker/tests/core_semantics.rs
+++ b/src/typechecker/tests/core_semantics.rs
@@ -3,6 +3,7 @@ use super::*;
 mod binary_ops;
 mod calls_and_returns;
 mod enum_assignment_and_modules;
+mod literals;
 mod match_semantics;
 mod struct_literals;
 mod type_helpers;

--- a/src/typechecker/tests/core_semantics/literals.rs
+++ b/src/typechecker/tests/core_semantics/literals.rs
@@ -1,0 +1,23 @@
+use super::*;
+
+#[test]
+fn range_expression_is_rejected_until_range_type_exists() {
+    let program = parse_program(
+        r#"
+main = () i32 {
+    1..3
+}
+"#,
+    );
+    let mut tc = TypeChecker::new();
+
+    let err = tc
+        .check_program(&program)
+        .expect_err("range expressions should be gated until range typing exists");
+
+    assert!(
+        err.iter()
+            .any(|d| d.message.contains("range expressions are not implemented")),
+        "expected range diagnostic, got {err:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- add parser coverage for range expression syntax
- reject range expressions in the typechecker with an explicit gated diagnostic until a concrete range type exists
- record the gated-semantics cleanup in phase docs and audit notes

## Validation
- `cargo test --lib parse_range_expr`
- `cargo test --lib range_expression_is_rejected_until_range_type_exists`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`