### PR TITLE
[codex] split legacy build graph host effect fixtures

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -298,6 +298,11 @@ and do not assume Phase 4 is ready without evidence.
   `tests/integration/cli_build/graph_validation_test_command_host_effects/file_reads.rs`,
   leaving env-effect ordering and unrelated executable skip coverage in the
   parent module.
+- Legacy `build-graph build.zen` host-effect integration tests now split
+  declared file-read fallback accept/reject coverage into
+  `tests/integration/cli_build/legacy_graph_command_host_effects/file_reads.rs`,
+  leaving env-effect ordering and unrelated test skip coverage in the parent
+  module.
 - Resolver-backed behavior impl metadata now builds restored impl-block tasks
   once and reuses them for both impl method signature restoration and omitted
   default-method synthesis, preserving the signature-before-defaults ordering.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -476,6 +476,9 @@ checked-in docs, tests, and commits only.
 - Test-command build graph host-effect tests now keep declared file-read
   fallback accept/reject cases in a focused child module, leaving env-effect
   ordering and unrelated executable skip coverage in the parent module.
+- Legacy `build-graph build.zen` host-effect tests now keep declared file-read
+  fallback accept/reject cases in a focused child module, leaving env-effect
+  ordering and unrelated test skip coverage in the parent module.
 - Resolver-backed behavior impl metadata now builds restored impl-block tasks
   once and reuses them for both impl method signature restoration and omitted
   default-method synthesis. Impl-block declaration collection now also uses a

--- a/tests/integration/cli_build/legacy_graph_command_host_effects.rs
+++ b/tests/integration/cli_build/legacy_graph_command_host_effects.rs
@@ -1,5 +1,8 @@
 use std::process::Command;
 
+#[path = "legacy_graph_command_host_effects/file_reads.rs"]
+mod file_reads;
+
 #[test]
 fn build_graph_command_rejects_undeclared_host_effects() {
     let tmp = tempfile::tempdir().expect("create temp dir");
@@ -194,127 +197,6 @@ main = () i32 {
     assert!(
         !stderr.contains("missing_test.zen"),
         "host-effect validation should run before unrelated test source handling, stderr={stderr}"
-    );
-    assert!(
-        !tmp.path().join("build").exists(),
-        "build-graph command should not start after graph validation fails"
-    );
-}
-
-#[test]
-fn build_graph_command_accepts_declared_file_read_effects() {
-    assert_build_graph_command_accepts_declared_file_read_effect(
-        r#"| .Err { "default" }"#,
-        "build_graph_command_accepts_declared_file_read_effects",
-    );
-}
-
-#[test]
-fn build_graph_command_accepts_wildcard_fallback_declared_file_read_effects() {
-    assert_build_graph_command_accepts_declared_file_read_effect(
-        r#"| _ { "default" }"#,
-        "build_graph_command_accepts_wildcard_fallback_declared_file_read_effects",
-    );
-}
-
-#[test]
-fn build_graph_command_accepts_identifier_fallback_declared_file_read_effects() {
-    assert_build_graph_command_accepts_declared_file_read_effect(
-        r#"| err { "default" }"#,
-        "build_graph_command_accepts_identifier_fallback_declared_file_read_effects",
-    );
-}
-
-fn assert_build_graph_command_accepts_declared_file_read_effect(
-    fallback_arm: &str,
-    case_name: &str,
-) {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        format!(
-            r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {{
-    manifest = b.os.read_file("build.targets") ?
-        | .Ok(contents) {{ contents }}
-        {fallback_arm}
-    b.add(Executable {{ name: "myapp", main: "main.zen", out_dir: "build/" }})
-    .Ok(b.config())
-}}
-"#,
-        ),
-    )
-    .expect("write build.zen");
-    std::fs::write(tmp.path().join("build.targets"), "myapp\n").expect("write manifest");
-    std::fs::write(
-        tmp.path().join("main.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write main.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["build-graph", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen build-graph");
-
-    assert!(
-        output.status.success(),
-        "{case_name}: zen build-graph failed: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let bin_path = tmp.path().join("build").join("myapp");
-    assert!(
-        bin_path.exists(),
-        "expected {} to exist",
-        bin_path.display()
-    );
-    let run = Command::new(&bin_path).output().expect("run built binary");
-    assert!(
-        run.status.success(),
-        "built binary exited with {}",
-        run.status
-    );
-}
-
-#[test]
-fn build_graph_command_rejects_undeclared_file_read_effects_before_execution() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    manifest = b.os.read_file("build.targets")
-    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["build-graph", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen build-graph");
-
-    assert!(
-        !output.status.success(),
-        "zen build-graph unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("undeclared host effect: read file `build.targets`"),
-        "expected undeclared file read diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
     );
     assert!(
         !tmp.path().join("build").exists(),

--- a/tests/integration/cli_build/legacy_graph_command_host_effects/file_reads.rs
+++ b/tests/integration/cli_build/legacy_graph_command_host_effects/file_reads.rs
@@ -1,0 +1,122 @@
+use std::process::Command;
+
+#[test]
+fn build_graph_command_accepts_declared_file_read_effects() {
+    assert_build_graph_command_accepts_declared_file_read_effect(
+        r#"| .Err { "default" }"#,
+        "build_graph_command_accepts_declared_file_read_effects",
+    );
+}
+
+#[test]
+fn build_graph_command_accepts_wildcard_fallback_declared_file_read_effects() {
+    assert_build_graph_command_accepts_declared_file_read_effect(
+        r#"| _ { "default" }"#,
+        "build_graph_command_accepts_wildcard_fallback_declared_file_read_effects",
+    );
+}
+
+#[test]
+fn build_graph_command_accepts_identifier_fallback_declared_file_read_effects() {
+    assert_build_graph_command_accepts_declared_file_read_effect(
+        r#"| err { "default" }"#,
+        "build_graph_command_accepts_identifier_fallback_declared_file_read_effects",
+    );
+}
+
+fn assert_build_graph_command_accepts_declared_file_read_effect(
+    fallback_arm: &str,
+    case_name: &str,
+) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
+    manifest = b.os.read_file("build.targets") ?
+        | .Ok(contents) {{ contents }}
+        {fallback_arm}
+    b.add(Executable {{ name: "myapp", main: "main.zen", out_dir: "build/" }})
+    .Ok(b.config())
+}}
+"#,
+        ),
+    )
+    .expect("write build.zen");
+    std::fs::write(tmp.path().join("build.targets"), "myapp\n").expect("write manifest");
+    std::fs::write(
+        tmp.path().join("main.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write main.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build-graph", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build-graph");
+
+    assert!(
+        output.status.success(),
+        "{case_name}: zen build-graph failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let bin_path = tmp.path().join("build").join("myapp");
+    assert!(
+        bin_path.exists(),
+        "expected {} to exist",
+        bin_path.display()
+    );
+    let run = Command::new(&bin_path).output().expect("run built binary");
+    assert!(
+        run.status.success(),
+        "built binary exited with {}",
+        run.status
+    );
+}
+
+#[test]
+fn build_graph_command_rejects_undeclared_file_read_effects_before_execution() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets")
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build-graph", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build-graph");
+
+    assert!(
+        !output.status.success(),
+        "zen build-graph unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("undeclared host effect: read file `build.targets`"),
+        "expected undeclared file read diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "build-graph command should not start after graph validation fails"
+    );
+}


### PR DESCRIPTION
## Summary

- Move legacy `zen build-graph build.zen` declared file-read host-effect accept/reject coverage into a focused child module.
- Keep env-effect ordering and unrelated test skip coverage in the parent module.
- Record the anti-slop split in the phase plan and completion audit.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`