### PR TITLE
[codex] Remove return from core iterator helpers

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3412,8 +3412,8 @@ and do not assume Phase 4 is ready without evidence.
 - All executing/checking `build.zen` command entrypoints now reject ordinary
   unknown executable target fields before creating outputs. Coverage:
   `build_zen_commands_reject_unknown_target_fields`.
-- Central stdlib core `Option`, `Result`, propagation, and byte-buffer helpers
-  no longer use the removed `return` keyword, guarded by
+- Central stdlib core `Option`, `Result`, propagation, byte-buffer, and iterator
+  helpers no longer use the removed `return` keyword, guarded by
   `central_stdlib_core_modules_do_not_use_removed_return_keyword`, establishing
   the first small stdlib cleanup gate before broader stdlib compilation is
   promoted.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3084,8 +3084,8 @@ checked-in docs, tests, and commits only.
 - All executing/checking `build.zen` command entrypoints now reject ordinary
   unknown target fields before outputs are created, covered by
   `build_zen_commands_reject_unknown_target_fields`.
-- Central stdlib core `Option`, `Result`, propagation, and byte-buffer helpers
-  no longer use the removed `return` keyword, guarded by
+- Central stdlib core `Option`, `Result`, propagation, byte-buffer, and iterator
+  helpers no longer use the removed `return` keyword, guarded by
   `central_stdlib_core_modules_do_not_use_removed_return_keyword`, so the
   first stdlib compilation cleanup point stays aligned with expression-tail
   returns before broader stdlib parsing/building is promoted.

--- a/stdlib/core/iterator.zen
+++ b/stdlib/core/iterator.zen
@@ -16,12 +16,12 @@ Range: {
 
 // Create a range from start to end (exclusive)
 Range.new = (start: i64, end: i64) Range {
-    return Range { current: start, end: end, step: 1 }
+    Range { current: start, end: end, step: 1 }
 }
 
 // Create a range with custom step
 Range.with_step = (start: i64, end: i64, step: i64) Range {
-    return Range { current: start, end: end, step: step }
+    Range { current: start, end: end, step: step }
 }
 
 // Get next value from range
@@ -30,29 +30,29 @@ Range.next = (self: MutPtr<Range>) Option<i64> {
         | true {
             value = self.val.current
             self.val.current = self.val.current + self.val.step
-            return Option.Some(value)
+            Option.Some(value)
         }
-        | false { return Option.None }
+        | false { Option.None }
 }
 
 // Check if range has more elements
 Range.has_next = (self: Range) bool {
-    return self.current < self.end
+    self.current < self.end
 }
 
 // Count remaining elements in range
 Range.count = (self: Range) i64 {
     self.end > self.current ?
-        | true { return (self.end - self.current) / self.step }
-        | false { return 0 }
+        | true { (self.end - self.current) / self.step }
+        | false { 0 }
 }
 
 // Convenience function: create a range from 0 to n
 range = (n: i64) Range {
-    return Range.new(0, n)
+    Range.new(0, n)
 }
 
 // Convenience function: create a range with step
 range_step = (start: i64, end: i64, step: i64) Range {
-    return Range.with_step(start, end, step)
+    Range.with_step(start, end, step)
 }

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -126,6 +126,7 @@ fn central_stdlib_core_modules_do_not_use_removed_return_keyword() {
         "stdlib/core/result.zen",
         "stdlib/core/propagate.zen",
         "stdlib/core/buffer.zen",
+        "stdlib/core/iterator.zen",
     ] {
         let source = read(path);
         assert!(


### PR DESCRIPTION
## Summary

- Convert `stdlib/core/iterator.zen` range helpers from removed `return` syntax to tail expressions.
- Extend the core stdlib docs-truth guard to include the iterator module.
- Update the phase plan and completion audit with the expanded stdlib cleanup evidence.

## Validation

- `cargo test --test docs_truth central_stdlib_core_modules_do_not_use_removed_return_keyword -- --nocapture` failed before the iterator cleanup and passes after it
- `cargo test --test docs_truth -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `rg -n "\\breturn\\b" stdlib/core/option.zen stdlib/core/result.zen stdlib/core/propagate.zen stdlib/core/buffer.zen stdlib/core/iterator.zen` returned no matches
- `gh run list --branch codex/stdlib-iterator-no-return --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]` after push