### PR TITLE
[codex] Remove return from core stdlib helpers

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3412,6 +3412,11 @@ and do not assume Phase 4 is ready without evidence.
 - All executing/checking `build.zen` command entrypoints now reject ordinary
   unknown executable target fields before creating outputs. Coverage:
   `build_zen_commands_reject_unknown_target_fields`.
+- Central stdlib core `Option`, `Result`, and propagation helpers no longer
+  use the removed `return` keyword, guarded by
+  `central_stdlib_core_modules_do_not_use_removed_return_keyword`, establishing
+  the first small stdlib cleanup gate before broader stdlib compilation is
+  promoted.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3084,6 +3084,11 @@ checked-in docs, tests, and commits only.
 - All executing/checking `build.zen` command entrypoints now reject ordinary
   unknown target fields before outputs are created, covered by
   `build_zen_commands_reject_unknown_target_fields`.
+- Central stdlib core `Option`, `Result`, and propagation helpers no longer use
+  the removed `return` keyword, guarded by
+  `central_stdlib_core_modules_do_not_use_removed_return_keyword`, so the
+  first stdlib compilation cleanup point stays aligned with expression-tail
+  returns before broader stdlib parsing/building is promoted.
 
 ## Current Phase
 

--- a/stdlib/core/option.zen
+++ b/stdlib/core/option.zen
@@ -10,12 +10,12 @@ Option<T>:
 
 // Create Some variant
 some<T> = (value: T) Option<T> {
-    return Option.Some(value)
+    Option.Some(value)
 }
 
 // Create None variant
 none<T> = () Option<T> {
-    return Option.None
+    Option.None
 }
 
 // Check if option has value

--- a/stdlib/core/result.zen
+++ b/stdlib/core/result.zen
@@ -10,12 +10,12 @@ Result<T, E>:
 
 // Create Ok variant
 ok<T, E> = (value: T) Result<T, E> {
-    return Result.Ok(value)
+    Result.Ok(value)
 }
 
 // Create Err variant
 err<T, E> = (error: E) Result<T, E> {
-    return Result.Err(error)
+    Result.Err(error)
 }
 
 // Check if Result is Ok

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -120,6 +120,21 @@ fn source_ast_no_longer_has_return_expression_nodes() {
 }
 
 #[test]
+fn central_stdlib_core_modules_do_not_use_removed_return_keyword() {
+    for path in [
+        "stdlib/core/option.zen",
+        "stdlib/core/result.zen",
+        "stdlib/core/propagate.zen",
+    ] {
+        let source = read(path);
+        assert!(
+            !source.contains("return "),
+            "{path} still uses the removed return keyword"
+        );
+    }
+}
+
+#[test]
 fn source_ast_does_not_carry_dead_char_literal_nodes() {
     for path in [
         "src/ast/expressions.rs",


### PR DESCRIPTION
## Summary

- Convert the central stdlib `Option` and `Result` constructor helpers from removed `return` syntax to tail expressions.
- Add a docs-truth guard for `stdlib/core/option.zen`, `stdlib/core/result.zen`, and `stdlib/core/propagate.zen` so the first core stdlib cleanup point stays aligned with the language surface.
- Record the cleanup evidence in the phase plan and completion audit.

## Validation

- `cargo test --test docs_truth central_stdlib_core_modules_do_not_use_removed_return_keyword -- --nocapture` failed before the cleanup and passes after it
- `cargo test --test docs_truth -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `rg -n "\\breturn\\b" stdlib/core/option.zen stdlib/core/result.zen stdlib/core/propagate.zen` returned no matches
- `gh run list --branch codex/stdlib-core-no-return --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]` after push