### PR TITLE
Split lexer number literal tests

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2720,6 +2720,10 @@ and do not assume Phase 4 is ready without evidence.
 - Lexer string literal and interpolation tests now live in
   `src/lexer/tests/string_literals.rs`, preserving literal escape and
   interpolation coverage while keeping the parent lexer test module smaller.
+- Lexer numeric literal and range-token tests now live in
+  `src/lexer/tests/number_literals.rs`, preserving integer, float, prefixed
+  integer, and float-vs-range token coverage while keeping the parent lexer
+  test module smaller.
 - Lexer whitespace and comment skipping now lives in `src/lexer/whitespace.rs`,
   preserving newline-token and string-interpolation comment coverage while
   keeping token dispatch smaller.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2589,6 +2589,9 @@ checked-in docs, tests, and commits only.
 - Range expressions now produce an explicit gated typechecker diagnostic until
   a concrete range type is designed, instead of silently carrying an unknown
   placeholder through function return checking.
+- Lexer numeric literal and range-token tests now live in
+  `src/lexer/tests/number_literals.rs`, keeping numeric lexing coverage
+  separate from punctuation, whitespace, and example-token tests.
 
 ## Current Phase
 

--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+mod number_literals;
 mod string_literals;
 
 /// Tokenise and return just token variants, filtering out Newline/EOF.
@@ -54,39 +55,6 @@ fn identifiers_and_pub() {
             Token::Identifier("world".into()),
             Token::Identifier("_foo".into()),
             Token::Identifier("_".into()),
-        ]
-    );
-}
-
-#[test]
-fn integers() {
-    assert_eq!(
-        toks("42 0 1_000"),
-        vec![
-            Token::IntLiteral(42),
-            Token::IntLiteral(0),
-            Token::IntLiteral(1000)
-        ]
-    );
-}
-
-#[test]
-fn floats() {
-    assert_eq!(
-        toks("3.14 0.0"),
-        vec![Token::FloatLiteral(3.14), Token::FloatLiteral(0.0)]
-    );
-}
-
-#[test]
-fn hex_binary_octal() {
-    assert_eq!(
-        toks("0xFF 0b1010 0o777 0xDE_AD"),
-        vec![
-            Token::IntLiteral(0xFF),
-            Token::IntLiteral(0b1010),
-            Token::IntLiteral(0o777),
-            Token::IntLiteral(0xDEAD),
         ]
     );
 }
@@ -339,15 +307,6 @@ fn zen_pattern_match() {
             Token::IntLiteral(0),
             Token::RBrace,
         ]
-    );
-}
-
-#[test]
-fn float_vs_range() {
-    assert_eq!(toks("3.14"), vec![Token::FloatLiteral(3.14)]);
-    assert_eq!(
-        toks("3..10"),
-        vec![Token::IntLiteral(3), Token::DotDot, Token::IntLiteral(10)]
     );
 }
 

--- a/src/lexer/tests/number_literals.rs
+++ b/src/lexer/tests/number_literals.rs
@@ -1,0 +1,44 @@
+use super::toks;
+use crate::lexer::Token;
+
+#[test]
+fn integers() {
+    assert_eq!(
+        toks("42 0 1_000"),
+        vec![
+            Token::IntLiteral(42),
+            Token::IntLiteral(0),
+            Token::IntLiteral(1000)
+        ]
+    );
+}
+
+#[test]
+fn floats() {
+    assert_eq!(
+        toks("3.14 0.0"),
+        vec![Token::FloatLiteral(3.14), Token::FloatLiteral(0.0)]
+    );
+}
+
+#[test]
+fn hex_binary_octal() {
+    assert_eq!(
+        toks("0xFF 0b1010 0o777 0xDE_AD"),
+        vec![
+            Token::IntLiteral(0xFF),
+            Token::IntLiteral(0b1010),
+            Token::IntLiteral(0o777),
+            Token::IntLiteral(0xDEAD),
+        ]
+    );
+}
+
+#[test]
+fn float_vs_range() {
+    assert_eq!(toks("3.14"), vec![Token::FloatLiteral(3.14)]);
+    assert_eq!(
+        toks("3..10"),
+        vec![Token::IntLiteral(3), Token::DotDot, Token::IntLiteral(10)]
+    );
+}


### PR DESCRIPTION
## Summary
- move integer, float, prefixed integer, and float-vs-range lexer tests into `src/lexer/tests/number_literals.rs`
- keep parent lexer tests focused on punctuation, whitespace, spans, and example token streams
- record the cleanup in phase docs and audit notes

## Validation
- `cargo test --lib lexer::tests::number_literals`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`