### PR TITLE
[codex] cover direct emit gated source skip

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2690,6 +2690,14 @@ and do not assume Phase 4 is ready without evidence.
   `build_command_build_zen_rejects_undeclared_host_effects_before_skipping_unrelated_tests`,
   and
   `test_command_build_zen_rejects_undeclared_host_effects_before_skipping_unrelated_executables`.
+- Direct `zen build.zen` and `zen emit build.zen` now have explicit matching
+  coverage for the same unrelated gated test source skip behavior and
+  deterministic host-effect ordering. Coverage includes
+  `direct_file_command_build_zen_ignores_unrelated_gated_test_source_errors`,
+  `emit_command_build_zen_ignores_unrelated_gated_test_source_errors`,
+  `direct_file_command_build_zen_rejects_undeclared_host_effects_before_skipping_unrelated_tests`,
+  and
+  `emit_command_build_zen_rejects_undeclared_host_effects_before_skipping_unrelated_tests`.
 
 ## Unresolved Gaps
 
@@ -2708,7 +2716,8 @@ and do not assume Phase 4 is ready without evidence.
   normal `zen emit build.zen`, validated library source dependencies for
   build/test/emit graph execution, direct and transitive gated executable/test
   dependency rejection for selected target kinds, skipped source validation for
-  unrelated gated executable/test targets during build/test execution,
+  unrelated gated executable/test targets during normal build/test execution
+  plus direct build and emit entrypoints,
   library-only graph execution rejection, and targeted rejection for legacy
   generic `emit-json build.zen` modes. Library
   execution, package/link semantics, and other broader graph semantics still

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2566,6 +2566,14 @@ checked-in docs, tests, and commits only.
   `build_command_build_zen_rejects_undeclared_host_effects_before_skipping_unrelated_tests`,
   and
   `test_command_build_zen_rejects_undeclared_host_effects_before_skipping_unrelated_executables`.
+- Direct `zen build.zen` and `zen emit build.zen` now have matching coverage for
+  skipping unrelated gated test source validation while preserving deterministic
+  host-effect ordering. Coverage includes
+  `direct_file_command_build_zen_ignores_unrelated_gated_test_source_errors`,
+  `emit_command_build_zen_ignores_unrelated_gated_test_source_errors`,
+  `direct_file_command_build_zen_rejects_undeclared_host_effects_before_skipping_unrelated_tests`,
+  and
+  `emit_command_build_zen_rejects_undeclared_host_effects_before_skipping_unrelated_tests`.
 - CLI C emission and binary compilation helpers now live in
   `src/cli/compile.rs`, keeping the root CLI module focused on command
   dispatch, graph loading, and frontend diagnostics while preserving existing

--- a/tests/integration/cli_build/direct_build_graph_host_effects.rs
+++ b/tests/integration/cli_build/direct_build_graph_host_effects.rs
@@ -228,3 +228,55 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
         "direct build.zen command should not start after graph validation fails"
     );
 }
+
+#[test]
+fn direct_file_command_build_zen_rejects_undeclared_host_effects_before_skipping_unrelated_tests() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    std_path = b.os.env("ZEN_STD")
+    b.add(Test { name: "unit", root: "missing_test.zen" })
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .arg("build.zen")
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("undeclared host effect: read env `ZEN_STD`"),
+        "expected undeclared host effect diagnostic, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("missing_test.zen"),
+        "host-effect validation should run before unrelated test source handling, stderr={stderr}"
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "direct build.zen command should not start after graph validation fails"
+    );
+}

--- a/tests/integration/cli_build/direct_build_graph_validation.rs
+++ b/tests/integration/cli_build/direct_build_graph_validation.rs
@@ -320,3 +320,45 @@ main = () i32 {
         "direct build.zen command should not start after gated dependency validation fails"
     );
 }
+
+#[test]
+fn direct_file_command_build_zen_ignores_unrelated_gated_test_source_errors() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Test { name: "unit", root: "missing_test.zen" })
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .arg("build.zen")
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build.zen");
+
+    assert!(
+        output.status.success(),
+        "zen build.zen failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        tmp.path().join("build").join("app").join("app").exists(),
+        "expected executable output to exist"
+    );
+}

--- a/tests/integration/cli_build/emit_direct_host_effects.rs
+++ b/tests/integration/cli_build/emit_direct_host_effects.rs
@@ -186,3 +186,56 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
         String::from_utf8_lossy(&output.stdout)
     );
 }
+
+#[test]
+fn emit_command_build_zen_rejects_undeclared_host_effects_before_skipping_unrelated_tests() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    std_path = b.os.env("ZEN_STD")
+    b.add(Test { name: "unit", root: "missing_test.zen" })
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen emit build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen emit build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("undeclared host effect: read env `ZEN_STD`"),
+        "expected undeclared host effect diagnostic, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("missing_test.zen"),
+        "host-effect validation should run before unrelated test source handling, stderr={stderr}"
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "emit should not write C source after graph validation fails, stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}

--- a/tests/integration/cli_build/emit_direct_validation.rs
+++ b/tests/integration/cli_build/emit_direct_validation.rs
@@ -229,3 +229,50 @@ main = () i32 {
         "zen emit build.zen should not create build outputs for a test-only graph"
     );
 }
+
+#[test]
+fn emit_command_build_zen_ignores_unrelated_gated_test_source_errors() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Test { name: "unit", root: "missing_test.zen" })
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen emit build.zen");
+
+    assert!(
+        output.status.success(),
+        "zen emit build.zen failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let c_source = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        c_source.contains("int32_t zen_main(void)"),
+        "expected target C source, stdout={c_source}"
+    );
+    assert!(
+        !tmp.path().join("build").join("app").exists(),
+        "zen emit build.zen should not compile the target binary"
+    );
+}


### PR DESCRIPTION
## Summary

Add direct `zen build.zen` and `zen emit build.zen` coverage for skipping unrelated gated test target source validation while preserving deterministic host-effect ordering.

## Why

PR #340 narrowed execution-time source validation to graph-only libraries. Normal build/test had explicit fixtures, but the direct build alias and emit path share the same execution helper and needed matching coverage.

## Changes

- Add direct `zen build.zen` positive fixture for ignoring unrelated gated test source errors.
- Add direct host-effect negative fixture proving host-effect validation runs before unrelated target skipping.
- Add `zen emit build.zen` positive fixture for the same source-skip behavior.
- Add emit host-effect negative fixture for the same ordering guard.
- Record coverage in the phase plan and completion audit.

## Validation

- `cargo test --test integration cli_build::direct_build_graph_validation`
- `cargo test --test integration cli_build::direct_build_graph_host_effects`
- `cargo test --test integration cli_build::emit_direct_validation`
- `cargo test --test integration cli_build::emit_direct_host_effects`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`