### PR TITLE
Split expected symbol leaf tests

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2874,6 +2874,11 @@ and do not assume Phase 4 is ready without evidence.
   missing generic type arguments, nongeneric type arguments, inherited method
   conflict, and implementation signature mismatch coverage while keeping
   positive inheritance cases focused.
+- Resolver expected-symbol leaf builder tests now live in
+  `src/typechecker/tests/resolver_validation/expected_symbols/leaf_symbols.rs`,
+  preserving import, module, local, behavior-edge, and behavior-association
+  expectation coverage while keeping value, type, field, and variant
+  expectation builders focused.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2618,6 +2618,10 @@ checked-in docs, tests, and commits only.
   `src/typechecker/tests/generic_behaviors/extends/diagnostics.rs`, keeping
   overlap, cycle, duplicate parent, generic arity, nongeneric type-argument,
   and signature-mismatch coverage separate from positive inheritance cases.
+- Resolver expected-symbol leaf builder tests now live in
+  `src/typechecker/tests/resolver_validation/expected_symbols/leaf_symbols.rs`,
+  keeping import, module, local, behavior-edge, and behavior-association
+  expectation builders separate from value, type, field, and variant builders.
 
 ## Current Phase
 

--- a/src/typechecker/tests/resolver_validation/expected_symbols.rs
+++ b/src/typechecker/tests/resolver_validation/expected_symbols.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod leaf_symbols;
+
 #[test]
 fn expected_parameter_builds_name_display_and_type_together() {
     let parameter = ExpectedParameter::new(
@@ -345,70 +347,4 @@ fn expected_variant_symbol_builds_owner_visibility_and_payload_together() {
             ret: Box::new(AstType::Bool),
         })
     );
-}
-
-#[test]
-fn expected_import_symbol_builds_source_and_visibility_together() {
-    let symbol = ExpectedImportSymbol::new("std.io");
-
-    assert_eq!(symbol.source, "std.io");
-    assert!(!symbol.is_public);
-}
-
-#[test]
-fn expected_module_symbol_builds_name_source_and_visibility_together() {
-    let symbol = ExpectedModuleSymbol::new("std.io");
-
-    assert_eq!(symbol.name, "std.io");
-    assert_eq!(symbol.source, None);
-    assert!(!symbol.is_public);
-}
-
-#[test]
-fn expected_local_symbol_builds_scope_mutability_source_and_visibility_together() {
-    let symbol = ExpectedLocalSymbol::new(true, 42);
-
-    assert_eq!(symbol.scope_id, 42);
-    assert!(symbol.is_mutable);
-    assert_eq!(symbol.source, None);
-    assert!(!symbol.is_public);
-}
-
-#[test]
-fn expected_behavior_edge_builds_display_and_metadata_together() {
-    let edge = ExpectedBehaviorEdge::new("Json", &[AstType::I32]);
-
-    assert_eq!(edge.display, "Json<i32>");
-    assert_eq!(edge.metadata.name, "Json");
-    assert_eq!(edge.metadata.type_args, vec![AstType::I32]);
-}
-
-#[test]
-fn expected_behavior_associations_build_impl_and_required_edges_together() {
-    let program = parse_program(
-        r#"
-Point: { x: i32 }
-
-Json<T>: behavior {
-    encode: (Self) T
-}
-
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
-}
-
-Point.requires(Json<str>)
-"#,
-    );
-
-    let expected = ExpectedBehaviorAssociations::new(&program);
-    let impl_edge = &expected.impls.edges_for("Point")[0];
-    let required_edge = &expected.required.edges_for("Point")[0];
-
-    assert_eq!(impl_edge.display, "Json<str>");
-    assert_eq!(impl_edge.metadata.name, "Json");
-    assert_eq!(impl_edge.metadata.type_args, vec![AstType::Str]);
-    assert_eq!(required_edge.display, "Json<str>");
-    assert_eq!(required_edge.metadata.name, "Json");
-    assert_eq!(required_edge.metadata.type_args, vec![AstType::Str]);
 }

--- a/src/typechecker/tests/resolver_validation/expected_symbols/leaf_symbols.rs
+++ b/src/typechecker/tests/resolver_validation/expected_symbols/leaf_symbols.rs
@@ -1,0 +1,67 @@
+use super::*;
+
+#[test]
+fn expected_import_symbol_builds_source_and_visibility_together() {
+    let symbol = ExpectedImportSymbol::new("std.io");
+
+    assert_eq!(symbol.source, "std.io");
+    assert!(!symbol.is_public);
+}
+
+#[test]
+fn expected_module_symbol_builds_name_source_and_visibility_together() {
+    let symbol = ExpectedModuleSymbol::new("std.io");
+
+    assert_eq!(symbol.name, "std.io");
+    assert_eq!(symbol.source, None);
+    assert!(!symbol.is_public);
+}
+
+#[test]
+fn expected_local_symbol_builds_scope_mutability_source_and_visibility_together() {
+    let symbol = ExpectedLocalSymbol::new(true, 42);
+
+    assert_eq!(symbol.scope_id, 42);
+    assert!(symbol.is_mutable);
+    assert_eq!(symbol.source, None);
+    assert!(!symbol.is_public);
+}
+
+#[test]
+fn expected_behavior_edge_builds_display_and_metadata_together() {
+    let edge = ExpectedBehaviorEdge::new("Json", &[AstType::I32]);
+
+    assert_eq!(edge.display, "Json<i32>");
+    assert_eq!(edge.metadata.name, "Json");
+    assert_eq!(edge.metadata.type_args, vec![AstType::I32]);
+}
+
+#[test]
+fn expected_behavior_associations_build_impl_and_required_edges_together() {
+    let program = parse_program(
+        r#"
+Point: { x: i32 }
+
+Json<T>: behavior {
+    encode: (Self) T
+}
+
+Point.implements(Json<str>) {
+    encode = (value: Point) str { "point" }
+}
+
+Point.requires(Json<str>)
+"#,
+    );
+
+    let expected = ExpectedBehaviorAssociations::new(&program);
+    let impl_edge = &expected.impls.edges_for("Point")[0];
+    let required_edge = &expected.required.edges_for("Point")[0];
+
+    assert_eq!(impl_edge.display, "Json<str>");
+    assert_eq!(impl_edge.metadata.name, "Json");
+    assert_eq!(impl_edge.metadata.type_args, vec![AstType::Str]);
+    assert_eq!(required_edge.display, "Json<str>");
+    assert_eq!(required_edge.metadata.name, "Json");
+    assert_eq!(required_edge.metadata.type_args, vec![AstType::Str]);
+}


### PR DESCRIPTION
## Summary
- move resolver expected-symbol leaf builder cases into `src/typechecker/tests/resolver_validation/expected_symbols/leaf_symbols.rs`
- keep value, type, field, and variant expectation builders in `expected_symbols.rs`
- record the cleanup in phase docs and audit notes

## Validation
- `cargo test --lib typechecker::tests::resolver_validation::expected_symbols`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`