### PR TITLE
[codex] Split C codegen helper tests

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2972,6 +2972,10 @@ and do not assume Phase 4 is ready without evidence.
   `src/codegen/c/tests/type_mapping.rs`, preserving primitive, string, pointer,
   named, and function-pointer type mapping coverage while keeping program
   generation and helper emission tests focused.
+- C codegen helper tests now live in `src/codegen/c/tests/helpers.rs`,
+  preserving identifier escaping, literal formatting, temporary naming, and
+  simple statement emission coverage while keeping whole-program generation
+  tests focused.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2707,6 +2707,10 @@ checked-in docs, tests, and commits only.
   `src/codegen/c/tests/type_mapping.rs`, keeping primitive, string, pointer,
   named, and function-pointer type mapping coverage separate from program
   generation and helper emission tests.
+- C codegen helper tests now live in
+  `src/codegen/c/tests/helpers.rs`, keeping identifier escaping, literal
+  formatting, temporary naming, and simple statement emission coverage separate
+  from whole-program generation tests.
 
 ## Current Phase
 

--- a/src/codegen/c/tests/helpers.rs
+++ b/src/codegen/c/tests/helpers.rs
@@ -1,0 +1,81 @@
+use super::*;
+
+#[test]
+fn c_ident_sanitization() {
+    assert_eq!(c_ident("Point"), "Point");
+    assert_eq!(c_ident("@std"), "_std");
+    assert_eq!(c_ident("Channel<SensorReading>"), "Channel_SensorReading");
+    assert_eq!(c_ident("std.io"), "std_io");
+}
+
+#[test]
+fn c_escape() {
+    assert_eq!(c_escape_string("hello\nworld"), "hello\\nworld");
+    assert_eq!(c_escape_string("say \"hi\""), "say \\\"hi\\\"");
+}
+
+#[test]
+fn c_keyword_escaping() {
+    assert_eq!(c_ident("int"), "zen_int");
+    assert_eq!(c_ident("return"), "zen_return");
+    assert_eq!(c_ident("void"), "zen_void");
+    assert_eq!(c_ident("while"), "zen_while");
+    assert_eq!(c_ident("count"), "count");
+    assert_eq!(c_ident("my_var"), "my_var");
+}
+
+#[test]
+fn c_func_ident_renames_main() {
+    assert_eq!(c_func_ident("main"), "zen_main");
+    assert_eq!(c_func_ident("add"), "add");
+    assert_eq!(c_func_ident("process"), "process");
+}
+
+#[test]
+fn format_float_values() {
+    assert_eq!(format_float(3.14), "3.14");
+    assert_eq!(format_float(0.0), "0.0");
+    assert_eq!(format_float(1.0), "1.0");
+    assert_eq!(format_float(100.0), "100.0");
+}
+
+#[test]
+fn fresh_tmp_increments() {
+    let mut e = CEmitter::new();
+    assert_eq!(e.fresh_tmp(), "__tmp0");
+    assert_eq!(e.fresh_tmp(), "__tmp1");
+    assert_eq!(e.fresh_tmp(), "__tmp2");
+}
+
+#[test]
+fn emit_return_statement() {
+    let mut e = CEmitter::new();
+    let ret = texpr(
+        TypedExprKind::Return(Some(Box::new(texpr(
+            TypedExprKind::IntLiteral(0),
+            Type::I32,
+        )))),
+        Type::Never,
+    );
+    assert_eq!(e.emit_expr_to_stmt(&ret), "return 0LL;");
+}
+
+#[test]
+fn emit_return_void() {
+    let mut e = CEmitter::new();
+    let ret = texpr(TypedExprKind::Return(None), Type::Never);
+    assert_eq!(e.emit_expr_to_stmt(&ret), "return;");
+}
+
+#[test]
+fn emit_break_continue() {
+    let mut e = CEmitter::new();
+    assert_eq!(
+        e.emit_expr_to_stmt(&texpr(TypedExprKind::Break, Type::Never)),
+        "break;"
+    );
+    assert_eq!(
+        e.emit_expr_to_stmt(&texpr(TypedExprKind::Continue, Type::Never)),
+        "continue;"
+    );
+}

--- a/src/codegen/c/tests/mod.rs
+++ b/src/codegen/c/tests/mod.rs
@@ -159,20 +159,6 @@ fn generates_entry_point() {
     assert!(output.contains("return zen_main()"));
 }
 
-#[test]
-fn c_ident_sanitization() {
-    assert_eq!(c_ident("Point"), "Point");
-    assert_eq!(c_ident("@std"), "_std");
-    assert_eq!(c_ident("Channel<SensorReading>"), "Channel_SensorReading");
-    assert_eq!(c_ident("std.io"), "std_io");
-}
-
-#[test]
-fn c_escape() {
-    assert_eq!(c_escape_string("hello\nworld"), "hello\\nworld");
-    assert_eq!(c_escape_string("say \"hi\""), "say \\\"hi\\\"");
-}
-
 fn dummy() -> crate::error::Span {
     crate::error::Span::dummy()
 }
@@ -186,75 +172,7 @@ fn texpr(kind: TypedExprKind, ty: Type) -> TypedExpression {
 }
 
 mod expression_emission;
-
-// ── Helper tests ─────────────────────────────────────────
-
-#[test]
-fn c_keyword_escaping() {
-    assert_eq!(c_ident("int"), "zen_int");
-    assert_eq!(c_ident("return"), "zen_return");
-    assert_eq!(c_ident("void"), "zen_void");
-    assert_eq!(c_ident("while"), "zen_while");
-    // Non-keywords pass through
-    assert_eq!(c_ident("count"), "count");
-    assert_eq!(c_ident("my_var"), "my_var");
-}
-
-#[test]
-fn c_func_ident_renames_main() {
-    assert_eq!(c_func_ident("main"), "zen_main");
-    assert_eq!(c_func_ident("add"), "add");
-    assert_eq!(c_func_ident("process"), "process");
-}
-
-#[test]
-fn format_float_values() {
-    assert_eq!(format_float(3.14), "3.14");
-    assert_eq!(format_float(0.0), "0.0");
-    assert_eq!(format_float(1.0), "1.0");
-    assert_eq!(format_float(100.0), "100.0");
-}
-
-#[test]
-fn fresh_tmp_increments() {
-    let mut e = CEmitter::new();
-    assert_eq!(e.fresh_tmp(), "__tmp0");
-    assert_eq!(e.fresh_tmp(), "__tmp1");
-    assert_eq!(e.fresh_tmp(), "__tmp2");
-}
-
-#[test]
-fn emit_return_statement() {
-    let mut e = CEmitter::new();
-    let ret = texpr(
-        TypedExprKind::Return(Some(Box::new(texpr(
-            TypedExprKind::IntLiteral(0),
-            Type::I32,
-        )))),
-        Type::Never,
-    );
-    assert_eq!(e.emit_expr_to_stmt(&ret), "return 0LL;");
-}
-
-#[test]
-fn emit_return_void() {
-    let mut e = CEmitter::new();
-    let ret = texpr(TypedExprKind::Return(None), Type::Never);
-    assert_eq!(e.emit_expr_to_stmt(&ret), "return;");
-}
-
-#[test]
-fn emit_break_continue() {
-    let mut e = CEmitter::new();
-    assert_eq!(
-        e.emit_expr_to_stmt(&texpr(TypedExprKind::Break, Type::Never)),
-        "break;"
-    );
-    assert_eq!(
-        e.emit_expr_to_stmt(&texpr(TypedExprKind::Continue, Type::Never)),
-        "continue;"
-    );
-}
+mod helpers;
 
 #[test]
 fn generates_enum_with_payload() {


### PR DESCRIPTION
## Summary
- move C codegen helper tests into `src/codegen/c/tests/helpers.rs`
- keep whole-program generation tests in the parent C codegen test module
- record the cleanup in the phase plan and completion audit

## Validation
- `cargo test --lib codegen::c::tests`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`