### PR TITLE
[codex] cover build dependency shapes

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2566,6 +2566,12 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test build_graph build_graph_orders_targets_before_dependents`
   and
   `cargo test --test integration build_command_build_zen_compiles_executable_dependencies_first`.
+- Normal build graph execution rejects unknown, self, and cyclic target
+  dependencies before execution, covered by
+  `cargo test --test integration build_command_build_zen_rejects_unknown_target_dependencies`,
+  `cargo test --test integration build_command_build_zen_rejects_self_target_dependencies`,
+  and
+  `cargo test --test integration build_command_build_zen_rejects_cyclic_target_dependencies`.
 - Normal build graph execution accepts declared deterministic file-read effects
   and rejects undeclared file reads before target execution, covered by
   `cargo test --test integration build_command_build_zen_accepts_declared_file_read_effects`

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2430,7 +2430,11 @@ checked-in docs, tests, and commits only.
   `build_graph_orders_targets_before_dependents` and
   `build_command_build_zen_compiles_executable_dependencies_first`, and reject
   dependencies on validated library source targets through
-  `build_command_build_zen_accepts_library_dependencies`. They still reject
+  `build_command_build_zen_accepts_library_dependencies`. They reject unknown,
+  self, and cyclic target dependencies before execution through
+  `build_command_build_zen_rejects_unknown_target_dependencies`,
+  `build_command_build_zen_rejects_self_target_dependencies`, and
+  `build_command_build_zen_rejects_cyclic_target_dependencies`. They still reject
   executable-target dependencies on gated test targets through
   `build_command_build_zen_rejects_gated_test_dependencies`. They reject
   graph-only library exports with missing sources through

--- a/tests/integration/cli_build/build_command_validation.rs
+++ b/tests/integration/cli_build/build_command_validation.rs
@@ -109,6 +109,111 @@ main = () i32 {
 }
 
 #[test]
+fn build_command_build_zen_rejects_unknown_target_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["core"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    assert_build_command_rejects_dependency_shape(
+        tmp.path(),
+        "build target `app` depends on unknown target `core`",
+    );
+}
+
+#[test]
+fn build_command_build_zen_rejects_self_target_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["app"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    assert_build_command_rejects_dependency_shape(
+        tmp.path(),
+        "build target `app` cannot depend on itself",
+    );
+}
+
+#[test]
+fn build_command_build_zen_rejects_cyclic_target_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["tool"],
+    })
+    b.add(Executable {
+        name: "tool",
+        main: "tool.zen",
+        out_dir: "build/tool/",
+        dependencies: ["app"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    assert_build_command_rejects_dependency_shape(
+        tmp.path(),
+        "build target dependency cycle includes `app`",
+    );
+}
+
+fn assert_build_command_rejects_dependency_shape(
+    project_dir: &std::path::Path,
+    expected_diagnostic: &str,
+) {
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build", "build.zen"])
+        .current_dir(project_dir)
+        .output()
+        .expect("run zen build build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen build build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains(expected_diagnostic),
+        "expected dependency diagnostic `{expected_diagnostic}`, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !project_dir.join("build").exists(),
+        "build command should not create outputs after dependency validation fails"
+    );
+}
+
+#[test]
 fn build_command_build_zen_rejects_undeclared_host_effects_before_library_typechecking() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(


### PR DESCRIPTION
## Summary

- Add normal `zen build build.zen` coverage for unknown, self, and cyclic target dependency diagnostics.
- Assert dependency-shape validation stops execution before build outputs are created.
- Update phase plan and completion audit evidence for command-path dependency validation.

## Validation

- `cargo test --test integration build_command_build_zen_rejects_unknown_target_dependencies`
- `cargo test --test integration build_command_build_zen_rejects_self_target_dependencies`
- `cargo test --test integration build_command_build_zen_rejects_cyclic_target_dependencies`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Branch push Actions check: `[]`