### PR TITLE
[codex] share gated cli test fixtures

### DIFF
--- a/tests/integration/cli_build.rs
+++ b/tests/integration/cli_build.rs
@@ -50,5 +50,7 @@ mod legacy_graph_command_host_effects;
 mod legacy_graph_command_validation;
 #[path = "cli_build/library_execution_gates.rs"]
 mod library_execution_gates;
+#[path = "cli_build/support.rs"]
+mod support;
 #[path = "cli_build/unsupported_targets.rs"]
 mod unsupported_targets;

--- a/tests/integration/cli_build/direct_build_graph_validation.rs
+++ b/tests/integration/cli_build/direct_build_graph_validation.rs
@@ -323,55 +323,7 @@ main = () i32 {
 
 #[test]
 fn direct_file_command_build_zen_rejects_transitive_gated_test_dependencies() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Test { name: "unit", root: "test.zen" })
-    b.add(Library {
-        name: "core",
-        exports: ["lib.zen"],
-        dependencies: ["unit"],
-    })
-    b.add(Executable {
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        dependencies: ["core"],
-    })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-    std::fs::write(
-        tmp.path().join("test.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write test.zen");
-    std::fs::write(
-        tmp.path().join("lib.zen"),
-        r#"
-value = () i32 {
-    1
-}
-"#,
-    )
-    .expect("write lib.zen");
-    std::fs::write(
-        tmp.path().join("app.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write app.zen");
+    let tmp = super::support::transitive_gated_test_dependency_graph();
 
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
         .arg("build.zen")

--- a/tests/integration/cli_build/emit_direct_validation/gated_dependencies.rs
+++ b/tests/integration/cli_build/emit_direct_validation/gated_dependencies.rs
@@ -12,55 +12,7 @@ fn emit_command_build_zen_rejects_gated_test_dependencies() {
 
 #[test]
 fn emit_command_build_zen_rejects_transitive_gated_test_dependencies() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Test { name: "unit", root: "test.zen" })
-    b.add(Library {
-        name: "core",
-        exports: ["lib.zen"],
-        dependencies: ["unit"],
-    })
-    b.add(Executable {
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        dependencies: ["core"],
-    })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-    std::fs::write(
-        tmp.path().join("test.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write test.zen");
-    std::fs::write(
-        tmp.path().join("lib.zen"),
-        r#"
-value = () i32 {
-    1
-}
-"#,
-    )
-    .expect("write lib.zen");
-    std::fs::write(
-        tmp.path().join("app.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write app.zen");
+    let tmp = super::super::support::transitive_gated_test_dependency_graph();
 
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
         .args(["emit", "build.zen"])

--- a/tests/integration/cli_build/legacy_graph_command_validation.rs
+++ b/tests/integration/cli_build/legacy_graph_command_validation.rs
@@ -118,55 +118,7 @@ fn build_graph_command_rejects_gated_test_dependencies() {
 
 #[test]
 fn build_graph_command_rejects_transitive_gated_test_dependencies() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Test { name: "unit", root: "test.zen" })
-    b.add(Library {
-        name: "core",
-        exports: ["lib.zen"],
-        dependencies: ["unit"],
-    })
-    b.add(Executable {
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        dependencies: ["core"],
-    })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-    std::fs::write(
-        tmp.path().join("test.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write test.zen");
-    std::fs::write(
-        tmp.path().join("lib.zen"),
-        r#"
-value = () i32 {
-    1
-}
-"#,
-    )
-    .expect("write lib.zen");
-    std::fs::write(
-        tmp.path().join("app.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write app.zen");
+    let tmp = super::support::transitive_gated_test_dependency_graph();
 
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
         .args(["build-graph", "build.zen"])

--- a/tests/integration/cli_build/support.rs
+++ b/tests/integration/cli_build/support.rs
@@ -1,0 +1,52 @@
+pub(super) fn transitive_gated_test_dependency_graph() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Test { name: "unit", root: "test.zen" })
+    b.add(Library {
+        name: "core",
+        exports: ["lib.zen"],
+        dependencies: ["unit"],
+    })
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["core"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("test.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write test.zen");
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    1
+}
+"#,
+    )
+    .expect("write lib.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+    tmp
+}


### PR DESCRIPTION
## Summary

Deduplicates the transitive gated dependency integration fixture used by the direct `build.zen`, legacy `build-graph`, and direct `emit build.zen` entrypoint tests.

The individual tests still assert their own CLI command behavior and diagnostics, but the repeated four-file build graph fixture now lives in shared CLI integration-test support.

## Validation

- `cargo test --test integration transitive_gated_test_dependencies`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`