### PR TITLE
[codex] Split generic method template integrity tests

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2932,6 +2932,11 @@ and do not assume Phase 4 is ready without evidence.
   preserving restored missing-method, inherited conflict, and cycle diagnostics
   while keeping behavior parent metadata restoration and default synthesis tests
   focused.
+- Resolver-restored top-level generic method integrity tests now live in
+  `src/typechecker/tests/resolver_collection/function_method_templates/generic_methods/integrity.rs`,
+  preserving stale AST fallback rejection, restored-key cleanup, and body
+  type-reference coverage while keeping template shape and mutability
+  restoration tests focused.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2668,6 +2668,11 @@ checked-in docs, tests, and commits only.
   keeping restored missing-method, inherited conflict, and cycle diagnostics
   separate from behavior parent metadata restoration and default synthesis
   tests.
+- Resolver-restored top-level generic method integrity tests now live in
+  `src/typechecker/tests/resolver_collection/function_method_templates/generic_methods/integrity.rs`,
+  keeping stale AST fallback rejection, restored-key cleanup, and body
+  type-reference coverage separate from template shape and mutability
+  restoration tests.
 
 ## Current Phase
 

--- a/src/typechecker/tests/resolver_collection/function_method_templates/generic_methods.rs
+++ b/src/typechecker/tests/resolver_collection/function_method_templates/generic_methods.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod integrity;
+
 #[test]
 fn collect_declarations_with_symbols_uses_resolver_generic_method_template_metadata() {
     let mut program = parse_program(
@@ -234,109 +236,5 @@ Box.choose<T> = (self: Box, left: T, mut right: T) T {
     assert!(
             !template.params[2].mutable,
             "resolver-restored second non-self method parameter should keep second AST position mutability"
-        );
-}
-
-#[test]
-fn collect_declarations_with_symbols_does_not_fallback_to_stale_ast_generic_method_template() {
-    let mut program = parse_program(
-        r#"
-Box: { value: i32 }
-Box.keep<T> = (self: Box, value: T) T { value }
-"#,
-    );
-    let mut symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    symbols.set_return_type_for_test(Namespace::Value, "Box.keep", None);
-    if let Declaration::Method {
-        params,
-        return_type,
-        ..
-    } = &mut program.declarations[1]
-    {
-        params[1].ty = AstType::Named("Stale".to_string());
-        *return_type = Some(AstType::Named("AlsoStale".to_string()));
-    }
-    let mut tc = TypeChecker::new();
-
-    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
-
-    assert!(
-            !tc.generic_methods.contains_key("Box.keep"),
-            "resolver-backed collection should not keep AST-only generic method templates when resolver signature metadata is incomplete"
-        );
-}
-
-#[test]
-fn collect_declarations_with_symbols_clears_stale_generic_method_template_after_key_restore() {
-    let mut program = parse_program(
-        r#"
-Box: { value: i32 }
-Box.keep<T> = (self: Box, value: T) T { value }
-"#,
-    );
-    let mut symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    symbols.set_return_type_for_test(Namespace::Value, "Box.keep", None);
-    if let Declaration::Method {
-        type_name,
-        method_name,
-        params,
-        return_type,
-        ..
-    } = &mut program.declarations[1]
-    {
-        *type_name = "Missing".to_string();
-        *method_name = "missing".to_string();
-        params[1].ty = AstType::Named("Stale".to_string());
-        *return_type = Some(AstType::Named("AlsoStale".to_string()));
-    }
-    let mut tc = TypeChecker::new();
-
-    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
-
-    assert!(
-            !tc.generic_methods.contains_key("Missing.missing"),
-            "resolver-backed collection should clear the stale AST generic method template key after resolver key restoration"
-        );
-    assert!(
-            !tc.generic_methods.contains_key("Box.keep"),
-            "resolver-backed collection should clear the restored generic method template key when resolver signature metadata is incomplete"
-        );
-}
-
-#[test]
-fn collect_declarations_with_symbols_uses_resolver_generic_method_name_for_body_type_refs() {
-    let mut program = parse_program(
-        r#"
-Box: { value: i32 }
-Box.keep<T> = (self: Box, value: T) T {
-    same: T = value
-    same
-}
-"#,
-    );
-    let symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    if let Declaration::Method {
-        method_name,
-        type_params,
-        ..
-    } = &mut program.declarations[1]
-    {
-        *method_name = "missing".to_string();
-        type_params[0].name = "Stale".to_string();
-    }
-    let mut tc = TypeChecker::new();
-
-    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
-
-    assert!(
-            tc.diagnostics.is_empty(),
-            "resolver-restored generic method name and type parameters should avoid stale AST body type-ref diagnostics: {:?}",
-            tc.diagnostics
         );
 }

--- a/src/typechecker/tests/resolver_collection/function_method_templates/generic_methods/integrity.rs
+++ b/src/typechecker/tests/resolver_collection/function_method_templates/generic_methods/integrity.rs
@@ -1,0 +1,105 @@
+use super::*;
+
+#[test]
+fn collect_declarations_with_symbols_does_not_fallback_to_stale_ast_generic_method_template() {
+    let mut program = parse_program(
+        r#"
+Box: { value: i32 }
+Box.keep<T> = (self: Box, value: T) T { value }
+"#,
+    );
+    let mut symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    symbols.set_return_type_for_test(Namespace::Value, "Box.keep", None);
+    if let Declaration::Method {
+        params,
+        return_type,
+        ..
+    } = &mut program.declarations[1]
+    {
+        params[1].ty = AstType::Named("Stale".to_string());
+        *return_type = Some(AstType::Named("AlsoStale".to_string()));
+    }
+    let mut tc = TypeChecker::new();
+
+    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
+
+    assert!(
+            !tc.generic_methods.contains_key("Box.keep"),
+            "resolver-backed collection should not keep AST-only generic method templates when resolver signature metadata is incomplete"
+        );
+}
+
+#[test]
+fn collect_declarations_with_symbols_clears_stale_generic_method_template_after_key_restore() {
+    let mut program = parse_program(
+        r#"
+Box: { value: i32 }
+Box.keep<T> = (self: Box, value: T) T { value }
+"#,
+    );
+    let mut symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    symbols.set_return_type_for_test(Namespace::Value, "Box.keep", None);
+    if let Declaration::Method {
+        type_name,
+        method_name,
+        params,
+        return_type,
+        ..
+    } = &mut program.declarations[1]
+    {
+        *type_name = "Missing".to_string();
+        *method_name = "missing".to_string();
+        params[1].ty = AstType::Named("Stale".to_string());
+        *return_type = Some(AstType::Named("AlsoStale".to_string()));
+    }
+    let mut tc = TypeChecker::new();
+
+    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
+
+    assert!(
+            !tc.generic_methods.contains_key("Missing.missing"),
+            "resolver-backed collection should clear the stale AST generic method template key after resolver key restoration"
+        );
+    assert!(
+            !tc.generic_methods.contains_key("Box.keep"),
+            "resolver-backed collection should clear the restored generic method template key when resolver signature metadata is incomplete"
+        );
+}
+
+#[test]
+fn collect_declarations_with_symbols_uses_resolver_generic_method_name_for_body_type_refs() {
+    let mut program = parse_program(
+        r#"
+Box: { value: i32 }
+Box.keep<T> = (self: Box, value: T) T {
+    same: T = value
+    same
+}
+"#,
+    );
+    let symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    if let Declaration::Method {
+        method_name,
+        type_params,
+        ..
+    } = &mut program.declarations[1]
+    {
+        *method_name = "missing".to_string();
+        type_params[0].name = "Stale".to_string();
+    }
+    let mut tc = TypeChecker::new();
+
+    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
+
+    assert!(
+            tc.diagnostics.is_empty(),
+            "resolver-restored generic method name and type parameters should avoid stale AST body type-ref diagnostics: {:?}",
+            tc.diagnostics
+        );
+}


### PR DESCRIPTION
## Summary
- move stale AST fallback, restored-key cleanup, and body type-reference coverage for top-level generic method templates into `generic_methods/integrity.rs`
- keep template shape and mutability restoration coverage in the parent module
- record the cleanup in the phase plan and completion audit

## Validation
- `cargo test --lib typechecker::tests::resolver_collection::function_method_templates`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`