### PR TITLE
[codex] Compile public examples

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2343,6 +2343,9 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration public_project_build_graph_typechecks_through_cli`.
   The project example includes an explicit `test.zen` target so
   `examples/project/build.zen` validates every advertised source.
+  Runnable public examples also compile through `zen build`, covered by
+  `cargo test --test integration public_runnable_examples_compile_through_cli`,
+  so public tutorial files cannot drift into typecheck-only codegen gaps.
 - Normal `zen check build.zen` validates the constrained deterministic graph
   without compiling targets, covered by
   `cargo test --test integration check_command_validates_build_zen_graph`, and

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2294,6 +2294,9 @@ checked-in docs, tests, and commits only.
   `public_project_build_graph_typechecks_through_cli`, so the README/tutorial
   examples and the canonical project build graph cannot drift back to removed
   syntax without failing integration.
+- Runnable public examples now also compile through the CLI under
+  `public_runnable_examples_compile_through_cli`, which keeps tutorial examples
+  from teaching typecheck-only syntax that C emission cannot lower yet.
 - A constrained `build.zen` lowering boundary now maps parsed build scripts into
   `BuildGraph` without enabling CLI execution. `parsed_project_build_zen_lowers_to_executable_and_test_graph`
   covers the checked-in project executable and test targets,

--- a/examples/05_loops.zen
+++ b/examples/05_loops.zen
@@ -54,15 +54,15 @@ fibonacci = (n: i32) i32 {
         }
 }
 
-// Collection loop
-sum_array = (arr: [i32; 5]) i32 {
+// Counted accumulation loop
+sum_to = (limit: i32) i32 {
     total ::= 0
-    i ::= 0
+    i ::= 1
     loop((l) {
-        i >= 5 ?
+        i > limit ?
             | true { l.done() }
             | false {
-                total = total + arr[i]
+                total = total + i
                 i = i + 1
                 l.next()
             }
@@ -123,8 +123,7 @@ main = () i32 {
             }
     })
 
-    numbers = [10, 20, 30, 40, 50]
-    io.println("Sum: ${sum_array(numbers)}")
+    io.println("Sum 1..5: ${sum_to(5)}")
     io.println("Nested stop count: ${nested_stop()}")
     io.println("UFC count: ${count_with_ufc(3)}")
 

--- a/tests/integration/public_examples.rs
+++ b/tests/integration/public_examples.rs
@@ -22,6 +22,21 @@ fn public_project_build_graph_typechecks_through_cli() {
     assert_zen_check_succeeds("examples/project/build.zen");
 }
 
+#[test]
+fn public_runnable_examples_compile_through_cli() {
+    for path in [
+        "examples/01_hello_world.zen",
+        "examples/02_variables_and_types.zen",
+        "examples/03_pattern_matching.zen",
+        "examples/04_structs_and_methods.zen",
+        "examples/05_loops.zen",
+        "examples/06_error_handling.zen",
+        "examples/project/main.zen",
+    ] {
+        assert_zen_build_succeeds(path);
+    }
+}
+
 fn assert_zen_check_succeeds(path: &str) {
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
         .args(["check", path])
@@ -32,6 +47,23 @@ fn assert_zen_check_succeeds(path: &str) {
     assert!(
         output.status.success(),
         "zen check {path} failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn assert_zen_build_succeeds(path: &str) {
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR")).join(path);
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build", source_path.to_str().expect("utf-8 source path")])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap_or_else(|err| panic!("run zen build {path}: {err}"));
+
+    assert!(
+        output.status.success(),
+        "zen build {path} failed: stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );


### PR DESCRIPTION
## Summary

- add a public-example integration check that runs `zen build` for runnable tutorial examples and the canonical project entrypoint
- replace the loop tutorial's array-indexing section with a counted accumulation loop so it stays runnable while array lowering remains outside the public example surface
- record the stronger public-example compile evidence in the phase plan and completion audit

## Validation

- `cargo test --test integration public_examples -- --nocapture`
- `cargo test --test docs_truth phase_audit -- --nocapture`
- `cargo test --test docs_truth public_docs -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

## Workflow check

- `gh run list --branch codex/build-public-examples --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]` after push, confirming raw branch pushes did not start Actions runs.