### PR TITLE
[codex] cover json env fallback arms

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2470,7 +2470,10 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration emit_json_build_graph_rejects_file_read_without_fallback`.
 - `emit-json build-graph` emits declared deterministic env-read effects
   through the advertised graph command, covered by
-  `cargo test --test integration emit_json_build_graph_outputs_declared_env_read_effects`.
+  `cargo test --test integration emit_json_build_graph_outputs_declared_env_read_effects`,
+  `cargo test --test integration emit_json_build_graph_outputs_wildcard_fallback_declared_env_read_effects`,
+  and
+  `cargo test --test integration emit_json_build_graph_outputs_identifier_fallback_declared_env_read_effects`.
   Missing fallback arms on deterministic env reads reject before graph JSON is
   emitted through
   `cargo test --test integration emit_json_build_graph_rejects_env_read_without_fallback`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2332,8 +2332,12 @@ checked-in docs, tests, and commits only.
   and `emit_json_build_graph_rejects_undeclared_host_effects_before_library_target_lowering`
   and `emit_json_build_graph_rejects_undeclared_host_effects_before_target_metadata_lowering`
   cover negative host-effect paths through the advertised compiler command.
-  `emit_json_build_graph_outputs_declared_env_read_effects` covers the
-  matching positive declared environment-read effect JSON, while
+  `emit_json_build_graph_outputs_declared_env_read_effects`,
+  `emit_json_build_graph_outputs_wildcard_fallback_declared_env_read_effects`,
+  and
+  `emit_json_build_graph_outputs_identifier_fallback_declared_env_read_effects`
+  cover `.Err`, wildcard, and identifier fallback arms for matching positive
+  declared environment-read effect JSON, while
   `emit_json_build_graph_rejects_env_read_without_fallback` covers missing
   fallback arms before graph JSON is emitted.
   `emit_json_build_graph_outputs_declared_file_read_effects`,

--- a/tests/integration/cli_build/build_graph_json_declared_env.rs
+++ b/tests/integration/cli_build/build_graph_json_declared_env.rs
@@ -2,19 +2,47 @@ use std::process::Command;
 
 #[test]
 fn emit_json_build_graph_outputs_declared_env_read_effects() {
+    assert_emit_json_build_graph_outputs_declared_env_read_effect(
+        r#"| .Err { "default" }"#,
+        "emit_json_build_graph_outputs_declared_env_read_effects",
+    );
+}
+
+#[test]
+fn emit_json_build_graph_outputs_wildcard_fallback_declared_env_read_effects() {
+    assert_emit_json_build_graph_outputs_declared_env_read_effect(
+        r#"| _ { "default" }"#,
+        "emit_json_build_graph_outputs_wildcard_fallback_declared_env_read_effects",
+    );
+}
+
+#[test]
+fn emit_json_build_graph_outputs_identifier_fallback_declared_env_read_effects() {
+    assert_emit_json_build_graph_outputs_declared_env_read_effect(
+        r#"| err { "default" }"#,
+        "emit_json_build_graph_outputs_identifier_fallback_declared_env_read_effects",
+    );
+}
+
+fn assert_emit_json_build_graph_outputs_declared_env_read_effect(
+    fallback_arm: &str,
+    case_name: &str,
+) {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let build_path = tmp.path().join("build.zen");
     std::fs::write(
         &build_path,
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
     std_path = b.os.env("ZEN_STD") ?
-        | .Ok(value) { value }
-        | .Err { "default" }
-    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+        | .Ok(value) {{ value }}
+        {fallback_arm}
+    b.add(Executable {{ name: "myapp", main: "main.zen", out_dir: "build/" }})
     .Ok(b.config())
-}
+}}
 "#,
+        ),
     )
     .expect("write build.zen");
 
@@ -25,7 +53,7 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
 
     assert!(
         output.status.success(),
-        "emit-json build-graph failed: stdout={}, stderr={}",
+        "{case_name}: emit-json build-graph failed: stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );


### PR DESCRIPTION
## Summary

- Add `emit-json build-graph` coverage for wildcard and identifier fallback arms on declared deterministic env reads.
- Refactor the existing declared env-read JSON test through the same helper used by the new cases.
- Update phase plan and completion audit evidence for the env-read JSON fallback matrix.

## Validation

- `cargo test --test integration emit_json_build_graph_outputs_declared_env_read_effects`
- `cargo test --test integration emit_json_build_graph_outputs_wildcard_fallback_declared_env_read_effects`
- `cargo test --test integration emit_json_build_graph_outputs_identifier_fallback_declared_env_read_effects`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `gh run list --branch codex/cover-json-env-fallback-arms --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]` after push.