### PR TITLE
[codex] validate build target fields

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3051,6 +3051,12 @@ and do not assume Phase 4 is ready without evidence.
   variant spelling in `HostEffectResultVariant`, preserving the existing
   `.Err`, wildcard, and identifier fallback behavior while removing the raw
   string comparison from semantic lowering logic.
+- Build graph target metadata lowering now validates duplicate and unknown
+  target fields before graph construction, so malformed `build.zen` target
+  metadata cannot silently disappear into a vague missing-target diagnostic.
+  Coverage includes `build_program_lowering_rejects_duplicate_target_fields`,
+  `build_program_lowering_rejects_unknown_target_fields`, and
+  `emit_json_build_graph_rejects_unknown_target_fields`.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2777,6 +2777,10 @@ checked-in docs, tests, and commits only.
 - Build graph host-effect fallback recognition now uses enum-backed
   `Ok`/`Err` result variant spelling instead of comparing raw variant strings,
   covered by `build_graph::lowering_tests::host_effect_result_variant_owns_source_spelling`.
+- Build graph target metadata lowering now rejects duplicate and unknown target
+  fields before graph construction, using enum-backed field spelling and
+  preserving CLI diagnostics through
+  `emit_json_build_graph_rejects_unknown_target_fields`.
 
 ## Current Phase
 

--- a/src/build_graph/lowering/dsl.rs
+++ b/src/build_graph/lowering/dsl.rs
@@ -7,7 +7,7 @@ pub(super) enum BuildTargetDslKind {
     Library,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub(super) enum BuildTargetField {
     Name,
     Main,
@@ -17,6 +17,8 @@ pub(super) enum BuildTargetField {
     Dependencies,
     Features,
     Exports,
+    Packages,
+    Link,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -73,6 +75,8 @@ impl BuildTargetField {
     const DEPENDENCIES: &'static str = "dependencies";
     const FEATURES: &'static str = "features";
     const EXPORTS: &'static str = "exports";
+    const PACKAGES: &'static str = "packages";
+    const LINK: &'static str = "link";
 
     pub(super) fn as_str(self) -> &'static str {
         match self {
@@ -84,6 +88,28 @@ impl BuildTargetField {
             Self::Dependencies => Self::DEPENDENCIES,
             Self::Features => Self::FEATURES,
             Self::Exports => Self::EXPORTS,
+            Self::Packages => Self::PACKAGES,
+            Self::Link => Self::LINK,
+        }
+    }
+}
+
+impl FromStr for BuildTargetField {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            Self::NAME => Ok(Self::Name),
+            Self::MAIN => Ok(Self::Main),
+            Self::ROOT => Ok(Self::Root),
+            Self::ROOT_SOURCE_FILE => Ok(Self::RootSourceFile),
+            Self::OUT_DIR => Ok(Self::OutDir),
+            Self::DEPENDENCIES => Ok(Self::Dependencies),
+            Self::FEATURES => Ok(Self::Features),
+            Self::EXPORTS => Ok(Self::Exports),
+            Self::PACKAGES => Ok(Self::Packages),
+            Self::LINK => Ok(Self::Link),
+            _ => Err(()),
         }
     }
 }

--- a/src/build_graph/lowering/targets.rs
+++ b/src/build_graph/lowering/targets.rs
@@ -30,9 +30,18 @@ pub(super) fn build_target_from_builder_add(
         return Ok(None);
     };
     let target = match name.parse::<BuildTargetDslKind>() {
-        Ok(BuildTargetDslKind::Executable) => executable_target_from_fields(fields),
-        Ok(BuildTargetDslKind::Test) => test_target_from_fields(fields),
-        Ok(BuildTargetDslKind::Library) => library_target_from_fields(fields),
+        Ok(kind @ BuildTargetDslKind::Executable) => {
+            validate_target_fields(kind, fields)?;
+            executable_target_from_fields(fields)
+        }
+        Ok(kind @ BuildTargetDslKind::Test) => {
+            validate_target_fields(kind, fields)?;
+            test_target_from_fields(fields)
+        }
+        Ok(kind @ BuildTargetDslKind::Library) => {
+            validate_target_fields(kind, fields)?;
+            library_target_from_fields(fields)
+        }
         Err(()) => {
             return Err(BuildGraphError::UnsupportedBuildScript(format!(
                 "unsupported build target kind `{name}`; supported target kinds are {}",
@@ -41,6 +50,64 @@ pub(super) fn build_target_from_builder_add(
         }
     };
     Ok(target)
+}
+
+fn validate_target_fields(
+    kind: BuildTargetDslKind,
+    fields: &[(String, Expression)],
+) -> Result<(), BuildGraphError> {
+    let allowed = allowed_fields(kind);
+    let mut seen = std::collections::BTreeSet::new();
+    for (name, _) in fields {
+        let field = name.parse::<BuildTargetField>().map_err(|()| {
+            BuildGraphError::UnsupportedBuildScript(format!(
+                "unknown field `{name}` in `{kind}` build target"
+            ))
+        })?;
+        if !allowed.contains(&field) {
+            return Err(BuildGraphError::UnsupportedBuildScript(format!(
+                "unknown field `{name}` in `{kind}` build target"
+            )));
+        }
+        if !seen.insert(field) {
+            return Err(BuildGraphError::UnsupportedBuildScript(format!(
+                "duplicate field `{name}` in `{kind}` build target"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn allowed_fields(kind: BuildTargetDslKind) -> &'static [BuildTargetField] {
+    match kind {
+        BuildTargetDslKind::Executable => &[
+            BuildTargetField::Name,
+            BuildTargetField::Main,
+            BuildTargetField::RootSourceFile,
+            BuildTargetField::OutDir,
+            BuildTargetField::Dependencies,
+            BuildTargetField::Features,
+            BuildTargetField::Packages,
+            BuildTargetField::Link,
+        ],
+        BuildTargetDslKind::Test => &[
+            BuildTargetField::Name,
+            BuildTargetField::Root,
+            BuildTargetField::RootSourceFile,
+            BuildTargetField::Dependencies,
+            BuildTargetField::Features,
+            BuildTargetField::Packages,
+            BuildTargetField::Link,
+        ],
+        BuildTargetDslKind::Library => &[
+            BuildTargetField::Name,
+            BuildTargetField::Exports,
+            BuildTargetField::Dependencies,
+            BuildTargetField::Features,
+            BuildTargetField::Packages,
+            BuildTargetField::Link,
+        ],
+    }
 }
 
 fn executable_target_from_fields(fields: &[(String, Expression)]) -> Option<BuildTargetInput> {

--- a/src/build_graph/lowering_tests.rs
+++ b/src/build_graph/lowering_tests.rs
@@ -31,6 +31,16 @@ fn build_target_field_owns_source_spelling() {
     assert_eq!(BuildTargetField::Dependencies.as_str(), "dependencies");
     assert_eq!(BuildTargetField::Features.as_str(), "features");
     assert_eq!(BuildTargetField::Exports.as_str(), "exports");
+    assert_eq!(BuildTargetField::Packages.as_str(), "packages");
+    assert_eq!(BuildTargetField::Link.as_str(), "link");
+    assert_eq!("name".parse(), Ok(BuildTargetField::Name));
+    assert_eq!(
+        "root_source_file".parse(),
+        Ok(BuildTargetField::RootSourceFile)
+    );
+    assert_eq!("packages".parse(), Ok(BuildTargetField::Packages));
+    assert_eq!("link".parse(), Ok(BuildTargetField::Link));
+    assert!("output_dir".parse::<BuildTargetField>().is_err());
     assert_eq!(
         BuildTargetField::RootSourceFile.to_string(),
         "root_source_file"

--- a/tests/build_graph.rs
+++ b/tests/build_graph.rs
@@ -246,6 +246,55 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
 }
 
 #[test]
+fn build_program_lowering_rejects_duplicate_target_fields() {
+    let program = parse_program(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        name: "tool",
+        main: "app.zen",
+        out_dir: "build/app/",
+    })
+    .Ok(b.config())
+}
+"#,
+    );
+
+    let err = BuildGraph::from_build_program(&program)
+        .expect_err("duplicate build target fields should fail");
+
+    assert_eq!(
+        err.to_string(),
+        "duplicate field `name` in `Executable` build target"
+    );
+}
+
+#[test]
+fn build_program_lowering_rejects_unknown_target_fields() {
+    let program = parse_program(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        output_dir: "build/app/",
+    })
+    .Ok(b.config())
+}
+"#,
+    );
+
+    let err = BuildGraph::from_build_program(&program)
+        .expect_err("unknown build target fields should fail");
+
+    assert_eq!(
+        err.to_string(),
+        "unknown field `output_dir` in `Executable` build target"
+    );
+}
+
+#[test]
 fn build_program_lowering_rejects_unsupported_package_targets() {
     assert_build_program_lowering_rejects_unsupported_target_kind("Package");
 }

--- a/tests/integration/cli_build/build_graph_json.rs
+++ b/tests/integration/cli_build/build_graph_json.rs
@@ -99,6 +99,44 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
 }
 
 #[test]
+fn emit_json_build_graph_rejects_unknown_target_fields() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let build_path = tmp.path().join("build.zen");
+    std::fs::write(
+        &build_path,
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        output_dir: "build/app/",
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "build-graph", build_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json build-graph");
+
+    assert!(
+        !output.status.success(),
+        "emit-json build-graph unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("unknown field `output_dir` in `Executable` build target"),
+        "expected unknown field diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn emit_json_build_graph_rejects_unknown_target_dependencies() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let build_path = tmp.path().join("build.zen");


### PR DESCRIPTION
## Summary

- Validate `build.zen` target metadata fields before constructing the deterministic build graph.
- Reject duplicate target fields and unknown target fields with direct diagnostics instead of letting malformed metadata degrade into a vague missing-target error.
- Keep canonical `packages` and `link` target metadata recognized as enum-owned DSL fields while preserving the constrained lowering semantics.
- Record the new evidence in the phase plan and completion audit.

## Why

Target field extraction used first-match lookup, so misspelled fields such as `output_dir` could be silently ignored and produce misleading downstream errors. This makes malformed target metadata fail at the DSL boundary.

## Validation

- `cargo test --test build_graph`
- `cargo test --test integration cli_build::build_graph_json`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `git diff --check`