### PR TITLE
[codex] Verify public examples

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2337,6 +2337,12 @@ and do not assume Phase 4 is ready without evidence.
   execution,
   covered by
   `cargo test --test integration build_command_multi_target_build_zen_rejects_undeclared_host_effects`.
+- Public examples now typecheck through the CLI instead of relying only on
+  README path checks, covered by
+  `cargo test --test integration public_examples_typecheck_through_cli` and
+  `cargo test --test integration public_project_build_graph_typechecks_through_cli`.
+  The project example includes an explicit `test.zen` target so
+  `examples/project/build.zen` validates every advertised source.
 - Normal `zen check build.zen` validates the constrained deterministic graph
   without compiling targets, covered by
   `cargo test --test integration check_command_validates_build_zen_graph`, and

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2289,6 +2289,11 @@ checked-in docs, tests, and commits only.
   `parse_project_build_zen_example`, and leading-dot enum shorthand used by
   build-style result/config flows is covered by
   `parse_shorthand_enum_variant_expr_and_pattern`.
+- Public examples now have executable CLI typecheck coverage through
+  `public_examples_typecheck_through_cli` and
+  `public_project_build_graph_typechecks_through_cli`, so the README/tutorial
+  examples and the canonical project build graph cannot drift back to removed
+  syntax without failing integration.
 - A constrained `build.zen` lowering boundary now maps parsed build scripts into
   `BuildGraph` without enabling CLI execution. `parsed_project_build_zen_lowers_to_executable_and_test_graph`
   covers the checked-in project executable and test targets,

--- a/examples/02_variables_and_types.zen
+++ b/examples/02_variables_and_types.zen
@@ -1,64 +1,50 @@
 // Variables and Types in Zen
-// 6 variable declaration forms, explicit pointer types, no null
+// Immutable bindings, mutable bindings, explicit types, casts, and booleans
 
 { io } = std
 
 main = () i32 {
-    // === Variable Declaration Forms ===
-
-    // 1. Immutable, inferred type
     x = 42
     io.println("x = ${x}")
 
-    // 2. Mutable, inferred type
     y ::= 10
     io.println("y = ${y}")
     y = y + 5
     io.println("y after mutation = ${y}")
 
-    // 3. Immutable, explicit type
-    pi: f64 = 3.14159265
-    io.println("pi = ${pi}")
-
-    // 4. Mutable, explicit type
-    counter:: i32 = 0
+    counter ::= 0
     io.println("counter = ${counter}")
     counter = counter + 1
     io.println("counter after increment = ${counter}")
 
-    // === Numeric Types ===
-
-    // Signed integers
+    // Numeric types
     small = cast(127, i8)
     medium: i32 = 2147483647
     big: i64 = 9223372036854775807
 
-    // Unsigned integers
     byte = cast(255, u8)
     word = cast(4294967295, u32)
 
-    // Floating point
     single = cast(3.14, f32)
     double: f64 = 3.14159265358979
 
     io.println("i8 max: ${small}")
     io.println("i32 max: ${medium}")
+    io.println("i64 max: ${big}")
     io.println("u8 max: ${byte}")
+    io.println("u32 max: ${word}")
     io.println("f32: ${single}")
     io.println("f64: ${double}")
 
-    // === Boolean ===
     flag = true
     flag ?
         | true { io.println("flag is true") }
         | false { io.println("flag is false") }
 
-    // === String Interpolation ===
     name = "Zen"
     version = 7
-    io.println("${name} v0.${version}.1 - zero keywords, infinite possibilities")
+    io.println("${name} v0.${version}.1")
 
-    // === Type Casting ===
     int_val: i32 = 42
     float_val = cast(int_val, f64)
     io.println("Cast i32 ${int_val} to f64: ${float_val}")

--- a/examples/03_pattern_matching.zen
+++ b/examples/03_pattern_matching.zen
@@ -3,33 +3,41 @@
 
 { io } = std
 
-// Simple enum
-Color: Red, Green, Blue
+Color:
+    Red,
+    Green,
+    Blue
 
-// Enum with payloads
-Shape:
-    Circle: f64,
-    Rectangle: { width: f64, height: f64 },
-    Triangle: { base: f64, height: f64 }
-
-// Pattern matching on enums
-describe_color = (c: Color) StringLiteral {
-    c ?
-        | .Red { "red" }
-        | .Green { "green" }
-        | .Blue { "blue" }
+Rectangle: {
+    width: f64,
+    height: f64,
 }
 
-// Pattern matching with payload extraction
+Triangle: {
+    base: f64,
+    height: f64,
+}
+
+Shape:
+    Circle(f64),
+    Rect(Rectangle),
+    Tri(Triangle)
+
+describe_color = (c: Color) StaticString {
+    c ?
+        | Red { "red" }
+        | Green { "green" }
+        | Blue { "blue" }
+}
+
 area = (s: Shape) f64 {
     s ?
-        | .Circle(radius) { 3.14159 * radius * radius }
-        | .Rectangle(r) { r.width * r.height }
-        | .Triangle(t) { 0.5 * t.base * t.height }
+        | Circle(radius) { 3.14159 * radius * radius }
+        | Rect(r) { r.width * r.height }
+        | Tri(t) { 0.5 * t.base * t.height }
 }
 
-// Conditional (boolean pattern matching)
-classify_number = (n: i32) StringLiteral {
+classify_number = (n: i32) StaticString {
     n > 0 ?
         | true { "positive" }
         | false {
@@ -40,20 +48,17 @@ classify_number = (n: i32) StringLiteral {
 }
 
 main = () i32 {
-    // Enum pattern matching
-    io.println(describe_color(.Red))
-    io.println(describe_color(.Blue))
+    io.println(describe_color(Color.Red))
+    io.println(describe_color(Color.Blue))
 
-    // Shape areas
     circle = Shape.Circle(5.0)
-    rect = Shape.Rectangle({ width: 10.0, height: 3.0 })
-    tri = Shape.Triangle({ base: 8.0, height: 4.0 })
+    rect = Shape.Rect(Rectangle { width: 10.0, height: 3.0 })
+    tri = Shape.Tri(Triangle { base: 8.0, height: 4.0 })
 
     io.println("Circle area: ${area(circle)}")
     io.println("Rectangle area: ${area(rect)}")
     io.println("Triangle area: ${area(tri)}")
 
-    // Number classification
     io.println(classify_number(42))
     io.println(classify_number(0))
     io.println(classify_number(-7))

--- a/examples/04_structs_and_methods.zen
+++ b/examples/04_structs_and_methods.zen
@@ -22,7 +22,7 @@ scale = (p: Point, factor: f64) Point {
     Point { x: p.x * factor, y: p.y * factor }
 }
 
-to_string = (p: Point) StringLiteral {
+to_string = (p: Point) StaticString {
     "(${p.x}, ${p.y})"
 }
 

--- a/examples/06_error_handling.zen
+++ b/examples/06_error_handling.zen
@@ -4,61 +4,72 @@
 
 { io } = std
 
-// A function that can fail
-divide = (a: f64, b: f64) Result<f64, StringLiteral> {
+Result<T, E>:
+    Ok(T),
+    Err(E)
+
+Option<T>:
+    None,
+    Some(T)
+
+divide = (a: f64, b: f64) Result<f64, StaticString> {
     b == 0.0 ?
-        | true { .Err("division by zero") }
-        | false { .Ok(a / b) }
+        | true { Result<f64, StaticString>.Err("division by zero") }
+        | false { Result<f64, StaticString>.Ok(a / b) }
 }
 
-// A function that might not have a value
-find_first_positive = (values: [i32; 5]) Option<i32> {
-    i ::= 0
-    loop i < 5 {
-        values[i] > 0 ?
-            | true { .Some(values[i]) }
-        i = i + 1
-    }
-    .None
+first_positive = (a: i32, b: i32, c: i32) Option<i32> {
+    a > 0 ?
+        | true { Option<i32>.Some(a) }
+        | false {
+            b > 0 ?
+                | true { Option<i32>.Some(b) }
+                | false {
+                    c > 0 ?
+                        | true { Option<i32>.Some(c) }
+                        | false { Option<i32>.None }
+                }
+        }
 }
 
-// Using .raise() for early error propagation
-// If divide returns Err, calculate_ratio returns that Err immediately
-calculate_ratio = (a: f64, b: f64, c: f64) Result<f64, StringLiteral> {
-    first = divide(a, b).raise()
-    second = divide(first, c).raise()
-    .Ok(second)
+calculate_ratio = (a: f64, b: f64, c: f64) Result<f64, StaticString> {
+    divide(a, b) ?
+        | Ok(first) {
+            divide(first, c) ?
+                | Ok(second) { Result<f64, StaticString>.Ok(second) }
+                | Err(msg) { Result<f64, StaticString>.Err(msg) }
+        }
+        | Err(msg) { Result<f64, StaticString>.Err(msg) }
+}
+
+print_ratio = (value: Result<f64, StaticString>) void {
+    value ?
+        | Ok(val) { io.println("Ratio: ${val}") }
+        | Err(msg) { io.println("Ratio error: ${msg}") }
+}
+
+print_positive = (value: Option<i32>) void {
+    value ?
+        | Some(n) { io.println("First positive: ${n}") }
+        | None { io.println("No positive numbers found") }
 }
 
 main = () i32 {
-    // Pattern matching on Result
     result = divide(10.0, 3.0)
     result ?
-        | .Ok(val) { io.println("10 / 3 = ${val}") }
-        | .Err(msg) { io.println("Error: ${msg}") }
+        | Ok(val) { io.println("10 / 3 = ${val}") }
+        | Err(msg) { io.println("Error: ${msg}") }
 
-    // Error case
     bad_result = divide(5.0, 0.0)
     bad_result ?
-        | .Ok(val) { io.println("Should not reach: ${val}") }
-        | .Err(msg) { io.println("Caught: ${msg}") }
+        | Ok(val) { io.println("Should not reach: ${val}") }
+        | Err(msg) { io.println("Caught: ${msg}") }
 
-    // Pattern matching on Option
-    numbers = [3, -1, 7, -5, 2]
-    find_first_positive(numbers) ?
-        | .Some(n) { io.println("First positive: ${n}") }
-        | .None { io.println("No positive numbers found") }
+    print_positive(first_positive(-3, -1, 7))
+    print_positive(first_positive(-3, -1, -7))
 
-    empty_numbers = [-3, -1, -7, -5, -2]
-    find_first_positive(empty_numbers) ?
-        | .Some(n) { io.println("First positive: ${n}") }
-        | .None { io.println("No positive numbers found") }
-
-    // Error propagation with .raise()
-    ratio_result = calculate_ratio(100.0, 5.0, 2.0)
-    ratio_result ?
-        | .Ok(val) { io.println("Ratio: ${val}") }
-        | .Err(msg) { io.println("Ratio error: ${msg}") }
+    print_ratio(calculate_ratio(100.0, 5.0, 2.0))
+    print_ratio(calculate_ratio(100.0, 0.0, 2.0))
 
     0
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,6 +22,7 @@ these files as focused language samples.
 
 - [examples/project/main.zen](project/main.zen)
 - [examples/project/math_utils.zen](project/math_utils.zen)
+- [examples/project/test.zen](project/test.zen)
 - [examples/project/build.zen](project/build.zen)
 
 `examples/project/` is the canonical multi-file example. The numbered files are

--- a/examples/project/math_utils.zen
+++ b/examples/project/math_utils.zen
@@ -2,18 +2,21 @@
 //
 // Shows how to organize reusable functions in a separate file.
 
-{ abs, max, min } = std.math.math
-
-clamp = (value: i32, lo: i32, hi: i32) i32 {
-    value.max(lo).min(hi)
+pub clamp = (value: i32, lo: i32, hi: i32) i32 {
+    lower = value < lo ?
+        | true { lo }
+        | false { value }
+    lower > hi ?
+        | true { hi }
+        | false { lower }
 }
 
-factorial = (n: i32) i32 {
+pub factorial = (n: i32) i32 {
     n <= 1 ?
         | true { 1 }
         | false { n * factorial(n - 1) }
 }
 
-is_even = (n: i32) bool {
+pub is_even = (n: i32) bool {
     n % 2 == 0
 }

--- a/examples/project/test.zen
+++ b/examples/project/test.zen
@@ -1,0 +1,9 @@
+// test.zen - Deterministic test target for the project build graph
+
+{ factorial } = math_utils
+
+main = () i32 {
+    factorial(4) == 24 ?
+        | true { 0 }
+        | false { 1 }
+}

--- a/tests/docs_truth/public_docs.rs
+++ b/tests/docs_truth/public_docs.rs
@@ -64,6 +64,7 @@ fn examples_index_uses_canonical_tutorial_and_project_paths() {
         "examples/05_loops.zen",
         "examples/06_error_handling.zen",
         "examples/project/main.zen",
+        "examples/project/test.zen",
     ] {
         assert!(
             examples.contains(required),
@@ -160,6 +161,7 @@ fn public_language_docs_and_examples_do_not_teach_return_keyword() {
         "examples/06_error_handling.zen",
         "examples/project/main.zen",
         "examples/project/math_utils.zen",
+        "examples/project/test.zen",
         "examples/project/build.zen",
         "tests/nested_struct_field_access.zen",
     ] {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -22,6 +22,8 @@ mod import_visibility_dependencies;
 mod import_visibility_private_methods;
 #[path = "integration/multi_file_fixtures.rs"]
 mod multi_file_fixtures;
+#[path = "integration/public_examples.rs"]
+mod public_examples;
 #[path = "integration/runtime_fixtures.rs"]
 mod runtime_fixtures;
 #[path = "integration/single_file_fixtures.rs"]

--- a/tests/integration/public_examples.rs
+++ b/tests/integration/public_examples.rs
@@ -1,0 +1,38 @@
+use std::path::Path;
+use std::process::Command;
+
+#[test]
+fn public_examples_typecheck_through_cli() {
+    for path in [
+        "examples/01_hello_world.zen",
+        "examples/02_variables_and_types.zen",
+        "examples/03_pattern_matching.zen",
+        "examples/04_structs_and_methods.zen",
+        "examples/05_loops.zen",
+        "examples/06_error_handling.zen",
+        "examples/project/main.zen",
+        "examples/project/math_utils.zen",
+    ] {
+        assert_zen_check_succeeds(path);
+    }
+}
+
+#[test]
+fn public_project_build_graph_typechecks_through_cli() {
+    assert_zen_check_succeeds("examples/project/build.zen");
+}
+
+fn assert_zen_check_succeeds(path: &str) {
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["check", path])
+        .current_dir(Path::new(env!("CARGO_MANIFEST_DIR")))
+        .output()
+        .unwrap_or_else(|err| panic!("run zen check {path}: {err}"));
+
+    assert!(
+        output.status.success(),
+        "zen check {path} failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## Summary

- add integration coverage that runs `zen check` over the public tutorial examples and the canonical project build graph
- update stale public examples to the current prefix enum, pattern, Result/Option, and final-expression syntax
- add the missing `examples/project/test.zen` target and export project helper functions
- record the new public-example evidence in the phase plan and completion audit

## Validation

- `cargo test --test integration public_examples -- --nocapture`
- `cargo test --test docs_truth public_docs -- --nocapture`
- `cargo test --test docs_truth phase_audit -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

## Workflow check

- `gh run list --branch codex/verify-public-examples --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]` after push, confirming raw branch pushes did not start Actions runs.