### PR TITLE
Split behavior parent default tests

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2863,6 +2863,11 @@ and do not assume Phase 4 is ready without evidence.
   preserving variant payload count/type, visibility, typed payload,
   generic enum payload, variant-list, and owner diagnostics while keeping
   struct metadata validation focused.
+- Resolver-restored behavior parent default synthesis tests now live in
+  `src/typechecker/tests/resolver_collection/behavior_parents/default_synthesis.rs`,
+  preserving inherited default method synthesis and generic default return
+  substitution coverage while keeping parent restoration, duplicate, conflict,
+  and cycle diagnostics focused.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2610,6 +2610,10 @@ checked-in docs, tests, and commits only.
   `src/typechecker/tests/resolver_struct_enum_metadata/enum_metadata.rs`,
   keeping variant payload, visibility, owner, and generic enum metadata
   diagnostics separate from struct field metadata coverage.
+- Resolver-restored behavior parent default synthesis tests now live in
+  `src/typechecker/tests/resolver_collection/behavior_parents/default_synthesis.rs`,
+  keeping inherited default method synthesis coverage separate from parent
+  restoration, duplicate, conflict, and cycle diagnostics.
 
 ## Current Phase
 

--- a/src/typechecker/tests/resolver_collection/behavior_parents.rs
+++ b/src/typechecker/tests/resolver_collection/behavior_parents.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod default_synthesis;
+
 #[test]
 fn collect_declarations_with_symbols_uses_resolver_behavior_parent_metadata() {
     let mut program = parse_program(
@@ -343,93 +345,4 @@ PrettyJson.extends(Json)
         .get("PrettyJson")
         .expect("behavior parents");
     assert_eq!(parents[0].behavior, "Json");
-}
-
-#[test]
-fn collect_declarations_with_symbols_synthesizes_defaults_from_restored_behavior_parent() {
-    let mut program = parse_program(
-        r#"
-Json: behavior {
-    encode: (Self) str { "json" }
-}
-PrettyJson: behavior {
-    pretty: (Self) str
-}
-Point: { x: i32 }
-
-PrettyJson.extends(Json)
-
-Point.implements(PrettyJson) {
-    pretty = (value: Point) str { "point" }
-}
-"#,
-    );
-    let symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    if let Declaration::BehaviorExtends { parent, .. } = &mut program.declarations[3] {
-        *parent = "Missing".to_string();
-    } else {
-        panic!("expected behavior extends declaration");
-    }
-    let mut tc = TypeChecker::new();
-
-    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
-
-    assert!(
-        tc.methods.contains_key("Point.encode"),
-        "resolver-restored parent metadata should synthesize inherited default method"
-    );
-    assert!(
-        !tc.methods.contains_key("Point.Missing"),
-        "stale AST-only parent names should not synthesize default methods"
-    );
-}
-
-#[test]
-fn collect_declarations_with_symbols_synthesizes_generic_defaults_from_restored_parent_args() {
-    let mut program = parse_program(
-        r#"
-Json<T>: behavior {
-    encode: (Self) T { "json" }
-}
-PrettyJson: behavior {
-    pretty: (Self) str
-}
-Point: { x: i32 }
-
-PrettyJson.extends(Json<str>)
-
-Point.implements(PrettyJson) {
-    pretty = (value: Point) str { "point" }
-}
-"#,
-    );
-    let symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    if let Declaration::BehaviorExtends {
-        parent,
-        parent_type_args,
-        ..
-    } = &mut program.declarations[3]
-    {
-        *parent = "Missing".to_string();
-        parent_type_args[0] = AstType::I32;
-    } else {
-        panic!("expected behavior extends declaration");
-    }
-    let mut tc = TypeChecker::new();
-
-    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
-
-    let encode = tc
-        .methods
-        .get("Point.encode")
-        .expect("resolver-restored parent should synthesize inherited default");
-    assert_eq!(
-        encode.return_type,
-        AstType::Str,
-        "resolver-restored parent type args should drive inherited default return type"
-    );
 }

--- a/src/typechecker/tests/resolver_collection/behavior_parents/default_synthesis.rs
+++ b/src/typechecker/tests/resolver_collection/behavior_parents/default_synthesis.rs
@@ -1,0 +1,90 @@
+use super::*;
+
+#[test]
+fn collect_declarations_with_symbols_synthesizes_defaults_from_restored_behavior_parent() {
+    let mut program = parse_program(
+        r#"
+Json: behavior {
+    encode: (Self) str { "json" }
+}
+PrettyJson: behavior {
+    pretty: (Self) str
+}
+Point: { x: i32 }
+
+PrettyJson.extends(Json)
+
+Point.implements(PrettyJson) {
+    pretty = (value: Point) str { "point" }
+}
+"#,
+    );
+    let symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    if let Declaration::BehaviorExtends { parent, .. } = &mut program.declarations[3] {
+        *parent = "Missing".to_string();
+    } else {
+        panic!("expected behavior extends declaration");
+    }
+    let mut tc = TypeChecker::new();
+
+    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
+
+    assert!(
+        tc.methods.contains_key("Point.encode"),
+        "resolver-restored parent metadata should synthesize inherited default method"
+    );
+    assert!(
+        !tc.methods.contains_key("Point.Missing"),
+        "stale AST-only parent names should not synthesize default methods"
+    );
+}
+
+#[test]
+fn collect_declarations_with_symbols_synthesizes_generic_defaults_from_restored_parent_args() {
+    let mut program = parse_program(
+        r#"
+Json<T>: behavior {
+    encode: (Self) T { "json" }
+}
+PrettyJson: behavior {
+    pretty: (Self) str
+}
+Point: { x: i32 }
+
+PrettyJson.extends(Json<str>)
+
+Point.implements(PrettyJson) {
+    pretty = (value: Point) str { "point" }
+}
+"#,
+    );
+    let symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    if let Declaration::BehaviorExtends {
+        parent,
+        parent_type_args,
+        ..
+    } = &mut program.declarations[3]
+    {
+        *parent = "Missing".to_string();
+        parent_type_args[0] = AstType::I32;
+    } else {
+        panic!("expected behavior extends declaration");
+    }
+    let mut tc = TypeChecker::new();
+
+    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
+
+    let encode = tc
+        .methods
+        .get("Point.encode")
+        .expect("resolver-restored parent should synthesize inherited default");
+    assert_eq!(
+        encode.return_type,
+        AstType::Str,
+        "resolver-restored parent type args should drive inherited default return type"
+    );
+}


### PR DESCRIPTION
## Summary
- move resolver-restored behavior parent default synthesis tests into `src/typechecker/tests/resolver_collection/behavior_parents/default_synthesis.rs`
- keep parent restoration, duplicate, conflict, and cycle diagnostics in `behavior_parents.rs`
- record the cleanup in phase docs and audit notes

## Validation
- `cargo test --lib typechecker::tests::resolver_collection::behavior_parents`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`