### PR TITLE
[codex] cover check dependency shapes

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2637,6 +2637,12 @@ and do not assume Phase 4 is ready without evidence.
   Library-only graphs are valid on this non-executing validation path, covered
   by
   `cargo test --test integration check_command_build_zen_accepts_library_only_graph_validation`.
+  Unknown, self, and cyclic target dependencies reject on the same
+  non-executing validation path before source validation, covered by
+  `cargo test --test integration check_command_build_zen_rejects_unknown_target_dependencies`,
+  `cargo test --test integration check_command_build_zen_rejects_self_target_dependencies`,
+  and
+  `cargo test --test integration check_command_build_zen_rejects_cyclic_target_dependencies`.
   Undeclared host effects still reject before target source typechecking,
   covered by
   `cargo test --test integration check_command_build_zen_rejects_undeclared_host_effects_before_target_typechecking`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2473,7 +2473,12 @@ checked-in docs, tests, and commits only.
   executable, test, and library sources through
   `check_command_build_zen_rejects_missing_executable_source`,
   `check_command_build_zen_rejects_missing_test_source`, and
-  `check_command_build_zen_rejects_missing_library_source`, and rejects
+  `check_command_build_zen_rejects_missing_library_source`. It rejects
+  unknown, self, and cyclic target dependencies before source validation
+  through
+  `check_command_build_zen_rejects_unknown_target_dependencies`,
+  `check_command_build_zen_rejects_self_target_dependencies`, and
+  `check_command_build_zen_rejects_cyclic_target_dependencies`, and rejects
   undeclared host effects before source validation through
   `check_command_build_zen_rejects_undeclared_host_effects_before_source_validation`.
   It also rejects undeclared host effects before target source typechecking

--- a/tests/integration/cli_build/graph_validation.rs
+++ b/tests/integration/cli_build/graph_validation.rs
@@ -89,6 +89,111 @@ value = () i32 {
 }
 
 #[test]
+fn check_command_build_zen_rejects_unknown_target_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["core"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    assert_check_command_rejects_dependency_shape(
+        tmp.path(),
+        "build target `app` depends on unknown target `core`",
+    );
+}
+
+#[test]
+fn check_command_build_zen_rejects_self_target_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["app"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    assert_check_command_rejects_dependency_shape(
+        tmp.path(),
+        "build target `app` cannot depend on itself",
+    );
+}
+
+#[test]
+fn check_command_build_zen_rejects_cyclic_target_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["tool"],
+    })
+    b.add(Executable {
+        name: "tool",
+        main: "tool.zen",
+        out_dir: "build/tool/",
+        dependencies: ["app"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    assert_check_command_rejects_dependency_shape(
+        tmp.path(),
+        "build target dependency cycle includes `app`",
+    );
+}
+
+fn assert_check_command_rejects_dependency_shape(
+    project_dir: &std::path::Path,
+    expected_diagnostic: &str,
+) {
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["check", "build.zen"])
+        .current_dir(project_dir)
+        .output()
+        .expect("run zen check build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen check build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains(expected_diagnostic),
+        "expected dependency diagnostic `{expected_diagnostic}`, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !project_dir.join("build").exists(),
+        "zen check build.zen should not create outputs after dependency validation fails"
+    );
+}
+
+#[test]
 fn check_command_build_zen_typechecks_target_sources() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(


### PR DESCRIPTION
## Summary

Adds `zen check build.zen` integration coverage for target dependency validation without execution. The new tests lock unknown, self, and cyclic dependency diagnostics on the check path and assert that no build outputs are created after validation fails.

Updates the Phase plan and completion audit so the evidence references the new check-path coverage alongside existing source-validation and host-effect gates.

## Validation

- `cargo test --test integration check_command_build_zen_rejects_unknown_target_dependencies`
- `cargo test --test integration check_command_build_zen_rejects_self_target_dependencies`
- `cargo test --test integration check_command_build_zen_rejects_cyclic_target_dependencies`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

## Workflow note

Pushing `codex/cover-check-dependency-shapes` produced no branch Actions runs before PR creation: `gh run list --branch codex/cover-check-dependency-shapes --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]`.