### PR TITLE
[codex] cover build graph json field diagnostics

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3333,14 +3333,16 @@ and do not assume Phase 4 is ready without evidence.
   metadata cannot silently disappear into a vague missing-target diagnostic.
   Coverage includes `build_program_lowering_rejects_duplicate_target_fields`,
   `build_program_lowering_rejects_unknown_target_fields`, and
-  `emit_json_build_graph_rejects_unknown_target_fields`.
+  `emit_json_build_graph_rejects_unknown_target_fields` plus
+  `emit_json_build_graph_rejects_duplicate_target_fields`.
 - Build graph target metadata extraction now validates required fields and
   field value shapes before graph construction, so missing `out_dir` and
   non-string string fields produce direct target-field diagnostics instead of
   falling through to missing graph targets. Coverage includes
   `build_program_lowering_rejects_missing_required_target_fields`,
   `build_program_lowering_rejects_invalid_target_field_types`, and
-  `emit_json_build_graph_rejects_missing_required_target_fields`.
+  `emit_json_build_graph_rejects_missing_required_target_fields` plus
+  `emit_json_build_graph_rejects_invalid_target_field_types`.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3010,12 +3010,14 @@ checked-in docs, tests, and commits only.
 - Build graph target metadata lowering now rejects duplicate and unknown target
   fields before graph construction, using enum-backed field spelling and
   preserving CLI diagnostics through
-  `emit_json_build_graph_rejects_unknown_target_fields`.
+  `emit_json_build_graph_rejects_unknown_target_fields` and
+  `emit_json_build_graph_rejects_duplicate_target_fields`.
 - Build graph target metadata lowering now rejects missing required fields and
   wrong field value types before graph construction, preserving direct
   diagnostics through `build_program_lowering_rejects_missing_required_target_fields`,
   `build_program_lowering_rejects_invalid_target_field_types`, and
-  `emit_json_build_graph_rejects_missing_required_target_fields`.
+  `emit_json_build_graph_rejects_missing_required_target_fields` plus
+  `emit_json_build_graph_rejects_invalid_target_field_types`.
 
 ## Current Phase
 

--- a/tests/integration/cli_build/build_graph_json/validation.rs
+++ b/tests/integration/cli_build/build_graph_json/validation.rs
@@ -5,10 +5,7 @@ mod unsupported_targets;
 
 #[test]
 fn emit_json_build_graph_rejects_unknown_target_fields() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let build_path = tmp.path().join("build.zen");
-    std::fs::write(
-        &build_path,
+    assert_emit_json_build_graph_error_contains(
         r#"
 build = (b: Builder) Result<BuildConfig, BuildError> {
     b.add(Executable {
@@ -19,34 +16,13 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
     .Ok(b.config())
 }
 "#,
-    )
-    .expect("write build.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "build-graph", build_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json build-graph");
-
-    assert!(
-        !output.status.success(),
-        "emit-json build-graph unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("unknown field `output_dir` in `Executable` build target"),
-        "expected unknown field diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
+        "unknown field `output_dir` in `Executable` build target",
     );
 }
 
 #[test]
 fn emit_json_build_graph_rejects_missing_required_target_fields() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let build_path = tmp.path().join("build.zen");
-    std::fs::write(
-        &build_path,
+    assert_emit_json_build_graph_error_contains(
         r#"
 build = (b: Builder) Result<BuildConfig, BuildError> {
     b.add(Executable {
@@ -56,34 +32,48 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
     .Ok(b.config())
 }
 "#,
-    )
-    .expect("write build.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "build-graph", build_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json build-graph");
-
-    assert!(
-        !output.status.success(),
-        "emit-json build-graph unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
+        "missing required field `out_dir` in `Executable` build target",
     );
-    assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("missing required field `out_dir` in `Executable` build target"),
-        "expected missing field diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
+}
+
+#[test]
+fn emit_json_build_graph_rejects_duplicate_target_fields() {
+    assert_emit_json_build_graph_error_contains(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        name: "tool",
+        main: "app.zen",
+        out_dir: "build/app/",
+    })
+    .Ok(b.config())
+}
+"#,
+        "duplicate field `name` in `Executable` build target",
+    );
+}
+
+#[test]
+fn emit_json_build_graph_rejects_invalid_target_field_types() {
+    assert_emit_json_build_graph_error_contains(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: 42,
+    })
+    .Ok(b.config())
+}
+"#,
+        "field `out_dir` in `Executable` build target must be a string",
     );
 }
 
 #[test]
 fn emit_json_build_graph_rejects_unknown_target_dependencies() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let build_path = tmp.path().join("build.zen");
-    std::fs::write(
-        &build_path,
+    assert_emit_json_build_graph_error_contains(
         r#"
 build = (b: Builder) Result<BuildConfig, BuildError> {
     b.add(Executable {
@@ -95,34 +85,13 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
     .Ok(b.config())
 }
 "#,
-    )
-    .expect("write build.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "build-graph", build_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json build-graph");
-
-    assert!(
-        !output.status.success(),
-        "emit-json build-graph unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("build target `app` depends on unknown target `core`"),
-        "expected unknown dependency diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
+        "build target `app` depends on unknown target `core`",
     );
 }
 
 #[test]
 fn emit_json_build_graph_rejects_self_target_dependencies() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let build_path = tmp.path().join("build.zen");
-    std::fs::write(
-        &build_path,
+    assert_emit_json_build_graph_error_contains(
         r#"
 build = (b: Builder) Result<BuildConfig, BuildError> {
     b.add(Executable {
@@ -134,34 +103,13 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
     .Ok(b.config())
 }
 "#,
-    )
-    .expect("write build.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "build-graph", build_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json build-graph");
-
-    assert!(
-        !output.status.success(),
-        "emit-json build-graph unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("build target `app` cannot depend on itself"),
-        "expected self dependency diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
+        "build target `app` cannot depend on itself",
     );
 }
 
 #[test]
 fn emit_json_build_graph_rejects_cyclic_target_dependencies() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let build_path = tmp.path().join("build.zen");
-    std::fs::write(
-        &build_path,
+    assert_emit_json_build_graph_error_contains(
         r#"
 build = (b: Builder) Result<BuildConfig, BuildError> {
     b.add(Executable {
@@ -179,9 +127,14 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
     .Ok(b.config())
 }
 "#,
-    )
-    .expect("write build.zen");
+        "build target dependency cycle includes `app`",
+    );
+}
 
+fn assert_emit_json_build_graph_error_contains(build_source: &str, expected: &str) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let build_path = tmp.path().join("build.zen");
+    std::fs::write(&build_path, build_source).expect("write build.zen");
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
         .args(["emit-json", "build-graph", build_path.to_str().unwrap()])
         .output()
@@ -193,10 +146,9 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+    let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("build target dependency cycle includes `app`"),
-        "expected cyclic dependency diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
+        stderr.contains(expected),
+        "expected {expected:?}, stderr={stderr}"
     );
 }


### PR DESCRIPTION
## Summary

- Add executable `emit-json build-graph` coverage for duplicate build target fields and invalid target field value types.
- Refactor the validation tests to share the temporary `build.zen` command harness.
- Update the phase plan and completion audit with the new CLI evidence.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Focused: `cargo test --test integration emit_json_build_graph_rejects -- --nocapture`

Push-only branch run check returned no GitHub Actions runs before PR creation.