### PR TITLE
[codex] cover test env fallback arms

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2597,9 +2597,12 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration test_command_build_zen_accepts_declared_file_read_effects`
   and
   `cargo test --test integration test_command_build_zen_rejects_undeclared_file_read_effects_before_execution`.
-  Declared deterministic env reads with fallbacks are accepted on the same
-  test execution path through
-  `cargo test --test integration test_command_build_zen_accepts_declared_env_read_with_fallback`.
+  Declared deterministic env reads with `.Err`, wildcard, and identifier
+  fallback arms are accepted on the same test execution path through
+  `cargo test --test integration test_command_build_zen_accepts_declared_env_read_with_fallback`,
+  `cargo test --test integration test_command_build_zen_accepts_wildcard_fallback_declared_env_read`,
+  and
+  `cargo test --test integration test_command_build_zen_accepts_identifier_fallback_declared_env_read`.
   Missing fallback arms on deterministic env reads reject before test
   execution through
   `cargo test --test integration test_command_build_zen_rejects_env_read_without_fallback_before_execution`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2520,9 +2520,11 @@ checked-in docs, tests, and commits only.
   preserves host-effect validation before graph-only library typechecking
   through
   `test_command_build_zen_rejects_undeclared_host_effects_before_library_typechecking`.
-  Declared deterministic env reads with fallbacks are accepted on the normal
-  test path through
-  `test_command_build_zen_accepts_declared_env_read_with_fallback`.
+  Declared deterministic env reads with `.Err`, wildcard, and identifier
+  fallback arms are accepted on the normal test path through
+  `test_command_build_zen_accepts_declared_env_read_with_fallback`,
+  `test_command_build_zen_accepts_wildcard_fallback_declared_env_read`, and
+  `test_command_build_zen_accepts_identifier_fallback_declared_env_read`.
   Env reads with `?` but no fallback arm reject before test execution through
   `test_command_build_zen_rejects_env_read_without_fallback_before_execution`.
   Declared deterministic file-read effects are accepted on the normal test

--- a/tests/integration/cli_build/declared_env_effects.rs
+++ b/tests/integration/cli_build/declared_env_effects.rs
@@ -122,18 +122,43 @@ fn build_graph_command_accepts_identifier_fallback_declared_env_read() {
 
 #[test]
 fn test_command_build_zen_accepts_declared_env_read_with_fallback() {
+    assert_test_command_accepts_declared_env_read(
+        r#"| .Err { "default" }"#,
+        "test_command_build_zen_accepts_declared_env_read_with_fallback",
+    );
+}
+
+#[test]
+fn test_command_build_zen_accepts_wildcard_fallback_declared_env_read() {
+    assert_test_command_accepts_declared_env_read(
+        r#"| _ { "default" }"#,
+        "test_command_build_zen_accepts_wildcard_fallback_declared_env_read",
+    );
+}
+
+#[test]
+fn test_command_build_zen_accepts_identifier_fallback_declared_env_read() {
+    assert_test_command_accepts_declared_env_read(
+        r#"| err { "default" }"#,
+        "test_command_build_zen_accepts_identifier_fallback_declared_env_read",
+    );
+}
+
+fn assert_test_command_accepts_declared_env_read(fallback_arm: &str, case_name: &str) {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(
         tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
     std_path = b.os.env("ZEN_STD") ?
-        | .Ok(value) { value }
-        | .Err { "default" }
-    b.add(Test { name: "unit", root: "test.zen" })
+        | .Ok(value) {{ value }}
+        {fallback_arm}
+    b.add(Test {{ name: "unit", root: "test.zen" }})
     .Ok(b.config())
-}
+}}
 "#,
+        ),
     )
     .expect("write build.zen");
     std::fs::write(
@@ -154,7 +179,7 @@ main = () i32 {
 
     assert!(
         output.status.success(),
-        "zen test build.zen failed: stdout={}, stderr={}",
+        "{case_name}: zen test build.zen failed: stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );


### PR DESCRIPTION
## Summary

- Add `zen test build.zen` coverage for wildcard and identifier fallback arms on declared deterministic env reads.
- Refactor the test-target env-read fixture helper so `.Err`, wildcard, and identifier fallback arms share one assertion path.
- Update the phase plan and completion audit evidence for expanded test-path fallback-arm coverage.

## Validation

- `cargo test --test integration test_command_build_zen_accepts_declared_env_read_with_fallback`
- `cargo test --test integration test_command_build_zen_accepts_wildcard_fallback_declared_env_read`
- `cargo test --test integration test_command_build_zen_accepts_identifier_fallback_declared_env_read`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Branch push Actions check: `[]`