### PR TITLE
[codex] split build graph json file read effect tests

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -287,6 +287,10 @@ and do not assume Phase 4 is ready without evidence.
   serialization coverage into
   `tests/integration/cli_build/frontend_json/module_graph.rs`, leaving
   typed-program and diagnostics JSON checks in the parent module.
+- Build-graph JSON host-effect tests now split declared file-read fallback
+  accept/reject coverage into
+  `tests/integration/cli_build/build_graph_json_host_effects/file_reads.rs`,
+  leaving env-effect rejection ordering coverage in the parent module.
 - Generic specialization generated-C assertions now split multi-file import and
   dependency cases into
   `tests/integration/generic_specializations/multifile_generated_c.rs`,

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -470,6 +470,9 @@ checked-in docs, tests, and commits only.
 - Frontend JSON integration tests now keep AST and symbol module-graph
   serialization coverage in a focused child module, leaving typed-program and
   diagnostics JSON checks in the parent module.
+- Build-graph JSON host-effect tests now keep declared file-read fallback
+  accept/reject cases in a focused child module, leaving env-effect rejection
+  ordering coverage in the parent integration module.
 - Generic specialization generated-C assertions now keep multi-file import and
   dependency cases in a focused integration module, separating them from
   single-file generic specialization emission assertions.

--- a/tests/integration/cli_build/build_graph_json_host_effects.rs
+++ b/tests/integration/cli_build/build_graph_json_host_effects.rs
@@ -1,5 +1,8 @@
 use std::process::Command;
 
+#[path = "build_graph_json_host_effects/file_reads.rs"]
+mod file_reads;
+
 #[test]
 fn emit_json_build_graph_rejects_undeclared_host_effects() {
     let tmp = tempfile::tempdir().expect("create temp dir");
@@ -31,106 +34,6 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
         String::from_utf8_lossy(&output.stderr)
             .contains("undeclared host effect: read env `ZEN_STD`"),
         "expected undeclared host effect diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-}
-
-#[test]
-fn emit_json_build_graph_outputs_declared_file_read_effects() {
-    assert_emit_json_build_graph_outputs_declared_file_read_effect(
-        r#"| .Err { "default" }"#,
-        "emit_json_build_graph_outputs_declared_file_read_effects",
-    );
-}
-
-#[test]
-fn emit_json_build_graph_outputs_wildcard_fallback_declared_file_read_effects() {
-    assert_emit_json_build_graph_outputs_declared_file_read_effect(
-        r#"| _ { "default" }"#,
-        "emit_json_build_graph_outputs_wildcard_fallback_declared_file_read_effects",
-    );
-}
-
-#[test]
-fn emit_json_build_graph_outputs_identifier_fallback_declared_file_read_effects() {
-    assert_emit_json_build_graph_outputs_declared_file_read_effect(
-        r#"| err { "default" }"#,
-        "emit_json_build_graph_outputs_identifier_fallback_declared_file_read_effects",
-    );
-}
-
-fn assert_emit_json_build_graph_outputs_declared_file_read_effect(
-    fallback_arm: &str,
-    case_name: &str,
-) {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let build_path = tmp.path().join("build.zen");
-    std::fs::write(
-        &build_path,
-        format!(
-            r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {{
-    manifest = b.os.read_file("build.targets") ?
-        | .Ok(contents) {{ contents }}
-        {fallback_arm}
-    b.add(Executable {{ name: "myapp", main: "main.zen", out_dir: "build/" }})
-    .Ok(b.config())
-}}
-"#,
-        ),
-    )
-    .expect("write build.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "build-graph", build_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json build-graph");
-
-    assert!(
-        output.status.success(),
-        "{case_name}: emit-json build-graph failed: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("build graph json");
-    assert_eq!(json["declared_host_effects"][0]["kind"], "read_file");
-    assert_eq!(json["declared_host_effects"][0]["value"], "build.targets");
-    assert_eq!(json["used_host_effects"][0]["kind"], "read_file");
-    assert_eq!(json["used_host_effects"][0]["value"], "build.targets");
-}
-
-#[test]
-fn emit_json_build_graph_rejects_undeclared_file_read_effects() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let build_path = tmp.path().join("build.zen");
-    std::fs::write(
-        &build_path,
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    manifest = b.os.read_file("build.targets")
-    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "build-graph", build_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json build-graph");
-
-    assert!(
-        !output.status.success(),
-        "emit-json build-graph unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("undeclared host effect: read file `build.targets`"),
-        "expected undeclared file-read effect diagnostic, stderr={}",
         String::from_utf8_lossy(&output.stderr)
     );
 }

--- a/tests/integration/cli_build/build_graph_json_host_effects/file_reads.rs
+++ b/tests/integration/cli_build/build_graph_json_host_effects/file_reads.rs
@@ -1,0 +1,101 @@
+use std::process::Command;
+
+#[test]
+fn emit_json_build_graph_outputs_declared_file_read_effects() {
+    assert_emit_json_build_graph_outputs_declared_file_read_effect(
+        r#"| .Err { "default" }"#,
+        "emit_json_build_graph_outputs_declared_file_read_effects",
+    );
+}
+
+#[test]
+fn emit_json_build_graph_outputs_wildcard_fallback_declared_file_read_effects() {
+    assert_emit_json_build_graph_outputs_declared_file_read_effect(
+        r#"| _ { "default" }"#,
+        "emit_json_build_graph_outputs_wildcard_fallback_declared_file_read_effects",
+    );
+}
+
+#[test]
+fn emit_json_build_graph_outputs_identifier_fallback_declared_file_read_effects() {
+    assert_emit_json_build_graph_outputs_declared_file_read_effect(
+        r#"| err { "default" }"#,
+        "emit_json_build_graph_outputs_identifier_fallback_declared_file_read_effects",
+    );
+}
+
+fn assert_emit_json_build_graph_outputs_declared_file_read_effect(
+    fallback_arm: &str,
+    case_name: &str,
+) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let build_path = tmp.path().join("build.zen");
+    std::fs::write(
+        &build_path,
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
+    manifest = b.os.read_file("build.targets") ?
+        | .Ok(contents) {{ contents }}
+        {fallback_arm}
+    b.add(Executable {{ name: "myapp", main: "main.zen", out_dir: "build/" }})
+    .Ok(b.config())
+}}
+"#,
+        ),
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "build-graph", build_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json build-graph");
+
+    assert!(
+        output.status.success(),
+        "{case_name}: emit-json build-graph failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("build graph json");
+    assert_eq!(json["declared_host_effects"][0]["kind"], "read_file");
+    assert_eq!(json["declared_host_effects"][0]["value"], "build.targets");
+    assert_eq!(json["used_host_effects"][0]["kind"], "read_file");
+    assert_eq!(json["used_host_effects"][0]["value"], "build.targets");
+}
+
+#[test]
+fn emit_json_build_graph_rejects_undeclared_file_read_effects() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let build_path = tmp.path().join("build.zen");
+    std::fs::write(
+        &build_path,
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets")
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "build-graph", build_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json build-graph");
+
+    assert!(
+        !output.status.success(),
+        "emit-json build-graph unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("undeclared host effect: read file `build.targets`"),
+        "expected undeclared file-read effect diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## Summary
- Split build-graph JSON declared file-read fallback accept/reject coverage into `tests/integration/cli_build/build_graph_json_host_effects/file_reads.rs`
- Leave env-effect rejection ordering coverage in the parent host-effect module
- Update the phase plan and completion audit with the split

## Validation
- `cargo fmt --check`
- `cargo test --test integration emit_json_build_graph_outputs_declared_file_read_effects`
- `cargo test --test integration emit_json_build_graph_outputs_wildcard_fallback_declared_file_read_effects`
- `cargo test --test integration emit_json_build_graph_outputs_identifier_fallback_declared_file_read_effects`
- `cargo test --test integration emit_json_build_graph_rejects_undeclared_file_read_effects`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `gh run list --branch codex/split-build-graph-json-file-read-effects --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]` after push