### PR TITLE
[codex] split legacy graph gated dependency tests

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -315,6 +315,10 @@ and do not assume Phase 4 is ready without evidence.
   test dependency rejection coverage into
   `tests/integration/cli_build/direct_build_graph_validation/gated_dependencies.rs`,
   matching the normal build-command validation layout.
+- Legacy `zen build-graph build.zen` validation tests now split direct and
+  transitive gated test dependency rejection coverage into
+  `tests/integration/cli_build/legacy_graph_command_validation/gated_dependencies.rs`,
+  aligning the executable graph validation entrypoints.
 - Resolver-backed behavior impl metadata now builds restored impl-block tasks
   once and reuses them for both impl method signature restoration and omitted
   default-method synthesis, preserving the signature-before-defaults ordering.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -490,6 +490,9 @@ checked-in docs, tests, and commits only.
 - Direct `zen build.zen` validation tests now keep direct and transitive gated
   test dependency rejection coverage in a focused child module, matching the
   normal build-command validation layout.
+- Legacy `zen build-graph build.zen` validation tests now keep direct and
+  transitive gated test dependency rejection coverage in a focused child
+  module, aligning the executable graph validation entrypoints.
 - Resolver-backed behavior impl metadata now builds restored impl-block tasks
   once and reuses them for both impl method signature restoration and omitted
   default-method synthesis. Impl-block declaration collection now also uses a

--- a/tests/integration/cli_build/legacy_graph_command_validation.rs
+++ b/tests/integration/cli_build/legacy_graph_command_validation.rs
@@ -1,5 +1,7 @@
 use std::process::Command;
 
+#[path = "legacy_graph_command_validation/gated_dependencies.rs"]
+mod gated_dependencies;
 #[path = "legacy_graph_command_validation/graph_only_libraries.rs"]
 mod graph_only_libraries;
 
@@ -107,44 +109,6 @@ main = () i32 {
 }
 
 #[test]
-fn build_graph_command_rejects_gated_test_dependencies() {
-    assert_build_graph_rejects_gated_dependency(
-        r#"b.add(Test { name: "unit", root: "test.zen" })"#,
-        "unit",
-        "test.zen",
-        "test",
-    );
-}
-
-#[test]
-fn build_graph_command_rejects_transitive_gated_test_dependencies() {
-    let tmp = super::support::transitive_gated_test_dependency_graph();
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["build-graph", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen build-graph");
-
-    assert!(
-        !output.status.success(),
-        "zen build-graph unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("build graph target `core` depends on gated test target `unit`"),
-        "expected transitive gated test dependency diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        !tmp.path().join("build").exists(),
-        "build-graph command should not start after transitive gated dependency validation fails"
-    );
-}
-
-#[test]
 fn build_graph_command_ignores_unrelated_gated_test_source_errors() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(
@@ -183,75 +147,6 @@ main = () i32 {
     assert!(
         tmp.path().join("build").join("app").join("app").exists(),
         "expected executable output to exist"
-    );
-}
-
-fn assert_build_graph_rejects_gated_dependency(
-    gated_target_decl: &str,
-    gated_target_name: &str,
-    gated_source_name: &str,
-    gated_target_kind: &str,
-) {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        format!(
-            r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {{
-    {gated_target_decl}
-    b.add(Executable {{
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        dependencies: ["{gated_target_name}"],
-    }})
-    .Ok(b.config())
-}}
-"#,
-        ),
-    )
-    .expect("write build.zen");
-    std::fs::write(
-        tmp.path().join(gated_source_name),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write gated target source");
-    std::fs::write(
-        tmp.path().join("app.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write app.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["build-graph", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen build-graph");
-
-    assert!(
-        !output.status.success(),
-        "zen build-graph unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr).contains(&format!(
-            "build graph target `app` depends on gated {gated_target_kind} target `{gated_target_name}`"
-        )),
-        "expected gated dependency diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        !tmp.path().join("build").exists(),
-        "build-graph command should not start after gated dependency validation fails"
     );
 }
 

--- a/tests/integration/cli_build/legacy_graph_command_validation/gated_dependencies.rs
+++ b/tests/integration/cli_build/legacy_graph_command_validation/gated_dependencies.rs
@@ -1,0 +1,108 @@
+use std::process::Command;
+
+#[test]
+fn build_graph_command_rejects_gated_test_dependencies() {
+    assert_build_graph_rejects_gated_dependency(
+        r#"b.add(Test { name: "unit", root: "test.zen" })"#,
+        "unit",
+        "test.zen",
+        "test",
+    );
+}
+
+#[test]
+fn build_graph_command_rejects_transitive_gated_test_dependencies() {
+    let tmp = super::super::support::transitive_gated_test_dependency_graph();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build-graph", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build-graph");
+
+    assert!(
+        !output.status.success(),
+        "zen build-graph unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("build graph target `core` depends on gated test target `unit`"),
+        "expected transitive gated test dependency diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "build-graph command should not start after transitive gated dependency validation fails"
+    );
+}
+
+fn assert_build_graph_rejects_gated_dependency(
+    gated_target_decl: &str,
+    gated_target_name: &str,
+    gated_source_name: &str,
+    gated_target_kind: &str,
+) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
+    {gated_target_decl}
+    b.add(Executable {{
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["{gated_target_name}"],
+    }})
+    .Ok(b.config())
+}}
+"#,
+        ),
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join(gated_source_name),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write gated target source");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build-graph", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build-graph");
+
+    assert!(
+        !output.status.success(),
+        "zen build-graph unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains(&format!(
+            "build graph target `app` depends on gated {gated_target_kind} target `{gated_target_name}`"
+        )),
+        "expected gated dependency diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "build-graph command should not start after gated dependency validation fails"
+    );
+}


### PR DESCRIPTION
## Summary
- Move direct and transitive legacy `zen build-graph build.zen` gated test dependency rejection tests into a focused child module.
- Align executable graph validation entrypoint test layout across normal, direct, and legacy build commands.
- Record the anti-slop split in the phase plan and completion audit.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`