### PR TITLE
[codex] cover legacy gated source skip

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2698,6 +2698,11 @@ and do not assume Phase 4 is ready without evidence.
   `direct_file_command_build_zen_rejects_undeclared_host_effects_before_skipping_unrelated_tests`,
   and
   `emit_command_build_zen_rejects_undeclared_host_effects_before_skipping_unrelated_tests`.
+- Legacy `zen build-graph build.zen` now has explicit matching coverage for the
+  same unrelated gated test source skip behavior and deterministic host-effect
+  ordering. Coverage includes
+  `build_graph_command_ignores_unrelated_gated_test_source_errors` and
+  `build_graph_command_rejects_undeclared_host_effects_before_skipping_unrelated_tests`.
 
 ## Unresolved Gaps
 
@@ -2717,7 +2722,7 @@ and do not assume Phase 4 is ready without evidence.
   build/test/emit graph execution, direct and transitive gated executable/test
   dependency rejection for selected target kinds, skipped source validation for
   unrelated gated executable/test targets during normal build/test execution
-  plus direct build and emit entrypoints,
+  plus direct build, legacy build-graph, and emit entrypoints,
   library-only graph execution rejection, and targeted rejection for legacy
   generic `emit-json build.zen` modes. Library
   execution, package/link semantics, and other broader graph semantics still

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2574,6 +2574,11 @@ checked-in docs, tests, and commits only.
   `direct_file_command_build_zen_rejects_undeclared_host_effects_before_skipping_unrelated_tests`,
   and
   `emit_command_build_zen_rejects_undeclared_host_effects_before_skipping_unrelated_tests`.
+- Legacy `zen build-graph build.zen` now has matching coverage for skipping
+  unrelated gated test source validation while preserving deterministic
+  host-effect ordering. Coverage includes
+  `build_graph_command_ignores_unrelated_gated_test_source_errors` and
+  `build_graph_command_rejects_undeclared_host_effects_before_skipping_unrelated_tests`.
 - CLI C emission and binary compilation helpers now live in
   `src/cli/compile.rs`, keeping the root CLI module focused on command
   dispatch, graph loading, and frontend diagnostics while preserving existing

--- a/tests/integration/cli_build/legacy_graph_command_host_effects.rs
+++ b/tests/integration/cli_build/legacy_graph_command_host_effects.rs
@@ -150,6 +150,58 @@ value = () i32 {
 }
 
 #[test]
+fn build_graph_command_rejects_undeclared_host_effects_before_skipping_unrelated_tests() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    std_path = b.os.env("ZEN_STD")
+    b.add(Test { name: "unit", root: "missing_test.zen" })
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build-graph", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build-graph");
+
+    assert!(
+        !output.status.success(),
+        "zen build-graph unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("undeclared host effect: read env `ZEN_STD`"),
+        "expected undeclared host effect diagnostic, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("missing_test.zen"),
+        "host-effect validation should run before unrelated test source handling, stderr={stderr}"
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "build-graph command should not start after graph validation fails"
+    );
+}
+
+#[test]
 fn build_graph_command_accepts_declared_file_read_effects() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(

--- a/tests/integration/cli_build/legacy_graph_command_validation.rs
+++ b/tests/integration/cli_build/legacy_graph_command_validation.rs
@@ -116,6 +116,48 @@ fn build_graph_command_rejects_gated_test_dependencies() {
     );
 }
 
+#[test]
+fn build_graph_command_ignores_unrelated_gated_test_source_errors() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Test { name: "unit", root: "missing_test.zen" })
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build-graph", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build-graph");
+
+    assert!(
+        output.status.success(),
+        "zen build-graph failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        tmp.path().join("build").join("app").join("app").exists(),
+        "expected executable output to exist"
+    );
+}
+
 fn assert_build_graph_rejects_gated_dependency(
     gated_target_decl: &str,
     gated_target_name: &str,


### PR DESCRIPTION
## Summary

Add legacy `zen build-graph build.zen` coverage for skipping unrelated gated test target source validation while preserving deterministic host-effect ordering.

## Why

The narrowed graph execution source-validation behavior is shared by normal build, direct build, emit, and legacy build-graph. The legacy command needed explicit positive and negative fixtures to keep that contract pinned.

## Changes

- Add legacy build-graph positive fixture for ignoring unrelated gated test source errors.
- Add legacy host-effect negative fixture proving host-effect validation runs before unrelated target skipping.
- Record coverage in the phase plan and completion audit.

## Validation

- `cargo test --test integration cli_build::legacy_graph_command_validation`
- `cargo test --test integration cli_build::legacy_graph_command_host_effects`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`