### PR TITLE
[codex] cover legacy env fallback arms

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2532,8 +2532,12 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration build_graph_command_rejects_undeclared_host_effects`
   and
   `cargo test --test integration build_graph_command_multi_target_rejects_undeclared_host_effects`.
-  Declared deterministic env reads with fallbacks are accepted through
-  `cargo test --test integration build_graph_command_accepts_declared_env_read_with_fallback`.
+  Declared deterministic env reads with `.Err`, wildcard, and identifier
+  fallback arms are accepted through
+  `cargo test --test integration build_graph_command_accepts_declared_env_read_with_fallback`,
+  `cargo test --test integration build_graph_command_accepts_wildcard_fallback_declared_env_read`,
+  and
+  `cargo test --test integration build_graph_command_accepts_identifier_fallback_declared_env_read`.
   Missing fallback arms on deterministic env reads reject before execution
   through
   `cargo test --test integration build_graph_command_rejects_env_read_without_fallback_before_execution`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2403,8 +2403,11 @@ checked-in docs, tests, and commits only.
   executable dependencies on gated test targets, and
   `build_graph_command_rejects_missing_root_source` covers a target execution
   failure before normal `zen build build.zen` is ungated.
-  Declared deterministic env reads with fallbacks are accepted through
-  `build_graph_command_accepts_declared_env_read_with_fallback`.
+  Declared deterministic env reads with `.Err`, wildcard, and identifier
+  fallback arms are accepted through
+  `build_graph_command_accepts_declared_env_read_with_fallback`,
+  `build_graph_command_accepts_wildcard_fallback_declared_env_read`, and
+  `build_graph_command_accepts_identifier_fallback_declared_env_read`.
   Env reads with `?` but no fallback arm reject before execution through
   `build_graph_command_rejects_env_read_without_fallback_before_execution`.
   Declared deterministic file-read effects are accepted through `.Err`,

--- a/tests/integration/cli_build/declared_env_effects.rs
+++ b/tests/integration/cli_build/declared_env_effects.rs
@@ -67,6 +67,22 @@ fn build_graph_command_accepts_declared_env_read_with_fallback() {
 }
 
 #[test]
+fn build_graph_command_accepts_wildcard_fallback_declared_env_read() {
+    assert_build_graph_command_accepts_declared_env_read(
+        r#"| _ { "default" }"#,
+        "build_graph_command_accepts_wildcard_fallback_declared_env_read",
+    );
+}
+
+#[test]
+fn build_graph_command_accepts_identifier_fallback_declared_env_read() {
+    assert_build_graph_command_accepts_declared_env_read(
+        r#"| err { "default" }"#,
+        "build_graph_command_accepts_identifier_fallback_declared_env_read",
+    );
+}
+
+#[test]
 fn emit_command_build_zen_accepts_declared_env_read_with_fallback() {
     let tmp = executable_graph_with_declared_env_read();
 
@@ -232,18 +248,45 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
 }
 
 fn executable_graph_with_declared_env_read() -> tempfile::TempDir {
+    executable_graph_with_declared_env_read_fallback(r#"| .Err { "default" }"#)
+}
+
+fn assert_build_graph_command_accepts_declared_env_read(fallback_arm: &str, case_name: &str) {
+    let tmp = executable_graph_with_declared_env_read_fallback(fallback_arm);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build-graph", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build-graph build.zen");
+
+    assert!(
+        output.status.success(),
+        "{case_name}: zen build-graph build.zen failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        tmp.path().join("build").join("app").exists(),
+        "{case_name}: expected build output after declared env effect"
+    );
+}
+
+fn executable_graph_with_declared_env_read_fallback(fallback_arm: &str) -> tempfile::TempDir {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(
         tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
     std_path = b.os.env("ZEN_STD") ?
-        | .Ok(value) { value }
-        | .Err { "default" }
-    b.add(Executable { name: "app", main: "main.zen", out_dir: "build/" })
+        | .Ok(value) {{ value }}
+        {fallback_arm}
+    b.add(Executable {{ name: "app", main: "main.zen", out_dir: "build/" }})
     .Ok(b.config())
-}
+}}
 "#,
+        ),
     )
     .expect("write build.zen");
     std::fs::write(


### PR DESCRIPTION
## Summary

- Add legacy `zen build-graph build.zen` coverage for wildcard and identifier fallback arms on declared deterministic env reads.
- Refactor the env-read executable graph helper to accept a fallback arm while preserving the existing `.Err` behavior.
- Update the phase plan and completion audit evidence for the expanded fallback-arm coverage.

## Validation

- `cargo test --test integration build_graph_command_accepts_declared_env_read_with_fallback`
- `cargo test --test integration build_graph_command_accepts_wildcard_fallback_declared_env_read`
- `cargo test --test integration build_graph_command_accepts_identifier_fallback_declared_env_read`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Branch push Actions check: `[]`