### PR TITLE
[codex] use resolver symbols for graph imports

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -782,6 +782,10 @@ and do not assume Phase 4 is ready without evidence.
   validating imported binding symbols.
 - The non-merging module graph records resolver `SymbolTable` data per module
   and rejects resolver diagnostics from loaded dependency modules.
+- Module-graph import binding validation now reads dependency resolver symbols
+  for exported values, types, and behaviors instead of re-scanning dependency
+  AST declarations, covered by
+  `module_system::graph_loading::tests::exported_module_symbol_reads_resolver_public_visibility`.
 - Typechecker setup has an opt-in module-graph entrypoint that validates entry
   resolver symbols and seeds imported signatures from graph-owned
   `ImportBinding`s without merging imported declarations into the entry AST.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1288,6 +1288,10 @@ checked-in docs, tests, and commits only.
 - The non-merging module graph now records resolver `SymbolTable` output for
   each loaded module and rejects resolver diagnostics in dependencies before the
   graph is returned.
+- Module-graph import binding validation now checks exported value, type, and
+  behavior names through dependency resolver symbols instead of scanning
+  dependency AST declarations, covered by
+  `module_system::graph_loading::tests::exported_module_symbol_reads_resolver_public_visibility`.
 - Typechecker setup now has an opt-in module-graph entrypoint that validates
   the entry resolver symbols and seeds imported signatures from graph-owned
   `ImportBinding`s without merging imported declarations into the entry AST.

--- a/src/module_system/graph_loading.rs
+++ b/src/module_system/graph_loading.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use crate::ast::{Declaration, Program};
 use crate::error::{CompileError, FileTable, Span};
-use crate::resolver::Resolver;
+use crate::resolver::{Namespace, Resolver, SymbolTable};
 
 use super::{ImportBinding, ModuleId, ModuleSystem, ResolvedModule, ResolvedModuleGraph};
 
@@ -167,45 +167,119 @@ impl ModuleSystem {
         bindings: &mut Vec<ImportBinding>,
     ) -> Result<(), Vec<CompileError>> {
         for name in names {
-            let mut found_private = false;
-            let mut found_public = false;
-
-            for decl in &dep_module.program.declarations {
-                if decl.name() == Some(name.as_str()) {
-                    if decl.is_public() {
-                        found_public = true;
-                    } else {
-                        found_private = true;
-                    }
+            match exported_module_symbol(&dep_module.symbols, name) {
+                ExportedModuleSymbol::Public => {
+                    bindings.push(ImportBinding {
+                        local_name: name.clone(),
+                        source_module: dep_module.info.id,
+                        source_symbol: name.clone(),
+                        span: import_span,
+                    });
+                }
+                ExportedModuleSymbol::Private => {
+                    return Err(vec![CompileError::Resolution(
+                        format!(
+                            "symbol '{}' in module '{}' is not exported",
+                            name, module_name
+                        ),
+                        Some(import_span),
+                    )]);
+                }
+                ExportedModuleSymbol::Missing => {
+                    return Err(vec![CompileError::Resolution(
+                        format!("module '{}' does not export '{}'", module_name, name),
+                        Some(import_span),
+                    )]);
                 }
             }
-
-            if found_public {
-                bindings.push(ImportBinding {
-                    local_name: name.clone(),
-                    source_module: dep_module.info.id,
-                    source_symbol: name.clone(),
-                    span: import_span,
-                });
-                continue;
-            }
-
-            if found_private {
-                return Err(vec![CompileError::Resolution(
-                    format!(
-                        "symbol '{}' in module '{}' is not exported",
-                        name, module_name
-                    ),
-                    Some(import_span),
-                )]);
-            }
-
-            return Err(vec![CompileError::Resolution(
-                format!("module '{}' does not export '{}'", module_name, name),
-                Some(import_span),
-            )]);
         }
 
         Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExportedModuleSymbol {
+    Public,
+    Private,
+    Missing,
+}
+
+fn exported_module_symbol(symbols: &SymbolTable, name: &str) -> ExportedModuleSymbol {
+    let mut found_private = false;
+
+    for namespace in [Namespace::Value, Namespace::Type, Namespace::Behavior] {
+        let Some(symbol) = symbols.lookup(namespace, name) else {
+            continue;
+        };
+        if symbol.is_public {
+            return ExportedModuleSymbol::Public;
+        }
+        found_private = true;
+    }
+
+    if found_private {
+        ExportedModuleSymbol::Private
+    } else {
+        ExportedModuleSymbol::Missing
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{lexer, parser};
+
+    fn resolve_symbols(source: &str) -> SymbolTable {
+        let tokens = lexer::tokenize(source, 0).expect("lex source");
+        let program = parser::parse(tokens, 0).expect("parse source");
+        Resolver::new()
+            .resolve_program(&program)
+            .expect("resolve source")
+    }
+
+    #[test]
+    fn exported_module_symbol_reads_resolver_public_visibility() {
+        let symbols = resolve_symbols(
+            r#"
+hidden = () i32 { 1 }
+pub Model: { value: i32 }
+pub Json<T>: behavior {
+    encode: (Self) T
+}
+"#,
+        );
+
+        assert_eq!(
+            exported_module_symbol(&symbols, "hidden"),
+            ExportedModuleSymbol::Private
+        );
+        assert_eq!(
+            exported_module_symbol(&symbols, "Model"),
+            ExportedModuleSymbol::Public
+        );
+        assert_eq!(
+            exported_module_symbol(&symbols, "Json"),
+            ExportedModuleSymbol::Public
+        );
+        assert_eq!(
+            exported_module_symbol(&symbols, "Missing"),
+            ExportedModuleSymbol::Missing
+        );
+    }
+
+    #[test]
+    fn exported_module_symbol_accepts_public_symbol_over_private_symbol_in_other_namespace() {
+        let symbols = resolve_symbols(
+            r#"
+Name = () i32 { 1 }
+pub Name: { value: i32 }
+"#,
+        );
+
+        assert_eq!(
+            exported_module_symbol(&symbols, "Name"),
+            ExportedModuleSymbol::Public
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Validate module-graph imported names against dependency resolver symbols for values, types, and behaviors.
- Preserve existing private/missing export diagnostics while removing an AST declaration scan from import binding validation.
- Add focused resolver-symbol export helper coverage and update the phase/audit evidence.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test module_graph --lib -- --nocapture`
- `cargo test module_graph --test integration -- --nocapture`
- `cargo test --lib`
- `cargo test --tests`

Push-only branch run check returned no GitHub Actions runs before PR creation.