### PR TITLE
[codex] remove dead return expression ast

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2717,6 +2717,10 @@ and do not assume Phase 4 is ready without evidence.
   instantiation is now covered by `tests/zen/generic_ufc_dedup.zen` and
   generated-C assertions that both calls resolve to a single emitted `id_i32`
   definition with no unspecialized `id` calls left behind.
+- The removed source `return` keyword no longer leaves dead source or typed AST
+  return-expression nodes behind. Final expressions remain the function result
+  path, and `repo_hygiene::source_ast_no_longer_has_return_expression_nodes`
+  guards the cleanup.
 - Imported behavior association dependency seeding is now split into
   `src/typechecker/resolver_validation/imports_behavior_dependencies.rs`,
   preserving imported behavior inheritance and impl coverage while keeping the

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2525,6 +2525,10 @@ checked-in docs, tests, and commits only.
   instantiation is now covered by `tests/zen/generic_ufc_dedup.zen` and
   generated-C assertions proving both calls resolve to one `id_i32`
   definition.
+- The removed source `return` keyword no longer leaves dead source or typed AST
+  return-expression nodes behind. Final expressions remain the function result
+  path, and `repo_hygiene::source_ast_no_longer_has_return_expression_nodes`
+  guards the cleanup.
 - Expression function checking now lives in
   `src/typechecker/expressions/function_checking.rs`, keeping
   `src/typechecker/expressions.rs` focused on expression dispatch while

--- a/src/ast/expressions.rs
+++ b/src/ast/expressions.rs
@@ -274,11 +274,6 @@ pub enum Expression {
         expr: Option<Box<Expression>>,
         span: Span,
     },
-    /// Return from function.
-    Return {
-        value: Option<Box<Expression>>,
-        span: Span,
-    },
     Break {
         span: Span,
     },
@@ -356,7 +351,6 @@ impl Expression {
             | Expression::LoopControl { span, .. }
             | Expression::If { span, .. }
             | Expression::Block { span, .. }
-            | Expression::Return { span, .. }
             | Expression::Break { span, .. }
             | Expression::Continue { span, .. }
             | Expression::Closure { span, .. }

--- a/src/ast/typed.rs
+++ b/src/ast/typed.rs
@@ -108,7 +108,6 @@ pub enum TypedExprKind {
 
     Block(TypedBlock),
 
-    Return(Option<Box<TypedExpression>>),
     Break,
     Continue,
     LoopControl {

--- a/src/build_graph/lowering.rs
+++ b/src/build_graph/lowering.rs
@@ -141,11 +141,6 @@ impl BuildProgramLowering {
                     self.collect_expr(expr);
                 }
             }
-            Expression::Return { value, .. } => {
-                if let Some(value) = value {
-                    self.collect_expr(value);
-                }
-            }
             Expression::Closure { body, .. } => self.collect_expr(body),
             Expression::Cast { expr, .. } | Expression::Defer { expr, .. } => {
                 self.collect_expr(expr)

--- a/src/codegen/c/emit.rs
+++ b/src/codegen/c/emit.rs
@@ -64,20 +64,6 @@ impl CEmitter {
                 self.emit_match(scrutinee, arms, kind, None);
                 String::new()
             }
-            TypedExprKind::Return(val) => match val {
-                Some(v) if self.current_defers.is_empty() => {
-                    format!("return {};", self.emit_expr_inline(v))
-                }
-                None if self.current_defers.is_empty() => "return;".into(),
-                Some(v) => {
-                    self.emit_return_with_current_defers(Some(v));
-                    String::new()
-                }
-                None => {
-                    self.emit_return_with_current_defers(None);
-                    String::new()
-                }
-            },
             TypedExprKind::Break => "break;".into(),
             TypedExprKind::Continue => "continue;".into(),
             TypedExprKind::LoopControl { action, label } => {
@@ -95,33 +81,6 @@ impl CEmitter {
                 } else {
                     format!("{};", inline)
                 }
-            }
-        }
-    }
-
-    fn emit_return_with_current_defers(&mut self, value: Option<&TypedExpression>) {
-        match value {
-            Some(expr) => {
-                let tmp = self.fresh_tmp();
-                let ty = self.c_type(&expr.ty);
-                let value = self.emit_expr_inline(expr);
-                self.line(&format!("{} {} = {};", ty, tmp, value));
-                self.emit_current_defers();
-                self.line(&format!("return {};", tmp));
-            }
-            None => {
-                self.emit_current_defers();
-                self.line("return;");
-            }
-        }
-    }
-
-    fn emit_current_defers(&mut self) {
-        let defers = self.current_defers.clone();
-        for defer_expr in &defers {
-            let s = self.emit_expr_to_stmt(defer_expr);
-            if !s.is_empty() {
-                self.line(&s);
             }
         }
     }
@@ -291,17 +250,6 @@ impl CEmitter {
                 self.dedent();
                 self.line("}");
                 tmp
-            }
-
-            TypedExprKind::Return(val) => {
-                // Shouldn't appear as inline expression, but handle it
-                match val {
-                    Some(v) => {
-                        let ve = self.emit_expr_inline(v);
-                        format!("({{ return {}; 0; }})", ve)
-                    }
-                    None => "(({ return; 0; }))".into(),
-                }
             }
 
             TypedExprKind::Match {

--- a/src/codegen/c/tests/helpers.rs
+++ b/src/codegen/c/tests/helpers.rs
@@ -48,26 +48,6 @@ fn fresh_tmp_increments() {
 }
 
 #[test]
-fn emit_return_statement() {
-    let mut e = CEmitter::new();
-    let ret = texpr(
-        TypedExprKind::Return(Some(Box::new(texpr(
-            TypedExprKind::IntLiteral(0),
-            Type::I32,
-        )))),
-        Type::Never,
-    );
-    assert_eq!(e.emit_expr_to_stmt(&ret), "return 0LL;");
-}
-
-#[test]
-fn emit_return_void() {
-    let mut e = CEmitter::new();
-    let ret = texpr(TypedExprKind::Return(None), Type::Never);
-    assert_eq!(e.emit_expr_to_stmt(&ret), "return;");
-}
-
-#[test]
 fn emit_break_continue() {
     let mut e = CEmitter::new();
     assert_eq!(

--- a/src/codegen/c/tests/program_generation.rs
+++ b/src/codegen/c/tests/program_generation.rs
@@ -21,24 +21,20 @@ fn make_simple_program() -> TypedProgram {
             body: TypedBlock {
                 statements: vec![],
                 expr: Some(Box::new(TypedExpression {
-                    kind: TypedExprKind::Return(Some(Box::new(TypedExpression {
-                        kind: TypedExprKind::BinaryOp {
-                            op: BinaryOp::Add,
-                            left: Box::new(TypedExpression {
-                                kind: TypedExprKind::Variable("a".into()),
-                                ty: Type::I32,
-                                span: crate::error::Span::dummy(),
-                            }),
-                            right: Box::new(TypedExpression {
-                                kind: TypedExprKind::Variable("b".into()),
-                                ty: Type::I32,
-                                span: crate::error::Span::dummy(),
-                            }),
-                        },
-                        ty: Type::I32,
-                        span: crate::error::Span::dummy(),
-                    }))),
-                    ty: Type::Never,
+                    kind: TypedExprKind::BinaryOp {
+                        op: BinaryOp::Add,
+                        left: Box::new(TypedExpression {
+                            kind: TypedExprKind::Variable("a".into()),
+                            ty: Type::I32,
+                            span: crate::error::Span::dummy(),
+                        }),
+                        right: Box::new(TypedExpression {
+                            kind: TypedExprKind::Variable("b".into()),
+                            ty: Type::I32,
+                            span: crate::error::Span::dummy(),
+                        }),
+                    },
+                    ty: Type::I32,
                     span: crate::error::Span::dummy(),
                 })),
                 ty: Type::I32,
@@ -134,12 +130,8 @@ fn generates_entry_point() {
             body: TypedBlock {
                 statements: vec![],
                 expr: Some(Box::new(TypedExpression {
-                    kind: TypedExprKind::Return(Some(Box::new(TypedExpression {
-                        kind: TypedExprKind::IntLiteral(0),
-                        ty: Type::I32,
-                        span: crate::error::Span::dummy(),
-                    }))),
-                    ty: Type::Never,
+                    kind: TypedExprKind::IntLiteral(0),
+                    ty: Type::I32,
                     span: crate::error::Span::dummy(),
                 })),
                 ty: Type::I32,
@@ -201,13 +193,7 @@ fn generates_function_with_defers() {
             return_type: Type::I32,
             body: TypedBlock {
                 statements: vec![],
-                expr: Some(Box::new(texpr(
-                    TypedExprKind::Return(Some(Box::new(texpr(
-                        TypedExprKind::IntLiteral(42),
-                        Type::I32,
-                    )))),
-                    Type::Never,
-                ))),
+                expr: Some(Box::new(texpr(TypedExprKind::IntLiteral(42), Type::I32))),
                 ty: Type::I32,
                 span: dummy(),
             },

--- a/src/codegen/c/types.rs
+++ b/src/codegen/c/types.rs
@@ -242,10 +242,6 @@ impl CEmitter {
                     let tmp = self.fresh_tmp();
                     let ty = self.c_type(&func.return_type);
                     match &expr.kind {
-                        TypedExprKind::Return(Some(v)) => {
-                            let val = self.emit_expr_inline(v);
-                            self.line(&format!("{} {} = {};", ty, tmp, val));
-                        }
                         TypedExprKind::Match {
                             scrutinee,
                             arms,
@@ -268,14 +264,7 @@ impl CEmitter {
                     }
                     self.line(&format!("return {};", tmp));
                 } else {
-                    // No defers: original behavior
                     match &expr.kind {
-                        TypedExprKind::Return(_) => {
-                            let s = self.emit_expr_to_stmt(expr);
-                            if !s.is_empty() {
-                                self.line(&s);
-                            }
-                        }
                         TypedExprKind::Match {
                             scrutinee,
                             arms,

--- a/src/resolver/expression_validation.rs
+++ b/src/resolver/expression_validation.rs
@@ -277,18 +277,6 @@ impl Resolver {
                     diagnostics,
                 );
             }
-            Expression::Return { value, .. } => {
-                if let Some(value) = value {
-                    self.validate_expr_refs(
-                        table,
-                        type_params,
-                        value,
-                        locals,
-                        allow_self_type,
-                        diagnostics,
-                    );
-                }
-            }
             Expression::Closure {
                 params,
                 return_type,

--- a/src/typechecker/closures.rs
+++ b/src/typechecker/closures.rs
@@ -80,9 +80,6 @@ pub(super) fn collect_captures(
         TypedExprKind::Block(block) => {
             collect_captures_block(block, params, outer_vars, captures, seen);
         }
-        TypedExprKind::Return(Some(v)) => {
-            collect_captures(v, params, outer_vars, captures, seen);
-        }
         TypedExprKind::StringInterpolation { parts } => {
             for part in parts {
                 if let TypedStringPart::Expr(e) = part {

--- a/src/typechecker/expressions.rs
+++ b/src/typechecker/expressions.rs
@@ -116,8 +116,6 @@ impl TypeChecker {
                 span,
             } => self.check_block_expr(statements, expr, *span),
 
-            Expression::Return { value, span } => self.check_return_expr(value, *span),
-
             Expression::Break { span } => Ok(TypedExpression {
                 kind: TypedExprKind::Break,
                 ty: Type::Never,

--- a/src/typechecker/expressions/call_validation.rs
+++ b/src/typechecker/expressions/call_validation.rs
@@ -335,7 +335,6 @@ impl TypeChecker {
 
     pub(super) fn expr_definitely_returns(&self, expr: &TypedExpression) -> bool {
         match &expr.kind {
-            TypedExprKind::Return(_) => true,
             TypedExprKind::Block(block) => self.block_definitely_returns(block),
             TypedExprKind::Match { arms, .. } => {
                 !arms.is_empty()

--- a/src/typechecker/expressions/simple_forms.rs
+++ b/src/typechecker/expressions/simple_forms.rs
@@ -79,38 +79,6 @@ impl TypeChecker {
         })
     }
 
-    pub(super) fn check_return_expr(
-        &mut self,
-        value: &Option<Box<Expression>>,
-        span: Span,
-    ) -> Result<TypedExpression, Diagnostic> {
-        let typed_val = match value {
-            Some(v) => Some(Box::new(self.check_expr(v)?)),
-            None => None,
-        };
-
-        if let Some(ref expected) = self.current_return_type {
-            let actual = typed_val.as_ref().map(|v| &v.ty).unwrap_or(&Type::Void);
-            if !self.types_compatible(expected, actual) {
-                self.diagnostics.push(Diagnostic::error(
-                    "E3030",
-                    format!(
-                        "return type mismatch: expected `{}`, found `{}`",
-                        expected.display_name(),
-                        actual.display_name()
-                    ),
-                    span,
-                ));
-            }
-        }
-
-        Ok(TypedExpression {
-            kind: TypedExprKind::Return(typed_val),
-            ty: Type::Never,
-            span,
-        })
-    }
-
     pub(super) fn check_cast_expr(
         &mut self,
         expr: &Expression,

--- a/src/typechecker/generic_type_reference_walker/expressions.rs
+++ b/src/typechecker/generic_type_reference_walker/expressions.rs
@@ -114,11 +114,6 @@ impl TypeChecker {
                     self.validate_generic_expr_type_references(expr, scoped_type_params);
                 }
             }
-            Expression::Return { value, .. } => {
-                if let Some(value) = value {
-                    self.validate_generic_expr_type_references(value, scoped_type_params);
-                }
-            }
             Expression::Closure {
                 params,
                 return_type,

--- a/src/typechecker/resolver_validation/local_traversal.rs
+++ b/src/typechecker/resolver_validation/local_traversal.rs
@@ -183,11 +183,6 @@ impl TypeChecker {
                     locals,
                 );
             }
-            Expression::Return { value, .. } => {
-                if let Some(value) = value {
-                    self.require_resolver_expr_locals(symbols, value, scope_cursor, locals);
-                }
-            }
             Expression::Closure { params, body, .. } => {
                 self.require_resolver_closure_locals(symbols, params, body, scope_cursor, locals);
             }

--- a/src/typechecker/resolver_validation_support/expected_local_traversal.rs
+++ b/src/typechecker/resolver_validation_support/expected_local_traversal.rs
@@ -100,11 +100,6 @@ fn expected_resolver_expr_locals(
                 expected,
             );
         }
-        Expression::Return { value, .. } => {
-            if let Some(value) = value {
-                expected_resolver_expr_locals(value, scope_cursor, locals, expected);
-            }
-        }
         Expression::Closure { params, body, .. } => {
             expected_resolver_closure_locals(params, body, scope_cursor, locals, expected);
         }

--- a/src/typechecker/self_type_validation/expressions.rs
+++ b/src/typechecker/self_type_validation/expressions.rs
@@ -126,11 +126,6 @@ impl TypeChecker {
                     self.validate_self_type_expr(expr, allow_self_type);
                 }
             }
-            Expression::Return { value, .. } => {
-                if let Some(value) = value {
-                    self.validate_self_type_expr(value, allow_self_type);
-                }
-            }
             Expression::Closure {
                 params,
                 return_type,

--- a/src/typechecker/tests/core_semantics/calls_and_returns.rs
+++ b/src/typechecker/tests/core_semantics/calls_and_returns.rs
@@ -49,11 +49,8 @@ fn return_type_mismatch_error() {
             return_type: Some(AstType::I32),
             body: Expression::Block {
                 statements: Vec::new(),
-                expr: Some(Box::new(Expression::Return {
-                    value: Some(Box::new(Expression::StringLiteral {
-                        value: "hello".into(),
-                        span: Span::dummy(),
-                    })),
+                expr: Some(Box::new(Expression::StringLiteral {
+                    value: "hello".into(),
                     span: Span::dummy(),
                 })),
                 span: Span::dummy(),
@@ -97,11 +94,8 @@ fn function_call_wrong_arity_is_error() {
                 return_type: Some(AstType::I32),
                 body: Expression::Block {
                     statements: Vec::new(),
-                    expr: Some(Box::new(Expression::Return {
-                        value: Some(Box::new(Expression::Identifier {
-                            name: "a".into(),
-                            span: Span::dummy(),
-                        })),
+                    expr: Some(Box::new(Expression::Identifier {
+                        name: "a".into(),
                         span: Span::dummy(),
                     })),
                     span: Span::dummy(),

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -70,6 +70,30 @@ fn production_rust_files_stay_below_cleanup_threshold() {
 }
 
 #[test]
+fn source_ast_no_longer_has_return_expression_nodes() {
+    for path in [
+        "src/ast/expressions.rs",
+        "src/ast/typed.rs",
+        "src/typechecker/expressions.rs",
+        "src/typechecker/expressions/simple_forms.rs",
+        "src/codegen/c/emit.rs",
+        "src/codegen/c/types.rs",
+    ] {
+        let source = read(path);
+        for forbidden in [
+            "Expression::Return",
+            "TypedExprKind::Return",
+            "check_return_expr",
+        ] {
+            assert!(
+                !source.contains(forbidden),
+                "{path} still contains dead return-expression support: {forbidden}"
+            );
+        }
+    }
+}
+
+#[test]
 fn ci_and_release_only_advertise_existing_targets() {
     let ci = read(".github/workflows/ci.yml");
     let release = read(".github/workflows/release.yml");


### PR DESCRIPTION
## Summary

- Remove the dead source-level `Expression::Return` and typed `TypedExprKind::Return` variants after the language-level `return` keyword removal.
- Drop now-unreachable return expression handling from typechecking, resolver/build graph traversals, closure capture traversal, and C emission.
- Add a docs truth guard so return-expression AST support cannot be reintroduced quietly.

## Validation

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`