### PR TITLE
[codex] accept wildcard host effect fallbacks

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2721,6 +2721,10 @@ and do not assume Phase 4 is ready without evidence.
   return-expression nodes behind. Final expressions remain the function result
   path, and `repo_hygiene::source_ast_no_longer_has_return_expression_nodes`
   guards the cleanup.
+- Build graph host-effect lowering now treats wildcard fallback match arms as
+  declared deterministic fallbacks for `b.os.env(...)` and
+  `b.os.read_file(...)`, covered by build-graph lowering tests and executable
+  `zen build build.zen` positive/negative fixtures.
 - Imported behavior association dependency seeding is now split into
   `src/typechecker/resolver_validation/imports_behavior_dependencies.rs`,
   preserving imported behavior inheritance and impl coverage while keeping the

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2529,6 +2529,10 @@ checked-in docs, tests, and commits only.
   return-expression nodes behind. Final expressions remain the function result
   path, and `repo_hygiene::source_ast_no_longer_has_return_expression_nodes`
   guards the cleanup.
+- Build graph host-effect lowering now treats wildcard fallback match arms as
+  declared deterministic fallbacks for `b.os.env(...)` and
+  `b.os.read_file(...)`, covered by build-graph lowering tests and executable
+  `zen build build.zen` positive/negative fixtures.
 - Expression function checking now lives in
   `src/typechecker/expressions/function_checking.rs`, keeping
   `src/typechecker/expressions.rs` focused on expression dispatch while

--- a/src/build_graph/lowering.rs
+++ b/src/build_graph/lowering.rs
@@ -194,13 +194,16 @@ fn declared_host_effect(expr: &Expression) -> Option<HostEffect> {
     else {
         return None;
     };
-    let has_fallback = arms.iter().any(|arm| {
-        matches!(
-            &arm.pattern,
-            crate::ast::Pattern::Enum { variant, .. } if variant == "Err"
-        )
-    });
+    let has_fallback = arms.iter().any(|arm| host_effect_arm_declares_fallback(&arm.pattern));
     has_fallback.then(|| host_effect(scrutinee)).flatten()
+}
+
+fn host_effect_arm_declares_fallback(pattern: &crate::ast::Pattern) -> bool {
+    match pattern {
+        crate::ast::Pattern::Wildcard { .. } => true,
+        crate::ast::Pattern::Enum { variant, .. } => variant == "Err",
+        _ => false,
+    }
 }
 
 fn host_effect(expr: &Expression) -> Option<HostEffect> {

--- a/tests/build_graph/host_effects.rs
+++ b/tests/build_graph/host_effects.rs
@@ -45,6 +45,29 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
 }
 
 #[test]
+fn build_program_lowering_accepts_wildcard_fallback_declared_env_reads() {
+    let program = parse_program(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    std_path = b.os.env("ZEN_STD") ?
+        | .Ok(value) { value }
+        | _ { "default" }
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    );
+
+    let graph = BuildGraph::from_build_program(&program).expect("lower build graph");
+    let json = graph.canonical_json().expect("build graph json");
+
+    assert!(
+        json.contains(r#""kind":"read_env","value":"ZEN_STD""#),
+        "expected wildcard fallback to declare read-env host effect, json={json}"
+    );
+}
+
+#[test]
 fn build_program_lowering_accepts_declared_file_reads() {
     let program = parse_program(
         r#"
@@ -64,6 +87,29 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
     assert!(
         json.contains(r#""kind":"read_file","value":"build.targets""#),
         "expected read-file host effect in graph json, json={json}"
+    );
+}
+
+#[test]
+fn build_program_lowering_accepts_wildcard_fallback_declared_file_reads() {
+    let program = parse_program(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets") ?
+        | .Ok(contents) { contents }
+        | _ { "default" }
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    );
+
+    let graph = BuildGraph::from_build_program(&program).expect("lower build graph");
+    let json = graph.canonical_json().expect("build graph json");
+
+    assert!(
+        json.contains(r#""kind":"read_file","value":"build.targets""#),
+        "expected wildcard fallback to declare read-file host effect, json={json}"
     );
 }
 

--- a/tests/integration/cli_build/build_command_host_effects.rs
+++ b/tests/integration/cli_build/build_command_host_effects.rs
@@ -169,6 +169,94 @@ main = () i32 {
 }
 
 #[test]
+fn build_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets") ?
+        | .Ok(contents) { contents }
+        | _ { "default" }
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(tmp.path().join("build.targets"), "myapp\n").expect("write manifest");
+    std::fs::write(
+        tmp.path().join("main.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write main.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build build.zen");
+
+    assert!(
+        output.status.success(),
+        "zen build build.zen failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let bin_path = tmp.path().join("build").join("myapp");
+    assert!(
+        bin_path.exists(),
+        "expected {} to exist",
+        bin_path.display()
+    );
+}
+
+#[test]
+fn build_command_build_zen_rejects_file_read_without_fallback_before_execution() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets") ?
+        | .Ok(contents) { contents }
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen build build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("undeclared host effect: read file `build.targets`"),
+        "expected undeclared file read diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "build should not start after graph validation fails"
+    );
+}
+
+#[test]
 fn build_command_build_zen_rejects_undeclared_file_read_effects_before_execution() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(


### PR DESCRIPTION
## Summary

- Treat wildcard match arms as deterministic fallbacks for build graph host-effect reads.
- Cover both `b.os.env(...)` and `b.os.read_file(...)` lowering with wildcard fallbacks.
- Add executable `zen build build.zen` positive and negative fixtures for wildcard fallback declaration behavior.

## Validation

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`