### PR TITLE
[codex] cover test command target fields

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3360,6 +3360,12 @@ and do not assume Phase 4 is ready without evidence.
   build, direct-file, legacy build-graph, check, emit, and test command
   diagnostics while keeping positive declared-env effect fixtures in the
   parent module.
+- `zen test build.zen` target metadata extraction now has executing `Test`
+  target diagnostics for duplicate fields, missing required root fields, and
+  invalid root field types. Coverage:
+  `test_command_build_zen_rejects_duplicate_test_target_fields`,
+  `test_command_build_zen_rejects_missing_required_test_target_fields`, and
+  `test_command_build_zen_rejects_invalid_test_target_field_types`.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3035,6 +3035,12 @@ checked-in docs, tests, and commits only.
   build, direct-file, legacy build-graph, check, emit, and test command
   no-fallback diagnostics while keeping the positive declared-env coverage
   focused in the parent test module.
+- `zen test build.zen` now has executing target metadata diagnostics for
+  `Test` targets, covering duplicate fields, missing `root`/`root_source_file`,
+  and non-string root fields through
+  `test_command_build_zen_rejects_duplicate_test_target_fields`,
+  `test_command_build_zen_rejects_missing_required_test_target_fields`, and
+  `test_command_build_zen_rejects_invalid_test_target_field_types`.
 
 ## Current Phase
 

--- a/tests/integration/cli_build/graph_validation_test_command_validation.rs
+++ b/tests/integration/cli_build/graph_validation_test_command_validation.rs
@@ -182,6 +182,80 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
     );
 }
 
+#[test]
+fn test_command_build_zen_rejects_duplicate_test_target_fields() {
+    assert_test_command_rejects_target_metadata(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Test {
+        name: "unit",
+        name: "integration",
+        root: "test.zen",
+    })
+    .Ok(b.config())
+}
+"#,
+        "duplicate field `name` in `Test` build target",
+    );
+}
+
+#[test]
+fn test_command_build_zen_rejects_missing_required_test_target_fields() {
+    assert_test_command_rejects_target_metadata(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Test {
+        name: "unit",
+    })
+    .Ok(b.config())
+}
+"#,
+        "missing required field `root` or `root_source_file` in `Test` build target",
+    );
+}
+
+#[test]
+fn test_command_build_zen_rejects_invalid_test_target_field_types() {
+    assert_test_command_rejects_target_metadata(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Test {
+        name: "unit",
+        root: 42,
+    })
+    .Ok(b.config())
+}
+"#,
+        "field `root` in `Test` build target must be a string",
+    );
+}
+
+fn assert_test_command_rejects_target_metadata(build_source: &str, expected_diagnostic: &str) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(tmp.path().join("build.zen"), build_source).expect("write build.zen");
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["test", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen test build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen test build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(expected_diagnostic),
+        "expected target metadata diagnostic `{expected_diagnostic}`, stderr={stderr}"
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "test command should not create outputs after target metadata validation fails"
+    );
+}
+
 fn assert_test_command_rejects_dependency_shape(
     project_dir: &std::path::Path,
     expected_diagnostic: &str,


### PR DESCRIPTION
## Summary
- add executing `zen test build.zen` diagnostics coverage for malformed `Test` target metadata
- cover duplicate fields, missing `root`/`root_source_file`, and invalid root field type before test execution
- update phase/audit docs with the new coverage evidence

## Local verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test integration test_command_build_zen_rejects_ -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

## CI hygiene
- verified branch push did not create workflow runs with `gh run list --branch codex/test-command-target-field-diagnostics --limit 10 --json databaseId,status,conclusion,name,event,headSha` returning `[]`