### PR TITLE
[codex] cover execution file read fallback rejection

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2528,6 +2528,9 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration build_graph_command_accepts_identifier_fallback_declared_file_read_effects`,
   and
   `cargo test --test integration build_graph_command_rejects_undeclared_file_read_effects_before_execution`.
+  Missing fallback arms on deterministic file reads also reject before
+  execution, covered by
+  `cargo test --test integration build_graph_command_rejects_file_read_without_fallback_before_execution`.
   Graph-only library export source validation and typechecking before
   execution are covered by
   `cargo test --test integration build_graph_command_rejects_missing_graph_only_library_source`,
@@ -2648,10 +2651,12 @@ and do not assume Phase 4 is ready without evidence.
   and
   `cargo test --test integration test_command_build_zen_rejects_library_only_graph_execution`.
 - Direct `zen build.zen` accepts declared deterministic file-read effects and
-  rejects undeclared file reads before execution, covered by
-  `cargo test --test integration direct_file_command_build_zen_accepts_declared_file_read_effects`
+  rejects undeclared file reads plus missing fallback arms before execution,
+  covered by
+  `cargo test --test integration direct_file_command_build_zen_accepts_declared_file_read_effects`,
+  `cargo test --test integration direct_file_command_build_zen_rejects_undeclared_file_read_effects_before_execution`,
   and
-  `cargo test --test integration direct_file_command_build_zen_rejects_undeclared_file_read_effects_before_execution`.
+  `cargo test --test integration direct_file_command_build_zen_rejects_file_read_without_fallback_before_execution`.
   Declared deterministic env reads with fallbacks are accepted on the same
   direct execution path through
   `cargo test --test integration direct_file_command_build_zen_accepts_declared_env_read_with_fallback`.
@@ -2873,11 +2878,13 @@ and do not assume Phase 4 is ready without evidence.
   an executable `zen build build.zen` file-read fixture.
 - `zen test build.zen` now has executable graph fixtures for `.Err`,
   wildcard, and identifier fallback arms on declared file reads, while keeping
-  the matching undeclared file-read rejection before test execution. Coverage:
+  the matching undeclared file-read and missing-fallback rejections before test
+  execution. Coverage:
   `test_command_build_zen_accepts_declared_file_read_effects`,
   `test_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects`,
   `test_command_build_zen_accepts_identifier_fallback_declared_file_read_effects`,
-  and `test_command_build_zen_rejects_undeclared_file_read_effects_before_execution`.
+  `test_command_build_zen_rejects_undeclared_file_read_effects_before_execution`,
+  and `test_command_build_zen_rejects_file_read_without_fallback_before_execution`.
 - `zen emit build.zen` now has executable graph fixtures for `.Err`,
   wildcard, and identifier fallback arms on declared file reads, while keeping
   the matching undeclared file-read rejection before C emission. Coverage:
@@ -2887,11 +2894,13 @@ and do not assume Phase 4 is ready without evidence.
   and `emit_command_build_zen_rejects_undeclared_file_read_effects`.
 - Direct `zen build.zen` execution now has executable graph fixtures for
   `.Err`, wildcard, and identifier fallback arms on declared file reads, while
-  keeping the matching undeclared file-read rejection before graph execution.
+  keeping the matching undeclared file-read and missing-fallback rejections
+  before graph execution.
   Coverage: `direct_file_command_build_zen_accepts_declared_file_read_effects`,
   `direct_file_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects`,
   `direct_file_command_build_zen_accepts_identifier_fallback_declared_file_read_effects`,
-  and `direct_file_command_build_zen_rejects_undeclared_file_read_effects_before_execution`.
+  `direct_file_command_build_zen_rejects_undeclared_file_read_effects_before_execution`,
+  and `direct_file_command_build_zen_rejects_file_read_without_fallback_before_execution`.
 - Imported behavior association dependency seeding is now split into
   `src/typechecker/resolver_validation/imports_behavior_dependencies.rs`,
   preserving imported behavior inheritance and impl coverage while keeping the

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2401,6 +2401,8 @@ checked-in docs, tests, and commits only.
   and `build_graph_command_accepts_identifier_fallback_declared_file_read_effects`,
   while undeclared file reads reject before execution through
   `build_graph_command_rejects_undeclared_file_read_effects_before_execution`.
+  File reads with `?` but no fallback arm also reject before execution through
+  `build_graph_command_rejects_file_read_without_fallback_before_execution`.
 - Normal `zen build build.zen` now routes through the same constrained
   deterministic graph pipeline used by `build-graph <build.zen>`, covered by
   `build_command_routes_build_zen_through_deterministic_graph`. The normal
@@ -2499,6 +2501,9 @@ checked-in docs, tests, and commits only.
   path through `test_command_build_zen_accepts_declared_file_read_effects`,
   while undeclared file reads reject before test execution through
   `test_command_build_zen_rejects_undeclared_file_read_effects_before_execution`.
+  File reads with `?` but no fallback arm also reject before test execution
+  through
+  `test_command_build_zen_rejects_file_read_without_fallback_before_execution`.
 - Normal `zen emit build.zen` emits generated C for the single executable graph
   target without compiling a binary, covered by
   `emit_command_build_zen_outputs_target_c_source`, rejects ambiguous
@@ -2575,6 +2580,8 @@ checked-in docs, tests, and commits only.
   `direct_file_command_build_zen_accepts_declared_file_read_effects`, while
   undeclared file reads reject before execution through
   `direct_file_command_build_zen_rejects_undeclared_file_read_effects_before_execution`.
+  File reads with `?` but no fallback arm also reject before execution through
+  `direct_file_command_build_zen_rejects_file_read_without_fallback_before_execution`.
 - Build script lowering collects multiple executable targets deterministically,
   covered by `build_program_lowering_collects_multiple_executable_targets`.
 - Legacy `emit-json ast|symbols|typed|diagnostics build.zen` modes stay
@@ -2623,11 +2630,13 @@ checked-in docs, tests, and commits only.
   an executable `zen build build.zen` file-read fixture.
 - `zen test build.zen` now has executable graph fixtures for `.Err`,
   wildcard, and identifier fallback arms on declared file reads, while keeping
-  the matching undeclared file-read rejection before test execution. Coverage:
+  the matching undeclared file-read and missing-fallback rejections before test
+  execution. Coverage:
   `test_command_build_zen_accepts_declared_file_read_effects`,
   `test_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects`,
   `test_command_build_zen_accepts_identifier_fallback_declared_file_read_effects`,
-  and `test_command_build_zen_rejects_undeclared_file_read_effects_before_execution`.
+  `test_command_build_zen_rejects_undeclared_file_read_effects_before_execution`,
+  and `test_command_build_zen_rejects_file_read_without_fallback_before_execution`.
 - `zen emit build.zen` now has executable graph fixtures for `.Err`,
   wildcard, and identifier fallback arms on declared file reads, while keeping
   the matching undeclared file-read and missing-fallback rejections before C
@@ -2639,11 +2648,13 @@ checked-in docs, tests, and commits only.
   `emit_command_build_zen_rejects_file_read_without_fallback`.
 - Direct `zen build.zen` execution now has executable graph fixtures for
   `.Err`, wildcard, and identifier fallback arms on declared file reads, while
-  keeping the matching undeclared file-read rejection before graph execution.
+  keeping the matching undeclared file-read and missing-fallback rejections
+  before graph execution.
   Coverage: `direct_file_command_build_zen_accepts_declared_file_read_effects`,
   `direct_file_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects`,
   `direct_file_command_build_zen_accepts_identifier_fallback_declared_file_read_effects`,
-  and `direct_file_command_build_zen_rejects_undeclared_file_read_effects_before_execution`.
+  `direct_file_command_build_zen_rejects_undeclared_file_read_effects_before_execution`,
+  and `direct_file_command_build_zen_rejects_file_read_without_fallback_before_execution`.
 - Expression function checking now lives in
   `src/typechecker/expressions/function_checking.rs`, keeping
   `src/typechecker/expressions.rs` focused on expression dispatch while

--- a/tests/integration/cli_build/direct_build_graph_host_effects/file_reads.rs
+++ b/tests/integration/cli_build/direct_build_graph_host_effects/file_reads.rs
@@ -120,3 +120,43 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
         "direct build.zen command should not start after graph validation fails"
     );
 }
+
+#[test]
+fn direct_file_command_build_zen_rejects_file_read_without_fallback_before_execution() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets") ?
+        | .Ok(contents) { contents }
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .arg("build.zen")
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("undeclared host effect: read file `build.targets`"),
+        "expected undeclared file read diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "direct build.zen command should not start after graph validation fails"
+    );
+}

--- a/tests/integration/cli_build/graph_validation_test_command_host_effects/file_reads.rs
+++ b/tests/integration/cli_build/graph_validation_test_command_host_effects/file_reads.rs
@@ -116,3 +116,43 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
         "test command should not start after graph validation fails"
     );
 }
+
+#[test]
+fn test_command_build_zen_rejects_file_read_without_fallback_before_execution() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("test.targets") ?
+        | .Ok(contents) { contents }
+    b.add(Test { name: "unit", root: "test.zen" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["test", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen test build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen test build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("undeclared host effect: read file `test.targets`"),
+        "expected undeclared file read diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "test command should not start after graph validation fails"
+    );
+}

--- a/tests/integration/cli_build/legacy_graph_command_host_effects/file_reads.rs
+++ b/tests/integration/cli_build/legacy_graph_command_host_effects/file_reads.rs
@@ -120,3 +120,43 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
         "build-graph command should not start after graph validation fails"
     );
 }
+
+#[test]
+fn build_graph_command_rejects_file_read_without_fallback_before_execution() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets") ?
+        | .Ok(contents) { contents }
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build-graph", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build-graph");
+
+    assert!(
+        !output.status.success(),
+        "zen build-graph unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("undeclared host effect: read file `build.targets`"),
+        "expected undeclared file read diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "build-graph command should not start after graph validation fails"
+    );
+}


### PR DESCRIPTION
## Summary
- Add direct `zen build.zen` coverage for `b.os.read_file(...) ?` with no fallback arm rejecting before execution
- Add `zen test build.zen` coverage for the same missing-fallback file-read rejection before test execution
- Add legacy `zen build-graph build.zen` coverage for the same missing-fallback file-read rejection before execution
- Update phase plan and completion audit evidence

## Validation
- `cargo fmt --check`
- `cargo test --test integration direct_file_command_build_zen_rejects_file_read_without_fallback_before_execution`
- `cargo test --test integration test_command_build_zen_rejects_file_read_without_fallback_before_execution`
- `cargo test --test integration build_graph_command_rejects_file_read_without_fallback_before_execution`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `gh run list --branch codex/add-execution-file-read-fallback-negative-tests --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]` after push