### PR TITLE
[codex] cover direct dependency shapes

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2378,6 +2378,12 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration direct_file_command_build_zen_accepts_library_dependencies`
   and
   `cargo test --test integration direct_file_command_build_zen_rejects_gated_test_dependencies`,
+  rejects unknown, self, and cyclic target dependencies before execution
+  through
+  `cargo test --test integration direct_file_command_build_zen_rejects_unknown_target_dependencies`,
+  `cargo test --test integration direct_file_command_build_zen_rejects_self_target_dependencies`,
+  and
+  `cargo test --test integration direct_file_command_build_zen_rejects_cyclic_target_dependencies`,
   rejects test-only graphs before execution starts through
   `cargo test --test integration direct_file_command_build_zen_rejects_graph_without_executable_targets`,
   and rejects undeclared host effects for single-target and multi-target graphs

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2602,6 +2602,10 @@ checked-in docs, tests, and commits only.
   dependencies through
   `direct_file_command_build_zen_accepts_library_dependencies` and
   `direct_file_command_build_zen_rejects_gated_test_dependencies`,
+  rejects unknown, self, and cyclic target dependencies before execution
+  through `direct_file_command_build_zen_rejects_unknown_target_dependencies`,
+  `direct_file_command_build_zen_rejects_self_target_dependencies`, and
+  `direct_file_command_build_zen_rejects_cyclic_target_dependencies`,
   rejects graph-only library exports with missing sources through
   `direct_file_command_build_zen_rejects_missing_graph_only_library_source`,
   accepts valid graph-only library exports through

--- a/tests/integration/cli_build/direct_build_graph_validation.rs
+++ b/tests/integration/cli_build/direct_build_graph_validation.rs
@@ -109,6 +109,111 @@ main = () i32 {
 }
 
 #[test]
+fn direct_file_command_build_zen_rejects_unknown_target_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["core"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    assert_direct_file_command_rejects_dependency_shape(
+        tmp.path(),
+        "build target `app` depends on unknown target `core`",
+    );
+}
+
+#[test]
+fn direct_file_command_build_zen_rejects_self_target_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["app"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    assert_direct_file_command_rejects_dependency_shape(
+        tmp.path(),
+        "build target `app` cannot depend on itself",
+    );
+}
+
+#[test]
+fn direct_file_command_build_zen_rejects_cyclic_target_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["tool"],
+    })
+    b.add(Executable {
+        name: "tool",
+        main: "tool.zen",
+        out_dir: "build/tool/",
+        dependencies: ["app"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    assert_direct_file_command_rejects_dependency_shape(
+        tmp.path(),
+        "build target dependency cycle includes `app`",
+    );
+}
+
+fn assert_direct_file_command_rejects_dependency_shape(
+    project_dir: &std::path::Path,
+    expected_diagnostic: &str,
+) {
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .arg("build.zen")
+        .current_dir(project_dir)
+        .output()
+        .expect("run zen build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains(expected_diagnostic),
+        "expected dependency diagnostic `{expected_diagnostic}`, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !project_dir.join("build").exists(),
+        "direct build.zen command should not create outputs after dependency validation fails"
+    );
+}
+
+#[test]
 fn direct_file_command_build_zen_ignores_unrelated_gated_test_source_errors() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(


### PR DESCRIPTION
## Summary

Adds direct `zen build.zen` integration coverage for unknown, self, and cyclic target dependency rejection. These tests mirror the normal `zen build build.zen` dependency-shape coverage while asserting that direct execution creates no build outputs after validation fails.

Updates the Phase plan and completion audit to reference the new direct-path evidence.

## Validation

- `cargo test --test integration direct_file_command_build_zen_rejects_unknown_target_dependencies`
- `cargo test --test integration direct_file_command_build_zen_rejects_self_target_dependencies`
- `cargo test --test integration direct_file_command_build_zen_rejects_cyclic_target_dependencies`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

## Workflow note

Pushing `codex/cover-direct-dependency-shapes` produced no branch Actions runs before PR creation: `gh run list --branch codex/cover-direct-dependency-shapes --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]`.