### PR TITLE
[codex] cover transitive gated entrypoints

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2681,6 +2681,13 @@ and do not assume Phase 4 is ready without evidence.
   test execution. Coverage includes
   `build_command_build_zen_rejects_transitive_gated_test_dependencies` and
   `test_command_build_zen_rejects_transitive_gated_executable_dependencies`.
+- Direct `zen build.zen`, legacy `zen build-graph build.zen`, and
+  `zen emit build.zen` now have explicit matching coverage for rejecting
+  transitive gated test dependencies pulled through graph-only libraries.
+  Coverage includes
+  `direct_file_command_build_zen_rejects_transitive_gated_test_dependencies`,
+  `build_graph_command_rejects_transitive_gated_test_dependencies`, and
+  `emit_command_build_zen_rejects_transitive_gated_test_dependencies`.
 - Build/test graph execution now validates graph-only library targets without
   validating unrelated gated executable/test target sources. Deterministic
   host-effect validation still runs before execution can skip unrelated gated

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2558,6 +2558,12 @@ checked-in docs, tests, and commits only.
   Coverage includes
   `build_command_build_zen_rejects_transitive_gated_test_dependencies` and
   `test_command_build_zen_rejects_transitive_gated_executable_dependencies`.
+- Direct `zen build.zen`, legacy `zen build-graph build.zen`, and
+  `zen emit build.zen` now have matching coverage for rejecting transitive gated
+  test dependencies pulled through graph-only libraries. Coverage includes
+  `direct_file_command_build_zen_rejects_transitive_gated_test_dependencies`,
+  `build_graph_command_rejects_transitive_gated_test_dependencies`, and
+  `emit_command_build_zen_rejects_transitive_gated_test_dependencies`.
 - Build/test graph execution now skips unrelated gated target source validation
   while preserving graph-only library validation and deterministic host-effect
   ordering. Coverage includes

--- a/tests/integration/cli_build/direct_build_graph_validation.rs
+++ b/tests/integration/cli_build/direct_build_graph_validation.rs
@@ -322,6 +322,82 @@ main = () i32 {
 }
 
 #[test]
+fn direct_file_command_build_zen_rejects_transitive_gated_test_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Test { name: "unit", root: "test.zen" })
+    b.add(Library {
+        name: "core",
+        exports: ["lib.zen"],
+        dependencies: ["unit"],
+    })
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["core"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("test.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write test.zen");
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    1
+}
+"#,
+    )
+    .expect("write lib.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .arg("build.zen")
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("build graph target `core` depends on gated test target `unit`"),
+        "expected transitive gated test dependency diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "direct build.zen command should not start after transitive gated dependency validation fails"
+    );
+}
+
+#[test]
 fn direct_file_command_build_zen_ignores_unrelated_gated_test_source_errors() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(

--- a/tests/integration/cli_build/emit_direct_validation/gated_dependencies.rs
+++ b/tests/integration/cli_build/emit_direct_validation/gated_dependencies.rs
@@ -10,6 +10,82 @@ fn emit_command_build_zen_rejects_gated_test_dependencies() {
     );
 }
 
+#[test]
+fn emit_command_build_zen_rejects_transitive_gated_test_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Test { name: "unit", root: "test.zen" })
+    b.add(Library {
+        name: "core",
+        exports: ["lib.zen"],
+        dependencies: ["unit"],
+    })
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["core"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("test.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write test.zen");
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    1
+}
+"#,
+    )
+    .expect("write lib.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen emit build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen emit build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("build graph target `core` depends on gated test target `unit`"),
+        "expected transitive gated test dependency diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "zen emit build.zen should not create build outputs after transitive gated dependency validation fails"
+    );
+}
+
 fn assert_emit_rejects_gated_dependency(
     gated_target_decl: &str,
     gated_target_name: &str,

--- a/tests/integration/cli_build/legacy_graph_command_validation.rs
+++ b/tests/integration/cli_build/legacy_graph_command_validation.rs
@@ -117,6 +117,82 @@ fn build_graph_command_rejects_gated_test_dependencies() {
 }
 
 #[test]
+fn build_graph_command_rejects_transitive_gated_test_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Test { name: "unit", root: "test.zen" })
+    b.add(Library {
+        name: "core",
+        exports: ["lib.zen"],
+        dependencies: ["unit"],
+    })
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["core"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("test.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write test.zen");
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    1
+}
+"#,
+    )
+    .expect("write lib.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build-graph", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build-graph");
+
+    assert!(
+        !output.status.success(),
+        "zen build-graph unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("build graph target `core` depends on gated test target `unit`"),
+        "expected transitive gated test dependency diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "build-graph command should not start after transitive gated dependency validation fails"
+    );
+}
+
+#[test]
 fn build_graph_command_ignores_unrelated_gated_test_source_errors() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(


### PR DESCRIPTION
## Summary

Adds matching coverage for transitive gated test dependencies across the remaining build graph entrypoints:

- direct `zen build.zen`
- legacy `zen build-graph build.zen`
- direct `zen emit build.zen`

Each test verifies that an executable depending on a graph-only library which depends on a test target is rejected before build outputs are created. The phase plan and completion audit now record the coverage.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`