### PR TITLE
[codex] Remove return from core pointer helpers

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3412,8 +3412,8 @@ and do not assume Phase 4 is ready without evidence.
 - All executing/checking `build.zen` command entrypoints now reject ordinary
   unknown executable target fields before creating outputs. Coverage:
   `build_zen_commands_reject_unknown_target_fields`.
-- Central stdlib core `Option`, `Result`, propagation, byte-buffer, and iterator
-  helpers no longer use the removed `return` keyword, guarded by
+- Central stdlib core `Option`, `Result`, propagation, byte-buffer, iterator,
+  and pointer helpers no longer use the removed `return` keyword, guarded by
   `central_stdlib_core_modules_do_not_use_removed_return_keyword`, establishing
   the first small stdlib cleanup gate before broader stdlib compilation is
   promoted.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3084,8 +3084,8 @@ checked-in docs, tests, and commits only.
 - All executing/checking `build.zen` command entrypoints now reject ordinary
   unknown target fields before outputs are created, covered by
   `build_zen_commands_reject_unknown_target_fields`.
-- Central stdlib core `Option`, `Result`, propagation, byte-buffer, and iterator
-  helpers no longer use the removed `return` keyword, guarded by
+- Central stdlib core `Option`, `Result`, propagation, byte-buffer, iterator,
+  and pointer helpers no longer use the removed `return` keyword, guarded by
   `central_stdlib_core_modules_do_not_use_removed_return_keyword`, so the
   first stdlib compilation cleanup point stays aligned with expression-tail
   returns before broader stdlib parsing/building is promoted.

--- a/stdlib/core/ptr.zen
+++ b/stdlib/core/ptr.zen
@@ -15,26 +15,26 @@ Ptr<T>:
 Ptr<T>.allocate = (size: usize) Ptr<T> {
     addr = compiler.raw_allocate(size)
     compiler.is_null(addr) ?
-        | true { return Ptr.None }
+        | true { Ptr.None }
         | false {
             addr_int = compiler.ptr_to_int(addr)
-            return Ptr.Some(addr_int)
+            Ptr.Some(addr_int)
     }
 }
 
 // Create a Ptr from an address (caller must ensure validity)
 Ptr<T>.from_addr = (addr: RawPtr<u8>) Ptr<T> {
     compiler.is_null(addr) ?
-        | true { return Ptr.None }
+        | true { Ptr.None }
         | false {
             addr_int = compiler.ptr_to_int(addr)
-            return Ptr.Some(addr_int)
+            Ptr.Some(addr_int)
     }
 }
 
 // Create a None pointer
 Ptr<T>.none = () Ptr<T> {
-    return Ptr.None
+    Ptr.None
 }
 
 // Check if pointer is valid
@@ -60,9 +60,9 @@ Ptr<T>.at = (self: Ptr<T>, index: usize) Ptr<T> {
             offset = index * item_size
             new_addr = compiler.gep(addr, offset)
             new_addr_int = compiler.ptr_to_int(new_addr)
-            return Ptr.Some(new_addr_int)
+            Ptr.Some(new_addr_int)
         }
-        | None { return Ptr.None }
+        | None { Ptr.None }
 }
 
 // Pointer arithmetic - advance by N items
@@ -74,9 +74,9 @@ Ptr<T>.offset = (self: Ptr<T>, count: i64) Ptr<T> {
             byte_offset = count * item_size
             new_addr = compiler.gep(addr, byte_offset)
             new_addr_int = compiler.ptr_to_int(new_addr)
-            return Ptr.Some(new_addr_int)
+            Ptr.Some(new_addr_int)
         }
-        | None { return Ptr.None }
+        | None { Ptr.None }
 }
 
 // Get raw address
@@ -107,7 +107,7 @@ Ptr<T>.free = (self: Ptr<T>, size: usize) void {
 Ptr<T>.eq = (self: Ptr<T>, other: Ptr<T>) bool {
     addr1 = self.addr()
     addr2 = other.addr()
-    return addr1 == addr2
+    addr1 == addr2
 }
 
 // ============================================================================
@@ -117,11 +117,11 @@ Ptr<T>.eq = (self: Ptr<T>, other: Ptr<T>) bool {
 // Check if raw pointer is null
 is_null = (ptr: RawPtr<u8>) bool {
     addr = compiler.ptr_to_int(ptr)
-    return addr == 0
+    addr == 0
 }
 
 // Check if raw pointer is valid (not null)
 is_valid = (ptr: RawPtr<u8>) bool {
     addr = compiler.ptr_to_int(ptr)
-    return addr != 0
+    addr != 0
 }

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -127,6 +127,7 @@ fn central_stdlib_core_modules_do_not_use_removed_return_keyword() {
         "stdlib/core/propagate.zen",
         "stdlib/core/buffer.zen",
         "stdlib/core/iterator.zen",
+        "stdlib/core/ptr.zen",
     ] {
         let source = read(path);
         assert!(


### PR DESCRIPTION
## Summary

- Convert `stdlib/core/ptr.zen` pointer helpers from removed `return` syntax to tail expressions.
- Extend the core stdlib docs-truth guard to include the pointer module.
- Update the phase plan and completion audit with the expanded stdlib cleanup evidence.

## Validation

- `cargo test --test docs_truth central_stdlib_core_modules_do_not_use_removed_return_keyword -- --nocapture` failed before the pointer cleanup and passes after it
- `cargo test --test docs_truth -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `rg -n "\\breturn\\b" stdlib/core/option.zen stdlib/core/result.zen stdlib/core/propagate.zen stdlib/core/buffer.zen stdlib/core/iterator.zen stdlib/core/ptr.zen` returned no matches
- `gh run list --branch codex/stdlib-ptr-no-return --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]` after push