### PR TITLE
[codex] cover legacy dependency shapes

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2599,6 +2599,12 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration build_graph_command_accepts_library_dependencies`,
   and
   `cargo test --test integration test_command_build_zen_accepts_library_dependencies`.
+  Legacy build graph execution rejects unknown, self, and cyclic target
+  dependencies before execution through
+  `cargo test --test integration build_graph_command_rejects_unknown_target_dependencies`,
+  `cargo test --test integration build_graph_command_rejects_self_target_dependencies`,
+  and
+  `cargo test --test integration build_graph_command_rejects_cyclic_target_dependencies`.
   Cross-mode execution gating is also covered by
   `cargo test --test integration build_command_build_zen_rejects_gated_test_dependencies`,
   `cargo test --test integration build_graph_command_rejects_gated_test_dependencies`,

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2399,6 +2399,10 @@ checked-in docs, tests, and commits only.
   preserves deterministic host-effect validation before graph-only library
   typechecking. `build_graph_command_accepts_library_dependencies` covers
   executable dependencies on validated library source targets, while
+  `build_graph_command_rejects_unknown_target_dependencies`,
+  `build_graph_command_rejects_self_target_dependencies`, and
+  `build_graph_command_rejects_cyclic_target_dependencies` cover legacy
+  build-graph dependency-shape rejection before execution starts, and
   `build_graph_command_rejects_gated_test_dependencies` covers rejected
   executable dependencies on gated test targets, and
   `build_graph_command_rejects_missing_root_source` covers a target execution

--- a/tests/integration/cli_build/legacy_graph_command_validation.rs
+++ b/tests/integration/cli_build/legacy_graph_command_validation.rs
@@ -109,6 +109,111 @@ main = () i32 {
 }
 
 #[test]
+fn build_graph_command_rejects_unknown_target_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["core"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    assert_build_graph_command_rejects_dependency_shape(
+        tmp.path(),
+        "build target `app` depends on unknown target `core`",
+    );
+}
+
+#[test]
+fn build_graph_command_rejects_self_target_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["app"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    assert_build_graph_command_rejects_dependency_shape(
+        tmp.path(),
+        "build target `app` cannot depend on itself",
+    );
+}
+
+#[test]
+fn build_graph_command_rejects_cyclic_target_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["tool"],
+    })
+    b.add(Executable {
+        name: "tool",
+        main: "tool.zen",
+        out_dir: "build/tool/",
+        dependencies: ["app"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    assert_build_graph_command_rejects_dependency_shape(
+        tmp.path(),
+        "build target dependency cycle includes `app`",
+    );
+}
+
+fn assert_build_graph_command_rejects_dependency_shape(
+    project_dir: &std::path::Path,
+    expected_diagnostic: &str,
+) {
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build-graph", "build.zen"])
+        .current_dir(project_dir)
+        .output()
+        .expect("run zen build-graph");
+
+    assert!(
+        !output.status.success(),
+        "zen build-graph unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains(expected_diagnostic),
+        "expected dependency diagnostic `{expected_diagnostic}`, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !project_dir.join("build").exists(),
+        "build-graph command should not create outputs after dependency validation fails"
+    );
+}
+
+#[test]
 fn build_graph_command_ignores_unrelated_gated_test_source_errors() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(


### PR DESCRIPTION
## Summary

Adds legacy `zen build-graph build.zen` integration coverage for unknown, self, and cyclic target dependency rejection. The tests mirror the other build graph entrypoints and assert that no build outputs are created after dependency validation fails.

Updates the Phase plan and completion audit to reference the new legacy build-graph evidence.

## Validation

- `cargo test --test integration build_graph_command_rejects_unknown_target_dependencies`
- `cargo test --test integration build_graph_command_rejects_self_target_dependencies`
- `cargo test --test integration build_graph_command_rejects_cyclic_target_dependencies`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

## Workflow note

Pushing `codex/cover-legacy-dependency-shapes` produced no branch Actions runs before PR creation: `gh run list --branch codex/cover-legacy-dependency-shapes --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]`.