### PR TITLE
[codex] Split generic annotation diagnostics

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3010,6 +3010,10 @@ and do not assume Phase 4 is ready without evidence.
   `tests/generic_diagnostics/call_site_bounds/methods.rs`, preserving the
   no-followup-body-error checks while keeping the parent call-site bound module
   focused on generic function bound failures.
+- Generic annotation arity diagnostics now keep local variable annotation
+  coverage in `tests/generic_diagnostics/annotations/local.rs`, preserving
+  struct/enum arity and unspecialized-generic checks while keeping the parent
+  annotation module focused on function/signature annotations.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2740,6 +2740,9 @@ checked-in docs, tests, and commits only.
   and UFC bound-failure coverage in
   `tests/generic_diagnostics/call_site_bounds/methods.rs`, leaving the parent
   call-site bound module focused on generic function bound failures.
+- Generic annotation arity diagnostics now keep local variable annotation
+  coverage in `tests/generic_diagnostics/annotations/local.rs`, leaving the
+  parent annotation module focused on function/signature annotations.
 
 ## Current Phase
 

--- a/tests/generic_diagnostics/annotations.rs
+++ b/tests/generic_diagnostics/annotations.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+#[path = "annotations/local.rs"]
+mod local;
+
 #[test]
 fn generic_struct_annotation_type_arg_arity_is_error() {
     let errors = typecheck_errors(
@@ -141,97 +144,5 @@ read = (value: Option) i32 {
             .message
             .contains("generic enum `Option` expects 1 type arguments, found 0")),
         "expected unspecialized generic enum annotation diagnostic, got {errors:?}"
-    );
-}
-
-#[test]
-fn generic_struct_local_annotation_type_arg_arity_is_error() {
-    let errors = typecheck_errors(
-        r#"
-Box<T>: {
-    value: T
-}
-
-main = () i32 {
-    box: Box<i32, str> = Box<i32> { value: 1 }
-    box.value
-}
-"#,
-    );
-
-    assert!(
-        errors.iter().any(|d| d
-            .message
-            .contains("generic struct `Box` expects 1 type arguments, found 2")),
-        "expected generic struct local annotation arity diagnostic, got {errors:?}"
-    );
-}
-
-#[test]
-fn generic_struct_local_annotation_without_type_args_is_error() {
-    let errors = typecheck_errors(
-        r#"
-Box<T>: {
-    value: T
-}
-
-main = () i32 {
-    box: Box = Box<i32> { value: 1 }
-    0
-}
-"#,
-    );
-
-    assert!(
-        errors.iter().any(|d| d
-            .message
-            .contains("generic struct `Box` expects 1 type arguments, found 0")),
-        "expected unspecialized generic struct local annotation diagnostic, got {errors:?}"
-    );
-}
-
-#[test]
-fn generic_enum_local_annotation_type_arg_arity_is_error() {
-    let errors = typecheck_errors(
-        r#"
-Option<T>:
-    None,
-    Some(T)
-
-main = () i32 {
-    value: Option<i32, str> = Option<i32>.Some(1)
-    0
-}
-"#,
-    );
-
-    assert!(
-        errors.iter().any(|d| d
-            .message
-            .contains("generic enum `Option` expects 1 type arguments, found 2")),
-        "expected generic enum local annotation arity diagnostic, got {errors:?}"
-    );
-}
-
-#[test]
-fn generic_enum_local_annotation_without_type_args_is_error() {
-    let errors = typecheck_errors(
-        r#"
-Option<T>:
-    None,
-    Some(T)
-
-main = () i32 {
-    value: Option = Option<i32>.Some(1)
-    0
-}
-"#,
-    );
-
-    assert!(
-        errors.iter().any(|d| d
-            .message
-            .contains("generic enum `Option` expects 1 type arguments, found 0")),
-        "expected unspecialized generic enum local annotation diagnostic, got {errors:?}"
     );
 }

--- a/tests/generic_diagnostics/annotations/local.rs
+++ b/tests/generic_diagnostics/annotations/local.rs
@@ -1,0 +1,93 @@
+use super::*;
+
+#[test]
+fn generic_struct_local_annotation_type_arg_arity_is_error() {
+    let errors = typecheck_errors(
+        r#"
+Box<T>: {
+    value: T
+}
+
+main = () i32 {
+    box: Box<i32, str> = Box<i32> { value: 1 }
+    box.value
+}
+"#,
+    );
+
+    assert!(
+        errors.iter().any(|d| d
+            .message
+            .contains("generic struct `Box` expects 1 type arguments, found 2")),
+        "expected generic struct local annotation arity diagnostic, got {errors:?}"
+    );
+}
+
+#[test]
+fn generic_struct_local_annotation_without_type_args_is_error() {
+    let errors = typecheck_errors(
+        r#"
+Box<T>: {
+    value: T
+}
+
+main = () i32 {
+    box: Box = Box<i32> { value: 1 }
+    0
+}
+"#,
+    );
+
+    assert!(
+        errors.iter().any(|d| d
+            .message
+            .contains("generic struct `Box` expects 1 type arguments, found 0")),
+        "expected unspecialized generic struct local annotation diagnostic, got {errors:?}"
+    );
+}
+
+#[test]
+fn generic_enum_local_annotation_type_arg_arity_is_error() {
+    let errors = typecheck_errors(
+        r#"
+Option<T>:
+    None,
+    Some(T)
+
+main = () i32 {
+    value: Option<i32, str> = Option<i32>.Some(1)
+    0
+}
+"#,
+    );
+
+    assert!(
+        errors.iter().any(|d| d
+            .message
+            .contains("generic enum `Option` expects 1 type arguments, found 2")),
+        "expected generic enum local annotation arity diagnostic, got {errors:?}"
+    );
+}
+
+#[test]
+fn generic_enum_local_annotation_without_type_args_is_error() {
+    let errors = typecheck_errors(
+        r#"
+Option<T>:
+    None,
+    Some(T)
+
+main = () i32 {
+    value: Option = Option<i32>.Some(1)
+    0
+}
+"#,
+    );
+
+    assert!(
+        errors.iter().any(|d| d
+            .message
+            .contains("generic enum `Option` expects 1 type arguments, found 0")),
+        "expected unspecialized generic enum local annotation diagnostic, got {errors:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- move generic local variable annotation arity diagnostics into `tests/generic_diagnostics/annotations/local.rs`
- keep `tests/generic_diagnostics/annotations.rs` focused on function/signature annotations
- record the cleanup in the phase plan and completion audit

## Validation
- `cargo test --test generic_diagnostics annotation`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`