### PR TITLE
[codex] Run public project graph

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2348,6 +2348,9 @@ and do not assume Phase 4 is ready without evidence.
   so public tutorial files cannot drift into typecheck-only codegen gaps.
   They also execute as compiled binaries, covered by
   `cargo test --test integration public_runnable_examples_execute_through_cli`.
+  The canonical project build graph also builds, runs its executable target,
+  and runs its test target from a temp copy, covered by
+  `cargo test --test integration public_project_build_graph_builds_and_tests_through_cli`.
 - Normal `zen check build.zen` validates the constrained deterministic graph
   without compiling targets, covered by
   `cargo test --test integration check_command_validates_build_zen_graph`, and

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2301,6 +2301,10 @@ checked-in docs, tests, and commits only.
   `public_runnable_examples_execute_through_cli`, proving the advertised
   examples are not only typechecked and compiled but also valid native
   programs.
+- The canonical project build graph now builds, runs its executable target, and
+  runs its test target from a temp copy through
+  `public_project_build_graph_builds_and_tests_through_cli`, keeping the
+  advertised multi-file project example aligned with CLI graph execution.
 - A constrained `build.zen` lowering boundary now maps parsed build scripts into
   `BuildGraph` without enabling CLI execution. `parsed_project_build_zen_lowers_to_executable_and_test_graph`
   covers the checked-in project executable and test targets,

--- a/tests/integration/public_examples.rs
+++ b/tests/integration/public_examples.rs
@@ -1,4 +1,5 @@
-use std::path::Path;
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use tempfile::TempDir;
 
@@ -21,6 +22,47 @@ fn public_examples_typecheck_through_cli() {
 #[test]
 fn public_project_build_graph_typechecks_through_cli() {
     assert_zen_check_succeeds("examples/project/build.zen");
+}
+
+#[test]
+fn public_project_build_graph_builds_and_tests_through_cli() {
+    let project = copy_public_project_example();
+    let build_path = project.path().join("build.zen");
+    let build_path_str = build_path.to_str().expect("utf-8 build path");
+
+    let build = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build", build_path_str])
+        .output()
+        .expect("run zen build public project");
+    assert!(
+        build.status.success(),
+        "zen build examples/project/build.zen failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr)
+    );
+
+    let binary_path = project.path().join("build").join("myapp");
+    let run = Command::new(&binary_path)
+        .output()
+        .unwrap_or_else(|err| panic!("run public project binary: {err}"));
+    assert!(
+        run.status.success(),
+        "public project binary exited with {}: stdout={}, stderr={}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+
+    let test = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["test", build_path_str])
+        .output()
+        .expect("run zen test public project");
+    assert!(
+        test.status.success(),
+        "zen test examples/project/build.zen failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&test.stdout),
+        String::from_utf8_lossy(&test.stderr)
+    );
 }
 
 #[test]
@@ -90,7 +132,7 @@ fn assert_zen_build_and_run_succeeds(path: &str) {
 
 struct BuiltPublicExample {
     temp_dir: TempDir,
-    binary_path: std::path::PathBuf,
+    binary_path: PathBuf,
 }
 
 fn build_public_example(path: &str) -> BuiltPublicExample {
@@ -117,4 +159,15 @@ fn build_public_example(path: &str) -> BuiltPublicExample {
         binary_path: temp_dir.path().join(stem),
         temp_dir,
     }
+}
+
+fn copy_public_project_example() -> TempDir {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let project_dir = temp_dir.path();
+    let source_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("examples/project");
+    for file_name in ["build.zen", "main.zen", "math_utils.zen", "test.zen"] {
+        fs::copy(source_dir.join(file_name), project_dir.join(file_name))
+            .unwrap_or_else(|err| panic!("copy examples/project/{file_name}: {err}"));
+    }
+    temp_dir
 }


### PR DESCRIPTION
## Summary

- Add CLI coverage that copies `examples/project`, builds its `build.zen` graph, runs the produced `myapp` executable, and runs the graph test target.
- Record the public project graph execution gate in the phase plan and completion audit.

## Validation

- `cargo test --test integration public_project_build_graph_builds_and_tests_through_cli -- --nocapture`
- `cargo test --test integration public_examples -- --nocapture`
- `cargo test --test docs_truth phase_audit -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `gh run list --branch codex/run-public-project-graph --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]` after push