### PR TITLE
[codex] Split generic enum method type argument diagnostics

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3014,6 +3014,12 @@ and do not assume Phase 4 is ready without evidence.
   coverage in `tests/generic_diagnostics/annotations/local.rs`, preserving
   struct/enum arity and unspecialized-generic checks while keeping the parent
   annotation module focused on function/signature annotations.
+- Generic method type-argument diagnostics now keep `Option<T>` and
+  `Result<T,E>` enum-method arity coverage in
+  `tests/generic_diagnostics/method_type_args/enum_methods.rs`, preserving
+  malformed enum-method arity and follow-up suppression checks while keeping
+  the parent method type-argument module focused on direct method and
+  non-generic callable cases.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2743,6 +2743,11 @@ checked-in docs, tests, and commits only.
 - Generic annotation arity diagnostics now keep local variable annotation
   coverage in `tests/generic_diagnostics/annotations/local.rs`, leaving the
   parent annotation module focused on function/signature annotations.
+- Generic method type-argument diagnostics now keep `Option<T>` and
+  `Result<T,E>` enum-method arity coverage in
+  `tests/generic_diagnostics/method_type_args/enum_methods.rs`, leaving the
+  parent method type-argument module focused on direct method and non-generic
+  callable cases.
 
 ## Current Phase
 

--- a/tests/generic_diagnostics/method_type_args.rs
+++ b/tests/generic_diagnostics/method_type_args.rs
@@ -2,6 +2,8 @@ use super::*;
 
 #[path = "method_type_args/arity_followups.rs"]
 mod arity_followups;
+#[path = "method_type_args/enum_methods.rs"]
+mod enum_methods;
 
 #[test]
 fn nongeneric_method_explicit_type_args_are_error() {
@@ -94,78 +96,6 @@ main = () i32 {
             .message
             .contains("generic method `Box.get` expects 1 type arguments, found 2")),
         "expected generic method arity diagnostic, got {errors:?}"
-    );
-}
-
-#[test]
-fn generic_enum_method_explicit_type_arg_arity_is_error() {
-    let errors = typecheck_errors(
-        r#"
-Option<T>:
-    None,
-    Some(T)
-
-Option.unwrap_or<T> = (self: Self, fallback: T) T {
-    self ?
-        | Some(value) { value }
-        | None { fallback }
-}
-
-main = () i32 {
-    value = Option<i32>.Some(1)
-    value.unwrap_or<i32, str>(0)
-}
-"#,
-    );
-
-    assert!(
-        errors.iter().any(|d| d
-            .message
-            .contains("generic method `Option.unwrap_or` expects 1 type arguments, found 2")),
-        "expected generic enum method arity diagnostic, got {errors:?}"
-    );
-    assert!(
-        errors.iter().all(|d| !d.message.contains("argument 2")),
-        "malformed generic enum method type arguments should not also report argument mismatch, got {errors:?}"
-    );
-}
-
-#[test]
-fn generic_result_enum_method_explicit_type_arg_arity_is_error() {
-    let errors = typecheck_errors(
-        r#"
-Result<T, E>:
-    Ok(T),
-    Err(E)
-
-Result.unwrap_or<T, E> = (self: Self, fallback: T) T {
-    self ?
-        | Ok(value) { value }
-        | Err(_) { fallback }
-}
-
-main = () i32 {
-    value = Result<i32, str>.Ok(1)
-    value.unwrap_or<i32>(0)
-}
-"#,
-    );
-
-    assert!(
-        errors.iter().any(|d| d
-            .message
-            .contains("generic method `Result.unwrap_or` expects 2 type arguments, found 1")),
-        "expected generic Result enum method arity diagnostic, got {errors:?}"
-    );
-    assert!(
-        errors
-            .iter()
-            .all(|d| !d.message.contains("cannot infer type argument")),
-        "malformed generic Result enum method type arguments should not also report inference, got {errors:?}"
-    );
-    assert!(
-        errors.iter().all(|d| !d.message.contains("argument 2")),
-        "malformed generic Result enum method type arguments should not also report argument mismatch, got {errors:?}"
     );
 }
 

--- a/tests/generic_diagnostics/method_type_args/enum_methods.rs
+++ b/tests/generic_diagnostics/method_type_args/enum_methods.rs
@@ -1,0 +1,73 @@
+use super::*;
+
+#[test]
+fn generic_enum_method_explicit_type_arg_arity_is_error() {
+    let errors = typecheck_errors(
+        r#"
+Option<T>:
+    None,
+    Some(T)
+
+Option.unwrap_or<T> = (self: Self, fallback: T) T {
+    self ?
+        | Some(value) { value }
+        | None { fallback }
+}
+
+main = () i32 {
+    value = Option<i32>.Some(1)
+    value.unwrap_or<i32, str>(0)
+}
+"#,
+    );
+
+    assert!(
+        errors.iter().any(|d| d
+            .message
+            .contains("generic method `Option.unwrap_or` expects 1 type arguments, found 2")),
+        "expected generic enum method arity diagnostic, got {errors:?}"
+    );
+    assert!(
+        errors.iter().all(|d| !d.message.contains("argument 2")),
+        "malformed generic enum method type arguments should not also report argument mismatch, got {errors:?}"
+    );
+}
+
+#[test]
+fn generic_result_enum_method_explicit_type_arg_arity_is_error() {
+    let errors = typecheck_errors(
+        r#"
+Result<T, E>:
+    Ok(T),
+    Err(E)
+
+Result.unwrap_or<T, E> = (self: Self, fallback: T) T {
+    self ?
+        | Ok(value) { value }
+        | Err(_) { fallback }
+}
+
+main = () i32 {
+    value = Result<i32, str>.Ok(1)
+    value.unwrap_or<i32>(0)
+}
+"#,
+    );
+
+    assert!(
+        errors.iter().any(|d| d
+            .message
+            .contains("generic method `Result.unwrap_or` expects 2 type arguments, found 1")),
+        "expected generic Result enum method arity diagnostic, got {errors:?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .all(|d| !d.message.contains("cannot infer type argument")),
+        "malformed generic Result enum method type arguments should not also report inference, got {errors:?}"
+    );
+    assert!(
+        errors.iter().all(|d| !d.message.contains("argument 2")),
+        "malformed generic Result enum method type arguments should not also report argument mismatch, got {errors:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- move `Option<T>` and `Result<T,E>` enum-method type-argument arity diagnostics into `tests/generic_diagnostics/method_type_args/enum_methods.rs`
- keep `tests/generic_diagnostics/method_type_args.rs` focused on direct method and non-generic callable cases
- record the cleanup in the phase plan and completion audit

## Validation
- `cargo test --test generic_diagnostics method_type_args`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`