### PR TITLE
[codex] Run public examples

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2346,6 +2346,8 @@ and do not assume Phase 4 is ready without evidence.
   Runnable public examples also compile through `zen build`, covered by
   `cargo test --test integration public_runnable_examples_compile_through_cli`,
   so public tutorial files cannot drift into typecheck-only codegen gaps.
+  They also execute as compiled binaries, covered by
+  `cargo test --test integration public_runnable_examples_execute_through_cli`.
 - Normal `zen check build.zen` validates the constrained deterministic graph
   without compiling targets, covered by
   `cargo test --test integration check_command_validates_build_zen_graph`, and

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2297,6 +2297,10 @@ checked-in docs, tests, and commits only.
 - Runnable public examples now also compile through the CLI under
   `public_runnable_examples_compile_through_cli`, which keeps tutorial examples
   from teaching typecheck-only syntax that C emission cannot lower yet.
+- The same runnable public set now executes through
+  `public_runnable_examples_execute_through_cli`, proving the advertised
+  examples are not only typechecked and compiled but also valid native
+  programs.
 - A constrained `build.zen` lowering boundary now maps parsed build scripts into
   `BuildGraph` without enabling CLI execution. `parsed_project_build_zen_lowers_to_executable_and_test_graph`
   covers the checked-in project executable and test targets,

--- a/tests/integration/public_examples.rs
+++ b/tests/integration/public_examples.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 use std::process::Command;
+use tempfile::TempDir;
 
 #[test]
 fn public_examples_typecheck_through_cli() {
@@ -37,6 +38,21 @@ fn public_runnable_examples_compile_through_cli() {
     }
 }
 
+#[test]
+fn public_runnable_examples_execute_through_cli() {
+    for path in [
+        "examples/01_hello_world.zen",
+        "examples/02_variables_and_types.zen",
+        "examples/03_pattern_matching.zen",
+        "examples/04_structs_and_methods.zen",
+        "examples/05_loops.zen",
+        "examples/06_error_handling.zen",
+        "examples/project/main.zen",
+    ] {
+        assert_zen_build_and_run_succeeds(path);
+    }
+}
+
 fn assert_zen_check_succeeds(path: &str) {
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
         .args(["check", path])
@@ -53,11 +69,36 @@ fn assert_zen_check_succeeds(path: &str) {
 }
 
 fn assert_zen_build_succeeds(path: &str) {
+    let _built = build_public_example(path);
+}
+
+fn assert_zen_build_and_run_succeeds(path: &str) {
+    let built = build_public_example(path);
+    let run = Command::new(&built.binary_path)
+        .current_dir(built.temp_dir.path())
+        .output()
+        .unwrap_or_else(|err| panic!("run compiled public example {path}: {err}"));
+
+    assert!(
+        run.status.success(),
+        "compiled public example {path} exited with {}: stdout={}, stderr={}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+}
+
+struct BuiltPublicExample {
+    temp_dir: TempDir,
+    binary_path: std::path::PathBuf,
+}
+
+fn build_public_example(path: &str) -> BuiltPublicExample {
     let source_path = Path::new(env!("CARGO_MANIFEST_DIR")).join(path);
-    let tmp = tempfile::tempdir().expect("create temp dir");
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
         .args(["build", source_path.to_str().expect("utf-8 source path")])
-        .current_dir(tmp.path())
+        .current_dir(temp_dir.path())
         .output()
         .unwrap_or_else(|err| panic!("run zen build {path}: {err}"));
 
@@ -67,4 +108,13 @@ fn assert_zen_build_succeeds(path: &str) {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+
+    let stem = source_path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .expect("example path has utf-8 file stem");
+    BuiltPublicExample {
+        binary_path: temp_dir.path().join(stem),
+        temp_dir,
+    }
 }


### PR DESCRIPTION
## Summary

- add a public-example integration check that builds and executes each runnable tutorial example and the canonical project entrypoint
- share the build helper between compile-only and execute checks so the public example gate uses one CLI path
- record the new execute-through-CLI evidence in the phase plan and completion audit

## Validation

- `cargo test --test integration public_examples -- --nocapture`
- `cargo test --test docs_truth phase_audit -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

## Workflow check

- `gh run list --branch codex/run-public-examples --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]` after push, confirming raw branch pushes did not start Actions runs.