### PR TITLE
[codex] Reject root generated artifacts

### DIFF
--- a/tests/docs_truth/public_docs.rs
+++ b/tests/docs_truth/public_docs.rs
@@ -173,11 +173,17 @@ fn public_language_docs_and_examples_do_not_teach_return_keyword() {
 
 #[test]
 fn stale_generated_tooling_directories_are_removed() {
-    for path in [".claude", "scripts", "examples/demo_project"] {
+    for path in [
+        ".claude",
+        "scripts",
+        "examples/demo_project",
+        "main",
+        "main.c",
+    ] {
         let absolute_path = repo_root().join(path);
         assert!(
             !absolute_path.exists(),
-            "{path} should not exist; stale generated tooling/examples should stay out of the repo"
+            "{path} should not exist; stale generated tooling/examples/build outputs should stay out of the repo"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Extends the public docs hygiene check to reject root-level generated `main` and `main.c` outputs.
- Removes the ignored local generated copies so the workspace matches the clean checkout expectation.

## Validation

- `cargo test --test docs_truth stale_generated_tooling_directories_are_removed -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`