### PR TITLE
[codex] split direct build gated dependency tests

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -311,6 +311,10 @@ and do not assume Phase 4 is ready without evidence.
   test dependency rejection coverage into
   `tests/integration/cli_build/build_command_validation/gated_dependencies.rs`,
   leaving executable-target and skipped-source checks in the parent module.
+- Direct `zen build.zen` validation tests now split direct and transitive gated
+  test dependency rejection coverage into
+  `tests/integration/cli_build/direct_build_graph_validation/gated_dependencies.rs`,
+  matching the normal build-command validation layout.
 - Resolver-backed behavior impl metadata now builds restored impl-block tasks
   once and reuses them for both impl method signature restoration and omitted
   default-method synthesis, preserving the signature-before-defaults ordering.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -487,6 +487,9 @@ checked-in docs, tests, and commits only.
   test dependency rejection coverage in a focused child module, leaving the
   parent build command validation file for executable-target and skipped-source
   checks.
+- Direct `zen build.zen` validation tests now keep direct and transitive gated
+  test dependency rejection coverage in a focused child module, matching the
+  normal build-command validation layout.
 - Resolver-backed behavior impl metadata now builds restored impl-block tasks
   once and reuses them for both impl method signature restoration and omitted
   default-method synthesis. Impl-block declaration collection now also uses a

--- a/tests/integration/cli_build/direct_build_graph_validation.rs
+++ b/tests/integration/cli_build/direct_build_graph_validation.rs
@@ -1,5 +1,7 @@
 use std::process::Command;
 
+#[path = "direct_build_graph_validation/gated_dependencies.rs"]
+mod gated_dependencies;
 #[path = "direct_build_graph_validation/graph_only_libraries.rs"]
 mod graph_only_libraries;
 
@@ -103,96 +105,6 @@ main = () i32 {
     assert!(
         tmp.path().join("build").join("app").join("app").exists(),
         "expected executable output to exist"
-    );
-}
-
-#[test]
-fn direct_file_command_build_zen_rejects_gated_test_dependencies() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Test { name: "unit", root: "test.zen" })
-    b.add(Executable {
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        dependencies: ["unit"],
-    })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-    std::fs::write(
-        tmp.path().join("test.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write test.zen");
-    std::fs::write(
-        tmp.path().join("app.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write app.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .arg("build.zen")
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen build.zen");
-
-    assert!(
-        !output.status.success(),
-        "zen build.zen unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("build graph target `app` depends on gated test target `unit`"),
-        "expected gated test dependency diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        !tmp.path().join("build").exists(),
-        "direct build.zen command should not start after gated dependency validation fails"
-    );
-}
-
-#[test]
-fn direct_file_command_build_zen_rejects_transitive_gated_test_dependencies() {
-    let tmp = super::support::transitive_gated_test_dependency_graph();
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .arg("build.zen")
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen build.zen");
-
-    assert!(
-        !output.status.success(),
-        "zen build.zen unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("build graph target `core` depends on gated test target `unit`"),
-        "expected transitive gated test dependency diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        !tmp.path().join("build").exists(),
-        "direct build.zen command should not start after transitive gated dependency validation fails"
     );
 }
 

--- a/tests/integration/cli_build/direct_build_graph_validation/gated_dependencies.rs
+++ b/tests/integration/cli_build/direct_build_graph_validation/gated_dependencies.rs
@@ -1,0 +1,91 @@
+use std::process::Command;
+
+#[test]
+fn direct_file_command_build_zen_rejects_gated_test_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Test { name: "unit", root: "test.zen" })
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["unit"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("test.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write test.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .arg("build.zen")
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("build graph target `app` depends on gated test target `unit`"),
+        "expected gated test dependency diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "direct build.zen command should not start after gated dependency validation fails"
+    );
+}
+
+#[test]
+fn direct_file_command_build_zen_rejects_transitive_gated_test_dependencies() {
+    let tmp = super::super::support::transitive_gated_test_dependency_graph();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .arg("build.zen")
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("build graph target `core` depends on gated test target `unit`"),
+        "expected transitive gated test dependency diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "direct build.zen command should not start after transitive gated dependency validation fails"
+    );
+}


### PR DESCRIPTION
## Summary
- Move direct and transitive direct `zen build.zen` gated test dependency rejection tests into a focused child module.
- Match the normal `zen build build.zen` validation layout while preserving test behavior.
- Record the anti-slop split in the phase plan and completion audit.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`