### PR TITLE
Reduce draft CI noise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
     branches: [master]
-    types: [opened, reopened, ready_for_review]
+    types: [reopened, ready_for_review]
   workflow_dispatch:
 
 concurrency:

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -86,8 +86,12 @@ fn ci_and_release_only_advertise_existing_targets() {
     assert!(ci.contains("cargo test --lib"));
     assert!(ci.contains("cargo test --tests"));
     assert!(
-        ci.contains("types: [opened, reopened, ready_for_review]"),
-        "CI pull_request triggers must avoid synchronize spam while still running when PRs leave draft"
+        ci.contains("types: [reopened, ready_for_review]"),
+        "CI pull_request triggers must avoid draft-open and synchronize spam while still running when PRs leave draft"
+    );
+    assert!(
+        !ci.contains("types: [opened") && !ci.contains(", opened") && !ci.contains("- opened"),
+        "CI workflow should not create skipped runs for draft PR creation"
     );
     assert!(
         !ci.contains("synchronize"),


### PR DESCRIPTION
## Summary
- remove the `opened` pull_request trigger so draft PR creation does not create skipped CI runs
- keep `ready_for_review` and `reopened` triggers for the existing draft-first PR workflow
- update docs truth coverage for the intended CI trigger shape

## Validation
- `cargo test --test docs_truth ci_and_release_only_advertise_existing_targets` failed before the workflow update
- `cargo fmt --check`
- `cargo test --test docs_truth ci_and_release_only_advertise_existing_targets`
- `cargo test --test docs_truth`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`