### PR TITLE
[codex] cover env read fallback rejection

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2520,6 +2520,9 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration build_graph_command_multi_target_rejects_undeclared_host_effects`.
   Declared deterministic env reads with fallbacks are accepted through
   `cargo test --test integration build_graph_command_accepts_declared_env_read_with_fallback`.
+  Missing fallback arms on deterministic env reads reject before execution
+  through
+  `cargo test --test integration build_graph_command_rejects_env_read_without_fallback_before_execution`.
   Declared deterministic file-read effects are accepted through `.Err`,
   wildcard, and identifier fallback arms, and undeclared file reads reject
   before execution, covered by
@@ -2553,6 +2556,9 @@ and do not assume Phase 4 is ready without evidence.
   Declared deterministic env reads with fallbacks are accepted on the same
   execution path through
   `cargo test --test integration build_command_build_zen_accepts_declared_env_read_with_fallback`.
+  Missing fallback arms on deterministic env reads reject before execution
+  through
+  `cargo test --test integration build_command_build_zen_rejects_env_read_without_fallback_before_execution`.
 - Build/test/legacy graph execution accepts dependencies on validated library
   source targets,
   covered by
@@ -2573,6 +2579,9 @@ and do not assume Phase 4 is ready without evidence.
   Declared deterministic env reads with fallbacks are accepted on the same
   test execution path through
   `cargo test --test integration test_command_build_zen_accepts_declared_env_read_with_fallback`.
+  Missing fallback arms on deterministic env reads reject before test
+  execution through
+  `cargo test --test integration test_command_build_zen_rejects_env_read_without_fallback_before_execution`.
 - Build/test/emit graph execution validates non-executed graph-only library
   exports before compiling or running selected targets, covered by
   `cargo test --test integration build_command_build_zen_rejects_missing_graph_only_library_source`,
@@ -2613,6 +2622,9 @@ and do not assume Phase 4 is ready without evidence.
   Declared deterministic env reads with fallbacks are accepted on the same
   validation path through
   `cargo test --test integration check_command_build_zen_accepts_declared_env_read_with_fallback`.
+  Missing fallback arms on deterministic env reads reject before source
+  validation through
+  `cargo test --test integration check_command_build_zen_rejects_env_read_without_fallback_before_source_validation`.
 - Single-target `zen emit build.zen` rejects multi-executable ambiguity before
   per-executable source validation, covered by
   `cargo test --test integration emit_command_build_zen_reports_multi_target_ambiguity_before_missing_executable_source`.
@@ -2630,6 +2642,9 @@ and do not assume Phase 4 is ready without evidence.
   Declared deterministic env reads with fallbacks are accepted on the same emit
   path through
   `cargo test --test integration emit_command_build_zen_accepts_declared_env_read_with_fallback`.
+  Missing fallback arms on deterministic env reads reject before C emission
+  through
+  `cargo test --test integration emit_command_build_zen_rejects_env_read_without_fallback`.
 - Single-target `zen emit build.zen` accepts selected executable dependencies
   on validated library source targets and rejects gated test dependencies
   before C emission, covered by
@@ -2660,6 +2675,9 @@ and do not assume Phase 4 is ready without evidence.
   Declared deterministic env reads with fallbacks are accepted on the same
   direct execution path through
   `cargo test --test integration direct_file_command_build_zen_accepts_declared_env_read_with_fallback`.
+  Missing fallback arms on deterministic env reads reject before execution
+  through
+  `cargo test --test integration direct_file_command_build_zen_rejects_env_read_without_fallback_before_execution`.
 - Direct `zen build.zen` validates and typechecks graph-only library exports
   before execution, covered by
   `cargo test --test integration direct_file_command_build_zen_accepts_valid_graph_only_library_sources`,

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2394,6 +2394,8 @@ checked-in docs, tests, and commits only.
   failure before normal `zen build build.zen` is ungated.
   Declared deterministic env reads with fallbacks are accepted through
   `build_graph_command_accepts_declared_env_read_with_fallback`.
+  Env reads with `?` but no fallback arm reject before execution through
+  `build_graph_command_rejects_env_read_without_fallback_before_execution`.
   Declared deterministic file-read effects are accepted through `.Err`,
   wildcard, and identifier fallback arms, covered by
   `build_graph_command_accepts_declared_file_read_effects`,
@@ -2437,6 +2439,8 @@ checked-in docs, tests, and commits only.
   Declared deterministic env reads with fallbacks are accepted on the normal
   build path through
   `build_command_build_zen_accepts_declared_env_read_with_fallback`.
+  Env reads with `?` but no fallback arm reject before execution through
+  `build_command_build_zen_rejects_env_read_without_fallback_before_execution`.
   Declared deterministic file-read effects are accepted on the normal build
   path through `build_command_build_zen_accepts_declared_file_read_effects`,
   while undeclared file reads reject before target execution through
@@ -2459,6 +2463,9 @@ checked-in docs, tests, and commits only.
   `check_command_build_zen_rejects_undeclared_host_effects`.
   Declared deterministic env reads with fallbacks are accepted through
   `check_command_build_zen_accepts_declared_env_read_with_fallback`.
+  Env reads with `?` but no fallback arm reject before source validation
+  through
+  `check_command_build_zen_rejects_env_read_without_fallback_before_source_validation`.
   Declared deterministic file-read effects are accepted through `.Err`,
   wildcard, and identifier fallback arms, covered by
   `check_command_build_zen_accepts_declared_file_read_effects`,
@@ -2497,6 +2504,8 @@ checked-in docs, tests, and commits only.
   Declared deterministic env reads with fallbacks are accepted on the normal
   test path through
   `test_command_build_zen_accepts_declared_env_read_with_fallback`.
+  Env reads with `?` but no fallback arm reject before test execution through
+  `test_command_build_zen_rejects_env_read_without_fallback_before_execution`.
   Declared deterministic file-read effects are accepted on the normal test
   path through `test_command_build_zen_accepts_declared_file_read_effects`,
   while undeclared file reads reject before test execution through
@@ -2534,6 +2543,8 @@ checked-in docs, tests, and commits only.
   library source checks.
   Declared deterministic env reads with fallbacks are accepted through
   `emit_command_build_zen_accepts_declared_env_read_with_fallback`.
+  Env reads with `?` but no fallback arm reject before C emission through
+  `emit_command_build_zen_rejects_env_read_without_fallback`.
   Declared deterministic file-read effects are accepted through
   `emit_command_build_zen_accepts_declared_file_read_effects`, while
   undeclared file reads reject before C emission through
@@ -2576,6 +2587,8 @@ checked-in docs, tests, and commits only.
   `direct_file_command_build_zen_rejects_undeclared_host_effects`.
   Declared deterministic env reads with fallbacks are accepted through
   `direct_file_command_build_zen_accepts_declared_env_read_with_fallback`.
+  Env reads with `?` but no fallback arm reject before execution through
+  `direct_file_command_build_zen_rejects_env_read_without_fallback_before_execution`.
   Declared deterministic file-read effects are accepted through
   `direct_file_command_build_zen_accepts_declared_file_read_effects`, while
   undeclared file reads reject before execution through

--- a/tests/integration/cli_build/declared_env_effects.rs
+++ b/tests/integration/cli_build/declared_env_effects.rs
@@ -133,6 +133,104 @@ main = () i32 {
     );
 }
 
+#[test]
+fn build_command_build_zen_rejects_env_read_without_fallback_before_execution() {
+    assert_env_read_without_fallback_is_rejected(
+        &["build", "build.zen"],
+        "build command should not start after graph validation fails",
+    );
+}
+
+#[test]
+fn direct_file_command_build_zen_rejects_env_read_without_fallback_before_execution() {
+    assert_env_read_without_fallback_is_rejected(
+        &["build.zen"],
+        "direct build.zen command should not start after graph validation fails",
+    );
+}
+
+#[test]
+fn build_graph_command_rejects_env_read_without_fallback_before_execution() {
+    assert_env_read_without_fallback_is_rejected(
+        &["build-graph", "build.zen"],
+        "build-graph command should not start after graph validation fails",
+    );
+}
+
+#[test]
+fn check_command_build_zen_rejects_env_read_without_fallback_before_source_validation() {
+    let tmp = executable_graph_with_env_read_without_fallback("missing.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["check", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen check build.zen");
+
+    assert_env_read_without_fallback_failed(&output);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("source not found"),
+        "host-effect validation should run before source validation, stderr={stderr}"
+    );
+}
+
+#[test]
+fn emit_command_build_zen_rejects_env_read_without_fallback() {
+    let tmp = executable_graph_with_env_read_without_fallback("main.zen");
+    std::fs::write(
+        tmp.path().join("main.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write main.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen emit build.zen");
+
+    assert_env_read_without_fallback_failed(&output);
+    assert!(
+        output.stdout.is_empty(),
+        "emit should not write C source after graph validation fails, stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn test_command_build_zen_rejects_env_read_without_fallback_before_execution() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    std_path = b.os.env("ZEN_STD") ?
+        | .Ok(value) { value }
+    b.add(Test { name: "unit", root: "test.zen" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["test", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen test build.zen");
+
+    assert_env_read_without_fallback_failed(&output);
+    assert!(
+        !tmp.path().join("build").exists(),
+        "test command should not start after graph validation fails"
+    );
+}
+
 fn executable_graph_with_declared_env_read() -> tempfile::TempDir {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(
@@ -157,5 +255,51 @@ main = () i32 {
 "#,
     )
     .expect("write main.zen");
+    tmp
+}
+
+fn assert_env_read_without_fallback_is_rejected(args: &[&str], build_message: &str) {
+    let tmp = executable_graph_with_env_read_without_fallback("main.zen");
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(args)
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build graph command");
+
+    assert_env_read_without_fallback_failed(&output);
+    assert!(!tmp.path().join("build").exists(), "{build_message}");
+}
+
+fn assert_env_read_without_fallback_failed(output: &std::process::Output) {
+    assert!(
+        !output.status.success(),
+        "zen command unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("undeclared host effect: read env `ZEN_STD`"),
+        "expected undeclared env read diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn executable_graph_with_env_read_without_fallback(main_source: &str) -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
+    std_path = b.os.env("ZEN_STD") ?
+        | .Ok(value) {{ value }}
+    b.add(Executable {{ name: "app", main: "{main_source}", out_dir: "build/" }})
+    .Ok(b.config())
+}}
+"#,
+        ),
+    )
+    .expect("write build.zen");
     tmp
 }


### PR DESCRIPTION
## Summary

- Add negative coverage for deterministic env reads that use `?` without a fallback arm across build graph entrypoints.
- Cover normal `zen build build.zen`, direct `zen build.zen`, legacy `zen build-graph build.zen`, `zen check build.zen`, `zen emit build.zen`, and `zen test build.zen`.
- Update the phase plan and completion audit evidence for these rejection paths.

## Validation

- `cargo test --test integration build_command_build_zen_rejects_env_read_without_fallback_before_execution`
- `cargo test --test integration direct_file_command_build_zen_rejects_env_read_without_fallback_before_execution`
- `cargo test --test integration build_graph_command_rejects_env_read_without_fallback_before_execution`
- `cargo test --test integration check_command_build_zen_rejects_env_read_without_fallback_before_source_validation`
- `cargo test --test integration emit_command_build_zen_rejects_env_read_without_fallback`
- `cargo test --test integration test_command_build_zen_rejects_env_read_without_fallback_before_execution`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `gh run list --branch codex/add-env-fallback-negative-tests --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]` after push.