### PR TITLE
[codex] cover build command unknown target fields

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3378,6 +3378,9 @@ and do not assume Phase 4 is ready without evidence.
   `emit_command_build_zen_rejects_duplicate_target_fields`,
   `emit_command_build_zen_rejects_missing_required_target_fields`, and
   `emit_command_build_zen_rejects_invalid_target_field_types`.
+- All executing/checking `build.zen` command entrypoints now reject ordinary
+  unknown executable target fields before creating outputs. Coverage:
+  `build_zen_commands_reject_unknown_target_fields`.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3052,6 +3052,9 @@ checked-in docs, tests, and commits only.
   `emit_command_build_zen_rejects_duplicate_target_fields`,
   `emit_command_build_zen_rejects_missing_required_target_fields`, and
   `emit_command_build_zen_rejects_invalid_target_field_types`.
+- All executing/checking `build.zen` command entrypoints now reject ordinary
+  unknown target fields before outputs are created, covered by
+  `build_zen_commands_reject_unknown_target_fields`.
 
 ## Current Phase
 

--- a/tests/integration/cli_build/unsupported_targets.rs
+++ b/tests/integration/cli_build/unsupported_targets.rs
@@ -73,6 +73,11 @@ fn build_zen_commands_reject_link_fields() {
     assert_build_zen_commands_reject_gated_target_field("link", r#"["m"]"#);
 }
 
+#[test]
+fn build_zen_commands_reject_unknown_target_fields() {
+    assert_build_zen_commands_reject_unknown_target_field("output_dir", r#""build/app/""#);
+}
+
 fn assert_build_zen_command_rejects_unsupported_target_kind(args: &[&str], target_kind: &str) {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(
@@ -168,5 +173,63 @@ build = (b: Builder) Result<BuildConfig, BuildError> {{
     assert!(
         !tmp.path().join("build").exists(),
         "zen {args:?} should reject gated target fields before creating build outputs"
+    );
+}
+
+fn assert_build_zen_commands_reject_unknown_target_field(field: &str, value: &str) {
+    for args in [
+        &["build", "build.zen"][..],
+        &["build.zen"][..],
+        &["check", "build.zen"][..],
+        &["test", "build.zen"][..],
+        &["emit", "build.zen"][..],
+        &["build-graph", "build.zen"][..],
+    ] {
+        assert_build_zen_command_rejects_unknown_target_field(args, field, value);
+    }
+}
+
+fn assert_build_zen_command_rejects_unknown_target_field(args: &[&str], field: &str, value: &str) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
+    b.add(Executable {{
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        {field}: {value},
+    }})
+    .Ok(b.config())
+}}
+"#
+        ),
+    )
+    .expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(args)
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build.zen command");
+
+    assert!(
+        !output.status.success(),
+        "zen {args:?} unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains(&format!(
+            "unknown field `{field}` in `Executable` build target"
+        )),
+        "expected unknown field diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "zen {args:?} should reject unknown target fields before creating build outputs"
     );
 }


### PR DESCRIPTION
## Summary
- add a shared command matrix proving ordinary unknown executable target fields are rejected across all `build.zen` entrypoints
- assert malformed `output_dir` does not create outputs before command execution/checking
- update phase/audit docs with the coverage evidence

## Local verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test integration unsupported_targets -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

## CI hygiene
- verified branch push did not create workflow runs with `gh run list --branch codex/build-commands-unknown-target-fields --limit 10 --json databaseId,status,conclusion,name,event,headSha` returning `[]`