### PR TITLE
[codex] Split lexer syntax example tests

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2964,6 +2964,10 @@ and do not assume Phase 4 is ready without evidence.
   `tests/generic_diagnostics/method_type_args/arity_followups.rs`, preserving
   function and method inference/argument follow-up checks while keeping direct
   method type-argument diagnostics focused.
+- Lexer syntax example tests now live in
+  `src/lexer/tests/syntax_examples.rs`, preserving Zen function/import,
+  declaration, UFC, pattern-match, and method-call tokenization examples while
+  keeping core token/operator coverage focused.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2699,6 +2699,10 @@ checked-in docs, tests, and commits only.
   `tests/generic_diagnostics/method_type_args/arity_followups.rs`, keeping
   function and method inference/argument follow-up checks separate from direct
   method type-argument diagnostics.
+- Lexer syntax example tests now live in
+  `src/lexer/tests/syntax_examples.rs`, keeping Zen function/import,
+  declaration, UFC, pattern-match, and method-call tokenization examples
+  separate from core token/operator coverage.
 
 ## Current Phase
 

--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 
 mod number_literals;
 mod string_literals;
+mod syntax_examples;
 
 /// Tokenise and return just token variants, filtering out Newline/EOF.
 fn toks(src: &str) -> Vec<Token> {
@@ -209,119 +210,6 @@ fn spans_multichar_operator() {
     let tokens = tokenize("::=", 0).unwrap();
     assert_eq!(tokens[0].0, Token::DeclareAssign);
     assert_eq!(tokens[0].1, Span::new(0, 0, 3));
-}
-
-#[test]
-fn zen_function_def() {
-    assert_eq!(
-        toks("add = (a: i32, b: i32) i32 {"),
-        vec![
-            Token::Identifier("add".into()),
-            Token::Assign,
-            Token::LParen,
-            Token::Identifier("a".into()),
-            Token::Colon,
-            Token::Identifier("i32".into()),
-            Token::Comma,
-            Token::Identifier("b".into()),
-            Token::Colon,
-            Token::Identifier("i32".into()),
-            Token::RParen,
-            Token::Identifier("i32".into()),
-            Token::LBrace,
-        ]
-    );
-}
-
-#[test]
-fn zen_import() {
-    assert_eq!(
-        toks("{ io } = std"),
-        vec![
-            Token::LBrace,
-            Token::Identifier("io".into()),
-            Token::RBrace,
-            Token::Assign,
-            Token::Identifier("std".into()),
-        ]
-    );
-}
-
-#[test]
-fn zen_declare_assign() {
-    assert_eq!(
-        toks("i ::= 0"),
-        vec![
-            Token::Identifier("i".into()),
-            Token::DeclareAssign,
-            Token::IntLiteral(0)
-        ]
-    );
-}
-
-#[test]
-fn zen_const_assign() {
-    assert_eq!(
-        toks("x := 42"),
-        vec![
-            Token::Identifier("x".into()),
-            Token::ConstAssign,
-            Token::IntLiteral(42)
-        ]
-    );
-}
-
-#[test]
-fn zen_ufc_chain() {
-    assert_eq!(
-        toks("5.double().add_ten()"),
-        vec![
-            Token::IntLiteral(5),
-            Token::Dot,
-            Token::Identifier("double".into()),
-            Token::LParen,
-            Token::RParen,
-            Token::Dot,
-            Token::Identifier("add_ten".into()),
-            Token::LParen,
-            Token::RParen,
-        ]
-    );
-}
-
-#[test]
-fn zen_pattern_match() {
-    assert_eq!(
-        toks("x ?\n    | true { 1 }\n    | false { 0 }"),
-        vec![
-            Token::Identifier("x".into()),
-            Token::Question,
-            Token::Pipe,
-            Token::Identifier("true".into()),
-            Token::LBrace,
-            Token::IntLiteral(1),
-            Token::RBrace,
-            Token::Pipe,
-            Token::Identifier("false".into()),
-            Token::LBrace,
-            Token::IntLiteral(0),
-            Token::RBrace,
-        ]
-    );
-}
-
-#[test]
-fn method_call_on_int() {
-    assert_eq!(
-        toks("5.double()"),
-        vec![
-            Token::IntLiteral(5),
-            Token::Dot,
-            Token::Identifier("double".into()),
-            Token::LParen,
-            Token::RParen,
-        ]
-    );
 }
 
 #[test]

--- a/src/lexer/tests/syntax_examples.rs
+++ b/src/lexer/tests/syntax_examples.rs
@@ -1,0 +1,114 @@
+use super::*;
+
+#[test]
+fn zen_function_def() {
+    assert_eq!(
+        toks("add = (a: i32, b: i32) i32 {"),
+        vec![
+            Token::Identifier("add".into()),
+            Token::Assign,
+            Token::LParen,
+            Token::Identifier("a".into()),
+            Token::Colon,
+            Token::Identifier("i32".into()),
+            Token::Comma,
+            Token::Identifier("b".into()),
+            Token::Colon,
+            Token::Identifier("i32".into()),
+            Token::RParen,
+            Token::Identifier("i32".into()),
+            Token::LBrace,
+        ]
+    );
+}
+
+#[test]
+fn zen_import() {
+    assert_eq!(
+        toks("{ io } = std"),
+        vec![
+            Token::LBrace,
+            Token::Identifier("io".into()),
+            Token::RBrace,
+            Token::Assign,
+            Token::Identifier("std".into()),
+        ]
+    );
+}
+
+#[test]
+fn zen_declare_assign() {
+    assert_eq!(
+        toks("i ::= 0"),
+        vec![
+            Token::Identifier("i".into()),
+            Token::DeclareAssign,
+            Token::IntLiteral(0),
+        ]
+    );
+}
+
+#[test]
+fn zen_const_assign() {
+    assert_eq!(
+        toks("x := 42"),
+        vec![
+            Token::Identifier("x".into()),
+            Token::ConstAssign,
+            Token::IntLiteral(42),
+        ]
+    );
+}
+
+#[test]
+fn zen_ufc_chain() {
+    assert_eq!(
+        toks("5.double().add_ten()"),
+        vec![
+            Token::IntLiteral(5),
+            Token::Dot,
+            Token::Identifier("double".into()),
+            Token::LParen,
+            Token::RParen,
+            Token::Dot,
+            Token::Identifier("add_ten".into()),
+            Token::LParen,
+            Token::RParen,
+        ]
+    );
+}
+
+#[test]
+fn zen_pattern_match() {
+    assert_eq!(
+        toks("x ?\n    | true { 1 }\n    | false { 0 }"),
+        vec![
+            Token::Identifier("x".into()),
+            Token::Question,
+            Token::Pipe,
+            Token::Identifier("true".into()),
+            Token::LBrace,
+            Token::IntLiteral(1),
+            Token::RBrace,
+            Token::Pipe,
+            Token::Identifier("false".into()),
+            Token::LBrace,
+            Token::IntLiteral(0),
+            Token::RBrace,
+        ]
+    );
+}
+
+#[test]
+fn method_call_on_int() {
+    assert_eq!(
+        toks("5.double()"),
+        vec![
+            Token::IntLiteral(5),
+            Token::Dot,
+            Token::Identifier("double".into()),
+            Token::LParen,
+            Token::RParen,
+        ]
+    );
+}


### PR DESCRIPTION
## Summary
- move Zen syntax example lexer tests into `src/lexer/tests/syntax_examples.rs`
- keep core token/operator coverage in the parent lexer test module
- record the cleanup in the phase plan and completion audit

## Validation
- `cargo test --lib lexer::tests`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`