### PR TITLE
[codex] cover emit dependency shapes

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2370,6 +2370,11 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration emit_command_build_zen_rejects_graph_without_executable_targets`
   and
   `cargo test --test integration emit_command_build_zen_rejects_multiple_executable_targets`,
+  rejects unknown, self, and cyclic target dependencies before emission through
+  `cargo test --test integration emit_command_build_zen_rejects_unknown_target_dependencies`,
+  `cargo test --test integration emit_command_build_zen_rejects_self_target_dependencies`,
+  and
+  `cargo test --test integration emit_command_build_zen_rejects_cyclic_target_dependencies`,
   and rejects undeclared host effects through
   `cargo test --test integration emit_command_build_zen_rejects_undeclared_host_effects`.
 - Direct `zen build.zen` aliases the same constrained deterministic graph build

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2562,6 +2562,10 @@ checked-in docs, tests, and commits only.
   selected executable dependencies before emission, accepting validated library
   source dependencies through
   `emit_command_build_zen_accepts_library_dependencies` and
+  rejecting unknown, self, and cyclic target dependencies before emission
+  through `emit_command_build_zen_rejects_unknown_target_dependencies`,
+  `emit_command_build_zen_rejects_self_target_dependencies`, and
+  `emit_command_build_zen_rejects_cyclic_target_dependencies`, while
   rejecting gated test dependencies through
   `emit_command_build_zen_rejects_gated_test_dependencies`. It validates
   graph-only library exports before emission through

--- a/tests/integration/cli_build/emit_direct_validation.rs
+++ b/tests/integration/cli_build/emit_direct_validation.rs
@@ -53,3 +53,107 @@ main = () i32 {
         "zen emit build.zen should not compile the target binary"
     );
 }
+
+#[test]
+fn emit_command_build_zen_rejects_unknown_target_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["core"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    assert_emit_command_rejects_dependency_shape(
+        tmp.path(),
+        "build target `app` depends on unknown target `core`",
+    );
+}
+
+#[test]
+fn emit_command_build_zen_rejects_self_target_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["app"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    assert_emit_command_rejects_dependency_shape(
+        tmp.path(),
+        "build target `app` cannot depend on itself",
+    );
+}
+
+#[test]
+fn emit_command_build_zen_rejects_cyclic_target_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Library {
+        name: "core",
+        exports: ["lib.zen"],
+        dependencies: ["app"],
+    })
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["core"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    assert_emit_command_rejects_dependency_shape(
+        tmp.path(),
+        "build target dependency cycle includes `app`",
+    );
+}
+
+fn assert_emit_command_rejects_dependency_shape(
+    project_dir: &std::path::Path,
+    expected_diagnostic: &str,
+) {
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit", "build.zen"])
+        .current_dir(project_dir)
+        .output()
+        .expect("run zen emit build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen emit build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains(expected_diagnostic),
+        "expected dependency diagnostic `{expected_diagnostic}`, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !project_dir.join("build").exists(),
+        "zen emit build.zen should not create outputs after dependency validation fails"
+    );
+}


### PR DESCRIPTION
## Summary

Adds `zen emit build.zen` integration coverage for unknown, self, and cyclic target dependency rejection before C emission. The cyclic fixture uses one executable and one library so the dependency validation is exercised without hitting multi-executable ambiguity first.

Updates the Phase plan and completion audit to reference the new emit-path evidence.

## Validation

- `cargo test --test integration emit_command_build_zen_rejects_unknown_target_dependencies`
- `cargo test --test integration emit_command_build_zen_rejects_self_target_dependencies`
- `cargo test --test integration emit_command_build_zen_rejects_cyclic_target_dependencies`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

## Workflow note

Pushing `codex/cover-emit-dependency-shapes` produced no branch Actions runs before PR creation: `gh run list --branch codex/cover-emit-dependency-shapes --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]`.