### PR TITLE
[codex] cover check env fallback arms

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2637,9 +2637,12 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration check_command_build_zen_rejects_undeclared_file_read_effects_before_source_validation`,
   and
   `cargo test --test integration check_command_build_zen_rejects_file_read_without_fallback_before_source_validation`.
-  Declared deterministic env reads with fallbacks are accepted on the same
-  validation path through
-  `cargo test --test integration check_command_build_zen_accepts_declared_env_read_with_fallback`.
+  Declared deterministic env reads with `.Err`, wildcard, and identifier
+  fallback arms are accepted on the same validation path through
+  `cargo test --test integration check_command_build_zen_accepts_declared_env_read_with_fallback`,
+  `cargo test --test integration check_command_build_zen_accepts_wildcard_fallback_declared_env_read`,
+  and
+  `cargo test --test integration check_command_build_zen_accepts_identifier_fallback_declared_env_read`.
   Missing fallback arms on deterministic env reads reject before source
   validation through
   `cargo test --test integration check_command_build_zen_rejects_env_read_without_fallback_before_source_validation`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2475,8 +2475,11 @@ checked-in docs, tests, and commits only.
   `check_command_build_zen_rejects_undeclared_host_effects_before_target_typechecking`.
   The single-target host-effect rejection remains covered by
   `check_command_build_zen_rejects_undeclared_host_effects`.
-  Declared deterministic env reads with fallbacks are accepted through
-  `check_command_build_zen_accepts_declared_env_read_with_fallback`.
+  Declared deterministic env reads with `.Err`, wildcard, and identifier
+  fallback arms are accepted through
+  `check_command_build_zen_accepts_declared_env_read_with_fallback`,
+  `check_command_build_zen_accepts_wildcard_fallback_declared_env_read`, and
+  `check_command_build_zen_accepts_identifier_fallback_declared_env_read`.
   Env reads with `?` but no fallback arm reject before source validation
   through
   `check_command_build_zen_rejects_env_read_without_fallback_before_source_validation`.

--- a/tests/integration/cli_build/graph_validation_host_effects.rs
+++ b/tests/integration/cli_build/graph_validation_host_effects.rs
@@ -40,18 +40,43 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
 
 #[test]
 fn check_command_build_zen_accepts_declared_env_read_with_fallback() {
+    assert_check_command_accepts_declared_env_read_fallback(
+        r#"| .Err { "~/.zen/std" }"#,
+        "check_command_build_zen_accepts_declared_env_read_with_fallback",
+    );
+}
+
+#[test]
+fn check_command_build_zen_accepts_wildcard_fallback_declared_env_read() {
+    assert_check_command_accepts_declared_env_read_fallback(
+        r#"| _ { "~/.zen/std" }"#,
+        "check_command_build_zen_accepts_wildcard_fallback_declared_env_read",
+    );
+}
+
+#[test]
+fn check_command_build_zen_accepts_identifier_fallback_declared_env_read() {
+    assert_check_command_accepts_declared_env_read_fallback(
+        r#"| err { "~/.zen/std" }"#,
+        "check_command_build_zen_accepts_identifier_fallback_declared_env_read",
+    );
+}
+
+fn assert_check_command_accepts_declared_env_read_fallback(fallback_arm: &str, case_name: &str) {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(
         tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
     std_path = b.os.env("ZEN_STD") ?
-        | .Ok(path) { path }
-        | .Err { "~/.zen/std" }
-    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+        | .Ok(path) {{ path }}
+        {fallback_arm}
+    b.add(Executable {{ name: "myapp", main: "main.zen", out_dir: "build/" }})
     .Ok(b.config())
-}
+}}
 "#,
+        ),
     )
     .expect("write build.zen");
     std::fs::write(
@@ -72,13 +97,13 @@ main = () i32 {
 
     assert!(
         output.status.success(),
-        "zen check build.zen failed: stdout={}, stderr={}",
+        "{case_name}: zen check build.zen failed: stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(
         String::from_utf8_lossy(&output.stdout).contains("1 build targets"),
-        "expected build graph check summary, stdout={}",
+        "{case_name}: expected build graph check summary, stdout={}",
         String::from_utf8_lossy(&output.stdout)
     );
 }


### PR DESCRIPTION
## Summary

- Add `zen check build.zen` coverage for wildcard and identifier fallback arms on declared deterministic env reads.
- Refactor the check-path env-read fixture helper to accept the fallback arm while preserving the existing `.Err` case.
- Update the phase plan and completion audit evidence for the expanded check-path fallback-arm coverage.

## Validation

- `cargo test --test integration check_command_build_zen_accepts_declared_env_read_with_fallback`
- `cargo test --test integration check_command_build_zen_accepts_wildcard_fallback_declared_env_read`
- `cargo test --test integration check_command_build_zen_accepts_identifier_fallback_declared_env_read`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Branch push Actions check: `[]`