### PR TITLE
Split build graph dependency tests

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2756,6 +2756,10 @@ and do not assume Phase 4 is ready without evidence.
 - Build graph lowering target extraction now lives in
   `src/build_graph/lowering/targets.rs`, preserving deterministic target
   lowering coverage while keeping build-script expression traversal smaller.
+- Build graph dependency validation tests now live in
+  `tests/build_graph/dependencies.rs`, preserving unknown, self, cyclic, and
+  dependency-order coverage while keeping the parent build-graph test target
+  focused on target lowering and graph shape.
 - Range expressions now produce an explicit gated typechecker diagnostic,
   covered by parser and typechecker tests
   `parser::tests::expressions::parse_range_expr` and

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2592,6 +2592,9 @@ checked-in docs, tests, and commits only.
 - Lexer numeric literal and range-token tests now live in
   `src/lexer/tests/number_literals.rs`, keeping numeric lexing coverage
   separate from punctuation, whitespace, and example-token tests.
+- Build graph dependency validation tests now live in
+  `tests/build_graph/dependencies.rs`, keeping dependency ordering and
+  rejection coverage separate from target lowering and host-effect coverage.
 
 ## Current Phase
 

--- a/tests/build_graph.rs
+++ b/tests/build_graph.rs
@@ -4,6 +4,8 @@ use zen::build_graph::{
 use zen::lexer;
 use zen::parser;
 
+#[path = "build_graph/dependencies.rs"]
+mod dependencies;
 #[path = "build_graph/host_effects.rs"]
 mod host_effects;
 
@@ -93,115 +95,6 @@ fn build_graph_rejects_undeclared_host_effects() {
     assert_eq!(
         err.to_string(),
         "undeclared host effect: read env `ZEN_STD`"
-    );
-}
-
-#[test]
-fn build_graph_rejects_unknown_target_dependencies() {
-    let mut target = executable_target("app", &["src/main.zen"]);
-    target.dependencies = vec!["core".to_string()];
-
-    let err = BuildGraph::from_input(BuildGraphInput {
-        targets: vec![target],
-        declared_host_effects: Vec::new(),
-        used_host_effects: Vec::new(),
-    })
-    .expect_err("unknown target dependency should fail");
-
-    assert_eq!(
-        err.to_string(),
-        "build target `app` depends on unknown target `core`"
-    );
-}
-
-#[test]
-fn build_graph_rejects_self_target_dependencies() {
-    let mut target = executable_target("app", &["src/main.zen"]);
-    target.dependencies = vec!["app".to_string()];
-
-    let err = BuildGraph::from_input(BuildGraphInput {
-        targets: vec![target],
-        declared_host_effects: Vec::new(),
-        used_host_effects: Vec::new(),
-    })
-    .expect_err("self target dependency should fail");
-
-    assert_eq!(
-        err.to_string(),
-        "build target `app` cannot depend on itself"
-    );
-}
-
-#[test]
-fn build_graph_rejects_cyclic_target_dependencies() {
-    let mut app = executable_target("app", &["src/app.zen"]);
-    app.dependencies = vec!["tool".to_string()];
-    let mut tool = executable_target("tool", &["src/tool.zen"]);
-    tool.dependencies = vec!["app".to_string()];
-
-    let err = BuildGraph::from_input(BuildGraphInput {
-        targets: vec![app, tool],
-        declared_host_effects: Vec::new(),
-        used_host_effects: Vec::new(),
-    })
-    .expect_err("cyclic target dependencies should fail");
-
-    assert_eq!(
-        err.to_string(),
-        "build target dependency cycle includes `app`"
-    );
-}
-
-#[test]
-fn build_graph_orders_targets_before_dependents() {
-    let mut app = executable_target("app", &["src/app.zen"]);
-    app.dependencies = vec!["tool".to_string()];
-    let tool = executable_target("tool", &["src/tool.zen"]);
-
-    let graph = BuildGraph::from_input(BuildGraphInput {
-        targets: vec![app, tool],
-        declared_host_effects: Vec::new(),
-        used_host_effects: Vec::new(),
-    })
-    .expect("build graph");
-
-    let ordered_names: Vec<_> = graph
-        .targets_in_dependency_order()
-        .expect("dependency order")
-        .into_iter()
-        .map(|target| target.name().to_string())
-        .collect();
-    assert_eq!(ordered_names, ["tool", "app"]);
-}
-
-#[test]
-fn build_program_lowering_rejects_cyclic_target_dependencies() {
-    let program = parse_program(
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable {
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        dependencies: ["tool"],
-    })
-    b.add(Executable {
-        name: "tool",
-        main: "tool.zen",
-        out_dir: "build/tool/",
-        dependencies: ["app"],
-    })
-    .Ok(b.config())
-}
-"#,
-    );
-
-    let err = BuildGraph::from_build_program(&program)
-        .expect_err("cyclic build target dependencies should fail");
-
-    assert_eq!(
-        err.to_string(),
-        "build target dependency cycle includes `app`"
     );
 }
 
@@ -353,31 +246,6 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
 }
 
 #[test]
-fn build_program_lowering_rejects_unknown_target_dependencies() {
-    let program = parse_program(
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable {
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        dependencies: ["core"],
-    })
-    .Ok(b.config())
-}
-"#,
-    );
-
-    let err = BuildGraph::from_build_program(&program)
-        .expect_err("unknown build target dependency should fail");
-
-    assert_eq!(
-        err.to_string(),
-        "build target `app` depends on unknown target `core`"
-    );
-}
-
-#[test]
 fn build_program_lowering_rejects_unsupported_package_targets() {
     assert_build_program_lowering_rejects_unsupported_target_kind("Package");
 }
@@ -405,30 +273,5 @@ build = (b: Builder) Result<BuildConfig, BuildError> {{
         format!(
             "unsupported build target kind `{target_kind}`; supported target kinds are `Executable`, `Test`, and `Library`"
         )
-    );
-}
-
-#[test]
-fn build_program_lowering_rejects_self_target_dependencies() {
-    let program = parse_program(
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable {
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        dependencies: ["app"],
-    })
-    .Ok(b.config())
-}
-"#,
-    );
-
-    let err = BuildGraph::from_build_program(&program)
-        .expect_err("self build target dependency should fail");
-
-    assert_eq!(
-        err.to_string(),
-        "build target `app` cannot depend on itself"
     );
 }

--- a/tests/build_graph/dependencies.rs
+++ b/tests/build_graph/dependencies.rs
@@ -1,0 +1,160 @@
+use super::{executable_target, parse_program, BuildGraph, BuildGraphInput};
+
+#[test]
+fn build_graph_rejects_unknown_target_dependencies() {
+    let mut target = executable_target("app", &["src/main.zen"]);
+    target.dependencies = vec!["core".to_string()];
+
+    let err = BuildGraph::from_input(BuildGraphInput {
+        targets: vec![target],
+        declared_host_effects: Vec::new(),
+        used_host_effects: Vec::new(),
+    })
+    .expect_err("unknown target dependency should fail");
+
+    assert_eq!(
+        err.to_string(),
+        "build target `app` depends on unknown target `core`"
+    );
+}
+
+#[test]
+fn build_graph_rejects_self_target_dependencies() {
+    let mut target = executable_target("app", &["src/main.zen"]);
+    target.dependencies = vec!["app".to_string()];
+
+    let err = BuildGraph::from_input(BuildGraphInput {
+        targets: vec![target],
+        declared_host_effects: Vec::new(),
+        used_host_effects: Vec::new(),
+    })
+    .expect_err("self target dependency should fail");
+
+    assert_eq!(
+        err.to_string(),
+        "build target `app` cannot depend on itself"
+    );
+}
+
+#[test]
+fn build_graph_rejects_cyclic_target_dependencies() {
+    let mut app = executable_target("app", &["src/app.zen"]);
+    app.dependencies = vec!["tool".to_string()];
+    let mut tool = executable_target("tool", &["src/tool.zen"]);
+    tool.dependencies = vec!["app".to_string()];
+
+    let err = BuildGraph::from_input(BuildGraphInput {
+        targets: vec![app, tool],
+        declared_host_effects: Vec::new(),
+        used_host_effects: Vec::new(),
+    })
+    .expect_err("cyclic target dependencies should fail");
+
+    assert_eq!(
+        err.to_string(),
+        "build target dependency cycle includes `app`"
+    );
+}
+
+#[test]
+fn build_graph_orders_targets_before_dependents() {
+    let mut app = executable_target("app", &["src/app.zen"]);
+    app.dependencies = vec!["tool".to_string()];
+    let tool = executable_target("tool", &["src/tool.zen"]);
+
+    let graph = BuildGraph::from_input(BuildGraphInput {
+        targets: vec![app, tool],
+        declared_host_effects: Vec::new(),
+        used_host_effects: Vec::new(),
+    })
+    .expect("build graph");
+
+    let ordered_names: Vec<_> = graph
+        .targets_in_dependency_order()
+        .expect("dependency order")
+        .into_iter()
+        .map(|target| target.name().to_string())
+        .collect();
+    assert_eq!(ordered_names, ["tool", "app"]);
+}
+
+#[test]
+fn build_program_lowering_rejects_cyclic_target_dependencies() {
+    let program = parse_program(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["tool"],
+    })
+    b.add(Executable {
+        name: "tool",
+        main: "tool.zen",
+        out_dir: "build/tool/",
+        dependencies: ["app"],
+    })
+    .Ok(b.config())
+}
+"#,
+    );
+
+    let err = BuildGraph::from_build_program(&program)
+        .expect_err("cyclic build target dependencies should fail");
+
+    assert_eq!(
+        err.to_string(),
+        "build target dependency cycle includes `app`"
+    );
+}
+
+#[test]
+fn build_program_lowering_rejects_unknown_target_dependencies() {
+    let program = parse_program(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["core"],
+    })
+    .Ok(b.config())
+}
+"#,
+    );
+
+    let err = BuildGraph::from_build_program(&program)
+        .expect_err("unknown build target dependency should fail");
+
+    assert_eq!(
+        err.to_string(),
+        "build target `app` depends on unknown target `core`"
+    );
+}
+
+#[test]
+fn build_program_lowering_rejects_self_target_dependencies() {
+    let program = parse_program(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["app"],
+    })
+    .Ok(b.config())
+}
+"#,
+    );
+
+    let err = BuildGraph::from_build_program(&program)
+        .expect_err("self build target dependency should fail");
+
+    assert_eq!(
+        err.to_string(),
+        "build target `app` cannot depend on itself"
+    );
+}


### PR DESCRIPTION
## Summary
- move build graph dependency validation and ordering tests into `tests/build_graph/dependencies.rs`
- keep parent build graph tests focused on target lowering, graph shape, and unsupported target diagnostics
- record the cleanup in phase docs and audit notes

## Validation
- `cargo test --test build_graph`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`