### PR TITLE
Remove stale return fixture

### DIFF
--- a/tests/docs_truth/public_docs.rs
+++ b/tests/docs_truth/public_docs.rs
@@ -128,6 +128,7 @@ fn public_language_docs_and_examples_do_not_teach_return_keyword() {
         "examples/project/math_utils.zen",
         "examples/project/build.zen",
         "examples/unified_allocator_demo.zen",
+        "tests/nested_struct_field_access.zen",
     ] {
         let contents = read(path);
         assert!(

--- a/tests/nested_struct_field_access.zen
+++ b/tests/nested_struct_field_access.zen
@@ -14,7 +14,7 @@ Rectangle: {
 rect_area = (r: Rectangle) f64 {
     width: f64 = r.bottom_right.x - r.top_left.x
     height: f64 = r.bottom_right.y - r.top_left.y
-    return width * height
+    width * height
 }
 
 main = () void {


### PR DESCRIPTION
## Summary
- remove the last stale `return` keyword from `tests/nested_struct_field_access.zen`
- include that fixture in the docs truth guard that prevents public examples from teaching removed return syntax

## Validation
- `cargo test --test docs_truth public_language_docs_and_examples_do_not_teach_return_keyword` failed before the fixture update
- `cargo fmt --check`
- `cargo test --test docs_truth public_language_docs_and_examples_do_not_teach_return_keyword`
- `cargo test --test docs_truth`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`