### PR TITLE
[codex] skip unrelated gated graph sources

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2671,7 +2671,7 @@ and do not assume Phase 4 is ready without evidence.
   threshold.
 - Build graph execution setup now shares one `BuildGraphExecutionContext`
   helper for graph loading, dependency gates, and base directory selection,
-  with shared dependency ordering and existing non-executed source-validation
+  with shared dependency ordering and existing graph-only library validation
   ordering preserved, covered by `cargo test --test integration
   library_execution_gates`.
 - Build graph execution dependency gates now validate reachable dependencies,
@@ -2681,6 +2681,15 @@ and do not assume Phase 4 is ready without evidence.
   test execution. Coverage includes
   `build_command_build_zen_rejects_transitive_gated_test_dependencies` and
   `test_command_build_zen_rejects_transitive_gated_executable_dependencies`.
+- Build/test graph execution now validates graph-only library targets without
+  validating unrelated gated executable/test target sources. Deterministic
+  host-effect validation still runs before execution can skip unrelated gated
+  target sources. Coverage includes
+  `build_command_build_zen_ignores_unrelated_gated_test_source_errors`,
+  `test_command_build_zen_ignores_unrelated_gated_executable_source_errors`,
+  `build_command_build_zen_rejects_undeclared_host_effects_before_skipping_unrelated_tests`,
+  and
+  `test_command_build_zen_rejects_undeclared_host_effects_before_skipping_unrelated_executables`.
 
 ## Unresolved Gaps
 
@@ -2698,8 +2707,10 @@ and do not assume Phase 4 is ready without evidence.
   execution, test and library target graph lowering/emission, single-target
   normal `zen emit build.zen`, validated library source dependencies for
   build/test/emit graph execution, direct and transitive gated executable/test
-  dependency rejection for selected target kinds, library-only graph execution
-  rejection, and targeted rejection for legacy generic `emit-json build.zen` modes. Library
+  dependency rejection for selected target kinds, skipped source validation for
+  unrelated gated executable/test targets during build/test execution,
+  library-only graph execution rejection, and targeted rejection for legacy
+  generic `emit-json build.zen` modes. Library
   execution, package/link semantics, and other broader graph semantics still
   need explicit deterministic semantics before promotion.
 - CLI compile helpers are now split into `src/cli/compile.rs`; this is an

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2549,7 +2549,7 @@ checked-in docs, tests, and commits only.
   growing back past the cleanup threshold.
 - Build graph execution setup now shares one `BuildGraphExecutionContext`
   helper for graph loading, dependency gates, and base directory selection,
-  with shared dependency ordering and existing non-executed source-validation
+  with shared dependency ordering and existing graph-only library validation
   ordering preserved, covered by `cargo test --test integration
   library_execution_gates`.
 - Build graph execution dependency gates now walk reachable dependencies, so a
@@ -2558,6 +2558,14 @@ checked-in docs, tests, and commits only.
   Coverage includes
   `build_command_build_zen_rejects_transitive_gated_test_dependencies` and
   `test_command_build_zen_rejects_transitive_gated_executable_dependencies`.
+- Build/test graph execution now skips unrelated gated target source validation
+  while preserving graph-only library validation and deterministic host-effect
+  ordering. Coverage includes
+  `build_command_build_zen_ignores_unrelated_gated_test_source_errors`,
+  `test_command_build_zen_ignores_unrelated_gated_executable_source_errors`,
+  `build_command_build_zen_rejects_undeclared_host_effects_before_skipping_unrelated_tests`,
+  and
+  `test_command_build_zen_rejects_undeclared_host_effects_before_skipping_unrelated_executables`.
 - CLI C emission and binary compilation helpers now live in
   `src/cli/compile.rs`, keeping the root CLI module focused on command
   dispatch, graph loading, and frontend diagnostics while preserving existing

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,11 +15,10 @@ mod usage;
 
 use build_graph_execution::{
     executable_build_targets, single_executable_build_target, test_build_targets,
-    BuildGraphExecutionKind,
 };
 use build_graph_loading::load_build_graph;
 use build_graph_sources::{
-    check_build_graph_sources, validate_build_graph_sources, validate_non_executed_target_sources,
+    check_build_graph_sources, validate_build_graph_sources, validate_graph_only_library_sources,
 };
 use build_graph_targets::{
     executable_build_target, test_build_target, BuildGraphExecutableTarget, BuildGraphTestTarget,

--- a/src/cli/build_graph_execution.rs
+++ b/src/cli/build_graph_execution.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::process;
 
 use super::{
-    executable_build_target, test_build_target, validate_non_executed_target_sources,
+    executable_build_target, test_build_target, validate_graph_only_library_sources,
     BuildGraphExecutableTarget, BuildGraphTestTarget,
 };
 
@@ -50,22 +50,14 @@ pub(super) fn single_executable_build_target(path_str: &str) -> BuildGraphExecut
         process::exit(1);
     }
 
-    validate_non_executed_target_sources(
-        &context.base_dir,
-        &context.graph,
-        BuildGraphExecutionKind::Executable,
-    );
+    validate_graph_only_library_sources(&context.base_dir, &context.graph);
     executable_build_target(&context.base_dir, executable_targets[0])
         .expect("one executable target")
 }
 
 pub(super) fn test_build_targets(path_str: &str) -> Vec<BuildGraphTestTarget> {
     let context = load_execution_context(path_str, BuildGraphExecutionKind::Test);
-    validate_non_executed_target_sources(
-        &context.base_dir,
-        &context.graph,
-        BuildGraphExecutionKind::Test,
-    );
+    validate_graph_only_library_sources(&context.base_dir, &context.graph);
     let ordered_targets = dependency_ordered_targets(&context.graph);
     let targets: Vec<_> = ordered_targets
         .into_iter()
@@ -89,11 +81,7 @@ pub(super) fn executable_build_targets(path_str: &str) -> Vec<BuildGraphExecutab
 
 fn collect_executable_build_targets(path_str: &str) -> Vec<BuildGraphExecutableTarget> {
     let context = load_execution_context(path_str, BuildGraphExecutionKind::Executable);
-    validate_non_executed_target_sources(
-        &context.base_dir,
-        &context.graph,
-        BuildGraphExecutionKind::Executable,
-    );
+    validate_graph_only_library_sources(&context.base_dir, &context.graph);
     dependency_ordered_targets(&context.graph)
         .into_iter()
         .filter_map(|target| executable_build_target(&context.base_dir, target))

--- a/src/cli/build_graph_sources.rs
+++ b/src/cli/build_graph_sources.rs
@@ -2,8 +2,6 @@ use std::collections::BTreeSet;
 use std::path::Path;
 use std::process;
 
-use super::BuildGraphExecutionKind;
-
 pub(super) fn validate_build_graph_sources(base_dir: &Path, graph: &zen::build_graph::BuildGraph) {
     for target in graph.targets() {
         for source in target.sources() {
@@ -30,17 +28,17 @@ pub(super) fn check_build_graph_sources(base_dir: &Path, graph: &zen::build_grap
     check_source_paths(source_paths);
 }
 
-pub(super) fn validate_non_executed_target_sources(
+pub(super) fn validate_graph_only_library_sources(
     base_dir: &Path,
     graph: &zen::build_graph::BuildGraph,
-    execution_kind: BuildGraphExecutionKind,
 ) {
     let mut checked_sources = BTreeSet::new();
-    for target in graph
-        .targets()
-        .iter()
-        .filter(|target| !execution_kind.includes(target.kind()))
-    {
+    for target in graph.targets().iter().filter(|target| {
+        matches!(
+            target.kind(),
+            zen::build_graph::BuildTargetKind::Library { .. }
+        )
+    }) {
         for source in target.sources() {
             let source_path = base_dir.join(source);
             if !source_path.exists() {

--- a/tests/integration/cli_build/build_command_host_effects.rs
+++ b/tests/integration/cli_build/build_command_host_effects.rs
@@ -342,3 +342,55 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
         "build should not start after graph validation fails"
     );
 }
+
+#[test]
+fn build_command_build_zen_rejects_undeclared_host_effects_before_skipping_unrelated_tests() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    std_path = b.os.env("ZEN_STD")
+    b.add(Test { name: "unit", root: "missing_test.zen" })
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen build build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("undeclared host effect: read env `ZEN_STD`"),
+        "expected undeclared host effect diagnostic, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("missing_test.zen"),
+        "host-effect validation should run before unrelated test source handling, stderr={stderr}"
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "build should not start after graph validation fails"
+    );
+}

--- a/tests/integration/cli_build/build_command_validation.rs
+++ b/tests/integration/cli_build/build_command_validation.rs
@@ -304,3 +304,45 @@ main = () i32 {
         "build command should not start after transitive gated dependency validation fails"
     );
 }
+
+#[test]
+fn build_command_build_zen_ignores_unrelated_gated_test_source_errors() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Test { name: "unit", root: "missing_test.zen" })
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build build.zen");
+
+    assert!(
+        output.status.success(),
+        "zen build build.zen failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        tmp.path().join("build").join("app").join("app").exists(),
+        "expected executable output to exist"
+    );
+}

--- a/tests/integration/cli_build/graph_validation_test_command_host_effects.rs
+++ b/tests/integration/cli_build/graph_validation_test_command_host_effects.rs
@@ -249,3 +249,55 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
         "test command should not start after graph validation fails"
     );
 }
+
+#[test]
+fn test_command_build_zen_rejects_undeclared_host_effects_before_skipping_unrelated_executables() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    std_path = b.os.env("ZEN_STD")
+    b.add(Executable { name: "app", main: "missing_app.zen", out_dir: "build/app/" })
+    b.add(Test { name: "unit", root: "test.zen" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("test.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write test.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["test", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen test build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen test build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("undeclared host effect: read env `ZEN_STD`"),
+        "expected undeclared host effect diagnostic, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("missing_app.zen"),
+        "host-effect validation should run before unrelated executable source handling, stderr={stderr}"
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "test command should not start after graph validation fails"
+    );
+}

--- a/tests/integration/cli_build/graph_validation_test_command_validation.rs
+++ b/tests/integration/cli_build/graph_validation_test_command_validation.rs
@@ -391,3 +391,50 @@ main = () i32 {
         "test command should not start after transitive gated dependency validation fails"
     );
 }
+
+#[test]
+fn test_command_build_zen_ignores_unrelated_gated_executable_source_errors() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable { name: "app", main: "missing_app.zen", out_dir: "build/app/" })
+    b.add(Test { name: "unit", root: "test.zen" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("test.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write test.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["test", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen test build.zen");
+
+    assert!(
+        output.status.success(),
+        "zen test build.zen failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        tmp.path().join("build").join("tests").join("unit").exists(),
+        "expected test output to exist"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("test unit passed"),
+        "expected test pass output, stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}


### PR DESCRIPTION
## Summary

Narrow build/test graph execution source validation to graph-only library targets and skip unrelated gated executable/test target sources.

## Why

Execution commands should validate deterministic `build.zen` lowering, dependency gates, and graph-only libraries before running selected targets. They should not fail because an unrelated gated target kind has a missing source unless that target is reachable through dependencies. Full graph source validation remains the job of `zen check build.zen`.

## Changes

- Replace non-executed target source validation with graph-only library source validation for build/test/emit execution paths.
- Keep dependency gates responsible for reachable gated executable/test targets.
- Add build/test fixtures proving unrelated gated target source errors are skipped.
- Add host-effect fixtures proving deterministic host-effect validation still runs before any skip behavior.
- Record the slice in the phase plan and completion audit.

## Validation

- `cargo test --test integration cli_build::build_command_validation`
- `cargo test --test integration cli_build::graph_validation_test_command_validation`
- `cargo test --test integration cli_build::build_command_host_effects`
- `cargo test --test integration cli_build::graph_validation_test_command_host_effects`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`