### PR TITLE
[codex] Cover check library target metadata

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3378,6 +3378,13 @@ and do not assume Phase 4 is ready without evidence.
   `emit_command_build_zen_rejects_duplicate_target_fields`,
   `emit_command_build_zen_rejects_missing_required_target_fields`, and
   `emit_command_build_zen_rejects_invalid_target_field_types`.
+- Normal `zen check build.zen` target metadata extraction now has `Library`
+  target diagnostics for duplicate fields, missing required `exports`, invalid
+  `exports` field types, and empty export lists. Coverage:
+  `check_command_build_zen_rejects_duplicate_library_target_fields`,
+  `check_command_build_zen_rejects_missing_library_exports`,
+  `check_command_build_zen_rejects_invalid_library_exports_type`, and
+  `check_command_build_zen_rejects_empty_library_exports`.
 - All executing/checking `build.zen` command entrypoints now reject ordinary
   unknown executable target fields before creating outputs. Coverage:
   `build_zen_commands_reject_unknown_target_fields`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3052,6 +3052,13 @@ checked-in docs, tests, and commits only.
   `emit_command_build_zen_rejects_duplicate_target_fields`,
   `emit_command_build_zen_rejects_missing_required_target_fields`, and
   `emit_command_build_zen_rejects_invalid_target_field_types`.
+- Normal `zen check build.zen` now has `Library` target metadata diagnostics
+  for duplicate fields, missing `exports`, non-array `exports`, and empty
+  `exports`, covered by
+  `check_command_build_zen_rejects_duplicate_library_target_fields`,
+  `check_command_build_zen_rejects_missing_library_exports`,
+  `check_command_build_zen_rejects_invalid_library_exports_type`, and
+  `check_command_build_zen_rejects_empty_library_exports`.
 - All executing/checking `build.zen` command entrypoints now reject ordinary
   unknown target fields before outputs are created, covered by
   `build_zen_commands_reject_unknown_target_fields`.

--- a/tests/integration/cli_build/graph_validation.rs
+++ b/tests/integration/cli_build/graph_validation.rs
@@ -166,6 +166,92 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
     );
 }
 
+#[test]
+fn check_command_build_zen_rejects_duplicate_library_target_fields() {
+    assert_check_command_rejects_library_target_metadata(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Library {
+        name: "core",
+        name: "utils",
+        exports: ["lib.zen"],
+    })
+    .Ok(b.config())
+}
+"#,
+        "duplicate field `name` in `Library` build target",
+    );
+}
+
+#[test]
+fn check_command_build_zen_rejects_missing_library_exports() {
+    assert_check_command_rejects_library_target_metadata(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Library { name: "core" })
+    .Ok(b.config())
+}
+"#,
+        "missing required field `exports` in `Library` build target",
+    );
+}
+
+#[test]
+fn check_command_build_zen_rejects_invalid_library_exports_type() {
+    assert_check_command_rejects_library_target_metadata(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Library { name: "core", exports: "lib.zen" })
+    .Ok(b.config())
+}
+"#,
+        "field `exports` in `Library` build target must be an array of strings",
+    );
+}
+
+#[test]
+fn check_command_build_zen_rejects_empty_library_exports() {
+    assert_check_command_rejects_library_target_metadata(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Library { name: "core", exports: [] })
+    .Ok(b.config())
+}
+"#,
+        "field `exports` in `Library` build target must contain at least one source",
+    );
+}
+
+fn assert_check_command_rejects_library_target_metadata(
+    build_source: &str,
+    expected_diagnostic: &str,
+) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(tmp.path().join("build.zen"), build_source).expect("write build.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["check", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen check build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen check build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains(expected_diagnostic),
+        "expected library target metadata diagnostic `{expected_diagnostic}`, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "zen check build.zen should not create outputs after library target metadata validation fails"
+    );
+}
+
 fn assert_check_command_rejects_dependency_shape(
     project_dir: &std::path::Path,
     expected_diagnostic: &str,


### PR DESCRIPTION
## Summary

- Adds `zen check build.zen` integration coverage for malformed `Library` target metadata.
- Covers duplicate fields, missing `exports`, invalid `exports` field shape, and empty export lists.
- Records the new evidence in the phase plan and completion audit.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`