### PR TITLE
[codex] split declared env effect rejections

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3355,6 +3355,11 @@ and do not assume Phase 4 is ready without evidence.
   `build_command_build_zen_rejects_invalid_target_field_types`, plus
   `direct_file_command_build_zen_rejects_missing_required_target_fields` and
   `direct_file_command_build_zen_rejects_invalid_target_field_types`.
+- Declared env-effect no-fallback rejection tests now live in
+  `tests/integration/cli_build/declared_env_effects/rejections.rs`, preserving
+  build, direct-file, legacy build-graph, check, emit, and test command
+  diagnostics while keeping positive declared-env effect fixtures in the
+  parent module.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3030,6 +3030,11 @@ checked-in docs, tests, and commits only.
   `build_command_build_zen_rejects_invalid_target_field_types`, plus
   `direct_file_command_build_zen_rejects_missing_required_target_fields` and
   `direct_file_command_build_zen_rejects_invalid_target_field_types`.
+- Declared env-effect integration rejection tests now live in
+  `tests/integration/cli_build/declared_env_effects/rejections.rs`, preserving
+  build, direct-file, legacy build-graph, check, emit, and test command
+  no-fallback diagnostics while keeping the positive declared-env coverage
+  focused in the parent test module.
 
 ## Current Phase
 

--- a/tests/integration/cli_build/declared_env_effects.rs
+++ b/tests/integration/cli_build/declared_env_effects.rs
@@ -1,3 +1,6 @@
+#[path = "declared_env_effects/rejections.rs"]
+mod rejections;
+
 use std::process::Command;
 
 #[test]
@@ -182,104 +185,6 @@ main = () i32 {
         "{case_name}: zen test build.zen failed: stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
-    );
-}
-
-#[test]
-fn build_command_build_zen_rejects_env_read_without_fallback_before_execution() {
-    assert_env_read_without_fallback_is_rejected(
-        &["build", "build.zen"],
-        "build command should not start after graph validation fails",
-    );
-}
-
-#[test]
-fn direct_file_command_build_zen_rejects_env_read_without_fallback_before_execution() {
-    assert_env_read_without_fallback_is_rejected(
-        &["build.zen"],
-        "direct build.zen command should not start after graph validation fails",
-    );
-}
-
-#[test]
-fn build_graph_command_rejects_env_read_without_fallback_before_execution() {
-    assert_env_read_without_fallback_is_rejected(
-        &["build-graph", "build.zen"],
-        "build-graph command should not start after graph validation fails",
-    );
-}
-
-#[test]
-fn check_command_build_zen_rejects_env_read_without_fallback_before_source_validation() {
-    let tmp = executable_graph_with_env_read_without_fallback("missing.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["check", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen check build.zen");
-
-    assert_env_read_without_fallback_failed(&output);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        !stderr.contains("source not found"),
-        "host-effect validation should run before source validation, stderr={stderr}"
-    );
-}
-
-#[test]
-fn emit_command_build_zen_rejects_env_read_without_fallback() {
-    let tmp = executable_graph_with_env_read_without_fallback("main.zen");
-    std::fs::write(
-        tmp.path().join("main.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write main.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen emit build.zen");
-
-    assert_env_read_without_fallback_failed(&output);
-    assert!(
-        output.stdout.is_empty(),
-        "emit should not write C source after graph validation fails, stdout={}",
-        String::from_utf8_lossy(&output.stdout)
-    );
-}
-
-#[test]
-fn test_command_build_zen_rejects_env_read_without_fallback_before_execution() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    std_path = b.os.env("ZEN_STD") ?
-        | .Ok(value) { value }
-    b.add(Test { name: "unit", root: "test.zen" })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["test", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen test build.zen");
-
-    assert_env_read_without_fallback_failed(&output);
-    assert!(
-        !tmp.path().join("build").exists(),
-        "test command should not start after graph validation fails"
     );
 }
 

--- a/tests/integration/cli_build/declared_env_effects/rejections.rs
+++ b/tests/integration/cli_build/declared_env_effects/rejections.rs
@@ -1,0 +1,101 @@
+use std::process::Command;
+
+use super::*;
+
+#[test]
+fn build_command_build_zen_rejects_env_read_without_fallback_before_execution() {
+    assert_env_read_without_fallback_is_rejected(
+        &["build", "build.zen"],
+        "build command should not start after graph validation fails",
+    );
+}
+
+#[test]
+fn direct_file_command_build_zen_rejects_env_read_without_fallback_before_execution() {
+    assert_env_read_without_fallback_is_rejected(
+        &["build.zen"],
+        "direct build.zen command should not start after graph validation fails",
+    );
+}
+
+#[test]
+fn build_graph_command_rejects_env_read_without_fallback_before_execution() {
+    assert_env_read_without_fallback_is_rejected(
+        &["build-graph", "build.zen"],
+        "build-graph command should not start after graph validation fails",
+    );
+}
+
+#[test]
+fn check_command_build_zen_rejects_env_read_without_fallback_before_source_validation() {
+    let tmp = executable_graph_with_env_read_without_fallback("missing.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["check", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen check build.zen");
+
+    assert_env_read_without_fallback_failed(&output);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("source not found"),
+        "host-effect validation should run before source validation, stderr={stderr}"
+    );
+}
+
+#[test]
+fn emit_command_build_zen_rejects_env_read_without_fallback() {
+    let tmp = executable_graph_with_env_read_without_fallback("main.zen");
+    std::fs::write(
+        tmp.path().join("main.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write main.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen emit build.zen");
+
+    assert_env_read_without_fallback_failed(&output);
+    assert!(
+        output.stdout.is_empty(),
+        "emit should not write C source after graph validation fails, stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn test_command_build_zen_rejects_env_read_without_fallback_before_execution() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    std_path = b.os.env("ZEN_STD") ?
+        | .Ok(value) { value }
+    b.add(Test { name: "unit", root: "test.zen" })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["test", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen test build.zen");
+
+    assert_env_read_without_fallback_failed(&output);
+    assert!(
+        !tmp.path().join("build").exists(),
+        "test command should not start after graph validation fails"
+    );
+}


### PR DESCRIPTION
## Summary
- move declared env-effect no-fallback rejection tests into a focused child module
- keep shared declared-env fixtures in the parent module
- update phase/audit docs with the cleanup evidence

## Local verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test integration env_read_without_fallback -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

## CI hygiene
- verified branch push did not create workflow runs with `gh run list --branch codex/split-declared-env-effect-rejections --limit 10 --json databaseId,status,conclusion,name,event,headSha` returning `[]`