### PR TITLE
[codex] cover test dependency shapes

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2357,6 +2357,12 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration test_command_build_zen_rejects_undeclared_host_effects`
   and
   `cargo test --test integration test_command_multi_target_build_zen_rejects_undeclared_host_effects`.
+  It rejects unknown, self, and cyclic target dependencies before execution
+  through
+  `cargo test --test integration test_command_build_zen_rejects_unknown_target_dependencies`,
+  `cargo test --test integration test_command_build_zen_rejects_self_target_dependencies`,
+  and
+  `cargo test --test integration test_command_build_zen_rejects_cyclic_target_dependencies`.
 - Normal `zen emit build.zen` emits generated C for the single executable graph
   target without compiling a binary, covered by
   `cargo test --test integration emit_command_build_zen_outputs_target_c_source`,

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2522,6 +2522,10 @@ checked-in docs, tests, and commits only.
   `test_command_multi_target_build_zen_rejects_undeclared_host_effects`.
   Test execution also accepts dependencies on validated library source targets
   through `test_command_build_zen_accepts_library_dependencies`, and rejects
+  unknown, self, and cyclic target dependencies before execution through
+  `test_command_build_zen_rejects_unknown_target_dependencies`,
+  `test_command_build_zen_rejects_self_target_dependencies`, and
+  `test_command_build_zen_rejects_cyclic_target_dependencies`. It rejects
   test-target dependencies on gated executable targets through
   `test_command_build_zen_rejects_gated_executable_dependencies`. It validates
   graph-only library exports before execution through

--- a/tests/integration/cli_build/graph_validation_test_command_validation.rs
+++ b/tests/integration/cli_build/graph_validation_test_command_validation.rs
@@ -109,6 +109,107 @@ main = () i32 {
 }
 
 #[test]
+fn test_command_build_zen_rejects_unknown_target_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Test {
+        name: "unit",
+        root: "test.zen",
+        dependencies: ["core"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    assert_test_command_rejects_dependency_shape(
+        tmp.path(),
+        "build target `unit` depends on unknown target `core`",
+    );
+}
+
+#[test]
+fn test_command_build_zen_rejects_self_target_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Test {
+        name: "unit",
+        root: "test.zen",
+        dependencies: ["unit"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    assert_test_command_rejects_dependency_shape(
+        tmp.path(),
+        "build target `unit` cannot depend on itself",
+    );
+}
+
+#[test]
+fn test_command_build_zen_rejects_cyclic_target_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Test {
+        name: "unit",
+        root: "unit.zen",
+        dependencies: ["integration"],
+    })
+    b.add(Test {
+        name: "integration",
+        root: "integration.zen",
+        dependencies: ["unit"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    assert_test_command_rejects_dependency_shape(
+        tmp.path(),
+        "build target dependency cycle includes `integration`",
+    );
+}
+
+fn assert_test_command_rejects_dependency_shape(
+    project_dir: &std::path::Path,
+    expected_diagnostic: &str,
+) {
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["test", "build.zen"])
+        .current_dir(project_dir)
+        .output()
+        .expect("run zen test build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen test build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains(expected_diagnostic),
+        "expected dependency diagnostic `{expected_diagnostic}`, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !project_dir.join("build").exists(),
+        "test command should not create outputs after dependency validation fails"
+    );
+}
+
+#[test]
 fn test_command_build_zen_ignores_unrelated_gated_executable_source_errors() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(


### PR DESCRIPTION
## Summary

Adds `zen test build.zen` integration coverage for unknown, self, and cyclic target dependency rejection. These fixtures use test targets and assert that no build outputs are created after dependency validation fails.

Updates the Phase plan and completion audit to reference the new test-path evidence.

## Validation

- `cargo test --test integration test_command_build_zen_rejects_unknown_target_dependencies`
- `cargo test --test integration test_command_build_zen_rejects_self_target_dependencies`
- `cargo test --test integration test_command_build_zen_rejects_cyclic_target_dependencies`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

## Workflow note

Pushing `codex/cover-test-dependency-shapes` produced no branch Actions runs before PR creation: `gh run list --branch codex/cover-test-dependency-shapes --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]`.