### PR TITLE
[codex] Remove return from core buffer helpers

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3412,8 +3412,8 @@ and do not assume Phase 4 is ready without evidence.
 - All executing/checking `build.zen` command entrypoints now reject ordinary
   unknown executable target fields before creating outputs. Coverage:
   `build_zen_commands_reject_unknown_target_fields`.
-- Central stdlib core `Option`, `Result`, and propagation helpers no longer
-  use the removed `return` keyword, guarded by
+- Central stdlib core `Option`, `Result`, propagation, and byte-buffer helpers
+  no longer use the removed `return` keyword, guarded by
   `central_stdlib_core_modules_do_not_use_removed_return_keyword`, establishing
   the first small stdlib cleanup gate before broader stdlib compilation is
   promoted.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3084,8 +3084,8 @@ checked-in docs, tests, and commits only.
 - All executing/checking `build.zen` command entrypoints now reject ordinary
   unknown target fields before outputs are created, covered by
   `build_zen_commands_reject_unknown_target_fields`.
-- Central stdlib core `Option`, `Result`, and propagation helpers no longer use
-  the removed `return` keyword, guarded by
+- Central stdlib core `Option`, `Result`, propagation, and byte-buffer helpers
+  no longer use the removed `return` keyword, guarded by
   `central_stdlib_core_modules_do_not_use_removed_return_keyword`, so the
   first stdlib compilation cleanup point stays aligned with expression-tail
   returns before broader stdlib parsing/building is promoted.

--- a/stdlib/core/buffer.zen
+++ b/stdlib/core/buffer.zen
@@ -16,14 +16,14 @@ ByteBuffer: {
 // Create a byte buffer (static method)
 ByteBuffer.new = (allocator: Allocator, buf_size: usize) ByteBuffer {
     buf_ptr = allocator.allocate(buf_size)
-    return ByteBuffer { ptr: buf_ptr, size: buf_size }
+    ByteBuffer { ptr: buf_ptr, size: buf_size }
 }
 
 // Create a zeroed byte buffer (static method)
 ByteBuffer.zeroed = (allocator: Allocator, buf_size: usize) ByteBuffer {
     buf_ptr = allocator.allocate(buf_size)
     compiler.memset(buf_ptr, 0, buf_size)
-    return ByteBuffer { ptr: buf_ptr, size: buf_size }
+    ByteBuffer { ptr: buf_ptr, size: buf_size }
 }
 
 // Free a byte buffer
@@ -33,18 +33,18 @@ ByteBuffer.free = (self: ByteBuffer, allocator: Allocator) void {
 
 // Get raw pointer
 ByteBuffer.ptr = (self: ByteBuffer) RawPtr<u8> {
-    return self.ptr
+    self.ptr
 }
 
 // Get address as i64 (for syscalls)
 ByteBuffer.addr = (self: ByteBuffer) i64 {
-    return compiler.ptr_to_int(self.ptr)
+    compiler.ptr_to_int(self.ptr)
 }
 
 // Read byte at offset
 ByteBuffer.get = (self: ByteBuffer, offset: usize) u8 {
     buf_src = compiler.gep(self.ptr, cast(offset, i64))
-    return compiler.load<u8>(buf_src)
+    compiler.load<u8>(buf_src)
 }
 
 // Write byte at offset
@@ -56,7 +56,7 @@ ByteBuffer.set = (self: ByteBuffer, offset: usize, value: u8) void {
 // Read i64 at offset
 ByteBuffer.get_i64 = (self: ByteBuffer, offset: usize) i64 {
     buf_src = compiler.gep(self.ptr, cast(offset, i64))
-    return compiler.load<i64>(buf_src)
+    compiler.load<i64>(buf_src)
 }
 
 // Write i64 at offset
@@ -68,7 +68,7 @@ ByteBuffer.set_i64 = (self: ByteBuffer, offset: usize, value: i64) void {
 // Read u32 at offset
 ByteBuffer.get_u32 = (self: ByteBuffer, offset: usize) u32 {
     buf_src = compiler.gep(self.ptr, cast(offset, i64))
-    return compiler.load<u32>(buf_src)
+    compiler.load<u32>(buf_src)
 }
 
 // Write u32 at offset

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -125,6 +125,7 @@ fn central_stdlib_core_modules_do_not_use_removed_return_keyword() {
         "stdlib/core/option.zen",
         "stdlib/core/result.zen",
         "stdlib/core/propagate.zen",
+        "stdlib/core/buffer.zen",
     ] {
         let source = read(path);
         assert!(


### PR DESCRIPTION
## Summary

- Convert `stdlib/core/buffer.zen` helpers from removed `return` syntax to tail expressions.
- Extend the core stdlib docs-truth guard to include the byte-buffer helper module.
- Update the phase plan and completion audit with the expanded stdlib cleanup evidence.

## Validation

- `cargo test --test docs_truth central_stdlib_core_modules_do_not_use_removed_return_keyword -- --nocapture` failed before the buffer cleanup and passes after it
- `cargo test --test docs_truth -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `rg -n "\\breturn\\b" stdlib/core/option.zen stdlib/core/result.zen stdlib/core/propagate.zen stdlib/core/buffer.zen` returned no matches
- `gh run list --branch codex/stdlib-buffer-no-return --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]` after push