### PR TITLE
[codex] factor generic function call resolution

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2705,6 +2705,10 @@ and do not assume Phase 4 is ready without evidence.
   methods and concrete generic receiver base methods, preserving existing
   generic method diagnostics and generated-C worklist coverage while reducing
   duplicate Phase 5 specialization logic.
+- Generic function-call checking now shares one helper for direct calls and
+  UFC calls, preserving generic function diagnostics, generic UFC fixture
+  coverage, and generated-C specialization coverage while reducing duplicate
+  Phase 5 specialization logic.
 - Imported behavior association dependency seeding is now split into
   `src/typechecker/resolver_validation/imports_behavior_dependencies.rs`,
   preserving imported behavior inheritance and impl coverage while keeping the

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2514,6 +2514,10 @@ checked-in docs, tests, and commits only.
   receiver methods and concrete generic receiver base methods, so inference,
   signature validation, bounds, and monomorphization cannot drift between the
   two Phase 5 method-specialization paths.
+- Generic function-call checking now shares one specialization path for direct
+  calls and UFC calls, keeping inference, explicit type arguments, substituted
+  signature checks, bounds, and monomorphization consistent across Phase 5
+  function-call syntax.
 - Expression function checking now lives in
   `src/typechecker/expressions/function_checking.rs`, keeping
   `src/typechecker/expressions.rs` focused on expression dispatch while

--- a/src/typechecker/expressions.rs
+++ b/src/typechecker/expressions.rs
@@ -17,7 +17,7 @@ use crate::error::{Diagnostic, Span};
 
 use super::closures::collect_captures;
 use super::monomorphize_inference::InferenceConflict;
-use super::{BehaviorBound, TypeChecker};
+use super::{BehaviorBound, FuncInfo, TypeChecker};
 
 impl TypeChecker {
     pub(crate) fn check_expr(&mut self, expr: &Expression) -> Result<TypedExpression, Diagnostic> {

--- a/src/typechecker/expressions/call_support.rs
+++ b/src/typechecker/expressions/call_support.rs
@@ -24,63 +24,7 @@ impl TypeChecker {
         let (resolved_name, ret_type) = if let Some(info) = self.functions.get(&full_name).cloned()
         {
             if !info.type_params.is_empty() {
-                let (subs, explicit_type_args_valid) = if type_args.is_empty() {
-                    let arg_types: Vec<Type> = typed_args.iter().map(|a| a.ty.clone()).collect();
-                    let (subs, conflicts) = self.infer_type_args_with_conflicts(
-                        &info.type_params,
-                        &info.params,
-                        &arg_types,
-                    );
-                    let inferred_type_args_valid =
-                        self.report_inference_conflicts("function", &full_name, conflicts, span);
-                    (subs, inferred_type_args_valid)
-                } else {
-                    self.explicit_type_arg_substitutions(
-                        "function",
-                        &full_name,
-                        &info.type_params,
-                        type_args,
-                        span,
-                    )
-                };
-                let (ret, mangled) = if explicit_type_args_valid {
-                    self.check_call_signature_with_substitutions(
-                        "function",
-                        &full_name,
-                        &info.params,
-                        &typed_args,
-                        &subs,
-                        &span,
-                    );
-                    if self.check_generic_bounds_valid(&info.type_param_bounds, &subs, span) {
-                        let ret = self.substitute_type(&info.return_type, &subs);
-                        let mangled = self
-                            .specialize_generic_function(&full_name, &subs, span)
-                            .unwrap_or_else(|| {
-                                self.generic_function_mangled_name(
-                                    &full_name,
-                                    &info.type_params,
-                                    &subs,
-                                )
-                            });
-                        (ret, mangled)
-                    } else {
-                        (
-                            Type::Unknown,
-                            self.generic_function_mangled_name(
-                                &full_name,
-                                &info.type_params,
-                                &subs,
-                            ),
-                        )
-                    }
-                } else {
-                    (
-                        Type::Unknown,
-                        self.generic_function_mangled_name(&full_name, &info.type_params, &subs),
-                    )
-                };
-                (mangled, ret)
+                self.resolve_generic_function_call(&full_name, &info, type_args, &typed_args, span)
             } else {
                 if !type_args.is_empty() {
                     self.diagnostics.push(Diagnostic::error(

--- a/src/typechecker/expressions/call_validation.rs
+++ b/src/typechecker/expressions/call_validation.rs
@@ -1,6 +1,57 @@
 use super::*;
 
 impl TypeChecker {
+    pub(super) fn resolve_generic_function_call(
+        &mut self,
+        function_name: &str,
+        info: &FuncInfo,
+        type_args: &[AstType],
+        typed_args: &[TypedExpression],
+        span: Span,
+    ) -> (String, Type) {
+        let (subs, type_args_valid) = if type_args.is_empty() {
+            let arg_types: Vec<Type> = typed_args.iter().map(|arg| arg.ty.clone()).collect();
+            let (subs, conflicts) =
+                self.infer_type_args_with_conflicts(&info.type_params, &info.params, &arg_types);
+            let inferred_type_args_valid =
+                self.report_inference_conflicts("function", function_name, conflicts, span);
+            (subs, inferred_type_args_valid)
+        } else {
+            self.explicit_type_arg_substitutions(
+                "function",
+                function_name,
+                &info.type_params,
+                type_args,
+                span,
+            )
+        };
+
+        let fallback_mangled =
+            self.generic_function_mangled_name(function_name, &info.type_params, &subs);
+        if !type_args_valid {
+            return (fallback_mangled, Type::Unknown);
+        }
+
+        self.check_call_signature_with_substitutions(
+            "function",
+            function_name,
+            &info.params,
+            typed_args,
+            &subs,
+            &span,
+        );
+
+        if self.check_generic_bounds_valid(&info.type_param_bounds, &subs, span) {
+            let ret_type = self.substitute_type(&info.return_type, &subs);
+            let mangled = self
+                .specialize_generic_function(function_name, &subs, span)
+                .unwrap_or(fallback_mangled);
+            (mangled, ret_type)
+        } else {
+            (fallback_mangled, Type::Unknown)
+        }
+    }
+
     pub(super) fn check_call_signature(
         &mut self,
         kind: &str,

--- a/src/typechecker/expressions/method_call_support.rs
+++ b/src/typechecker/expressions/method_call_support.rs
@@ -113,55 +113,7 @@ impl TypeChecker {
         } else if let Some(info) = self.functions.get(method).cloned() {
             // UFC: x.f(args) -> f(x, args)
             let (resolved_function, ret_type) = if !info.type_params.is_empty() {
-                let (subs, explicit_type_args_valid) = if type_args.is_empty() {
-                    let arg_types: Vec<Type> = typed_args.iter().map(|a| a.ty.clone()).collect();
-                    let (subs, conflicts) = self.infer_type_args_with_conflicts(
-                        &info.type_params,
-                        &info.params,
-                        &arg_types,
-                    );
-                    let inferred_type_args_valid =
-                        self.report_inference_conflicts("function", method, conflicts, span);
-                    (subs, inferred_type_args_valid)
-                } else {
-                    self.explicit_type_arg_substitutions(
-                        "function",
-                        method,
-                        &info.type_params,
-                        type_args,
-                        span,
-                    )
-                };
-                let (ret, mangled) = if explicit_type_args_valid {
-                    self.check_call_signature_with_substitutions(
-                        "function",
-                        method,
-                        &info.params,
-                        &typed_args,
-                        &subs,
-                        &span,
-                    );
-                    if self.check_generic_bounds_valid(&info.type_param_bounds, &subs, span) {
-                        let ret = self.substitute_type(&info.return_type, &subs);
-                        let mangled = self
-                            .specialize_generic_function(method, &subs, span)
-                            .unwrap_or_else(|| {
-                                self.generic_function_mangled_name(method, &info.type_params, &subs)
-                            });
-                        (ret, mangled)
-                    } else {
-                        (
-                            Type::Unknown,
-                            self.generic_function_mangled_name(method, &info.type_params, &subs),
-                        )
-                    }
-                } else {
-                    (
-                        Type::Unknown,
-                        self.generic_function_mangled_name(method, &info.type_params, &subs),
-                    )
-                };
-                (mangled, ret)
+                self.resolve_generic_function_call(method, &info, type_args, &typed_args, span)
             } else {
                 if !type_args.is_empty() {
                     self.diagnostics.push(Diagnostic::error(


### PR DESCRIPTION
## Summary

- Factor direct generic calls and UFC generic function calls through one shared specialization helper.
- Preserve inference, explicit type arguments, substituted signature checks, bounds validation, and monomorphization behavior while removing duplicated Phase 5 function-call logic.
- Record the cleanup in the phase plan and completion audit.

## Validation

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `cargo test --test generic_diagnostics generic_function -- --nocapture`
- `cargo test --test integration generic_ufc -- --nocapture`
- `cargo test --test integration generic_specializations -- --nocapture`
- `cargo test --test docs_truth phase_audit -- --nocapture`
- `git diff --check`