### PR TITLE
[codex] Split generic arity followup tests

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2960,6 +2960,10 @@ and do not assume Phase 4 is ready without evidence.
   `tests/integration/frontend_diagnostics/behavior_extends.rs`, preserving
   direct, imported-parent, and transitive parent-method diagnostics while
   keeping frontend helper and generic arity diagnostics focused.
+- Generic explicit arity follow-up suppression diagnostics now live in
+  `tests/generic_diagnostics/method_type_args/arity_followups.rs`, preserving
+  function and method inference/argument follow-up checks while keeping direct
+  method type-argument diagnostics focused.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2695,6 +2695,10 @@ checked-in docs, tests, and commits only.
   `tests/integration/frontend_diagnostics/behavior_extends.rs`, keeping
   direct, imported-parent, and transitive parent-method diagnostics separate
   from frontend helper and generic arity diagnostics.
+- Generic explicit arity follow-up suppression diagnostics now live in
+  `tests/generic_diagnostics/method_type_args/arity_followups.rs`, keeping
+  function and method inference/argument follow-up checks separate from direct
+  method type-argument diagnostics.
 
 ## Current Phase
 

--- a/tests/generic_diagnostics/method_type_args.rs
+++ b/tests/generic_diagnostics/method_type_args.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+#[path = "method_type_args/arity_followups.rs"]
+mod arity_followups;
+
 #[test]
 fn nongeneric_method_explicit_type_args_are_error() {
     let errors = typecheck_errors(
@@ -217,123 +220,5 @@ main = () i32 {
             .message
             .contains("method `Box.get` expects 1 arguments, found 2")),
         "expected generic method arity diagnostic to name method kind, got {errors:?}"
-    );
-}
-
-#[test]
-fn generic_function_explicit_type_arg_arity_does_not_emit_inference_followup() {
-    let errors = typecheck_errors(
-        r#"
-pick<T, U> = (value: T) T {
-    value
-}
-
-main = () i32 {
-    pick<i32>(1)
-}
-"#,
-    );
-
-    assert!(
-        errors.iter().any(|d| d
-            .message
-            .contains("generic function `pick` expects 2 type arguments, found 1")),
-        "expected explicit generic arity diagnostic, got {errors:?}"
-    );
-    assert!(
-        errors
-            .iter()
-            .all(|d| !d.message.contains("cannot infer type argument")),
-        "explicit generic arity failure should not also report inference, got {errors:?}"
-    );
-}
-
-#[test]
-fn generic_method_explicit_type_arg_arity_does_not_emit_inference_followup() {
-    let errors = typecheck_errors(
-        r#"
-Box: {
-    value: i32
-}
-
-Box.pick<T, U> = (self: Box, value: T) T {
-    value
-}
-
-main = () i32 {
-    box = Box { value: 1 }
-    box.pick<i32>(1)
-}
-"#,
-    );
-
-    assert!(
-        errors.iter().any(|d| d
-            .message
-            .contains("generic method `Box.pick` expects 2 type arguments, found 1")),
-        "expected explicit generic method arity diagnostic, got {errors:?}"
-    );
-    assert!(
-        errors
-            .iter()
-            .all(|d| !d.message.contains("cannot infer type argument")),
-        "explicit generic method arity failure should not also report inference, got {errors:?}"
-    );
-}
-
-#[test]
-fn generic_function_explicit_type_arg_arity_does_not_emit_argument_followup() {
-    let errors = typecheck_errors(
-        r#"
-take_second<T, U> = (value: U) U {
-    value
-}
-
-main = () i32 {
-    take_second<i32>(1)
-}
-"#,
-    );
-
-    assert!(
-        errors.iter().any(|d| d
-            .message
-            .contains("generic function `take_second` expects 2 type arguments, found 1")),
-        "expected explicit generic arity diagnostic, got {errors:?}"
-    );
-    assert!(
-        errors.iter().all(|d| !d.message.contains("argument 1")),
-        "explicit generic arity failure should not also report argument mismatch, got {errors:?}"
-    );
-}
-
-#[test]
-fn generic_method_explicit_type_arg_arity_does_not_emit_argument_followup() {
-    let errors = typecheck_errors(
-        r#"
-Box: {
-    value: i32
-}
-
-Box.take_second<T, U> = (self: Box, value: U) U {
-    value
-}
-
-main = () i32 {
-    box = Box { value: 1 }
-    box.take_second<i32>(1)
-}
-"#,
-    );
-
-    assert!(
-        errors.iter().any(|d| d
-            .message
-            .contains("generic method `Box.take_second` expects 2 type arguments, found 1")),
-        "expected explicit generic method arity diagnostic, got {errors:?}"
-    );
-    assert!(
-        errors.iter().all(|d| !d.message.contains("argument 2")),
-        "explicit generic method arity failure should not also report argument mismatch, got {errors:?}"
     );
 }

--- a/tests/generic_diagnostics/method_type_args/arity_followups.rs
+++ b/tests/generic_diagnostics/method_type_args/arity_followups.rs
@@ -1,0 +1,119 @@
+use super::*;
+
+#[test]
+fn generic_function_explicit_type_arg_arity_does_not_emit_inference_followup() {
+    let errors = typecheck_errors(
+        r#"
+pick<T, U> = (value: T) T {
+    value
+}
+
+main = () i32 {
+    pick<i32>(1)
+}
+"#,
+    );
+
+    assert!(
+        errors.iter().any(|d| d
+            .message
+            .contains("generic function `pick` expects 2 type arguments, found 1")),
+        "expected explicit generic arity diagnostic, got {errors:?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .all(|d| !d.message.contains("cannot infer type argument")),
+        "explicit generic arity failure should not also report inference, got {errors:?}"
+    );
+}
+
+#[test]
+fn generic_method_explicit_type_arg_arity_does_not_emit_inference_followup() {
+    let errors = typecheck_errors(
+        r#"
+Box: {
+    value: i32
+}
+
+Box.pick<T, U> = (self: Box, value: T) T {
+    value
+}
+
+main = () i32 {
+    box = Box { value: 1 }
+    box.pick<i32>(1)
+}
+"#,
+    );
+
+    assert!(
+        errors.iter().any(|d| d
+            .message
+            .contains("generic method `Box.pick` expects 2 type arguments, found 1")),
+        "expected explicit generic method arity diagnostic, got {errors:?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .all(|d| !d.message.contains("cannot infer type argument")),
+        "explicit generic method arity failure should not also report inference, got {errors:?}"
+    );
+}
+
+#[test]
+fn generic_function_explicit_type_arg_arity_does_not_emit_argument_followup() {
+    let errors = typecheck_errors(
+        r#"
+take_second<T, U> = (value: U) U {
+    value
+}
+
+main = () i32 {
+    take_second<i32>(1)
+}
+"#,
+    );
+
+    assert!(
+        errors.iter().any(|d| d
+            .message
+            .contains("generic function `take_second` expects 2 type arguments, found 1")),
+        "expected explicit generic arity diagnostic, got {errors:?}"
+    );
+    assert!(
+        errors.iter().all(|d| !d.message.contains("argument 1")),
+        "explicit generic arity failure should not also report argument mismatch, got {errors:?}"
+    );
+}
+
+#[test]
+fn generic_method_explicit_type_arg_arity_does_not_emit_argument_followup() {
+    let errors = typecheck_errors(
+        r#"
+Box: {
+    value: i32
+}
+
+Box.take_second<T, U> = (self: Box, value: U) U {
+    value
+}
+
+main = () i32 {
+    box = Box { value: 1 }
+    box.take_second<i32>(1)
+}
+"#,
+    );
+
+    assert!(
+        errors.iter().any(|d| d
+            .message
+            .contains("generic method `Box.take_second` expects 2 type arguments, found 1")),
+        "expected explicit generic method arity diagnostic, got {errors:?}"
+    );
+    assert!(
+        errors.iter().all(|d| !d.message.contains("argument 2")),
+        "explicit generic method arity failure should not also report argument mismatch, got {errors:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- move explicit generic arity inference and argument follow-up suppression checks into `method_type_args/arity_followups.rs`
- keep direct method and callable type-argument diagnostics in the parent module
- record the cleanup in the phase plan and completion audit

## Validation
- `cargo test --test generic_diagnostics method_type_args`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`