### PR TITLE
[codex] split check command file read host effects

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -311,6 +311,10 @@ and do not assume Phase 4 is ready without evidence.
   test dependency rejection coverage into
   `tests/integration/cli_build/build_command_validation/gated_dependencies.rs`,
   leaving executable-target and skipped-source checks in the parent module.
+- `zen check build.zen` host-effect integration tests now split declared
+  file-read fallback accept/reject coverage into
+  `tests/integration/cli_build/graph_validation_host_effects/file_reads.rs`,
+  leaving env-effect ordering coverage in the parent module.
 - Direct `zen build.zen` validation tests now split direct and transitive gated
   test dependency rejection coverage into
   `tests/integration/cli_build/direct_build_graph_validation/gated_dependencies.rs`,

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -467,6 +467,9 @@ checked-in docs, tests, and commits only.
 - Check-command build graph validation tests now keep host-effect ordering and
   declared-effect cases in a focused integration module, separating them from
   target source and library graph validation cases.
+- Check-command build graph host-effect tests now keep declared file-read
+  fallback accept/reject cases in a focused child module, leaving env-effect
+  ordering coverage in the parent integration module.
 - Build-command host-effect tests now keep declared file-read fallback accept
   and reject cases in a focused child module, leaving env-effect and
   ordering-before-execution cases in the parent integration module.

--- a/tests/integration/cli_build/graph_validation_host_effects.rs
+++ b/tests/integration/cli_build/graph_validation_host_effects.rs
@@ -1,5 +1,8 @@
 use std::process::Command;
 
+#[path = "graph_validation_host_effects/file_reads.rs"]
+mod file_reads;
+
 #[test]
 fn check_command_build_zen_rejects_undeclared_host_effects() {
     let tmp = tempfile::tempdir().expect("create temp dir");
@@ -77,115 +80,6 @@ main = () i32 {
         String::from_utf8_lossy(&output.stdout).contains("1 build targets"),
         "expected build graph check summary, stdout={}",
         String::from_utf8_lossy(&output.stdout)
-    );
-}
-
-#[test]
-fn check_command_build_zen_accepts_declared_file_read_effects() {
-    assert_check_command_accepts_declared_file_read_effect(
-        r#"| .Err { "default" }"#,
-        "check_command_build_zen_accepts_declared_file_read_effects",
-    );
-}
-
-#[test]
-fn check_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects() {
-    assert_check_command_accepts_declared_file_read_effect(
-        r#"| _ { "default" }"#,
-        "check_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects",
-    );
-}
-
-#[test]
-fn check_command_build_zen_accepts_identifier_fallback_declared_file_read_effects() {
-    assert_check_command_accepts_declared_file_read_effect(
-        r#"| err { "default" }"#,
-        "check_command_build_zen_accepts_identifier_fallback_declared_file_read_effects",
-    );
-}
-
-fn assert_check_command_accepts_declared_file_read_effect(fallback_arm: &str, case_name: &str) {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        format!(
-            r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {{
-    manifest = b.os.read_file("build.targets") ?
-        | .Ok(contents) {{ contents }}
-        {fallback_arm}
-    b.add(Executable {{ name: "myapp", main: "main.zen", out_dir: "build/" }})
-    .Ok(b.config())
-}}
-"#,
-        ),
-    )
-    .expect("write build.zen");
-    std::fs::write(tmp.path().join("build.targets"), "myapp\n").expect("write manifest");
-    std::fs::write(
-        tmp.path().join("main.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write main.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["check", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen check build.zen");
-
-    assert!(
-        output.status.success(),
-        "{case_name}: zen check build.zen failed: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stdout).contains("1 build targets"),
-        "expected build graph check summary, stdout={}",
-        String::from_utf8_lossy(&output.stdout)
-    );
-}
-
-#[test]
-fn check_command_build_zen_rejects_undeclared_file_read_effects_before_source_validation() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    manifest = b.os.read_file("build.targets")
-    b.add(Executable { name: "myapp", main: "missing.zen", out_dir: "build/" })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["check", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen check build.zen");
-
-    assert!(
-        !output.status.success(),
-        "zen check build.zen unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("undeclared host effect: read file `build.targets`"),
-        "expected undeclared file read diagnostic, stderr={stderr}"
-    );
-    assert!(
-        !stderr.contains("source not found"),
-        "host-effect validation should run before source validation, stderr={stderr}"
     );
 }
 

--- a/tests/integration/cli_build/graph_validation_host_effects/file_reads.rs
+++ b/tests/integration/cli_build/graph_validation_host_effects/file_reads.rs
@@ -1,0 +1,110 @@
+use std::process::Command;
+
+#[test]
+fn check_command_build_zen_accepts_declared_file_read_effects() {
+    assert_check_command_accepts_declared_file_read_effect(
+        r#"| .Err { "default" }"#,
+        "check_command_build_zen_accepts_declared_file_read_effects",
+    );
+}
+
+#[test]
+fn check_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects() {
+    assert_check_command_accepts_declared_file_read_effect(
+        r#"| _ { "default" }"#,
+        "check_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects",
+    );
+}
+
+#[test]
+fn check_command_build_zen_accepts_identifier_fallback_declared_file_read_effects() {
+    assert_check_command_accepts_declared_file_read_effect(
+        r#"| err { "default" }"#,
+        "check_command_build_zen_accepts_identifier_fallback_declared_file_read_effects",
+    );
+}
+
+fn assert_check_command_accepts_declared_file_read_effect(fallback_arm: &str, case_name: &str) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
+    manifest = b.os.read_file("build.targets") ?
+        | .Ok(contents) {{ contents }}
+        {fallback_arm}
+    b.add(Executable {{ name: "myapp", main: "main.zen", out_dir: "build/" }})
+    .Ok(b.config())
+}}
+"#,
+        ),
+    )
+    .expect("write build.zen");
+    std::fs::write(tmp.path().join("build.targets"), "myapp\n").expect("write manifest");
+    std::fs::write(
+        tmp.path().join("main.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write main.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["check", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen check build.zen");
+
+    assert!(
+        output.status.success(),
+        "{case_name}: zen check build.zen failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("1 build targets"),
+        "expected build graph check summary, stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn check_command_build_zen_rejects_undeclared_file_read_effects_before_source_validation() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets")
+    b.add(Executable { name: "myapp", main: "missing.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["check", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen check build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen check build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("undeclared host effect: read file `build.targets`"),
+        "expected undeclared file read diagnostic, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("source not found"),
+        "host-effect validation should run before source validation, stderr={stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

- Split `zen check build.zen` file-read host-effect integration coverage into `tests/integration/cli_build/graph_validation_host_effects/file_reads.rs`.
- Left env-effect ordering coverage in the parent module.
- Updated the phase plan and completion audit docs to record the cleanup slice.

## Validation

- `cargo fmt --check`
- `cargo test --test integration check_command_build_zen_accepts_declared_file_read_effects`
- `cargo test --test integration check_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects`
- `cargo test --test integration check_command_build_zen_accepts_identifier_fallback_declared_file_read_effects`
- `cargo test --test integration check_command_build_zen_rejects_undeclared_file_read_effects_before_source_validation`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Branch push check before opening PR: `gh run list --branch codex/split-check-command-file-read-host-effects --limit 10 ...` returned `[]`, so the branch push itself did not spawn Actions.