### PR TITLE
[codex] cover build command target fields

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3338,7 +3338,9 @@ and do not assume Phase 4 is ready without evidence.
   Coverage includes `build_program_lowering_rejects_duplicate_target_fields`,
   `build_program_lowering_rejects_unknown_target_fields`, and
   `emit_json_build_graph_rejects_unknown_target_fields` plus
-  `emit_json_build_graph_rejects_duplicate_target_fields`.
+  `emit_json_build_graph_rejects_duplicate_target_fields`, with executing
+  `zen build build.zen` coverage in
+  `build_command_build_zen_rejects_duplicate_target_fields`.
 - Build graph target metadata extraction now validates required fields and
   field value shapes before graph construction, so missing `out_dir` and
   non-string string fields produce direct target-field diagnostics instead of
@@ -3346,7 +3348,10 @@ and do not assume Phase 4 is ready without evidence.
   `build_program_lowering_rejects_missing_required_target_fields`,
   `build_program_lowering_rejects_invalid_target_field_types`, and
   `emit_json_build_graph_rejects_missing_required_target_fields` plus
-  `emit_json_build_graph_rejects_invalid_target_field_types`.
+  `emit_json_build_graph_rejects_invalid_target_field_types`, with executing
+  `zen build build.zen` coverage in
+  `build_command_build_zen_rejects_missing_required_target_fields` and
+  `build_command_build_zen_rejects_invalid_target_field_types`.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3015,13 +3015,18 @@ checked-in docs, tests, and commits only.
   fields before graph construction, using enum-backed field spelling and
   preserving CLI diagnostics through
   `emit_json_build_graph_rejects_unknown_target_fields` and
-  `emit_json_build_graph_rejects_duplicate_target_fields`.
+  `emit_json_build_graph_rejects_duplicate_target_fields`, with executing
+  `zen build build.zen` duplicate-field coverage in
+  `build_command_build_zen_rejects_duplicate_target_fields`.
 - Build graph target metadata lowering now rejects missing required fields and
   wrong field value types before graph construction, preserving direct
   diagnostics through `build_program_lowering_rejects_missing_required_target_fields`,
   `build_program_lowering_rejects_invalid_target_field_types`, and
   `emit_json_build_graph_rejects_missing_required_target_fields` plus
-  `emit_json_build_graph_rejects_invalid_target_field_types`.
+  `emit_json_build_graph_rejects_invalid_target_field_types`, with executing
+  `zen build build.zen` coverage in
+  `build_command_build_zen_rejects_missing_required_target_fields` and
+  `build_command_build_zen_rejects_invalid_target_field_types`.
 
 ## Current Phase
 

--- a/tests/integration/cli_build/build_command_validation.rs
+++ b/tests/integration/cli_build/build_command_validation.rs
@@ -186,6 +186,83 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
     );
 }
 
+#[test]
+fn build_command_build_zen_rejects_duplicate_target_fields() {
+    assert_build_command_rejects_target_metadata(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        name: "tool",
+        main: "app.zen",
+        out_dir: "build/app/",
+    })
+    .Ok(b.config())
+}
+"#,
+        "duplicate field `name` in `Executable` build target",
+    );
+}
+
+#[test]
+fn build_command_build_zen_rejects_missing_required_target_fields() {
+    assert_build_command_rejects_target_metadata(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+    })
+    .Ok(b.config())
+}
+"#,
+        "missing required field `out_dir` in `Executable` build target",
+    );
+}
+
+#[test]
+fn build_command_build_zen_rejects_invalid_target_field_types() {
+    assert_build_command_rejects_target_metadata(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: 42,
+    })
+    .Ok(b.config())
+}
+"#,
+        "field `out_dir` in `Executable` build target must be a string",
+    );
+}
+
+fn assert_build_command_rejects_target_metadata(build_source: &str, expected_diagnostic: &str) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(tmp.path().join("build.zen"), build_source).expect("write build.zen");
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen build build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(expected_diagnostic),
+        "expected target metadata diagnostic `{expected_diagnostic}`, stderr={stderr}"
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "build command should not create outputs after target metadata validation fails"
+    );
+}
+
 fn assert_build_command_rejects_dependency_shape(
     project_dir: &std::path::Path,
     expected_diagnostic: &str,


### PR DESCRIPTION
## Summary

- Add `zen build build.zen` negative coverage for duplicate target fields.
- Add executing build-command coverage for missing required target fields and invalid field value types.
- Update phase/audit docs to distinguish build-command evidence from `emit-json build-graph` coverage.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --test integration build_command_build_zen_rejects -- --nocapture`
- `cargo test --lib`
- `cargo test --tests`

Push-only branch run check returned no GitHub Actions runs before PR creation.