### PR TITLE
[codex] Split C codegen type mapping tests

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2968,6 +2968,10 @@ and do not assume Phase 4 is ready without evidence.
   `src/lexer/tests/syntax_examples.rs`, preserving Zen function/import,
   declaration, UFC, pattern-match, and method-call tokenization examples while
   keeping core token/operator coverage focused.
+- C codegen type mapping tests now live in
+  `src/codegen/c/tests/type_mapping.rs`, preserving primitive, string, pointer,
+  named, and function-pointer type mapping coverage while keeping program
+  generation and helper emission tests focused.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2703,6 +2703,10 @@ checked-in docs, tests, and commits only.
   `src/lexer/tests/syntax_examples.rs`, keeping Zen function/import,
   declaration, UFC, pattern-match, and method-call tokenization examples
   separate from core token/operator coverage.
+- C codegen type mapping tests now live in
+  `src/codegen/c/tests/type_mapping.rs`, keeping primitive, string, pointer,
+  named, and function-pointer type mapping coverage separate from program
+  generation and helper emission tests.
 
 ## Current Phase
 

--- a/src/codegen/c/tests/mod.rs
+++ b/src/codegen/c/tests/mod.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::ast::expressions::BinaryOp;
 
+mod type_mapping;
+
 fn make_simple_program() -> TypedProgram {
     TypedProgram {
         functions: vec![TypedFunction {
@@ -170,76 +172,6 @@ fn c_escape() {
     assert_eq!(c_escape_string("hello\nworld"), "hello\\nworld");
     assert_eq!(c_escape_string("say \"hi\""), "say \\\"hi\\\"");
 }
-
-// ── Type mapping tests ───────────────────────────────────
-
-#[test]
-fn c_type_primitives() {
-    let e = CEmitter::new();
-    assert_eq!(e.c_type(&Type::I8), "int8_t");
-    assert_eq!(e.c_type(&Type::I16), "int16_t");
-    assert_eq!(e.c_type(&Type::I32), "int32_t");
-    assert_eq!(e.c_type(&Type::I64), "int64_t");
-    assert_eq!(e.c_type(&Type::U8), "uint8_t");
-    assert_eq!(e.c_type(&Type::U16), "uint16_t");
-    assert_eq!(e.c_type(&Type::U32), "uint32_t");
-    assert_eq!(e.c_type(&Type::U64), "uint64_t");
-    assert_eq!(e.c_type(&Type::Usize), "size_t");
-    assert_eq!(e.c_type(&Type::F32), "float");
-    assert_eq!(e.c_type(&Type::F64), "double");
-    assert_eq!(e.c_type(&Type::Bool), "bool");
-    assert_eq!(e.c_type(&Type::Void), "void");
-}
-
-#[test]
-fn c_type_strings() {
-    let e = CEmitter::new();
-    assert_eq!(e.c_type(&Type::Str), "zen_str");
-    assert_eq!(e.c_type(&Type::String), "zen_string");
-}
-
-#[test]
-fn c_type_pointers() {
-    let e = CEmitter::new();
-    assert_eq!(e.c_type(&Type::Ptr(Box::new(Type::I32))), "const int32_t*");
-    assert_eq!(e.c_type(&Type::MutPtr(Box::new(Type::I32))), "int32_t*");
-    assert_eq!(e.c_type(&Type::RawPtr(Box::new(Type::U8))), "uint8_t*");
-    assert_eq!(e.c_type(&Type::Slice(Box::new(Type::F64))), "double*");
-}
-
-#[test]
-fn c_type_named_and_struct() {
-    let e = CEmitter::new();
-    assert_eq!(e.c_type(&Type::Named("Widget".into())), "Widget");
-    assert_eq!(
-        e.c_type(&Type::Struct {
-            name: "Point".into(),
-            fields: vec![],
-        }),
-        "Point"
-    );
-    assert_eq!(
-        e.c_type(&Type::Enum {
-            name: "Color".into(),
-            variants: vec![],
-        }),
-        "Color"
-    );
-}
-
-#[test]
-fn c_type_function_pointer() {
-    let e = CEmitter::new();
-    assert_eq!(
-        e.c_type(&Type::Function {
-            params: vec![Type::I32, Type::I32],
-            ret: Box::new(Type::Bool),
-        }),
-        "bool(*)(int32_t, int32_t)"
-    );
-}
-
-// ── Expression emission tests ────────────────────────────
 
 fn dummy() -> crate::error::Span {
     crate::error::Span::dummy()

--- a/src/codegen/c/tests/type_mapping.rs
+++ b/src/codegen/c/tests/type_mapping.rs
@@ -1,0 +1,67 @@
+use super::*;
+
+#[test]
+fn c_type_primitives() {
+    let e = CEmitter::new();
+    assert_eq!(e.c_type(&Type::I8), "int8_t");
+    assert_eq!(e.c_type(&Type::I16), "int16_t");
+    assert_eq!(e.c_type(&Type::I32), "int32_t");
+    assert_eq!(e.c_type(&Type::I64), "int64_t");
+    assert_eq!(e.c_type(&Type::U8), "uint8_t");
+    assert_eq!(e.c_type(&Type::U16), "uint16_t");
+    assert_eq!(e.c_type(&Type::U32), "uint32_t");
+    assert_eq!(e.c_type(&Type::U64), "uint64_t");
+    assert_eq!(e.c_type(&Type::Usize), "size_t");
+    assert_eq!(e.c_type(&Type::F32), "float");
+    assert_eq!(e.c_type(&Type::F64), "double");
+    assert_eq!(e.c_type(&Type::Bool), "bool");
+    assert_eq!(e.c_type(&Type::Void), "void");
+}
+
+#[test]
+fn c_type_strings() {
+    let e = CEmitter::new();
+    assert_eq!(e.c_type(&Type::Str), "zen_str");
+    assert_eq!(e.c_type(&Type::String), "zen_string");
+}
+
+#[test]
+fn c_type_pointers() {
+    let e = CEmitter::new();
+    assert_eq!(e.c_type(&Type::Ptr(Box::new(Type::I32))), "const int32_t*");
+    assert_eq!(e.c_type(&Type::MutPtr(Box::new(Type::I32))), "int32_t*");
+    assert_eq!(e.c_type(&Type::RawPtr(Box::new(Type::U8))), "uint8_t*");
+    assert_eq!(e.c_type(&Type::Slice(Box::new(Type::F64))), "double*");
+}
+
+#[test]
+fn c_type_named_and_struct() {
+    let e = CEmitter::new();
+    assert_eq!(e.c_type(&Type::Named("Widget".into())), "Widget");
+    assert_eq!(
+        e.c_type(&Type::Struct {
+            name: "Point".into(),
+            fields: vec![],
+        }),
+        "Point"
+    );
+    assert_eq!(
+        e.c_type(&Type::Enum {
+            name: "Color".into(),
+            variants: vec![],
+        }),
+        "Color"
+    );
+}
+
+#[test]
+fn c_type_function_pointer() {
+    let e = CEmitter::new();
+    assert_eq!(
+        e.c_type(&Type::Function {
+            params: vec![Type::I32, Type::I32],
+            ret: Box::new(Type::Bool),
+        }),
+        "bool(*)(int32_t, int32_t)"
+    );
+}


### PR DESCRIPTION
## Summary
- move C codegen type mapping tests into `src/codegen/c/tests/type_mapping.rs`
- keep program generation and helper emission tests in the parent C codegen test module
- record the cleanup in the phase plan and completion audit

## Validation
- `cargo test --lib codegen::c::tests`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`