### PR TITLE
[codex] cover direct build target fields

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3339,8 +3339,9 @@ and do not assume Phase 4 is ready without evidence.
   `build_program_lowering_rejects_unknown_target_fields`, and
   `emit_json_build_graph_rejects_unknown_target_fields` plus
   `emit_json_build_graph_rejects_duplicate_target_fields`, with executing
-  `zen build build.zen` coverage in
-  `build_command_build_zen_rejects_duplicate_target_fields`.
+  `zen build build.zen` and direct `zen build.zen` coverage in
+  `build_command_build_zen_rejects_duplicate_target_fields` and
+  `direct_file_command_build_zen_rejects_duplicate_target_fields`.
 - Build graph target metadata extraction now validates required fields and
   field value shapes before graph construction, so missing `out_dir` and
   non-string string fields produce direct target-field diagnostics instead of
@@ -3349,9 +3350,11 @@ and do not assume Phase 4 is ready without evidence.
   `build_program_lowering_rejects_invalid_target_field_types`, and
   `emit_json_build_graph_rejects_missing_required_target_fields` plus
   `emit_json_build_graph_rejects_invalid_target_field_types`, with executing
-  `zen build build.zen` coverage in
+  `zen build build.zen` and direct `zen build.zen` coverage in
   `build_command_build_zen_rejects_missing_required_target_fields` and
-  `build_command_build_zen_rejects_invalid_target_field_types`.
+  `build_command_build_zen_rejects_invalid_target_field_types`, plus
+  `direct_file_command_build_zen_rejects_missing_required_target_fields` and
+  `direct_file_command_build_zen_rejects_invalid_target_field_types`.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3016,17 +3016,20 @@ checked-in docs, tests, and commits only.
   preserving CLI diagnostics through
   `emit_json_build_graph_rejects_unknown_target_fields` and
   `emit_json_build_graph_rejects_duplicate_target_fields`, with executing
-  `zen build build.zen` duplicate-field coverage in
-  `build_command_build_zen_rejects_duplicate_target_fields`.
+  `zen build build.zen` and direct `zen build.zen` duplicate-field coverage in
+  `build_command_build_zen_rejects_duplicate_target_fields` and
+  `direct_file_command_build_zen_rejects_duplicate_target_fields`.
 - Build graph target metadata lowering now rejects missing required fields and
   wrong field value types before graph construction, preserving direct
   diagnostics through `build_program_lowering_rejects_missing_required_target_fields`,
   `build_program_lowering_rejects_invalid_target_field_types`, and
   `emit_json_build_graph_rejects_missing_required_target_fields` plus
   `emit_json_build_graph_rejects_invalid_target_field_types`, with executing
-  `zen build build.zen` coverage in
+  `zen build build.zen` and direct `zen build.zen` coverage in
   `build_command_build_zen_rejects_missing_required_target_fields` and
-  `build_command_build_zen_rejects_invalid_target_field_types`.
+  `build_command_build_zen_rejects_invalid_target_field_types`, plus
+  `direct_file_command_build_zen_rejects_missing_required_target_fields` and
+  `direct_file_command_build_zen_rejects_invalid_target_field_types`.
 
 ## Current Phase
 

--- a/tests/integration/cli_build/direct_build_graph_validation.rs
+++ b/tests/integration/cli_build/direct_build_graph_validation.rs
@@ -186,6 +186,86 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
     );
 }
 
+#[test]
+fn direct_file_command_build_zen_rejects_duplicate_target_fields() {
+    assert_direct_file_command_rejects_target_metadata(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        name: "tool",
+        main: "app.zen",
+        out_dir: "build/app/",
+    })
+    .Ok(b.config())
+}
+"#,
+        "duplicate field `name` in `Executable` build target",
+    );
+}
+
+#[test]
+fn direct_file_command_build_zen_rejects_missing_required_target_fields() {
+    assert_direct_file_command_rejects_target_metadata(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+    })
+    .Ok(b.config())
+}
+"#,
+        "missing required field `out_dir` in `Executable` build target",
+    );
+}
+
+#[test]
+fn direct_file_command_build_zen_rejects_invalid_target_field_types() {
+    assert_direct_file_command_rejects_target_metadata(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: 42,
+    })
+    .Ok(b.config())
+}
+"#,
+        "field `out_dir` in `Executable` build target must be a string",
+    );
+}
+
+fn assert_direct_file_command_rejects_target_metadata(
+    build_source: &str,
+    expected_diagnostic: &str,
+) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(tmp.path().join("build.zen"), build_source).expect("write build.zen");
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .arg("build.zen")
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(expected_diagnostic),
+        "expected target metadata diagnostic `{expected_diagnostic}`, stderr={stderr}"
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "direct build.zen command should not create outputs after target metadata validation fails"
+    );
+}
+
 fn assert_direct_file_command_rejects_dependency_shape(
     project_dir: &std::path::Path,
     expected_diagnostic: &str,


### PR DESCRIPTION
## Summary
- add direct `zen build.zen` target metadata diagnostics coverage for duplicate fields, missing required fields, and invalid field types
- update phase/audit docs to record direct-file command coverage alongside `zen build build.zen`

## Local verification
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

## CI hygiene
- verified branch push did not create workflow runs with `gh run list --branch codex/direct-build-target-field-diagnostics --limit 10 --json databaseId,status,conclusion,name,event,headSha` returning `[]`