### PR TITLE
[codex] split test command host effect fixtures

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -293,6 +293,11 @@ and do not assume Phase 4 is ready without evidence.
   `tests/integration/cli_build/direct_build_graph_validation/graph_only_libraries.rs`,
   leaving executable target and gated test dependency validation in the parent
   module.
+- Test-command build graph host-effect integration tests now split declared
+  file-read fallback accept/reject coverage into
+  `tests/integration/cli_build/graph_validation_test_command_host_effects/file_reads.rs`,
+  leaving env-effect ordering and unrelated executable skip coverage in the
+  parent module.
 - Resolver-backed behavior impl metadata now builds restored impl-block tasks
   once and reuses them for both impl method signature restoration and omitted
   default-method synthesis, preserving the signature-before-defaults ordering.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -473,6 +473,9 @@ checked-in docs, tests, and commits only.
 - Direct `zen build.zen` validation tests now keep graph-only library source
   and typecheck cases in a focused child module, separating them from
   executable target and gated test dependency validation.
+- Test-command build graph host-effect tests now keep declared file-read
+  fallback accept/reject cases in a focused child module, leaving env-effect
+  ordering and unrelated executable skip coverage in the parent module.
 - Resolver-backed behavior impl metadata now builds restored impl-block tasks
   once and reuses them for both impl method signature restoration and omitted
   default-method synthesis. Impl-block declaration collection now also uses a

--- a/tests/integration/cli_build/graph_validation_test_command_host_effects.rs
+++ b/tests/integration/cli_build/graph_validation_test_command_host_effects.rs
@@ -1,5 +1,8 @@
 use std::process::Command;
 
+#[path = "graph_validation_test_command_host_effects/file_reads.rs"]
+mod file_reads;
+
 #[test]
 fn test_command_build_zen_rejects_undeclared_host_effects() {
     let tmp = tempfile::tempdir().expect("create temp dir");
@@ -151,123 +154,6 @@ value = () i32 {
     assert!(
         !stderr.contains("return type mismatch"),
         "host-effect validation should run before graph-only library typechecking, stderr={stderr}"
-    );
-    assert!(
-        !tmp.path().join("build").exists(),
-        "test command should not start after graph validation fails"
-    );
-}
-
-#[test]
-fn test_command_build_zen_accepts_declared_file_read_effects() {
-    assert_test_command_accepts_declared_file_read_effect(
-        r#"| .Err { "default" }"#,
-        "test_command_build_zen_accepts_declared_file_read_effects",
-    );
-}
-
-#[test]
-fn test_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects() {
-    assert_test_command_accepts_declared_file_read_effect(
-        r#"| _ { "default" }"#,
-        "test_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects",
-    );
-}
-
-#[test]
-fn test_command_build_zen_accepts_identifier_fallback_declared_file_read_effects() {
-    assert_test_command_accepts_declared_file_read_effect(
-        r#"| err { "default" }"#,
-        "test_command_build_zen_accepts_identifier_fallback_declared_file_read_effects",
-    );
-}
-
-fn assert_test_command_accepts_declared_file_read_effect(fallback_arm: &str, case_name: &str) {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        format!(
-            r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {{
-    manifest = b.os.read_file("test.targets") ?
-        | .Ok(contents) {{ contents }}
-        {fallback_arm}
-    b.add(Test {{ name: "unit", root: "test.zen" }})
-    .Ok(b.config())
-}}
-"#,
-        ),
-    )
-    .expect("write build.zen");
-    std::fs::write(tmp.path().join("test.targets"), "unit\n").expect("write manifest");
-    std::fs::write(
-        tmp.path().join("test.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write test.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["test", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen test build.zen");
-
-    assert!(
-        output.status.success(),
-        "{case_name}: zen test build.zen failed: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let bin_path = tmp.path().join("build").join("tests").join("unit");
-    assert!(
-        bin_path.exists(),
-        "expected {} to exist",
-        bin_path.display()
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stdout).contains("test unit passed"),
-        "{case_name}: expected test pass output, stdout={}",
-        String::from_utf8_lossy(&output.stdout)
-    );
-}
-
-#[test]
-fn test_command_build_zen_rejects_undeclared_file_read_effects_before_execution() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    manifest = b.os.read_file("test.targets")
-    b.add(Test { name: "unit", root: "test.zen" })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["test", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen test build.zen");
-
-    assert!(
-        !output.status.success(),
-        "zen test build.zen unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("undeclared host effect: read file `test.targets`"),
-        "expected undeclared file read diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
     );
     assert!(
         !tmp.path().join("build").exists(),

--- a/tests/integration/cli_build/graph_validation_test_command_host_effects/file_reads.rs
+++ b/tests/integration/cli_build/graph_validation_test_command_host_effects/file_reads.rs
@@ -1,0 +1,118 @@
+use std::process::Command;
+
+#[test]
+fn test_command_build_zen_accepts_declared_file_read_effects() {
+    assert_test_command_accepts_declared_file_read_effect(
+        r#"| .Err { "default" }"#,
+        "test_command_build_zen_accepts_declared_file_read_effects",
+    );
+}
+
+#[test]
+fn test_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects() {
+    assert_test_command_accepts_declared_file_read_effect(
+        r#"| _ { "default" }"#,
+        "test_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects",
+    );
+}
+
+#[test]
+fn test_command_build_zen_accepts_identifier_fallback_declared_file_read_effects() {
+    assert_test_command_accepts_declared_file_read_effect(
+        r#"| err { "default" }"#,
+        "test_command_build_zen_accepts_identifier_fallback_declared_file_read_effects",
+    );
+}
+
+fn assert_test_command_accepts_declared_file_read_effect(fallback_arm: &str, case_name: &str) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
+    manifest = b.os.read_file("test.targets") ?
+        | .Ok(contents) {{ contents }}
+        {fallback_arm}
+    b.add(Test {{ name: "unit", root: "test.zen" }})
+    .Ok(b.config())
+}}
+"#,
+        ),
+    )
+    .expect("write build.zen");
+    std::fs::write(tmp.path().join("test.targets"), "unit\n").expect("write manifest");
+    std::fs::write(
+        tmp.path().join("test.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write test.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["test", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen test build.zen");
+
+    assert!(
+        output.status.success(),
+        "{case_name}: zen test build.zen failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let bin_path = tmp.path().join("build").join("tests").join("unit");
+    assert!(
+        bin_path.exists(),
+        "expected {} to exist",
+        bin_path.display()
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("test unit passed"),
+        "{case_name}: expected test pass output, stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn test_command_build_zen_rejects_undeclared_file_read_effects_before_execution() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("test.targets")
+    b.add(Test { name: "unit", root: "test.zen" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["test", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen test build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen test build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("undeclared host effect: read file `test.targets`"),
+        "expected undeclared file read diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "test command should not start after graph validation fails"
+    );
+}


### PR DESCRIPTION
## Summary

- Move `zen test build.zen` declared file-read host-effect accept/reject coverage into a focused child module.
- Keep env-effect ordering and unrelated executable skip coverage in the parent module.
- Record the anti-slop split in the phase plan and completion audit.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`