### PR TITLE
[codex] route type declaration keywords through enum

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2844,6 +2844,11 @@ and do not assume Phase 4 is ready without evidence.
   `typechecker::tests::core_semantics::literals::range_expression_is_rejected_until_range_type_exists`,
   so parser-accepted range syntax no longer succeeds with an unknown typed
   placeholder before range semantics exist.
+- Type declaration suffix parsing now uses enum-backed `impl`/`implements`/
+  `requires`/`extends` spellings, keeping parser dispatch and diagnostics off
+  ad hoc string comparisons. Coverage:
+  `parser::tests::behaviors::type_declaration_keyword_owns_text_spelling` and
+  `repo_hygiene::parser_type_declaration_suffixes_use_owned_keyword_enum`.
 - Dead char-literal AST support has been removed because no lexer/parser
   surface produces it. The cleanup removes the stale typechecker `Unknown`
   fallback and is guarded by

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2128,6 +2128,11 @@ checked-in docs, tests, and commits only.
 - Prefix loop syntax now accepts `loop((l) { ... })` with enum-backed
   `done`/`next` control actions, including nested outer-loop exits and UFC
   `done(l)` / `next(l)` forms, with fixture and docs coverage.
+- Type declaration suffix parsing now uses enum-backed `impl`/`implements`/
+  `requires`/`extends` spellings, keeping parser dispatch and diagnostics off
+  ad hoc string comparisons. Coverage:
+  `parser::tests::behaviors::type_declaration_keyword_owns_text_spelling` and
+  `repo_hygiene::parser_type_declaration_suffixes_use_owned_keyword_enum`.
 - Resolver-backed type behavior refresh now receives the full resolver
   declaration metadata task bundle and selects type declarations internally,
   keeping the final replay step aligned with the bundled call sites.

--- a/src/ast/declarations.rs
+++ b/src/ast/declarations.rs
@@ -2,6 +2,56 @@ use crate::ast::expressions::Expression;
 use crate::ast::types::{AstType, Param};
 use crate::error::Span;
 use serde::Serialize;
+use std::fmt;
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum TypeDeclarationKeyword {
+    Impl,
+    Implements,
+    Requires,
+    Extends,
+}
+
+impl TypeDeclarationKeyword {
+    pub const IMPL: &'static str = "impl";
+    pub const IMPLEMENTS: &'static str = "implements";
+    pub const REQUIRES: &'static str = "requires";
+    pub const EXTENDS: &'static str = "extends";
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Impl => Self::IMPL,
+            Self::Implements => Self::IMPLEMENTS,
+            Self::Requires => Self::REQUIRES,
+            Self::Extends => Self::EXTENDS,
+        }
+    }
+}
+
+impl fmt::Display for TypeDeclarationKeyword {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for TypeDeclarationKeyword {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value == Self::Impl.as_str() {
+            Ok(Self::Impl)
+        } else if value == Self::Implements.as_str() {
+            Ok(Self::Implements)
+        } else if value == Self::Requires.as_str() {
+            Ok(Self::Requires)
+        } else if value == Self::Extends.as_str() {
+            Ok(Self::Extends)
+        } else {
+            Err(())
+        }
+    }
+}
 
 /// A field in a struct definition.
 #[derive(Debug, Clone, PartialEq, Serialize)]

--- a/src/parser/declarations.rs
+++ b/src/parser/declarations.rs
@@ -52,10 +52,16 @@ impl Parser {
                         let (method_name, _method_span) = self.expect_identifier()?;
                         self.skip_newlines();
 
-                        if matches!(method_name.as_str(), "implements" | "requires" | "extends") {
+                        if let Ok(keyword) = method_name.parse::<TypeDeclarationKeyword>() {
+                            if matches!(keyword, TypeDeclarationKeyword::Impl) {
+                                return Err(CompileError::Syntax(
+                                    "generic impl blocks are not implemented".to_string(),
+                                    Some(self.peek_span()),
+                                ));
+                            }
                             return Err(CompileError::Syntax(
                                 format!(
-                                    "gated v1 feature '{method_name}': type association and behavior constraints are specified in docs/V1_SPEC.md but are not implemented"
+                                    "gated v1 feature '{keyword}': type association and behavior constraints are specified in docs/V1_SPEC.md but are not implemented"
                                 ),
                                 Some(self.peek_span()),
                             ));
@@ -106,21 +112,19 @@ impl Parser {
                 let (method_name, _method_span) = self.expect_identifier()?;
                 self.skip_newlines();
 
-                if method_name == "implements" {
-                    return self.parse_behavior_impl_block(name, name_span);
-                }
-
-                if method_name == "requires" {
-                    return self.parse_behavior_requires(name, name_span);
-                }
-
-                if method_name == "extends" {
-                    return self.parse_behavior_extends(name, name_span);
-                }
-
-                // Type.impl = { methods }
-                if method_name == "impl" {
-                    return self.parse_impl_block(name, name_span);
+                if let Ok(keyword) = method_name.parse::<TypeDeclarationKeyword>() {
+                    return match keyword {
+                        TypeDeclarationKeyword::Impl => self.parse_impl_block(name, name_span),
+                        TypeDeclarationKeyword::Implements => {
+                            self.parse_behavior_impl_block(name, name_span)
+                        }
+                        TypeDeclarationKeyword::Requires => {
+                            self.parse_behavior_requires(name, name_span)
+                        }
+                        TypeDeclarationKeyword::Extends => {
+                            self.parse_behavior_extends(name, name_span)
+                        }
+                    };
                 }
 
                 // Type.method<T> = (params) ret { body }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,4 +1,6 @@
-use crate::ast::declarations::{Declaration, EnumVariant, StructField, TypeParam};
+use crate::ast::declarations::{
+    Declaration, EnumVariant, StructField, TypeDeclarationKeyword, TypeParam,
+};
 use crate::ast::expressions::{
     BinaryOp, Expression, LoopControlAction, MatchArm, StringPart, UnaryOp,
 };

--- a/src/parser/tests/behaviors.rs
+++ b/src/parser/tests/behaviors.rs
@@ -1,4 +1,31 @@
 use super::*;
+use crate::ast::declarations::TypeDeclarationKeyword;
+
+#[test]
+fn type_declaration_keyword_owns_text_spelling() {
+    assert_eq!(TypeDeclarationKeyword::Impl.as_str(), "impl");
+    assert_eq!(TypeDeclarationKeyword::Implements.as_str(), "implements");
+    assert_eq!(TypeDeclarationKeyword::Requires.as_str(), "requires");
+    assert_eq!(TypeDeclarationKeyword::Extends.as_str(), "extends");
+    assert_eq!(
+        "impl".parse::<TypeDeclarationKeyword>(),
+        Ok(TypeDeclarationKeyword::Impl)
+    );
+    assert_eq!(
+        "implements".parse::<TypeDeclarationKeyword>(),
+        Ok(TypeDeclarationKeyword::Implements)
+    );
+    assert_eq!(
+        "requires".parse::<TypeDeclarationKeyword>(),
+        Ok(TypeDeclarationKeyword::Requires)
+    );
+    assert_eq!(
+        "extends".parse::<TypeDeclarationKeyword>(),
+        Ok(TypeDeclarationKeyword::Extends)
+    );
+    assert!("implement".parse::<TypeDeclarationKeyword>().is_err());
+    assert_eq!(TypeDeclarationKeyword::Implements.to_string(), "implements");
+}
 
 #[test]
 fn parse_behavior_requires_assertion() {

--- a/tests/docs_truth/phase_audit.rs
+++ b/tests/docs_truth/phase_audit.rs
@@ -41,6 +41,7 @@ fn phase_plan_records_recovered_progress_and_next_slice() {
         "build_program_lowering_rejects_undeclared_env_reads",
         "production_rust_files_stay_below_cleanup_threshold",
         "source_ast_does_not_carry_dead_char_literal_nodes",
+        "parser_type_declaration_suffixes_use_owned_keyword_enum",
         "every tracked Rust source file",
         "BuildGraphExecutionContext",
         "emit_json_build_graph_outputs_project_build_graph",
@@ -149,6 +150,7 @@ fn phase_plan_records_recovered_progress_and_next_slice() {
         "behavior_extends_nongeneric_parent_type_args_are_error",
         "generic_bound_nongeneric_behavior_type_args_are_error",
         "generic_enum_constructor_without_type_args_is_error",
+        "type_declaration_keyword_owns_text_spelling",
     ] {
         assert!(
             plan.contains(required),
@@ -234,6 +236,7 @@ fn completion_audit_records_recovery_objective_evidence_and_gaps() {
         "build_program_lowering_accepts_declared_env_reads",
         "production_rust_files_stay_below_cleanup_threshold",
         "source_ast_does_not_carry_dead_char_literal_nodes",
+        "parser_type_declaration_suffixes_use_owned_keyword_enum",
         "every tracked Rust source file",
         "BuildGraphExecutionContext",
         "emit_json_build_graph_outputs_library_target",

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -116,6 +116,28 @@ fn source_ast_does_not_carry_dead_char_literal_nodes() {
 }
 
 #[test]
+fn parser_type_declaration_suffixes_use_owned_keyword_enum() {
+    let source = read("src/parser/declarations.rs");
+
+    for forbidden in [
+        r#"method_name == "impl""#,
+        r#"method_name == "implements""#,
+        r#"method_name == "requires""#,
+        r#"method_name == "extends""#,
+        r#"matches!(method_name.as_str(), "implements" | "requires" | "extends")"#,
+    ] {
+        assert!(
+            !source.contains(forbidden),
+            "parser type declaration suffix dispatch should use TypeDeclarationKeyword, not raw spelling checks: {forbidden}"
+        );
+    }
+    assert!(
+        source.contains("TypeDeclarationKeyword"),
+        "parser type declaration suffix dispatch should use TypeDeclarationKeyword"
+    );
+}
+
+#[test]
 fn ci_and_release_only_advertise_existing_targets() {
     let ci = read(".github/workflows/ci.yml");
     let release = read(".github/workflows/release.yml");


### PR DESCRIPTION
## Summary

- Adds `TypeDeclarationKeyword` for `impl`, `implements`, `requires`, and `extends` suffix spellings.
- Routes parser declaration dispatch and gated diagnostics through the enum instead of raw string comparisons.
- Adds parser and docs-truth hygiene coverage plus phase/audit notes.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`