### PR TITLE
Split behavior association replay tests

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2899,6 +2899,11 @@ and do not assume Phase 4 is ready without evidence.
   preserving method name, return, parameter, order, and count restoration
   coverage while keeping incomplete-metadata and default-method behavior
   collection tests focused.
+- Resolver behavior-association replay helper tests now live in
+  `src/typechecker/tests/resolver_validation/replay_tasks/association_lists/association_validation.rs`,
+  preserving extends, requires, combined association collection, and validation
+  replay coverage while keeping resolver replay bundle aggregation tests
+  focused.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2639,6 +2639,10 @@ checked-in docs, tests, and commits only.
   keeping method name, return, parameter, order, and count restoration coverage
   separate from incomplete-metadata and default-method behavior collection
   tests.
+- Resolver behavior-association replay helper tests now live in
+  `src/typechecker/tests/resolver_validation/replay_tasks/association_lists/association_validation.rs`,
+  keeping extends, requires, combined association collection, and validation
+  replay coverage separate from resolver replay bundle aggregation tests.
 
 ## Current Phase
 

--- a/src/typechecker/tests/resolver_validation/replay_tasks/association_lists.rs
+++ b/src/typechecker/tests/resolver_validation/replay_tasks/association_lists.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod association_validation;
+
 #[test]
 fn resolver_behavior_association_list_tasks_collect_type_and_parent_edges_together() {
     let program = parse_program(
@@ -281,130 +283,5 @@ value := 1
             ResolverTypeReferenceValidationTask::TopLevelExpr { .. }
         )),
         "top-level expression type references should stay in the shared resolver task collector"
-    );
-}
-
-#[test]
-fn behavior_extends_replay_task_helper_pushes_parent_validation() {
-    let program = parse_program(
-        r#"
-Json<T>: behavior {
-}
-Pretty<T>: behavior {
-}
-
-Pretty.extends(Json<T>)
-"#,
-    );
-    let mut tasks = Vec::new();
-
-    let handled =
-        TypeChecker::push_behavior_extends_replay_task(&program.declarations[2], &mut tasks);
-
-    assert!(handled);
-    assert_eq!(tasks.len(), 1);
-    assert_eq!(tasks[0].behavior, "Pretty");
-    assert_eq!(tasks[0].parent, "Json");
-    assert_eq!(
-        tasks[0].parent_type_args,
-        &[AstType::Named("T".to_string())]
-    );
-}
-
-#[test]
-fn behavior_requires_replay_task_helper_pushes_requires_validation() {
-    let program = parse_program(
-        r#"
-Point: { x: i32 }
-
-Json<T>: behavior {
-    encode: (Self) T
-}
-
-Point.requires(Json<str>)
-"#,
-    );
-    let mut tasks = Vec::new();
-
-    let handled =
-        TypeChecker::push_behavior_requires_replay_task(&program.declarations[2], &mut tasks);
-
-    assert!(handled);
-    assert_eq!(tasks.len(), 1);
-    assert_eq!(tasks[0].type_name, "Point");
-    assert_eq!(tasks[0].behavior, "Json");
-    assert_eq!(tasks[0].behavior_type_args, &[AstType::Str]);
-}
-
-#[test]
-fn behavior_association_validation_tasks_collect_extends_impls_and_requires_together() {
-    let program = parse_program(
-        r#"
-Point: { x: i32 }
-
-Json<T>: behavior {
-    encode: (Self) T
-}
-
-Pretty<T>: behavior {
-    pretty: (Self) T
-}
-
-Pretty.extends(Json<T>)
-
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
-}
-
-Point.requires(Json<str>)
-"#,
-    );
-
-    let tasks = TypeChecker::collect_behavior_association_validation_tasks(&program.declarations);
-
-    assert_eq!(tasks.extends.len(), 1);
-    assert_eq!(tasks.extends[0].behavior, "Pretty");
-    assert_eq!(tasks.extends[0].parent, "Json");
-    assert_eq!(
-        tasks.extends[0].parent_type_args,
-        &[AstType::Named("T".to_string())]
-    );
-    assert_eq!(tasks.impls.len(), 1);
-    assert_eq!(tasks.impls[0].ast_type_name, "Point");
-    assert_eq!(tasks.impls[0].behavior, "Json");
-    assert_eq!(tasks.impls[0].behavior_type_args, &[AstType::Str]);
-    assert_eq!(tasks.requires.len(), 1);
-    assert_eq!(tasks.requires[0].type_name, "Point");
-    assert_eq!(tasks.requires[0].behavior, "Json");
-    assert_eq!(tasks.requires[0].behavior_type_args, &[AstType::Str]);
-}
-
-#[test]
-fn behavior_association_validation_helper_replays_impls_and_requires() {
-    let program = parse_program(
-        r#"
-Point: { x: i32 }
-
-Json<T>: behavior {
-    encode: (Self) T
-}
-
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
-}
-
-Point.requires(Json<str>)
-"#,
-    );
-    let mut checker = TypeChecker::new();
-    checker.collect_declarations(&program.declarations);
-    let tasks = TypeChecker::collect_behavior_association_validation_tasks(&program.declarations);
-
-    checker.validate_behavior_association_tasks(&tasks, None);
-
-    assert!(
-        checker.diagnostics().is_empty(),
-        "valid impl+requires replay should not emit diagnostics: {:?}",
-        checker.diagnostics()
     );
 }

--- a/src/typechecker/tests/resolver_validation/replay_tasks/association_lists/association_validation.rs
+++ b/src/typechecker/tests/resolver_validation/replay_tasks/association_lists/association_validation.rs
@@ -1,0 +1,126 @@
+use super::*;
+
+#[test]
+fn behavior_extends_replay_task_helper_pushes_parent_validation() {
+    let program = parse_program(
+        r#"
+Json<T>: behavior {
+}
+Pretty<T>: behavior {
+}
+
+Pretty.extends(Json<T>)
+"#,
+    );
+    let mut tasks = Vec::new();
+
+    let handled =
+        TypeChecker::push_behavior_extends_replay_task(&program.declarations[2], &mut tasks);
+
+    assert!(handled);
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0].behavior, "Pretty");
+    assert_eq!(tasks[0].parent, "Json");
+    assert_eq!(
+        tasks[0].parent_type_args,
+        &[AstType::Named("T".to_string())]
+    );
+}
+
+#[test]
+fn behavior_requires_replay_task_helper_pushes_requires_validation() {
+    let program = parse_program(
+        r#"
+Point: { x: i32 }
+
+Json<T>: behavior {
+    encode: (Self) T
+}
+
+Point.requires(Json<str>)
+"#,
+    );
+    let mut tasks = Vec::new();
+
+    let handled =
+        TypeChecker::push_behavior_requires_replay_task(&program.declarations[2], &mut tasks);
+
+    assert!(handled);
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0].type_name, "Point");
+    assert_eq!(tasks[0].behavior, "Json");
+    assert_eq!(tasks[0].behavior_type_args, &[AstType::Str]);
+}
+
+#[test]
+fn behavior_association_validation_tasks_collect_extends_impls_and_requires_together() {
+    let program = parse_program(
+        r#"
+Point: { x: i32 }
+
+Json<T>: behavior {
+    encode: (Self) T
+}
+
+Pretty<T>: behavior {
+    pretty: (Self) T
+}
+
+Pretty.extends(Json<T>)
+
+Point.implements(Json<str>) {
+    encode = (value: Point) str { "point" }
+}
+
+Point.requires(Json<str>)
+"#,
+    );
+
+    let tasks = TypeChecker::collect_behavior_association_validation_tasks(&program.declarations);
+
+    assert_eq!(tasks.extends.len(), 1);
+    assert_eq!(tasks.extends[0].behavior, "Pretty");
+    assert_eq!(tasks.extends[0].parent, "Json");
+    assert_eq!(
+        tasks.extends[0].parent_type_args,
+        &[AstType::Named("T".to_string())]
+    );
+    assert_eq!(tasks.impls.len(), 1);
+    assert_eq!(tasks.impls[0].ast_type_name, "Point");
+    assert_eq!(tasks.impls[0].behavior, "Json");
+    assert_eq!(tasks.impls[0].behavior_type_args, &[AstType::Str]);
+    assert_eq!(tasks.requires.len(), 1);
+    assert_eq!(tasks.requires[0].type_name, "Point");
+    assert_eq!(tasks.requires[0].behavior, "Json");
+    assert_eq!(tasks.requires[0].behavior_type_args, &[AstType::Str]);
+}
+
+#[test]
+fn behavior_association_validation_helper_replays_impls_and_requires() {
+    let program = parse_program(
+        r#"
+Point: { x: i32 }
+
+Json<T>: behavior {
+    encode: (Self) T
+}
+
+Point.implements(Json<str>) {
+    encode = (value: Point) str { "point" }
+}
+
+Point.requires(Json<str>)
+"#,
+    );
+    let mut checker = TypeChecker::new();
+    checker.collect_declarations(&program.declarations);
+    let tasks = TypeChecker::collect_behavior_association_validation_tasks(&program.declarations);
+
+    checker.validate_behavior_association_tasks(&tasks, None);
+
+    assert!(
+        checker.diagnostics().is_empty(),
+        "valid impl+requires replay should not emit diagnostics: {:?}",
+        checker.diagnostics()
+    );
+}


### PR DESCRIPTION
## Summary
- move behavior-association replay helper tests into `association_lists/association_validation.rs`
- keep resolver replay bundle aggregation tests in `association_lists.rs`
- record the cleanup in phase docs and audit notes

## Validation
- `cargo test --lib typechecker::tests::resolver_validation::replay_tasks`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`