### PR TITLE
Split resolver collection enum type tests

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2879,6 +2879,11 @@ and do not assume Phase 4 is ready without evidence.
   preserving import, module, local, behavior-edge, and behavior-association
   expectation coverage while keeping value, type, field, and variant
   expectation builders focused.
+- Resolver-backed enum type metadata collection tests now live in
+  `src/typechecker/tests/resolver_collection/type_metadata/enum_metadata.rs`,
+  preserving enum payload/name restoration, stale AST enum rejection, and
+  restored-name cleanup coverage while keeping struct field/default validation
+  focused.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2622,6 +2622,10 @@ checked-in docs, tests, and commits only.
   `src/typechecker/tests/resolver_validation/expected_symbols/leaf_symbols.rs`,
   keeping import, module, local, behavior-edge, and behavior-association
   expectation builders separate from value, type, field, and variant builders.
+- Resolver-backed enum type metadata collection tests now live in
+  `src/typechecker/tests/resolver_collection/type_metadata/enum_metadata.rs`,
+  keeping enum payload/name restoration and incomplete-variant metadata
+  coverage separate from struct field and default validation coverage.
 
 ## Current Phase
 

--- a/src/typechecker/tests/resolver_collection/type_metadata.rs
+++ b/src/typechecker/tests/resolver_collection/type_metadata.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod enum_metadata;
+
 #[test]
 fn collect_declarations_with_symbols_uses_resolver_struct_field_metadata() {
     let mut program = parse_program(
@@ -288,126 +290,5 @@ Point: { x: i32 }
     assert!(
             !tc.structs.contains_key("Point"),
             "resolver-backed collection should clear the restored struct key when resolver field metadata is incomplete"
-        );
-}
-
-#[test]
-fn collect_declarations_with_symbols_uses_resolver_enum_payload_metadata() {
-    let mut program = parse_program(
-        r#"
-Json<T>: behavior {
-    encode: (Self) T
-}
-Debug: behavior {
-    debug: (Self) str
-}
-Callback<T: Json<T>>: Wrap((i32) i32), None
-"#,
-    );
-    let symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    if let Declaration::Enum {
-        type_params,
-        variants,
-        ..
-    } = &mut program.declarations[2]
-    {
-        type_params[0].constraint = Some("Debug".to_string());
-        type_params[0].constraint_type_args.clear();
-        variants[0].payload = Some(AstType::I32);
-    }
-    let mut tc = TypeChecker::new();
-
-    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
-
-    let info = tc.enums.get("Callback").expect("enum info");
-    assert_eq!(
-        info.type_param_bounds.get("T"),
-        Some(&BehaviorBound {
-            behavior: "Json".to_string(),
-            type_args: vec![AstType::Named("T".to_string())],
-        })
-    );
-    assert_eq!(
-        info.variants[0].1,
-        Some(AstType::Function {
-            params: vec![AstType::I32],
-            ret: Box::new(AstType::I32),
-        })
-    );
-}
-
-#[test]
-fn collect_declarations_with_symbols_uses_resolver_enum_name_metadata() {
-    let mut program = parse_program(
-        r#"
-Option<T>: Some(T), None
-"#,
-    );
-    let symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    if let Declaration::Enum { name, .. } = &mut program.declarations[0] {
-        *name = "Missing".to_string();
-    }
-    let mut tc = TypeChecker::new();
-
-    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
-
-    assert!(tc.enums.contains_key("Option"));
-    assert!(!tc.enums.contains_key("Missing"));
-}
-
-#[test]
-fn collect_declarations_with_symbols_does_not_fallback_to_stale_ast_enum_variants() {
-    let mut program = parse_program(
-        r#"
-Option<T>: Some(T), None
-"#,
-    );
-    let mut symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    symbols.set_variant_names_for_test(Namespace::Type, "Option", None);
-    if let Declaration::Enum { variants, .. } = &mut program.declarations[0] {
-        variants[0].payload = Some(AstType::Named("Stale".to_string()));
-    }
-    let mut tc = TypeChecker::new();
-
-    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
-
-    assert!(
-            !tc.enums.contains_key("Option"),
-            "resolver-backed collection should not keep AST-only enum variants when resolver variant metadata is incomplete"
-        );
-}
-
-#[test]
-fn collect_declarations_with_symbols_clears_stale_enum_variants_after_name_restore() {
-    let mut program = parse_program(
-        r#"
-Option<T>: Some(T), None
-"#,
-    );
-    let mut symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    symbols.set_variant_names_for_test(Namespace::Type, "Option", None);
-    if let Declaration::Enum { name, variants, .. } = &mut program.declarations[0] {
-        *name = "Missing".to_string();
-        variants[0].payload = Some(AstType::Named("Stale".to_string()));
-    }
-    let mut tc = TypeChecker::new();
-
-    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
-
-    assert!(
-            !tc.enums.contains_key("Missing"),
-            "resolver-backed collection should clear the stale AST enum key after resolver name restoration"
-        );
-    assert!(
-            !tc.enums.contains_key("Option"),
-            "resolver-backed collection should clear the restored enum key when resolver variant metadata is incomplete"
         );
 }

--- a/src/typechecker/tests/resolver_collection/type_metadata/enum_metadata.rs
+++ b/src/typechecker/tests/resolver_collection/type_metadata/enum_metadata.rs
@@ -1,0 +1,122 @@
+use super::*;
+
+#[test]
+fn collect_declarations_with_symbols_uses_resolver_enum_payload_metadata() {
+    let mut program = parse_program(
+        r#"
+Json<T>: behavior {
+    encode: (Self) T
+}
+Debug: behavior {
+    debug: (Self) str
+}
+Callback<T: Json<T>>: Wrap((i32) i32), None
+"#,
+    );
+    let symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    if let Declaration::Enum {
+        type_params,
+        variants,
+        ..
+    } = &mut program.declarations[2]
+    {
+        type_params[0].constraint = Some("Debug".to_string());
+        type_params[0].constraint_type_args.clear();
+        variants[0].payload = Some(AstType::I32);
+    }
+    let mut tc = TypeChecker::new();
+
+    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
+
+    let info = tc.enums.get("Callback").expect("enum info");
+    assert_eq!(
+        info.type_param_bounds.get("T"),
+        Some(&BehaviorBound {
+            behavior: "Json".to_string(),
+            type_args: vec![AstType::Named("T".to_string())],
+        })
+    );
+    assert_eq!(
+        info.variants[0].1,
+        Some(AstType::Function {
+            params: vec![AstType::I32],
+            ret: Box::new(AstType::I32),
+        })
+    );
+}
+
+#[test]
+fn collect_declarations_with_symbols_uses_resolver_enum_name_metadata() {
+    let mut program = parse_program(
+        r#"
+Option<T>: Some(T), None
+"#,
+    );
+    let symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    if let Declaration::Enum { name, .. } = &mut program.declarations[0] {
+        *name = "Missing".to_string();
+    }
+    let mut tc = TypeChecker::new();
+
+    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
+
+    assert!(tc.enums.contains_key("Option"));
+    assert!(!tc.enums.contains_key("Missing"));
+}
+
+#[test]
+fn collect_declarations_with_symbols_does_not_fallback_to_stale_ast_enum_variants() {
+    let mut program = parse_program(
+        r#"
+Option<T>: Some(T), None
+"#,
+    );
+    let mut symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    symbols.set_variant_names_for_test(Namespace::Type, "Option", None);
+    if let Declaration::Enum { variants, .. } = &mut program.declarations[0] {
+        variants[0].payload = Some(AstType::Named("Stale".to_string()));
+    }
+    let mut tc = TypeChecker::new();
+
+    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
+
+    assert!(
+            !tc.enums.contains_key("Option"),
+            "resolver-backed collection should not keep AST-only enum variants when resolver variant metadata is incomplete"
+        );
+}
+
+#[test]
+fn collect_declarations_with_symbols_clears_stale_enum_variants_after_name_restore() {
+    let mut program = parse_program(
+        r#"
+Option<T>: Some(T), None
+"#,
+    );
+    let mut symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    symbols.set_variant_names_for_test(Namespace::Type, "Option", None);
+    if let Declaration::Enum { name, variants, .. } = &mut program.declarations[0] {
+        *name = "Missing".to_string();
+        variants[0].payload = Some(AstType::Named("Stale".to_string()));
+    }
+    let mut tc = TypeChecker::new();
+
+    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
+
+    assert!(
+            !tc.enums.contains_key("Missing"),
+            "resolver-backed collection should clear the stale AST enum key after resolver name restoration"
+        );
+    assert!(
+            !tc.enums.contains_key("Option"),
+            "resolver-backed collection should clear the restored enum key when resolver variant metadata is incomplete"
+        );
+}


### PR DESCRIPTION
## Summary
- move resolver-backed enum type metadata collection cases into `src/typechecker/tests/resolver_collection/type_metadata/enum_metadata.rs`
- keep struct field/default resolver collection coverage in `type_metadata.rs`
- record the cleanup in phase docs and audit notes

## Validation
- `cargo test --lib typechecker::tests::resolver_collection::type_metadata`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`