### PR TITLE
[codex] validate transitive build graph gates

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2674,6 +2674,13 @@ and do not assume Phase 4 is ready without evidence.
   with shared dependency ordering and existing non-executed source-validation
   ordering preserved, covered by `cargo test --test integration
   library_execution_gates`.
+- Build graph execution dependency gates now validate reachable dependencies,
+  not only direct dependencies from executed targets. Graph-only libraries can
+  still be source/typechecked dependencies, but they cannot transitively pull in
+  gated test targets during build execution or gated executable targets during
+  test execution. Coverage includes
+  `build_command_build_zen_rejects_transitive_gated_test_dependencies` and
+  `test_command_build_zen_rejects_transitive_gated_executable_dependencies`.
 
 ## Unresolved Gaps
 
@@ -2690,9 +2697,9 @@ and do not assume Phase 4 is ready without evidence.
   graph-only library source validation and typechecking before build/test/emit
   execution, test and library target graph lowering/emission, single-target
   normal `zen emit build.zen`, validated library source dependencies for
-  build/test/emit graph execution, gated executable/test dependency rejection
-  for selected target kinds, library-only graph execution rejection, and
-  targeted rejection for legacy generic `emit-json build.zen` modes. Library
+  build/test/emit graph execution, direct and transitive gated executable/test
+  dependency rejection for selected target kinds, library-only graph execution
+  rejection, and targeted rejection for legacy generic `emit-json build.zen` modes. Library
   execution, package/link semantics, and other broader graph semantics still
   need explicit deterministic semantics before promotion.
 - CLI compile helpers are now split into `src/cli/compile.rs`; this is an

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2552,6 +2552,12 @@ checked-in docs, tests, and commits only.
   with shared dependency ordering and existing non-executed source-validation
   ordering preserved, covered by `cargo test --test integration
   library_execution_gates`.
+- Build graph execution dependency gates now walk reachable dependencies, so a
+  graph-only library cannot transitively pull in a gated test target during
+  `zen build build.zen` or a gated executable target during `zen test build.zen`.
+  Coverage includes
+  `build_command_build_zen_rejects_transitive_gated_test_dependencies` and
+  `test_command_build_zen_rejects_transitive_gated_executable_dependencies`.
 - CLI C emission and binary compilation helpers now live in
   `src/cli/compile.rs`, keeping the root CLI module focused on command
   dispatch, graph loading, and frontend diagnostics while preserving existing

--- a/src/cli/build_graph_execution.rs
+++ b/src/cli/build_graph_execution.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::process;
 
@@ -137,30 +137,55 @@ fn validate_executed_dependency_targets(
         .map(|target| (target.name(), target))
         .collect();
 
+    let mut validated_targets = HashSet::new();
     for target in graph
         .targets()
         .iter()
         .filter(|target| execution_kind.includes(target.kind()))
     {
-        for dependency in target.dependencies() {
-            let Some(dependency_target) = targets_by_name.get(dependency.as_str()) else {
-                continue;
-            };
-            if execution_kind.includes(dependency_target.kind())
-                || matches!(
-                    dependency_target.kind(),
-                    zen::build_graph::BuildTargetKind::Library { .. }
-                )
-            {
-                continue;
-            }
-            eprintln!(
-                "build graph target `{}` depends on gated {} target `{}`",
-                target.name(),
+        validate_reachable_dependency_targets(
+            target,
+            &targets_by_name,
+            execution_kind,
+            &mut validated_targets,
+        );
+    }
+}
+
+fn validate_reachable_dependency_targets(
+    target: &zen::build_graph::BuildTarget,
+    targets_by_name: &HashMap<&str, &zen::build_graph::BuildTarget>,
+    execution_kind: BuildGraphExecutionKind,
+    validated_targets: &mut HashSet<String>,
+) {
+    if !validated_targets.insert(target.name().to_string()) {
+        return;
+    }
+
+    for dependency in target.dependencies() {
+        let Some(dependency_target) = targets_by_name.get(dependency.as_str()) else {
+            continue;
+        };
+        if execution_kind.includes(dependency_target.kind())
+            || matches!(
                 dependency_target.kind(),
-                dependency_target.name()
+                zen::build_graph::BuildTargetKind::Library { .. }
+            )
+        {
+            validate_reachable_dependency_targets(
+                dependency_target,
+                targets_by_name,
+                execution_kind,
+                validated_targets,
             );
-            process::exit(1);
+            continue;
         }
+        eprintln!(
+            "build graph target `{}` depends on gated {} target `{}`",
+            target.name(),
+            dependency_target.kind(),
+            dependency_target.name()
+        );
+        process::exit(1);
     }
 }

--- a/tests/integration/cli_build/build_command_validation.rs
+++ b/tests/integration/cli_build/build_command_validation.rs
@@ -228,3 +228,79 @@ main = () i32 {
         "build command should not start after gated dependency validation fails"
     );
 }
+
+#[test]
+fn build_command_build_zen_rejects_transitive_gated_test_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Test { name: "unit", root: "test.zen" })
+    b.add(Library {
+        name: "core",
+        exports: ["lib.zen"],
+        dependencies: ["unit"],
+    })
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["core"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("test.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write test.zen");
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    1
+}
+"#,
+    )
+    .expect("write lib.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen build build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("build graph target `core` depends on gated test target `unit`"),
+        "expected transitive gated test dependency diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "build command should not start after transitive gated dependency validation fails"
+    );
+}

--- a/tests/integration/cli_build/graph_validation_test_command_validation.rs
+++ b/tests/integration/cli_build/graph_validation_test_command_validation.rs
@@ -320,3 +320,74 @@ main = () i32 {
         "test command should not start after gated dependency validation fails"
     );
 }
+
+#[test]
+fn test_command_build_zen_rejects_transitive_gated_executable_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    b.add(Library {
+        name: "core",
+        exports: ["lib.zen"],
+        dependencies: ["app"],
+    })
+    b.add(Test { name: "unit", root: "test.zen", dependencies: ["core"] })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    1
+}
+"#,
+    )
+    .expect("write lib.zen");
+    std::fs::write(
+        tmp.path().join("test.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write test.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["test", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen test build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen test build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("build graph target `core` depends on gated executable target `app`"),
+        "expected transitive gated executable dependency diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "test command should not start after transitive gated dependency validation fails"
+    );
+}


### PR DESCRIPTION
## Summary

Validate reachable build graph dependencies before executing build/test graph targets.

## Why

The previous gate only checked direct dependencies from executed targets. A graph-only library could transitively depend on a gated test target during build execution, or a gated executable target during test execution, and the command would proceed.

## Changes

- Walk reachable dependencies from executable/test graph roots.
- Preserve library dependencies as allowed graph-only validation targets.
- Reject transitive gated test dependencies during `zen build build.zen`.
- Reject transitive gated executable dependencies during `zen test build.zen`.
- Record the slice in the phase plan and completion audit.

## Validation

- `cargo test --test integration cli_build::build_command_validation`
- `cargo test --test integration cli_build::graph_validation_test_command_validation`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`