### PR TITLE
[codex] Split build command library validation tests

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2946,6 +2946,10 @@ and do not assume Phase 4 is ready without evidence.
   `tests/integration/cli_build/emit_direct_validation/graph_only_libraries.rs`,
   preserving missing source, valid source, and library typecheck coverage while
   keeping executable target-count ambiguity checks focused.
+- `zen build build.zen` graph-only library validation tests now live in
+  `tests/integration/cli_build/build_command_validation/graph_only_libraries.rs`,
+  preserving missing source, valid source, and library typecheck coverage while
+  keeping executable-target and gated-dependency validation checks focused.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2682,6 +2682,10 @@ checked-in docs, tests, and commits only.
   `tests/integration/cli_build/emit_direct_validation/graph_only_libraries.rs`,
   keeping missing source, valid source, and library typecheck coverage separate
   from executable target-count ambiguity checks.
+- `zen build build.zen` graph-only library validation tests now live in
+  `tests/integration/cli_build/build_command_validation/graph_only_libraries.rs`,
+  keeping missing source, valid source, and library typecheck coverage separate
+  from executable-target and gated-dependency validation checks.
 
 ## Current Phase
 

--- a/tests/integration/cli_build/build_command_validation/graph_only_libraries.rs
+++ b/tests/integration/cli_build/build_command_validation/graph_only_libraries.rs
@@ -1,30 +1,28 @@
 use std::process::Command;
 
-#[path = "build_command_validation/graph_only_libraries.rs"]
-mod graph_only_libraries;
-
 #[test]
-fn build_command_build_zen_rejects_graph_without_executable_targets() {
+fn build_command_build_zen_rejects_missing_graph_only_library_source() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(
         tmp.path().join("build.zen"),
         r#"
 build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Test { name: "unit", root: "test.zen" })
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    b.add(Library { name: "core", exports: ["missing_lib.zen"] })
     .Ok(b.config())
 }
 "#,
     )
     .expect("write build.zen");
     std::fs::write(
-        tmp.path().join("test.zen"),
+        tmp.path().join("app.zen"),
         r#"
 main = () i32 {
     0
 }
 "#,
     )
-    .expect("write test.zen");
+    .expect("write app.zen");
 
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
         .args(["build", "build.zen"])
@@ -40,44 +38,30 @@ main = () i32 {
     );
     assert!(
         String::from_utf8_lossy(&output.stderr)
-            .contains("build graph execution requires at least one executable target"),
-        "expected no executable target diagnostic, stderr={}",
+            .contains("build graph target `core` source not found: missing_lib.zen"),
+        "expected missing graph-only library source diagnostic, stderr={}",
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(
         !tmp.path().join("build").exists(),
-        "build command should not create outputs for a test-only graph"
+        "build command should not start after graph source validation fails"
     );
 }
 
 #[test]
-fn build_command_build_zen_accepts_library_dependencies() {
+fn build_command_build_zen_accepts_valid_graph_only_library_sources() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(
         tmp.path().join("build.zen"),
         r#"
 build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
     b.add(Library { name: "core", exports: ["lib.zen"] })
-    b.add(Executable {
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        dependencies: ["core"],
-    })
     .Ok(b.config())
 }
 "#,
     )
     .expect("write build.zen");
-    std::fs::write(
-        tmp.path().join("lib.zen"),
-        r#"
-value = () i32 {
-    1
-}
-"#,
-    )
-    .expect("write lib.zen");
     std::fs::write(
         tmp.path().join("app.zen"),
         r#"
@@ -87,6 +71,15 @@ main = () i32 {
 "#,
     )
     .expect("write app.zen");
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    1
+}
+"#,
+    )
+    .expect("write lib.zen");
 
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
         .args(["build", "build.zen"])
@@ -107,13 +100,12 @@ main = () i32 {
 }
 
 #[test]
-fn build_command_build_zen_rejects_undeclared_host_effects_before_library_typechecking() {
+fn build_command_build_zen_rejects_graph_only_library_type_errors() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(
         tmp.path().join("build.zen"),
         r#"
 build = (b: Builder) Result<BuildConfig, BuildError> {
-    std_path = b.os.env("ZEN_STD")
     b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
     b.add(Library { name: "core", exports: ["lib.zen"] })
     .Ok(b.config())
@@ -152,79 +144,14 @@ value = () i32 {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("undeclared host effect: read env `ZEN_STD`"),
-        "expected undeclared host effect diagnostic, stderr={stderr}"
-    );
-    assert!(
-        !stderr.contains("return type mismatch"),
-        "host-effect validation should run before graph-only library typechecking, stderr={stderr}"
-    );
-    assert!(
-        !tmp.path().join("build").exists(),
-        "build command should not start after graph validation fails"
-    );
-}
-
-#[test]
-fn build_command_build_zen_rejects_gated_test_dependencies() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Test { name: "unit", root: "test.zen" })
-    b.add(Executable {
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        dependencies: ["unit"],
-    })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-    std::fs::write(
-        tmp.path().join("test.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write test.zen");
-    std::fs::write(
-        tmp.path().join("app.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write app.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["build", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen build build.zen");
-
-    assert!(
-        !output.status.success(),
-        "zen build build.zen unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
     assert!(
         String::from_utf8_lossy(&output.stderr)
-            .contains("build graph target `app` depends on gated test target `unit`"),
-        "expected gated test dependency diagnostic, stderr={}",
+            .contains("return type mismatch: expected `i32`, found `bool`"),
+        "expected graph-only library type diagnostic, stderr={}",
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(
         !tmp.path().join("build").exists(),
-        "build command should not start after gated dependency validation fails"
+        "build command should not start after graph-only library typechecking fails"
     );
 }


### PR DESCRIPTION
## Summary
- move `zen build build.zen` graph-only library validation coverage into `build_command_validation/graph_only_libraries.rs`
- keep executable-target and gated-dependency validation checks in the parent build command validation module
- record the cleanup in the phase plan and completion audit

## Validation
- `cargo test --test integration build_command_build_zen`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`