### PR TITLE
[codex] cover emit build target fields

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3372,6 +3372,12 @@ and do not assume Phase 4 is ready without evidence.
   `build_graph_command_rejects_duplicate_target_fields`,
   `build_graph_command_rejects_missing_required_target_fields`, and
   `build_graph_command_rejects_invalid_target_field_types`.
+- `zen emit build.zen` target metadata extraction now has executing
+  `Executable` target diagnostics for duplicate fields, missing required
+  `out_dir`, and invalid `out_dir` field types. Coverage:
+  `emit_command_build_zen_rejects_duplicate_target_fields`,
+  `emit_command_build_zen_rejects_missing_required_target_fields`, and
+  `emit_command_build_zen_rejects_invalid_target_field_types`.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3047,6 +3047,11 @@ checked-in docs, tests, and commits only.
   `build_graph_command_rejects_duplicate_target_fields`,
   `build_graph_command_rejects_missing_required_target_fields`, and
   `build_graph_command_rejects_invalid_target_field_types`.
+- `zen emit build.zen` now has target metadata diagnostics for duplicate
+  executable fields, missing `out_dir`, and non-string `out_dir`, covered by
+  `emit_command_build_zen_rejects_duplicate_target_fields`,
+  `emit_command_build_zen_rejects_missing_required_target_fields`, and
+  `emit_command_build_zen_rejects_invalid_target_field_types`.
 
 ## Current Phase
 

--- a/tests/integration/cli_build/emit_direct_validation.rs
+++ b/tests/integration/cli_build/emit_direct_validation.rs
@@ -131,6 +131,88 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
     );
 }
 
+#[test]
+fn emit_command_build_zen_rejects_duplicate_target_fields() {
+    assert_emit_command_rejects_target_metadata(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        name: "tool",
+        main: "app.zen",
+        out_dir: "build/app/",
+    })
+    .Ok(b.config())
+}
+"#,
+        "duplicate field `name` in `Executable` build target",
+    );
+}
+
+#[test]
+fn emit_command_build_zen_rejects_missing_required_target_fields() {
+    assert_emit_command_rejects_target_metadata(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+    })
+    .Ok(b.config())
+}
+"#,
+        "missing required field `out_dir` in `Executable` build target",
+    );
+}
+
+#[test]
+fn emit_command_build_zen_rejects_invalid_target_field_types() {
+    assert_emit_command_rejects_target_metadata(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: 42,
+    })
+    .Ok(b.config())
+}
+"#,
+        "field `out_dir` in `Executable` build target must be a string",
+    );
+}
+
+fn assert_emit_command_rejects_target_metadata(build_source: &str, expected_diagnostic: &str) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(tmp.path().join("build.zen"), build_source).expect("write build.zen");
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen emit build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen emit build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(expected_diagnostic),
+        "expected target metadata diagnostic `{expected_diagnostic}`, stderr={stderr}"
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "zen emit build.zen should not write C source after target metadata validation fails, stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "zen emit build.zen should not create outputs after target metadata validation fails"
+    );
+}
+
 fn assert_emit_command_rejects_dependency_shape(
     project_dir: &std::path::Path,
     expected_diagnostic: &str,


### PR DESCRIPTION
## Summary
- add `zen emit build.zen` diagnostics coverage for malformed executable target metadata
- cover duplicate fields, missing `out_dir`, and invalid `out_dir` before C emission
- update phase/audit docs with the new coverage evidence

## Local verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test integration emit_command_build_zen_rejects_ -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

## CI hygiene
- verified branch push did not create workflow runs with `gh run list --branch codex/emit-build-target-field-diagnostics --limit 10 --json databaseId,status,conclusion,name,event,headSha` returning `[]`