### PR TITLE
[codex] enum host effect fallback spelling

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3047,6 +3047,10 @@ and do not assume Phase 4 is ready without evidence.
   malformed enum-method arity and follow-up suppression checks while keeping
   the parent method type-argument module focused on direct method and
   non-generic callable cases.
+- Build graph host-effect fallback recognition now keeps `Ok`/`Err` result
+  variant spelling in `HostEffectResultVariant`, preserving the existing
+  `.Err`, wildcard, and identifier fallback behavior while removing the raw
+  string comparison from semantic lowering logic.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2774,6 +2774,9 @@ checked-in docs, tests, and commits only.
   `tests/generic_diagnostics/method_type_args/enum_methods.rs`, leaving the
   parent method type-argument module focused on direct method and non-generic
   callable cases.
+- Build graph host-effect fallback recognition now uses enum-backed
+  `Ok`/`Err` result variant spelling instead of comparing raw variant strings,
+  covered by `build_graph::lowering_tests::host_effect_result_variant_owns_source_spelling`.
 
 ## Current Phase
 

--- a/src/build_graph/lowering.rs
+++ b/src/build_graph/lowering.rs
@@ -5,7 +5,7 @@ mod dsl;
 #[path = "lowering/targets.rs"]
 mod targets;
 
-use dsl::BuildTargetDslIdent;
+use dsl::{BuildTargetDslIdent, HostEffectResultVariant};
 #[cfg(test)]
 use dsl::{BuildTargetDslKind, BuildTargetField};
 use targets::build_target_from_builder_add;
@@ -201,7 +201,9 @@ fn declared_host_effect(expr: &Expression) -> Option<HostEffect> {
 fn host_effect_arm_declares_fallback(pattern: &crate::ast::Pattern) -> bool {
     match pattern {
         crate::ast::Pattern::Wildcard { .. } | crate::ast::Pattern::Identifier { .. } => true,
-        crate::ast::Pattern::Enum { variant, .. } => variant == "Err",
+        crate::ast::Pattern::Enum { variant, .. } => {
+            variant.parse::<HostEffectResultVariant>() == Ok(HostEffectResultVariant::Err)
+        }
         _ => false,
     }
 }

--- a/src/build_graph/lowering/dsl.rs
+++ b/src/build_graph/lowering/dsl.rs
@@ -29,6 +29,12 @@ pub(super) enum BuildTargetDslIdent {
     ReadFile,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum HostEffectResultVariant {
+    Ok,
+    Err,
+}
+
 impl BuildTargetDslKind {
     const ALL: [Self; 3] = [Self::Executable, Self::Test, Self::Library];
     const EXECUTABLE: &'static str = "Executable";
@@ -78,6 +84,36 @@ impl BuildTargetField {
             Self::Dependencies => Self::DEPENDENCIES,
             Self::Features => Self::FEATURES,
             Self::Exports => Self::EXPORTS,
+        }
+    }
+}
+
+impl HostEffectResultVariant {
+    const OK: &'static str = "Ok";
+    const ERR: &'static str = "Err";
+
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Ok => Self::OK,
+            Self::Err => Self::ERR,
+        }
+    }
+}
+
+impl fmt::Display for HostEffectResultVariant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for HostEffectResultVariant {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, <Self as FromStr>::Err> {
+        match value {
+            Self::OK => Ok(Self::Ok),
+            Self::ERR => Ok(Self::Err),
+            _ => Err(()),
         }
     }
 }

--- a/src/build_graph/lowering_tests.rs
+++ b/src/build_graph/lowering_tests.rs
@@ -1,4 +1,4 @@
-use super::{BuildTargetDslIdent, BuildTargetDslKind, BuildTargetField};
+use super::{BuildTargetDslIdent, BuildTargetDslKind, BuildTargetField, HostEffectResultVariant};
 
 #[test]
 fn build_target_dsl_kind_owns_source_spelling() {
@@ -46,4 +46,15 @@ fn build_target_dsl_ident_owns_source_spelling() {
     assert_eq!(BuildTargetDslIdent::Os.as_str(), "os");
     assert_eq!(BuildTargetDslIdent::ReadFile.as_str(), "read_file");
     assert_eq!(BuildTargetDslIdent::Builder.to_string(), "b");
+}
+
+#[test]
+fn host_effect_result_variant_owns_source_spelling() {
+    assert_eq!(HostEffectResultVariant::Ok.as_str(), "Ok");
+    assert_eq!(HostEffectResultVariant::Err.as_str(), "Err");
+    assert_eq!("Ok".parse(), Ok(HostEffectResultVariant::Ok));
+    assert_eq!("Err".parse(), Ok(HostEffectResultVariant::Err));
+    assert!("Missing".parse::<HostEffectResultVariant>().is_err());
+    assert_eq!(HostEffectResultVariant::Ok.to_string(), "Ok");
+    assert_eq!(HostEffectResultVariant::Err.to_string(), "Err");
 }


### PR DESCRIPTION
## Summary

- Add `HostEffectResultVariant` so build-graph lowering owns `Ok`/`Err` result variant spelling in one enum-backed location.
- Use that enum when deciding whether a matched host-effect result arm declares a deterministic fallback.
- Record the cleanup in the phase plan and completion audit.

## Why

The host-effect fallback recognizer still compared the raw `.Err` variant string in semantic lowering logic. This keeps the spelling centralized while preserving the existing `.Err`, wildcard, and identifier fallback behavior.

## Validation

- `cargo test build_graph::lowering_tests`
- `cargo test --test build_graph host_effects`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`