### PR TITLE
[codex] split build graph json unsupported target tests

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -275,6 +275,10 @@ and do not assume Phase 4 is ready without evidence.
 - Build-graph JSON integration tests now split host-effect JSON coverage into
   `tests/integration/cli_build/build_graph_json_host_effects.rs`, keeping target
   metadata/dependency JSON tests separate from effect determinism tests.
+- Build-graph JSON validation tests now split unsupported target kind and gated
+  package/link field diagnostics into
+  `tests/integration/cli_build/build_graph_json/validation/unsupported_targets.rs`,
+  leaving target field and dependency graph diagnostics in the parent module.
 - Generic specialization generated-C assertions now split multi-file import and
   dependency cases into
   `tests/integration/generic_specializations/multifile_generated_c.rs`,

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -461,6 +461,9 @@ checked-in docs, tests, and commits only.
 - Build-graph JSON integration tests now keep host-effect JSON coverage in a
   focused module, separating effect determinism cases from target metadata and
   dependency JSON assertions.
+- Build-graph JSON validation tests now keep unsupported target kind and gated
+  package/link field diagnostics in a focused child module, leaving target
+  field and dependency graph diagnostics in the parent module.
 - Generic specialization generated-C assertions now keep multi-file import and
   dependency cases in a focused integration module, separating them from
   single-file generic specialization emission assertions.

--- a/tests/integration/cli_build/build_graph_json/validation.rs
+++ b/tests/integration/cli_build/build_graph_json/validation.rs
@@ -1,5 +1,8 @@
 use std::process::Command;
 
+#[path = "validation/unsupported_targets.rs"]
+mod unsupported_targets;
+
 #[test]
 fn emit_json_build_graph_rejects_unknown_target_fields() {
     let tmp = tempfile::tempdir().expect("create temp dir");
@@ -110,105 +113,6 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
         String::from_utf8_lossy(&output.stderr)
             .contains("build target `app` depends on unknown target `core`"),
         "expected unknown dependency diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-}
-
-#[test]
-fn emit_json_build_graph_rejects_unsupported_package_targets() {
-    assert_emit_json_build_graph_rejects_unsupported_target_kind("Package");
-}
-
-#[test]
-fn emit_json_build_graph_rejects_unsupported_link_targets() {
-    assert_emit_json_build_graph_rejects_unsupported_target_kind("Link");
-}
-
-#[test]
-fn emit_json_build_graph_rejects_gated_package_fields() {
-    assert_emit_json_build_graph_rejects_gated_target_field("packages", r#"["std"]"#);
-}
-
-#[test]
-fn emit_json_build_graph_rejects_gated_link_fields() {
-    assert_emit_json_build_graph_rejects_gated_target_field("link", r#"["m"]"#);
-}
-
-fn assert_emit_json_build_graph_rejects_unsupported_target_kind(target_kind: &str) {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let build_path = tmp.path().join("build.zen");
-    std::fs::write(
-        &build_path,
-        format!(
-            r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {{
-    b.add({target_kind} {{ name: "core", root: "src/lib.zen" }})
-    .Ok(b.config())
-}}
-"#,
-        ),
-    )
-    .expect("write build.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "build-graph", build_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json build-graph");
-
-    assert!(
-        !output.status.success(),
-        "emit-json build-graph unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr).contains(
-            &format!(
-                "unsupported build target kind `{target_kind}`; supported target kinds are `Executable`, `Test`, and `Library`"
-            )
-        ),
-        "expected unsupported target diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-}
-
-fn assert_emit_json_build_graph_rejects_gated_target_field(field: &str, value: &str) {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let build_path = tmp.path().join("build.zen");
-    std::fs::write(
-        &build_path,
-        format!(
-            r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {{
-    b.add(Executable {{
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        {field}: {value},
-    }})
-    .Ok(b.config())
-}}
-"#,
-        ),
-    )
-    .expect("write build.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "build-graph", build_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json build-graph");
-
-    assert!(
-        !output.status.success(),
-        "emit-json build-graph unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr).contains(&format!(
-            "unsupported field `{field}` in `Executable` build target; package/link semantics are gated"
-        )),
-        "expected gated field diagnostic, stderr={}",
         String::from_utf8_lossy(&output.stderr)
     );
 }

--- a/tests/integration/cli_build/build_graph_json/validation/unsupported_targets.rs
+++ b/tests/integration/cli_build/build_graph_json/validation/unsupported_targets.rs
@@ -1,0 +1,100 @@
+use std::process::Command;
+
+#[test]
+fn emit_json_build_graph_rejects_unsupported_package_targets() {
+    assert_emit_json_build_graph_rejects_unsupported_target_kind("Package");
+}
+
+#[test]
+fn emit_json_build_graph_rejects_unsupported_link_targets() {
+    assert_emit_json_build_graph_rejects_unsupported_target_kind("Link");
+}
+
+#[test]
+fn emit_json_build_graph_rejects_gated_package_fields() {
+    assert_emit_json_build_graph_rejects_gated_target_field("packages", r#"["std"]"#);
+}
+
+#[test]
+fn emit_json_build_graph_rejects_gated_link_fields() {
+    assert_emit_json_build_graph_rejects_gated_target_field("link", r#"["m"]"#);
+}
+
+fn assert_emit_json_build_graph_rejects_unsupported_target_kind(target_kind: &str) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let build_path = tmp.path().join("build.zen");
+    std::fs::write(
+        &build_path,
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
+    b.add({target_kind} {{ name: "core", root: "src/lib.zen" }})
+    .Ok(b.config())
+}}
+"#,
+        ),
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "build-graph", build_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json build-graph");
+
+    assert!(
+        !output.status.success(),
+        "emit-json build-graph unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains(
+            &format!(
+                "unsupported build target kind `{target_kind}`; supported target kinds are `Executable`, `Test`, and `Library`"
+            )
+        ),
+        "expected unsupported target diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn assert_emit_json_build_graph_rejects_gated_target_field(field: &str, value: &str) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let build_path = tmp.path().join("build.zen");
+    std::fs::write(
+        &build_path,
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
+    b.add(Executable {{
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        {field}: {value},
+    }})
+    .Ok(b.config())
+}}
+"#,
+        ),
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "build-graph", build_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json build-graph");
+
+    assert!(
+        !output.status.success(),
+        "emit-json build-graph unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains(&format!(
+            "unsupported field `{field}` in `Executable` build target; package/link semantics are gated"
+        )),
+        "expected gated field diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## Summary

- Split unsupported `Package`/`Link` target kind and gated package/link field diagnostics into `tests/integration/cli_build/build_graph_json/validation/unsupported_targets.rs`.
- Left target field and dependency graph diagnostics in the parent JSON validation module.
- Updated the phase plan and completion audit docs to record the cleanup slice.

## Validation

- `cargo fmt --check`
- `cargo test --test integration emit_json_build_graph_rejects_unsupported_package_targets`
- `cargo test --test integration emit_json_build_graph_rejects_unsupported_link_targets`
- `cargo test --test integration emit_json_build_graph_rejects_gated_package_fields`
- `cargo test --test integration emit_json_build_graph_rejects_gated_link_fields`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Branch push check before opening PR returned `[]`, so the branch push itself did not spawn Actions.