### PR TITLE
[codex] cover check emit file read fallback rejection

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2600,12 +2600,13 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration check_command_build_zen_rejects_undeclared_host_effects_before_target_typechecking`.
 - `zen check build.zen` accepts declared deterministic file-read effects through
   `.Err`, wildcard, and identifier fallback arms, and rejects undeclared file
-  reads before source validation, covered by
+  reads plus missing fallback arms before source validation, covered by
   `cargo test --test integration check_command_build_zen_accepts_declared_file_read_effects`,
   `cargo test --test integration check_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects`,
   `cargo test --test integration check_command_build_zen_accepts_identifier_fallback_declared_file_read_effects`,
+  `cargo test --test integration check_command_build_zen_rejects_undeclared_file_read_effects_before_source_validation`,
   and
-  `cargo test --test integration check_command_build_zen_rejects_undeclared_file_read_effects_before_source_validation`.
+  `cargo test --test integration check_command_build_zen_rejects_file_read_without_fallback_before_source_validation`.
   Declared deterministic env reads with fallbacks are accepted on the same
   validation path through
   `cargo test --test integration check_command_build_zen_accepts_declared_env_read_with_fallback`.
@@ -2620,6 +2621,9 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration emit_command_build_zen_accepts_declared_file_read_effects`
   and
   `cargo test --test integration emit_command_build_zen_rejects_undeclared_file_read_effects`.
+  Missing fallback arms on deterministic file reads also reject before C
+  emission, covered by
+  `cargo test --test integration emit_command_build_zen_rejects_file_read_without_fallback`.
   Declared deterministic env reads with fallbacks are accepted on the same emit
   path through
   `cargo test --test integration emit_command_build_zen_accepts_declared_env_read_with_fallback`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2464,6 +2464,9 @@ checked-in docs, tests, and commits only.
   and `check_command_build_zen_accepts_identifier_fallback_declared_file_read_effects`,
   while undeclared file reads reject before source validation through
   `check_command_build_zen_rejects_undeclared_file_read_effects_before_source_validation`.
+  File reads with `?` but no fallback arm also reject before source validation
+  through
+  `check_command_build_zen_rejects_file_read_without_fallback_before_source_validation`.
   Library-only graphs remain valid on this non-executing path through
   `check_command_build_zen_accepts_library_only_graph_validation`.
 - Normal `zen test build.zen` compiles and runs test graph targets, covered by
@@ -2530,6 +2533,8 @@ checked-in docs, tests, and commits only.
   `emit_command_build_zen_accepts_declared_file_read_effects`, while
   undeclared file reads reject before C emission through
   `emit_command_build_zen_rejects_undeclared_file_read_effects`.
+  File reads with `?` but no fallback arm also reject before C emission through
+  `emit_command_build_zen_rejects_file_read_without_fallback`.
 - Library-only build graphs remain non-executable across build, direct,
   legacy, emit, and test execution entrypoints through
   `build_command_build_zen_rejects_library_only_graph_execution`,
@@ -2625,11 +2630,13 @@ checked-in docs, tests, and commits only.
   and `test_command_build_zen_rejects_undeclared_file_read_effects_before_execution`.
 - `zen emit build.zen` now has executable graph fixtures for `.Err`,
   wildcard, and identifier fallback arms on declared file reads, while keeping
-  the matching undeclared file-read rejection before C emission. Coverage:
+  the matching undeclared file-read and missing-fallback rejections before C
+  emission. Coverage:
   `emit_command_build_zen_accepts_declared_file_read_effects`,
   `emit_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects`,
   `emit_command_build_zen_accepts_identifier_fallback_declared_file_read_effects`,
-  and `emit_command_build_zen_rejects_undeclared_file_read_effects`.
+  `emit_command_build_zen_rejects_undeclared_file_read_effects`, and
+  `emit_command_build_zen_rejects_file_read_without_fallback`.
 - Direct `zen build.zen` execution now has executable graph fixtures for
   `.Err`, wildcard, and identifier fallback arms on declared file reads, while
   keeping the matching undeclared file-read rejection before graph execution.

--- a/tests/integration/cli_build/emit_direct_host_effects/file_reads.rs
+++ b/tests/integration/cli_build/emit_direct_host_effects/file_reads.rs
@@ -114,3 +114,44 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
         String::from_utf8_lossy(&output.stdout)
     );
 }
+
+#[test]
+fn emit_command_build_zen_rejects_file_read_without_fallback() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets") ?
+        | .Ok(contents) { contents }
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen emit build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen emit build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("undeclared host effect: read file `build.targets`"),
+        "expected undeclared file read diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "emit should not write C source after graph validation fails, stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}

--- a/tests/integration/cli_build/graph_validation_host_effects/file_reads.rs
+++ b/tests/integration/cli_build/graph_validation_host_effects/file_reads.rs
@@ -108,3 +108,42 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
         "host-effect validation should run before source validation, stderr={stderr}"
     );
 }
+
+#[test]
+fn check_command_build_zen_rejects_file_read_without_fallback_before_source_validation() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets") ?
+        | .Ok(contents) { contents }
+    b.add(Executable { name: "myapp", main: "missing.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["check", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen check build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen check build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("undeclared host effect: read file `build.targets`"),
+        "expected undeclared file read diagnostic, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("source not found"),
+        "host-effect validation should run before source validation, stderr={stderr}"
+    );
+}


### PR DESCRIPTION
## Summary
- Add `zen check build.zen` coverage for `b.os.read_file(...) ?` with no fallback arm rejecting before source validation
- Add `zen emit build.zen` coverage for the same missing-fallback file-read rejection before C emission
- Update phase plan and completion audit evidence

## Validation
- `cargo fmt --check`
- `cargo test --test integration check_command_build_zen_rejects_file_read_without_fallback_before_source_validation`
- `cargo test --test integration emit_command_build_zen_rejects_file_read_without_fallback`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `gh run list --branch codex/add-check-emit-file-read-fallback-negative-tests --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]` after push