### PR TITLE
[codex] guard loop control parser spellings

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -103,6 +103,9 @@ and do not assume Phase 4 is ready without evidence.
   proving both `Result_unwrap_or_i32_str` and `Result_unwrap_or_bool_str`
   resolve to emitted definitions exactly once without unspecialized `Result_T`
   symbols.
+- Loop-control parser dispatch now has repo hygiene coverage through
+  `repo_hygiene::parser_loop_control_calls_use_owned_action_enum`, guarding the
+  `LoopControlAction` parsing path against raw `done`/`next` spelling checks.
   Imported public generic non-behavior `Type.impl` method templates that use
   source-module imported generic types and methods are covered by
   `tests/zen/multi_file_type_impl_imported_type_dependency/main.zen` and

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2181,6 +2181,9 @@ checked-in docs, tests, and commits only.
 - Prefix loop syntax now accepts `loop((l) { ... })` with enum-backed
   `done`/`next` control actions, including nested outer-loop exits and UFC
   `done(l)` / `next(l)` forms, with fixture and docs coverage.
+- Repo hygiene now guards loop-control parser dispatch against raw `done`/`next`
+  spelling checks, so parser suffix handling must continue to use
+  `LoopControlAction` parsing.
 - Type declaration suffix parsing now uses enum-backed `impl`/`implements`/
   `requires`/`extends` spellings, keeping parser dispatch and diagnostics off
   ad hoc string comparisons. Coverage:

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -138,6 +138,34 @@ fn parser_type_declaration_suffixes_use_owned_keyword_enum() {
 }
 
 #[test]
+fn parser_loop_control_calls_use_owned_action_enum() {
+    for path in [
+        "src/parser/expressions.rs",
+        "src/parser/expressions/suffixes.rs",
+    ] {
+        let source = read(path);
+        for forbidden in [
+            r#"name.as_str() == "done""#,
+            r#"name.as_str() == "next""#,
+            r#"match name.as_str()"#,
+            r#""done" => Expression::LoopControl"#,
+            r#""next" => Expression::LoopControl"#,
+        ] {
+            assert!(
+                !source.contains(forbidden),
+                "{path} should parse loop control calls through LoopControlAction, not raw spelling checks: {forbidden}"
+            );
+        }
+    }
+
+    let suffixes = read("src/parser/expressions/suffixes.rs");
+    assert!(
+        suffixes.contains("name.parse::<LoopControlAction>()"),
+        "parser loop-control suffix handling should parse through LoopControlAction"
+    );
+}
+
+#[test]
 fn ci_and_release_only_advertise_existing_targets() {
     let ci = read(".github/workflows/ci.yml");
     let release = read(".github/workflows/release.yml");


### PR DESCRIPTION
## Summary
- Add a repo hygiene guard that prevents loop-control parser dispatch from regressing to raw `done`/`next` spelling checks
- Record the `LoopControlAction` parser guard in the phase plan and completion audit

## Validation
- `cargo fmt --check`
- `cargo test --test docs_truth parser_loop_control_calls_use_owned_action_enum`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `gh run list --branch codex/guard-loop-control-spellings --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]` after push