### PR TITLE
[codex] cover executable env fallback arms

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2571,9 +2571,12 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration build_command_build_zen_accepts_declared_file_read_effects`
   and
   `cargo test --test integration build_command_build_zen_rejects_undeclared_file_read_effects_before_execution`.
-  Declared deterministic env reads with fallbacks are accepted on the same
-  execution path through
-  `cargo test --test integration build_command_build_zen_accepts_declared_env_read_with_fallback`.
+  Declared deterministic env reads with `.Err`, wildcard, and identifier
+  fallback arms are accepted on the same execution path through
+  `cargo test --test integration build_command_build_zen_accepts_declared_env_read_with_fallback`,
+  `cargo test --test integration build_command_build_zen_accepts_wildcard_fallback_declared_env_read`,
+  and
+  `cargo test --test integration build_command_build_zen_accepts_identifier_fallback_declared_env_read`.
   Missing fallback arms on deterministic env reads reject before execution
   through
   `cargo test --test integration build_command_build_zen_rejects_env_read_without_fallback_before_execution`.
@@ -2660,9 +2663,12 @@ and do not assume Phase 4 is ready without evidence.
   Missing fallback arms on deterministic file reads also reject before C
   emission, covered by
   `cargo test --test integration emit_command_build_zen_rejects_file_read_without_fallback`.
-  Declared deterministic env reads with fallbacks are accepted on the same emit
-  path through
-  `cargo test --test integration emit_command_build_zen_accepts_declared_env_read_with_fallback`.
+  Declared deterministic env reads with `.Err`, wildcard, and identifier
+  fallback arms are accepted on the same emit path through
+  `cargo test --test integration emit_command_build_zen_accepts_declared_env_read_with_fallback`,
+  `cargo test --test integration emit_command_build_zen_accepts_wildcard_fallback_declared_env_read`,
+  and
+  `cargo test --test integration emit_command_build_zen_accepts_identifier_fallback_declared_env_read`.
   Missing fallback arms on deterministic env reads reject before C emission
   through
   `cargo test --test integration emit_command_build_zen_rejects_env_read_without_fallback`.
@@ -2693,9 +2699,12 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration direct_file_command_build_zen_rejects_undeclared_file_read_effects_before_execution`,
   and
   `cargo test --test integration direct_file_command_build_zen_rejects_file_read_without_fallback_before_execution`.
-  Declared deterministic env reads with fallbacks are accepted on the same
-  direct execution path through
-  `cargo test --test integration direct_file_command_build_zen_accepts_declared_env_read_with_fallback`.
+  Declared deterministic env reads with `.Err`, wildcard, and identifier
+  fallback arms are accepted on the same direct execution path through
+  `cargo test --test integration direct_file_command_build_zen_accepts_declared_env_read_with_fallback`,
+  `cargo test --test integration direct_file_command_build_zen_accepts_wildcard_fallback_declared_env_read`,
+  and
+  `cargo test --test integration direct_file_command_build_zen_accepts_identifier_fallback_declared_env_read`.
   Missing fallback arms on deterministic env reads reject before execution
   through
   `cargo test --test integration direct_file_command_build_zen_rejects_env_read_without_fallback_before_execution`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2450,9 +2450,11 @@ checked-in docs, tests, and commits only.
   `build_command_multi_target_build_zen_rejects_undeclared_host_effects`. The
   single-target rejection remains covered by
   `build_command_build_zen_rejects_undeclared_host_effects`.
-  Declared deterministic env reads with fallbacks are accepted on the normal
-  build path through
-  `build_command_build_zen_accepts_declared_env_read_with_fallback`.
+  Declared deterministic env reads with `.Err`, wildcard, and identifier
+  fallback arms are accepted on the normal build path through
+  `build_command_build_zen_accepts_declared_env_read_with_fallback`,
+  `build_command_build_zen_accepts_wildcard_fallback_declared_env_read`, and
+  `build_command_build_zen_accepts_identifier_fallback_declared_env_read`.
   Env reads with `?` but no fallback arm reject before execution through
   `build_command_build_zen_rejects_env_read_without_fallback_before_execution`.
   Declared deterministic file-read effects are accepted on the normal build
@@ -2558,8 +2560,11 @@ checked-in docs, tests, and commits only.
   `emit_command_build_zen_reports_multi_target_ambiguity_before_graph_only_library_typechecking`
   keep multi-executable ambiguity ahead of per-executable and graph-only
   library source checks.
-  Declared deterministic env reads with fallbacks are accepted through
-  `emit_command_build_zen_accepts_declared_env_read_with_fallback`.
+  Declared deterministic env reads with `.Err`, wildcard, and identifier
+  fallback arms are accepted through
+  `emit_command_build_zen_accepts_declared_env_read_with_fallback`,
+  `emit_command_build_zen_accepts_wildcard_fallback_declared_env_read`, and
+  `emit_command_build_zen_accepts_identifier_fallback_declared_env_read`.
   Env reads with `?` but no fallback arm reject before C emission through
   `emit_command_build_zen_rejects_env_read_without_fallback`.
   Declared deterministic file-read effects are accepted through
@@ -2602,8 +2607,12 @@ checked-in docs, tests, and commits only.
   `direct_file_command_multi_target_build_zen_rejects_undeclared_host_effects`
   and
   `direct_file_command_build_zen_rejects_undeclared_host_effects`.
-  Declared deterministic env reads with fallbacks are accepted through
-  `direct_file_command_build_zen_accepts_declared_env_read_with_fallback`.
+  Declared deterministic env reads with `.Err`, wildcard, and identifier
+  fallback arms are accepted through
+  `direct_file_command_build_zen_accepts_declared_env_read_with_fallback`,
+  `direct_file_command_build_zen_accepts_wildcard_fallback_declared_env_read`,
+  and
+  `direct_file_command_build_zen_accepts_identifier_fallback_declared_env_read`.
   Env reads with `?` but no fallback arm reject before execution through
   `direct_file_command_build_zen_rejects_env_read_without_fallback_before_execution`.
   Declared deterministic file-read effects are accepted through

--- a/tests/integration/cli_build/declared_env_effects.rs
+++ b/tests/integration/cli_build/declared_env_effects.rs
@@ -2,110 +2,121 @@ use std::process::Command;
 
 #[test]
 fn build_command_build_zen_accepts_declared_env_read_with_fallback() {
-    let tmp = executable_graph_with_declared_env_read();
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["build", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen build build.zen");
-
-    assert!(
-        output.status.success(),
-        "zen build build.zen failed: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
+    assert_executable_command_accepts_declared_env_read(
+        &["build", "build.zen"],
+        r#"| .Err { "default" }"#,
+        "build_command_build_zen_accepts_declared_env_read_with_fallback",
+        ExecutableCommandExpectation::BuildOutput,
     );
-    assert!(
-        tmp.path().join("build").join("app").exists(),
-        "expected build output after declared env effect"
+}
+
+#[test]
+fn build_command_build_zen_accepts_wildcard_fallback_declared_env_read() {
+    assert_executable_command_accepts_declared_env_read(
+        &["build", "build.zen"],
+        r#"| _ { "default" }"#,
+        "build_command_build_zen_accepts_wildcard_fallback_declared_env_read",
+        ExecutableCommandExpectation::BuildOutput,
+    );
+}
+
+#[test]
+fn build_command_build_zen_accepts_identifier_fallback_declared_env_read() {
+    assert_executable_command_accepts_declared_env_read(
+        &["build", "build.zen"],
+        r#"| err { "default" }"#,
+        "build_command_build_zen_accepts_identifier_fallback_declared_env_read",
+        ExecutableCommandExpectation::BuildOutput,
     );
 }
 
 #[test]
 fn direct_file_command_build_zen_accepts_declared_env_read_with_fallback() {
-    let tmp = executable_graph_with_declared_env_read();
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .arg("build.zen")
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen build.zen");
-
-    assert!(
-        output.status.success(),
-        "zen build.zen failed: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        tmp.path().join("build").join("app").exists(),
-        "expected build output after declared env effect"
+    assert_executable_command_accepts_declared_env_read(
+        &["build.zen"],
+        r#"| .Err { "default" }"#,
+        "direct_file_command_build_zen_accepts_declared_env_read_with_fallback",
+        ExecutableCommandExpectation::BuildOutput,
     );
 }
 
 #[test]
-fn build_graph_command_accepts_declared_env_read_with_fallback() {
-    let tmp = executable_graph_with_declared_env_read();
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["build-graph", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen build-graph build.zen");
-
-    assert!(
-        output.status.success(),
-        "zen build-graph build.zen failed: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        tmp.path().join("build").join("app").exists(),
-        "expected build output after declared env effect"
-    );
-}
-
-#[test]
-fn build_graph_command_accepts_wildcard_fallback_declared_env_read() {
-    assert_build_graph_command_accepts_declared_env_read(
+fn direct_file_command_build_zen_accepts_wildcard_fallback_declared_env_read() {
+    assert_executable_command_accepts_declared_env_read(
+        &["build.zen"],
         r#"| _ { "default" }"#,
-        "build_graph_command_accepts_wildcard_fallback_declared_env_read",
+        "direct_file_command_build_zen_accepts_wildcard_fallback_declared_env_read",
+        ExecutableCommandExpectation::BuildOutput,
     );
 }
 
 #[test]
-fn build_graph_command_accepts_identifier_fallback_declared_env_read() {
-    assert_build_graph_command_accepts_declared_env_read(
+fn direct_file_command_build_zen_accepts_identifier_fallback_declared_env_read() {
+    assert_executable_command_accepts_declared_env_read(
+        &["build.zen"],
         r#"| err { "default" }"#,
-        "build_graph_command_accepts_identifier_fallback_declared_env_read",
+        "direct_file_command_build_zen_accepts_identifier_fallback_declared_env_read",
+        ExecutableCommandExpectation::BuildOutput,
     );
 }
 
 #[test]
 fn emit_command_build_zen_accepts_declared_env_read_with_fallback() {
-    let tmp = executable_graph_with_declared_env_read();
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen emit build.zen");
-
-    assert!(
-        output.status.success(),
-        "zen emit build.zen failed: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
+    assert_executable_command_accepts_declared_env_read(
+        &["emit", "build.zen"],
+        r#"| .Err { "default" }"#,
+        "emit_command_build_zen_accepts_declared_env_read_with_fallback",
+        ExecutableCommandExpectation::EmitStdout,
     );
-    assert!(
-        String::from_utf8_lossy(&output.stdout).contains("int32_t zen_main(void)"),
-        "expected C output after declared env effect, stdout={}",
-        String::from_utf8_lossy(&output.stdout)
+}
+
+#[test]
+fn emit_command_build_zen_accepts_wildcard_fallback_declared_env_read() {
+    assert_executable_command_accepts_declared_env_read(
+        &["emit", "build.zen"],
+        r#"| _ { "default" }"#,
+        "emit_command_build_zen_accepts_wildcard_fallback_declared_env_read",
+        ExecutableCommandExpectation::EmitStdout,
     );
-    assert!(
-        !tmp.path().join("build").exists(),
-        "zen emit build.zen should not create build outputs"
+}
+
+#[test]
+fn emit_command_build_zen_accepts_identifier_fallback_declared_env_read() {
+    assert_executable_command_accepts_declared_env_read(
+        &["emit", "build.zen"],
+        r#"| err { "default" }"#,
+        "emit_command_build_zen_accepts_identifier_fallback_declared_env_read",
+        ExecutableCommandExpectation::EmitStdout,
+    );
+}
+
+#[test]
+fn build_graph_command_accepts_declared_env_read_with_fallback() {
+    assert_executable_command_accepts_declared_env_read(
+        &["build-graph", "build.zen"],
+        r#"| .Err { "default" }"#,
+        "build_graph_command_accepts_declared_env_read_with_fallback",
+        ExecutableCommandExpectation::BuildOutput,
+    );
+}
+
+#[test]
+fn build_graph_command_accepts_wildcard_fallback_declared_env_read() {
+    assert_executable_command_accepts_declared_env_read(
+        &["build-graph", "build.zen"],
+        r#"| _ { "default" }"#,
+        "build_graph_command_accepts_wildcard_fallback_declared_env_read",
+        ExecutableCommandExpectation::BuildOutput,
+    );
+}
+
+#[test]
+fn build_graph_command_accepts_identifier_fallback_declared_env_read() {
+    assert_executable_command_accepts_declared_env_read(
+        &["build-graph", "build.zen"],
+        r#"| err { "default" }"#,
+        "build_graph_command_accepts_identifier_fallback_declared_env_read",
+        ExecutableCommandExpectation::BuildOutput,
     );
 }
 
@@ -247,29 +258,48 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
     );
 }
 
-fn executable_graph_with_declared_env_read() -> tempfile::TempDir {
-    executable_graph_with_declared_env_read_fallback(r#"| .Err { "default" }"#)
+enum ExecutableCommandExpectation {
+    BuildOutput,
+    EmitStdout,
 }
 
-fn assert_build_graph_command_accepts_declared_env_read(fallback_arm: &str, case_name: &str) {
+fn assert_executable_command_accepts_declared_env_read(
+    args: &[&str],
+    fallback_arm: &str,
+    case_name: &str,
+    expectation: ExecutableCommandExpectation,
+) {
     let tmp = executable_graph_with_declared_env_read_fallback(fallback_arm);
 
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["build-graph", "build.zen"])
+        .args(args)
         .current_dir(tmp.path())
         .output()
-        .expect("run zen build-graph build.zen");
+        .expect("run zen build graph command");
 
     assert!(
         output.status.success(),
-        "{case_name}: zen build-graph build.zen failed: stdout={}, stderr={}",
+        "{case_name}: zen command failed: stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    assert!(
-        tmp.path().join("build").join("app").exists(),
-        "{case_name}: expected build output after declared env effect"
-    );
+    match expectation {
+        ExecutableCommandExpectation::BuildOutput => assert!(
+            tmp.path().join("build").join("app").exists(),
+            "{case_name}: expected build output after declared env effect"
+        ),
+        ExecutableCommandExpectation::EmitStdout => {
+            assert!(
+                String::from_utf8_lossy(&output.stdout).contains("int32_t zen_main(void)"),
+                "{case_name}: expected C output after declared env effect, stdout={}",
+                String::from_utf8_lossy(&output.stdout)
+            );
+            assert!(
+                !tmp.path().join("build").exists(),
+                "{case_name}: zen emit build.zen should not create build outputs"
+            );
+        }
+    }
 }
 
 fn executable_graph_with_declared_env_read_fallback(fallback_arm: &str) -> tempfile::TempDir {


### PR DESCRIPTION
## Summary

- Add `zen build build.zen`, direct `zen build.zen`, and `zen emit build.zen` coverage for wildcard and identifier fallback arms on declared deterministic env reads.
- Refactor the executable env-read fixture helper so `.Err`, wildcard, and identifier fallback arms share one command assertion path.
- Update the phase plan and completion audit evidence for the expanded executable-path fallback-arm coverage.

## Validation

- `cargo test --test integration build_command_build_zen_accepts_declared_env_read_with_fallback`
- `cargo test --test integration build_command_build_zen_accepts_wildcard_fallback_declared_env_read`
- `cargo test --test integration build_command_build_zen_accepts_identifier_fallback_declared_env_read`
- `cargo test --test integration direct_file_command_build_zen_accepts_declared_env_read_with_fallback`
- `cargo test --test integration direct_file_command_build_zen_accepts_wildcard_fallback_declared_env_read`
- `cargo test --test integration direct_file_command_build_zen_accepts_identifier_fallback_declared_env_read`
- `cargo test --test integration emit_command_build_zen_accepts_declared_env_read_with_fallback`
- `cargo test --test integration emit_command_build_zen_accepts_wildcard_fallback_declared_env_read`
- `cargo test --test integration emit_command_build_zen_accepts_identifier_fallback_declared_env_read`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Branch push Actions check: `[]`