### PR TITLE
[codex] share generic receiver name matching

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2709,6 +2709,10 @@ and do not assume Phase 4 is ready without evidence.
   UFC calls, preserving generic function diagnostics, generic UFC fixture
   coverage, and generated-C specialization coverage while reducing duplicate
   Phase 5 specialization logic.
+- Generic receiver base detection now uses the same generic concrete-name
+  matcher as monomorphization, preserving generic method/generated-C
+  specialization coverage while removing a hand-rolled mangled-name prefix
+  check from method lookup.
 - Imported behavior association dependency seeding is now split into
   `src/typechecker/resolver_validation/imports_behavior_dependencies.rs`,
   preserving imported behavior inheritance and impl coverage while keeping the

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2518,6 +2518,9 @@ checked-in docs, tests, and commits only.
   calls and UFC calls, keeping inference, explicit type arguments, substituted
   signature checks, bounds, and monomorphization consistent across Phase 5
   function-call syntax.
+- Generic receiver base detection now reuses the shared generic concrete-name
+  matcher used by monomorphization, keeping method lookup and specialization
+  from drifting on mangled generic type names.
 - Expression function checking now lives in
   `src/typechecker/expressions/function_checking.rs`, keeping
   `src/typechecker/expressions.rs` focused on expression dispatch while

--- a/src/typechecker/expressions.rs
+++ b/src/typechecker/expressions.rs
@@ -17,6 +17,7 @@ use crate::error::{Diagnostic, Span};
 
 use super::closures::collect_captures;
 use super::monomorphize_inference::InferenceConflict;
+use super::monomorphize_types::concrete_name_matches_generic;
 use super::{BehaviorBound, FuncInfo, TypeChecker};
 
 impl TypeChecker {

--- a/src/typechecker/expressions/call_validation.rs
+++ b/src/typechecker/expressions/call_validation.rs
@@ -247,13 +247,13 @@ impl TypeChecker {
         self.structs
             .values()
             .filter(|info| !info.type_params.is_empty())
-            .find(|info| concrete_name.starts_with(&format!("{}_", info.name)))
+            .find(|info| concrete_name_matches_generic(concrete_name, &info.name))
             .map(|info| info.name.clone())
             .or_else(|| {
                 self.enums
                     .values()
                     .filter(|info| !info.type_params.is_empty())
-                    .find(|info| concrete_name.starts_with(&format!("{}_", info.name)))
+                    .find(|info| concrete_name_matches_generic(concrete_name, &info.name))
                     .map(|info| info.name.clone())
             })
     }


### PR DESCRIPTION
## Summary

- Reuse the monomorphization generic concrete-name matcher for generic receiver base detection in method lookup.
- Remove the hand-rolled mangled generic type prefix check from the method-call path.
- Record the cleanup in the phase plan and completion audit.

## Validation

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `cargo test --test integration generic_method -- --nocapture`
- `cargo test --test integration generic_specializations -- --nocapture`
- `cargo test --test docs_truth phase_audit -- --nocapture`
- `git diff --check`