### PR TITLE
[codex] split test command gated dependency tests

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -319,6 +319,10 @@ and do not assume Phase 4 is ready without evidence.
   transitive gated test dependency rejection coverage into
   `tests/integration/cli_build/legacy_graph_command_validation/gated_dependencies.rs`,
   aligning the executable graph validation entrypoints.
+- `zen test build.zen` validation tests now split direct and transitive gated
+  executable dependency rejection coverage into
+  `tests/integration/cli_build/graph_validation_test_command_validation/gated_dependencies.rs`,
+  matching the executable graph validation split layout.
 - Resolver-backed behavior impl metadata now builds restored impl-block tasks
   once and reuses them for both impl method signature restoration and omitted
   default-method synthesis, preserving the signature-before-defaults ordering.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -493,6 +493,9 @@ checked-in docs, tests, and commits only.
 - Legacy `zen build-graph build.zen` validation tests now keep direct and
   transitive gated test dependency rejection coverage in a focused child
   module, aligning the executable graph validation entrypoints.
+- `zen test build.zen` validation tests now keep direct and transitive gated
+  executable dependency rejection coverage in a focused child module, matching
+  the executable graph validation split layout.
 - Resolver-backed behavior impl metadata now builds restored impl-block tasks
   once and reuses them for both impl method signature restoration and omitted
   default-method synthesis. Impl-block declaration collection now also uses a

--- a/tests/integration/cli_build/graph_validation_test_command_validation.rs
+++ b/tests/integration/cli_build/graph_validation_test_command_validation.rs
@@ -1,5 +1,7 @@
 use std::process::Command;
 
+#[path = "graph_validation_test_command_validation/gated_dependencies.rs"]
+mod gated_dependencies;
 #[path = "graph_validation_test_command_validation/graph_only_libraries.rs"]
 mod graph_only_libraries;
 
@@ -103,134 +105,6 @@ main = () i32 {
         String::from_utf8_lossy(&output.stdout).contains("test unit passed"),
         "expected test pass output, stdout={}",
         String::from_utf8_lossy(&output.stdout)
-    );
-}
-
-#[test]
-fn test_command_build_zen_rejects_gated_executable_dependencies() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
-    b.add(Test { name: "unit", root: "test.zen", dependencies: ["app"] })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-    std::fs::write(
-        tmp.path().join("app.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write app.zen");
-    std::fs::write(
-        tmp.path().join("test.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write test.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["test", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen test build.zen");
-
-    assert!(
-        !output.status.success(),
-        "zen test build.zen unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("build graph target `unit` depends on gated executable target `app`"),
-        "expected gated executable dependency diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        !tmp.path().join("build").exists(),
-        "test command should not start after gated dependency validation fails"
-    );
-}
-
-#[test]
-fn test_command_build_zen_rejects_transitive_gated_executable_dependencies() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
-    b.add(Library {
-        name: "core",
-        exports: ["lib.zen"],
-        dependencies: ["app"],
-    })
-    b.add(Test { name: "unit", root: "test.zen", dependencies: ["core"] })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-    std::fs::write(
-        tmp.path().join("app.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write app.zen");
-    std::fs::write(
-        tmp.path().join("lib.zen"),
-        r#"
-value = () i32 {
-    1
-}
-"#,
-    )
-    .expect("write lib.zen");
-    std::fs::write(
-        tmp.path().join("test.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write test.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["test", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen test build.zen");
-
-    assert!(
-        !output.status.success(),
-        "zen test build.zen unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("build graph target `core` depends on gated executable target `app`"),
-        "expected transitive gated executable dependency diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        !tmp.path().join("build").exists(),
-        "test command should not start after transitive gated dependency validation fails"
     );
 }
 

--- a/tests/integration/cli_build/graph_validation_test_command_validation/gated_dependencies.rs
+++ b/tests/integration/cli_build/graph_validation_test_command_validation/gated_dependencies.rs
@@ -1,0 +1,129 @@
+use std::process::Command;
+
+#[test]
+fn test_command_build_zen_rejects_gated_executable_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    b.add(Test { name: "unit", root: "test.zen", dependencies: ["app"] })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+    std::fs::write(
+        tmp.path().join("test.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write test.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["test", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen test build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen test build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("build graph target `unit` depends on gated executable target `app`"),
+        "expected gated executable dependency diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "test command should not start after gated dependency validation fails"
+    );
+}
+
+#[test]
+fn test_command_build_zen_rejects_transitive_gated_executable_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    b.add(Library {
+        name: "core",
+        exports: ["lib.zen"],
+        dependencies: ["app"],
+    })
+    b.add(Test { name: "unit", root: "test.zen", dependencies: ["core"] })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    1
+}
+"#,
+    )
+    .expect("write lib.zen");
+    std::fs::write(
+        tmp.path().join("test.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write test.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["test", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen test build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen test build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("build graph target `core` depends on gated executable target `app`"),
+        "expected transitive gated executable dependency diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "test command should not start after transitive gated dependency validation fails"
+    );
+}


### PR DESCRIPTION
## Summary
- Move direct and transitive `zen test build.zen` gated executable dependency rejection tests into a focused child module.
- Align test-command validation with the executable graph validation split layout.
- Record the anti-slop split in the phase plan and completion audit.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`