### PR TITLE
[codex] cover json file fallback rejection

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2465,6 +2465,9 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration emit_json_build_graph_outputs_identifier_fallback_declared_file_read_effects`,
   and
   `cargo test --test integration emit_json_build_graph_rejects_undeclared_file_read_effects`.
+  Missing fallback arms on deterministic file reads reject before graph JSON is
+  emitted through
+  `cargo test --test integration emit_json_build_graph_rejects_file_read_without_fallback`.
 - `emit-json build-graph` emits declared deterministic env-read effects
   through the advertised graph command, covered by
   `cargo test --test integration emit_json_build_graph_outputs_declared_env_read_effects`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2343,7 +2343,9 @@ checked-in docs, tests, and commits only.
   cover `.Err`, wildcard, and identifier fallback arms for declared
   deterministic file-read effect JSON. The
   `emit_json_build_graph_rejects_undeclared_file_read_effects` fixture covers
-  the matching negative path through that same graph-emission command.
+  undeclared file reads, and
+  `emit_json_build_graph_rejects_file_read_without_fallback` covers missing
+  fallback arms through that same graph-emission command.
   `emit_json_build_graph_rejects_unknown_target_dependencies` covers unresolved
   target dependency rejection through the same graph-emission path, and
   `emit_json_build_graph_rejects_self_target_dependencies` covers

--- a/tests/integration/cli_build/build_graph_json_host_effects/file_reads.rs
+++ b/tests/integration/cli_build/build_graph_json_host_effects/file_reads.rs
@@ -99,3 +99,44 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
         String::from_utf8_lossy(&output.stderr)
     );
 }
+
+#[test]
+fn emit_json_build_graph_rejects_file_read_without_fallback() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let build_path = tmp.path().join("build.zen");
+    std::fs::write(
+        &build_path,
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets") ?
+        | .Ok(contents) { contents }
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "build-graph", build_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json build-graph");
+
+    assert!(
+        !output.status.success(),
+        "emit-json build-graph unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("undeclared host effect: read file `build.targets`"),
+        "expected undeclared file-read effect diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "emit-json build-graph should not emit graph JSON after validation fails, stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}


### PR DESCRIPTION
## Summary

- Add `emit-json build-graph` coverage for deterministic file reads that use `?` without fallback arms.
- Assert graph JSON is not emitted after missing-fallback host-effect validation fails.
- Update phase plan and completion audit evidence for the JSON graph file-read rejection path.

## Validation

- `cargo test --test integration emit_json_build_graph_rejects_file_read_without_fallback`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `gh run list --branch codex/cover-json-file-fallback-rejection --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]` after push.