### PR TITLE
[codex] cover legacy build graph target fields

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3366,6 +3366,12 @@ and do not assume Phase 4 is ready without evidence.
   `test_command_build_zen_rejects_duplicate_test_target_fields`,
   `test_command_build_zen_rejects_missing_required_test_target_fields`, and
   `test_command_build_zen_rejects_invalid_test_target_field_types`.
+- Legacy `zen build-graph build.zen` target metadata extraction now has
+  executing `Executable` target diagnostics for duplicate fields, missing
+  required `out_dir`, and invalid `out_dir` field types. Coverage:
+  `build_graph_command_rejects_duplicate_target_fields`,
+  `build_graph_command_rejects_missing_required_target_fields`, and
+  `build_graph_command_rejects_invalid_target_field_types`.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3041,6 +3041,12 @@ checked-in docs, tests, and commits only.
   `test_command_build_zen_rejects_duplicate_test_target_fields`,
   `test_command_build_zen_rejects_missing_required_test_target_fields`, and
   `test_command_build_zen_rejects_invalid_test_target_field_types`.
+- Legacy `zen build-graph build.zen` execution now has target metadata
+  diagnostics for duplicate executable fields, missing `out_dir`, and
+  non-string `out_dir`, covered by
+  `build_graph_command_rejects_duplicate_target_fields`,
+  `build_graph_command_rejects_missing_required_target_fields`, and
+  `build_graph_command_rejects_invalid_target_field_types`.
 
 ## Current Phase
 

--- a/tests/integration/cli_build/legacy_graph_command_validation.rs
+++ b/tests/integration/cli_build/legacy_graph_command_validation.rs
@@ -186,6 +186,86 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
     );
 }
 
+#[test]
+fn build_graph_command_rejects_duplicate_target_fields() {
+    assert_build_graph_command_rejects_target_metadata(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        name: "tool",
+        main: "app.zen",
+        out_dir: "build/app/",
+    })
+    .Ok(b.config())
+}
+"#,
+        "duplicate field `name` in `Executable` build target",
+    );
+}
+
+#[test]
+fn build_graph_command_rejects_missing_required_target_fields() {
+    assert_build_graph_command_rejects_target_metadata(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+    })
+    .Ok(b.config())
+}
+"#,
+        "missing required field `out_dir` in `Executable` build target",
+    );
+}
+
+#[test]
+fn build_graph_command_rejects_invalid_target_field_types() {
+    assert_build_graph_command_rejects_target_metadata(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: 42,
+    })
+    .Ok(b.config())
+}
+"#,
+        "field `out_dir` in `Executable` build target must be a string",
+    );
+}
+
+fn assert_build_graph_command_rejects_target_metadata(
+    build_source: &str,
+    expected_diagnostic: &str,
+) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(tmp.path().join("build.zen"), build_source).expect("write build.zen");
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build-graph", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build-graph");
+
+    assert!(
+        !output.status.success(),
+        "zen build-graph unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(expected_diagnostic),
+        "expected target metadata diagnostic `{expected_diagnostic}`, stderr={stderr}"
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "build-graph command should not create outputs after target metadata validation fails"
+    );
+}
+
 fn assert_build_graph_command_rejects_dependency_shape(
     project_dir: &std::path::Path,
     expected_diagnostic: &str,


### PR DESCRIPTION
## Summary
- add legacy `zen build-graph build.zen` diagnostics coverage for malformed executable target metadata
- cover duplicate fields, missing `out_dir`, and invalid `out_dir` before graph execution
- update phase/audit docs with the new coverage evidence

## Local verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test integration build_graph_command_rejects_ -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

## CI hygiene
- verified branch push did not create workflow runs with `gh run list --branch codex/legacy-build-graph-target-fields --limit 10 --json databaseId,status,conclusion,name,event,headSha` returning `[]`