### PR TITLE
[codex] split emit file read host effects

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -308,6 +308,11 @@ and do not assume Phase 4 is ready without evidence.
   `tests/integration/cli_build/direct_build_graph_host_effects/file_reads.rs`,
   leaving env-effect ordering and unrelated test skip coverage in the parent
   module.
+- Emit-command build graph host-effect integration tests now split declared
+  file-read fallback accept/reject coverage into
+  `tests/integration/cli_build/emit_direct_host_effects/file_reads.rs`,
+  leaving env-effect ordering and unrelated test skip coverage in the parent
+  module.
 - Build graph unit tests now split target metadata validation and gated
   package/link target rejection coverage into
   `tests/build_graph/target_metadata.rs`, leaving the root build graph test

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -485,6 +485,9 @@ checked-in docs, tests, and commits only.
 - Direct `zen build.zen` host-effect tests now keep declared file-read fallback
   accept/reject cases in a focused child module, leaving env-effect ordering and
   unrelated test skip coverage in the parent integration module.
+- Emit-command build graph host-effect tests now keep declared file-read
+  fallback accept/reject cases in a focused child module, leaving env-effect
+  ordering and unrelated test skip coverage in the parent integration module.
 - Build graph unit tests now keep target metadata validation and gated
   package/link target rejection coverage in a focused child module, leaving the
   root build graph test file for shared helpers and positive lowering smoke

--- a/tests/integration/cli_build/emit_direct_host_effects.rs
+++ b/tests/integration/cli_build/emit_direct_host_effects.rs
@@ -1,5 +1,8 @@
 use std::process::Command;
 
+#[path = "emit_direct_host_effects/file_reads.rs"]
+mod file_reads;
+
 #[test]
 fn emit_command_build_zen_rejects_undeclared_host_effects() {
     let tmp = tempfile::tempdir().expect("create temp dir");
@@ -89,121 +92,6 @@ value = () i32 {
     assert!(
         !stderr.contains("return type mismatch"),
         "host-effect validation should run before graph-only library typechecking, stderr={stderr}"
-    );
-    assert!(
-        output.stdout.is_empty(),
-        "emit should not write C source after graph validation fails, stdout={}",
-        String::from_utf8_lossy(&output.stdout)
-    );
-}
-
-#[test]
-fn emit_command_build_zen_accepts_declared_file_read_effects() {
-    assert_emit_command_accepts_declared_file_read_effect(
-        r#"| .Err { "default" }"#,
-        "emit_command_build_zen_accepts_declared_file_read_effects",
-    );
-}
-
-#[test]
-fn emit_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects() {
-    assert_emit_command_accepts_declared_file_read_effect(
-        r#"| _ { "default" }"#,
-        "emit_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects",
-    );
-}
-
-#[test]
-fn emit_command_build_zen_accepts_identifier_fallback_declared_file_read_effects() {
-    assert_emit_command_accepts_declared_file_read_effect(
-        r#"| err { "default" }"#,
-        "emit_command_build_zen_accepts_identifier_fallback_declared_file_read_effects",
-    );
-}
-
-fn assert_emit_command_accepts_declared_file_read_effect(fallback_arm: &str, case_name: &str) {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        format!(
-            r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {{
-    manifest = b.os.read_file("build.targets") ?
-        | .Ok(contents) {{ contents }}
-        {fallback_arm}
-    b.add(Executable {{ name: "myapp", main: "main.zen", out_dir: "build/" }})
-    .Ok(b.config())
-}}
-"#,
-        ),
-    )
-    .expect("write build.zen");
-    std::fs::write(tmp.path().join("build.targets"), "myapp\n").expect("write manifest");
-    std::fs::write(
-        tmp.path().join("main.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write main.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen emit build.zen");
-
-    assert!(
-        output.status.success(),
-        "{case_name}: zen emit build.zen failed: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let c_source = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        c_source.contains("int32_t zen_main(void)"),
-        "{case_name}: expected target C source, stdout={c_source}"
-    );
-    assert!(
-        !tmp.path().join("build").join("myapp").exists(),
-        "zen emit build.zen should not compile the target binary"
-    );
-}
-
-#[test]
-fn emit_command_build_zen_rejects_undeclared_file_read_effects() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    manifest = b.os.read_file("build.targets")
-    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen emit build.zen");
-
-    assert!(
-        !output.status.success(),
-        "zen emit build.zen unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("undeclared host effect: read file `build.targets`"),
-        "expected undeclared file read diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
     );
     assert!(
         output.stdout.is_empty(),

--- a/tests/integration/cli_build/emit_direct_host_effects/file_reads.rs
+++ b/tests/integration/cli_build/emit_direct_host_effects/file_reads.rs
@@ -1,0 +1,116 @@
+use std::process::Command;
+
+#[test]
+fn emit_command_build_zen_accepts_declared_file_read_effects() {
+    assert_emit_command_accepts_declared_file_read_effect(
+        r#"| .Err { "default" }"#,
+        "emit_command_build_zen_accepts_declared_file_read_effects",
+    );
+}
+
+#[test]
+fn emit_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects() {
+    assert_emit_command_accepts_declared_file_read_effect(
+        r#"| _ { "default" }"#,
+        "emit_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects",
+    );
+}
+
+#[test]
+fn emit_command_build_zen_accepts_identifier_fallback_declared_file_read_effects() {
+    assert_emit_command_accepts_declared_file_read_effect(
+        r#"| err { "default" }"#,
+        "emit_command_build_zen_accepts_identifier_fallback_declared_file_read_effects",
+    );
+}
+
+fn assert_emit_command_accepts_declared_file_read_effect(fallback_arm: &str, case_name: &str) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
+    manifest = b.os.read_file("build.targets") ?
+        | .Ok(contents) {{ contents }}
+        {fallback_arm}
+    b.add(Executable {{ name: "myapp", main: "main.zen", out_dir: "build/" }})
+    .Ok(b.config())
+}}
+"#,
+        ),
+    )
+    .expect("write build.zen");
+    std::fs::write(tmp.path().join("build.targets"), "myapp\n").expect("write manifest");
+    std::fs::write(
+        tmp.path().join("main.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write main.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen emit build.zen");
+
+    assert!(
+        output.status.success(),
+        "{case_name}: zen emit build.zen failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let c_source = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        c_source.contains("int32_t zen_main(void)"),
+        "{case_name}: expected target C source, stdout={c_source}"
+    );
+    assert!(
+        !tmp.path().join("build").join("myapp").exists(),
+        "zen emit build.zen should not compile the target binary"
+    );
+}
+
+#[test]
+fn emit_command_build_zen_rejects_undeclared_file_read_effects() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets")
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen emit build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen emit build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("undeclared host effect: read file `build.targets`"),
+        "expected undeclared file read diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "emit should not write C source after graph validation fails, stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}


### PR DESCRIPTION
## Summary

- Split `zen emit build.zen` file-read host-effect integration coverage into `tests/integration/cli_build/emit_direct_host_effects/file_reads.rs`.
- Left env-effect ordering and unrelated test skip coverage in the parent module.
- Updated the phase plan and completion audit docs to record the cleanup slice.

## Validation

- `cargo fmt --check`
- `cargo test --test integration emit_command_build_zen_accepts_declared_file_read_effects`
- `cargo test --test integration emit_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects`
- `cargo test --test integration emit_command_build_zen_accepts_identifier_fallback_declared_file_read_effects`
- `cargo test --test integration emit_command_build_zen_rejects_undeclared_file_read_effects`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Branch push check before opening PR returned `[]`, so the branch push itself did not spawn Actions.