### PR TITLE
[codex] cover json env fallback rejection

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2431,6 +2431,11 @@ and do not assume Phase 4 is ready without evidence.
 - Build graph lowering accepts declared deterministic env-read effects before
   graph promotion, covered by
   `cargo test --test build_graph build_program_lowering_accepts_declared_env_reads`.
+  Missing fallback arms on deterministic env and file reads reject during
+  lowering through
+  `cargo test --test build_graph build_program_lowering_rejects_env_read_without_fallback`
+  and
+  `cargo test --test build_graph build_program_lowering_rejects_file_read_without_fallback`.
 - Build target kind spellings are owned by enums instead of duplicated in
   semantic and CLI logic. `build_target_dsl_kind_owns_source_spelling` covers
   accepted build target DSL names and the supported-target diagnostic list, and
@@ -2463,6 +2468,9 @@ and do not assume Phase 4 is ready without evidence.
 - `emit-json build-graph` emits declared deterministic env-read effects
   through the advertised graph command, covered by
   `cargo test --test integration emit_json_build_graph_outputs_declared_env_read_effects`.
+  Missing fallback arms on deterministic env reads reject before graph JSON is
+  emitted through
+  `cargo test --test integration emit_json_build_graph_rejects_env_read_without_fallback`.
 - `emit-json build-graph` rejects unresolved target dependencies through the
   advertised graph-emission path, covered by
   `cargo test --test integration emit_json_build_graph_rejects_unknown_target_dependencies`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2316,6 +2316,9 @@ checked-in docs, tests, and commits only.
   `build_program_lowering_accepts_declared_env_reads`, and declared
   `b.os.read_file("...")` effects, covered by
   `build_program_lowering_accepts_declared_file_reads`, while
+  `build_program_lowering_rejects_env_read_without_fallback` and
+  `build_program_lowering_rejects_file_read_without_fallback` keep `?`
+  host-effect reads without fallback arms rejected during lowering, and
   `build_program_lowering_rejects_undeclared_file_reads` keeps undeclared file
   reads rejected before graph promotion.
 - `emit-json build-graph <build.zen>` now exposes the constrained graph-emission
@@ -2330,7 +2333,9 @@ checked-in docs, tests, and commits only.
   and `emit_json_build_graph_rejects_undeclared_host_effects_before_target_metadata_lowering`
   cover negative host-effect paths through the advertised compiler command.
   `emit_json_build_graph_outputs_declared_env_read_effects` covers the
-  matching positive declared environment-read effect JSON.
+  matching positive declared environment-read effect JSON, while
+  `emit_json_build_graph_rejects_env_read_without_fallback` covers missing
+  fallback arms before graph JSON is emitted.
   `emit_json_build_graph_outputs_declared_file_read_effects`,
   `emit_json_build_graph_outputs_wildcard_fallback_declared_file_read_effects`,
   and

--- a/tests/build_graph/host_effects.rs
+++ b/tests/build_graph/host_effects.rs
@@ -91,6 +91,28 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
 }
 
 #[test]
+fn build_program_lowering_rejects_env_read_without_fallback() {
+    let program = parse_program(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    std_path = b.os.env("ZEN_STD") ?
+        | .Ok(value) { value }
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    );
+
+    let err = BuildGraph::from_build_program(&program)
+        .expect_err("build.zen env read without fallback should fail");
+
+    assert_eq!(
+        err.to_string(),
+        "undeclared host effect: read env `ZEN_STD`"
+    );
+}
+
+#[test]
 fn build_program_lowering_accepts_declared_file_reads() {
     let program = parse_program(
         r#"
@@ -173,6 +195,28 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
 
     let err = BuildGraph::from_build_program(&program)
         .expect_err("undeclared build.zen file read should fail");
+
+    assert_eq!(
+        err.to_string(),
+        "undeclared host effect: read file `build.targets`"
+    );
+}
+
+#[test]
+fn build_program_lowering_rejects_file_read_without_fallback() {
+    let program = parse_program(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets") ?
+        | .Ok(contents) { contents }
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    );
+
+    let err = BuildGraph::from_build_program(&program)
+        .expect_err("build.zen file read without fallback should fail");
 
     assert_eq!(
         err.to_string(),

--- a/tests/integration/cli_build/build_graph_json_declared_env.rs
+++ b/tests/integration/cli_build/build_graph_json_declared_env.rs
@@ -36,3 +36,44 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
     assert_eq!(json["used_host_effects"][0]["kind"], "read_env");
     assert_eq!(json["used_host_effects"][0]["value"], "ZEN_STD");
 }
+
+#[test]
+fn emit_json_build_graph_rejects_env_read_without_fallback() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let build_path = tmp.path().join("build.zen");
+    std::fs::write(
+        &build_path,
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    std_path = b.os.env("ZEN_STD") ?
+        | .Ok(value) { value }
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "build-graph", build_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json build-graph");
+
+    assert!(
+        !output.status.success(),
+        "emit-json build-graph unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("undeclared host effect: read env `ZEN_STD`"),
+        "expected undeclared env-read effect diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "emit-json build-graph should not emit graph JSON after validation fails, stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}


### PR DESCRIPTION
## Summary

- Add build-graph lowering tests for deterministic env/file reads that use `?` without fallback arms.
- Add `emit-json build-graph` coverage proving an env read without fallback rejects before graph JSON is emitted.
- Update phase plan and completion audit evidence for the new host-effect rejection coverage.

## Validation

- `cargo test --test build_graph build_program_lowering_rejects_env_read_without_fallback`
- `cargo test --test build_graph build_program_lowering_rejects_file_read_without_fallback`
- `cargo test --test integration emit_json_build_graph_rejects_env_read_without_fallback`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `gh run list --branch codex/cover-json-env-fallback-rejection --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]` after push.