### PR TITLE
[codex] validate required build target fields

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3057,6 +3057,13 @@ and do not assume Phase 4 is ready without evidence.
   Coverage includes `build_program_lowering_rejects_duplicate_target_fields`,
   `build_program_lowering_rejects_unknown_target_fields`, and
   `emit_json_build_graph_rejects_unknown_target_fields`.
+- Build graph target metadata extraction now validates required fields and
+  field value shapes before graph construction, so missing `out_dir` and
+  non-string string fields produce direct target-field diagnostics instead of
+  falling through to missing graph targets. Coverage includes
+  `build_program_lowering_rejects_missing_required_target_fields`,
+  `build_program_lowering_rejects_invalid_target_field_types`, and
+  `emit_json_build_graph_rejects_missing_required_target_fields`.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2781,6 +2781,11 @@ checked-in docs, tests, and commits only.
   fields before graph construction, using enum-backed field spelling and
   preserving CLI diagnostics through
   `emit_json_build_graph_rejects_unknown_target_fields`.
+- Build graph target metadata lowering now rejects missing required fields and
+  wrong field value types before graph construction, preserving direct
+  diagnostics through `build_program_lowering_rejects_missing_required_target_fields`,
+  `build_program_lowering_rejects_invalid_target_field_types`, and
+  `emit_json_build_graph_rejects_missing_required_target_fields`.
 
 ## Current Phase
 

--- a/src/build_graph/lowering/targets.rs
+++ b/src/build_graph/lowering/targets.rs
@@ -32,15 +32,15 @@ pub(super) fn build_target_from_builder_add(
     let target = match name.parse::<BuildTargetDslKind>() {
         Ok(kind @ BuildTargetDslKind::Executable) => {
             validate_target_fields(kind, fields)?;
-            executable_target_from_fields(fields)
+            Some(executable_target_from_fields(kind, fields)?)
         }
         Ok(kind @ BuildTargetDslKind::Test) => {
             validate_target_fields(kind, fields)?;
-            test_target_from_fields(fields)
+            Some(test_target_from_fields(kind, fields)?)
         }
         Ok(kind @ BuildTargetDslKind::Library) => {
             validate_target_fields(kind, fields)?;
-            library_target_from_fields(fields)
+            Some(library_target_from_fields(kind, fields)?)
         }
         Err(()) => {
             return Err(BuildGraphError::UnsupportedBuildScript(format!(
@@ -110,16 +110,24 @@ fn allowed_fields(kind: BuildTargetDslKind) -> &'static [BuildTargetField] {
     }
 }
 
-fn executable_target_from_fields(fields: &[(String, Expression)]) -> Option<BuildTargetInput> {
-    let target_name = string_field(fields, BuildTargetField::Name)?;
-    let root_source_file = string_field(fields, BuildTargetField::Main)
-        .or_else(|| string_field(fields, BuildTargetField::RootSourceFile))?;
-    let out_dir = string_field(fields, BuildTargetField::OutDir)?;
+fn executable_target_from_fields(
+    kind: BuildTargetDslKind,
+    fields: &[(String, Expression)],
+) -> Result<BuildTargetInput, BuildGraphError> {
+    let target_name = required_string_field(kind, fields, BuildTargetField::Name)?;
+    let root_source_file = required_one_of_string_fields(
+        kind,
+        fields,
+        &[BuildTargetField::Main, BuildTargetField::RootSourceFile],
+    )?;
+    let out_dir = required_string_field(kind, fields, BuildTargetField::OutDir)?;
     let dependencies =
-        string_array_field(fields, BuildTargetField::Dependencies).unwrap_or_default();
-    let features = string_array_field(fields, BuildTargetField::Features).unwrap_or_default();
+        optional_string_array_field(kind, fields, BuildTargetField::Dependencies)?
+            .unwrap_or_default();
+    let features =
+        optional_string_array_field(kind, fields, BuildTargetField::Features)?.unwrap_or_default();
 
-    Some(BuildTargetInput {
+    Ok(BuildTargetInput {
         name: target_name,
         kind: BuildTargetKind::Executable {
             root_source_file: root_source_file.clone(),
@@ -131,16 +139,24 @@ fn executable_target_from_fields(fields: &[(String, Expression)]) -> Option<Buil
     })
 }
 
-fn test_target_from_fields(fields: &[(String, Expression)]) -> Option<BuildTargetInput> {
-    let root_source_file = string_field(fields, BuildTargetField::Root)
-        .or_else(|| string_field(fields, BuildTargetField::RootSourceFile))?;
-    let target_name = string_field(fields, BuildTargetField::Name)
+fn test_target_from_fields(
+    kind: BuildTargetDslKind,
+    fields: &[(String, Expression)],
+) -> Result<BuildTargetInput, BuildGraphError> {
+    let root_source_file = required_one_of_string_fields(
+        kind,
+        fields,
+        &[BuildTargetField::Root, BuildTargetField::RootSourceFile],
+    )?;
+    let target_name = optional_string_field(kind, fields, BuildTargetField::Name)?
         .unwrap_or_else(|| target_name_from_root(&root_source_file));
     let dependencies =
-        string_array_field(fields, BuildTargetField::Dependencies).unwrap_or_default();
-    let features = string_array_field(fields, BuildTargetField::Features).unwrap_or_default();
+        optional_string_array_field(kind, fields, BuildTargetField::Dependencies)?
+            .unwrap_or_default();
+    let features =
+        optional_string_array_field(kind, fields, BuildTargetField::Features)?.unwrap_or_default();
 
-    Some(BuildTargetInput {
+    Ok(BuildTargetInput {
         name: target_name,
         kind: BuildTargetKind::Test {
             root_source_file: root_source_file.clone(),
@@ -151,17 +167,25 @@ fn test_target_from_fields(fields: &[(String, Expression)]) -> Option<BuildTarge
     })
 }
 
-fn library_target_from_fields(fields: &[(String, Expression)]) -> Option<BuildTargetInput> {
-    let target_name = string_field(fields, BuildTargetField::Name)?;
-    let exports = string_array_field(fields, BuildTargetField::Exports)?;
+fn library_target_from_fields(
+    kind: BuildTargetDslKind,
+    fields: &[(String, Expression)],
+) -> Result<BuildTargetInput, BuildGraphError> {
+    let target_name = required_string_field(kind, fields, BuildTargetField::Name)?;
+    let exports = required_string_array_field(kind, fields, BuildTargetField::Exports)?;
     let dependencies =
-        string_array_field(fields, BuildTargetField::Dependencies).unwrap_or_default();
-    let features = string_array_field(fields, BuildTargetField::Features).unwrap_or_default();
+        optional_string_array_field(kind, fields, BuildTargetField::Dependencies)?
+            .unwrap_or_default();
+    let features =
+        optional_string_array_field(kind, fields, BuildTargetField::Features)?.unwrap_or_default();
     if exports.is_empty() {
-        return None;
+        return Err(BuildGraphError::UnsupportedBuildScript(format!(
+            "field `{}` in `{kind}` build target must contain at least one source",
+            BuildTargetField::Exports
+        )));
     }
 
-    Some(BuildTargetInput {
+    Ok(BuildTargetInput {
         name: target_name,
         kind: BuildTargetKind::Library {
             exports: exports.clone(),
@@ -181,32 +205,102 @@ fn target_name_from_root(root: &str) -> String {
         .to_string()
 }
 
-fn string_field(fields: &[(String, Expression)], field_name: BuildTargetField) -> Option<String> {
-    fields.iter().find_map(|(name, value)| {
-        (name == field_name.as_str()).then(|| match value {
-            Expression::StringLiteral { value, .. } => Some(value.clone()),
-            _ => None,
-        })?
+fn required_string_field(
+    kind: BuildTargetDslKind,
+    fields: &[(String, Expression)],
+    field: BuildTargetField,
+) -> Result<String, BuildGraphError> {
+    optional_string_field(kind, fields, field)?.ok_or_else(|| {
+        BuildGraphError::UnsupportedBuildScript(format!(
+            "missing required field `{field}` in `{kind}` build target"
+        ))
     })
 }
 
-fn string_array_field(
+fn required_one_of_string_fields(
+    kind: BuildTargetDslKind,
     fields: &[(String, Expression)],
-    field_name: BuildTargetField,
-) -> Option<Vec<String>> {
-    fields.iter().find_map(|(name, value)| {
-        if name != field_name.as_str() {
-            return None;
+    options: &[BuildTargetField],
+) -> Result<String, BuildGraphError> {
+    for field in options {
+        if let Some(value) = optional_string_field(kind, fields, *field)? {
+            return Ok(value);
         }
-        let Expression::ArrayLiteral { elements, .. } = value else {
-            return None;
-        };
-        elements
-            .iter()
-            .map(|element| match element {
-                Expression::StringLiteral { value, .. } => Some(value.clone()),
-                _ => None,
-            })
-            .collect()
+    }
+    let names = options
+        .iter()
+        .map(|field| format!("`{field}`"))
+        .collect::<Vec<_>>();
+    let Some((last, rest)) = names.split_last() else {
+        return Err(BuildGraphError::UnsupportedBuildScript(format!(
+            "missing required source field in `{kind}` build target"
+        )));
+    };
+    let display = if rest.is_empty() {
+        last.clone()
+    } else {
+        format!("{} or {last}", rest.join(", "))
+    };
+    Err(BuildGraphError::UnsupportedBuildScript(format!(
+        "missing required field {display} in `{kind}` build target"
+    )))
+}
+
+fn optional_string_field(
+    kind: BuildTargetDslKind,
+    fields: &[(String, Expression)],
+    field: BuildTargetField,
+) -> Result<Option<String>, BuildGraphError> {
+    let Some(value) = field_value(fields, field) else {
+        return Ok(None);
+    };
+    match value {
+        Expression::StringLiteral { value, .. } => Ok(Some(value.clone())),
+        _ => Err(BuildGraphError::UnsupportedBuildScript(format!(
+            "field `{field}` in `{kind}` build target must be a string"
+        ))),
+    }
+}
+
+fn required_string_array_field(
+    kind: BuildTargetDslKind,
+    fields: &[(String, Expression)],
+    field: BuildTargetField,
+) -> Result<Vec<String>, BuildGraphError> {
+    optional_string_array_field(kind, fields, field)?.ok_or_else(|| {
+        BuildGraphError::UnsupportedBuildScript(format!(
+            "missing required field `{field}` in `{kind}` build target"
+        ))
     })
+}
+
+fn optional_string_array_field(
+    kind: BuildTargetDslKind,
+    fields: &[(String, Expression)],
+    field: BuildTargetField,
+) -> Result<Option<Vec<String>>, BuildGraphError> {
+    let Some(value) = field_value(fields, field) else {
+        return Ok(None);
+    };
+    let Expression::ArrayLiteral { elements, .. } = value else {
+        return Err(BuildGraphError::UnsupportedBuildScript(format!(
+            "field `{field}` in `{kind}` build target must be an array of strings"
+        )));
+    };
+    let mut values = Vec::with_capacity(elements.len());
+    for element in elements {
+        let Expression::StringLiteral { value, .. } = element else {
+            return Err(BuildGraphError::UnsupportedBuildScript(format!(
+                "field `{field}` in `{kind}` build target must be an array of strings"
+            )));
+        };
+        values.push(value.clone());
+    }
+    Ok(Some(values))
+}
+
+fn field_value(fields: &[(String, Expression)], field: BuildTargetField) -> Option<&Expression> {
+    fields
+        .iter()
+        .find_map(|(name, value)| (name == field.as_str()).then_some(value))
 }

--- a/tests/build_graph.rs
+++ b/tests/build_graph.rs
@@ -295,6 +295,53 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
 }
 
 #[test]
+fn build_program_lowering_rejects_missing_required_target_fields() {
+    let program = parse_program(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+    })
+    .Ok(b.config())
+}
+"#,
+    );
+
+    let err = BuildGraph::from_build_program(&program)
+        .expect_err("missing required build target fields should fail");
+
+    assert_eq!(
+        err.to_string(),
+        "missing required field `out_dir` in `Executable` build target"
+    );
+}
+
+#[test]
+fn build_program_lowering_rejects_invalid_target_field_types() {
+    let program = parse_program(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: 42,
+    })
+    .Ok(b.config())
+}
+"#,
+    );
+
+    let err = BuildGraph::from_build_program(&program)
+        .expect_err("invalid build target field type should fail");
+
+    assert_eq!(
+        err.to_string(),
+        "field `out_dir` in `Executable` build target must be a string"
+    );
+}
+
+#[test]
 fn build_program_lowering_rejects_unsupported_package_targets() {
     assert_build_program_lowering_rejects_unsupported_target_kind("Package");
 }

--- a/tests/integration/cli_build/build_graph_json.rs
+++ b/tests/integration/cli_build/build_graph_json.rs
@@ -137,6 +137,43 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
 }
 
 #[test]
+fn emit_json_build_graph_rejects_missing_required_target_fields() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let build_path = tmp.path().join("build.zen");
+    std::fs::write(
+        &build_path,
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "build-graph", build_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json build-graph");
+
+    assert!(
+        !output.status.success(),
+        "emit-json build-graph unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("missing required field `out_dir` in `Executable` build target"),
+        "expected missing field diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn emit_json_build_graph_rejects_unknown_target_dependencies() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let build_path = tmp.path().join("build.zen");


### PR DESCRIPTION
## Summary

Validate required build target fields and field value shapes during `build.zen` target lowering before graph construction.

## Why

Malformed target metadata was previously dropped during lowering, which let errors fall through to the vague `build graph must contain at least one target` diagnostic. This keeps the constrained `build.zen` subset explicit and gives users the target-field error directly.

## Changes

- Require executable, test, and library target fields through enum-owned build target field names.
- Reject wrong field value shapes, including non-string string fields and non-string-array list fields.
- Preserve direct CLI diagnostics for `emit-json build-graph`.
- Record the slice in the phase plan and completion audit.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`