### PR TITLE
[codex] Remove return from core slice helpers

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3413,7 +3413,8 @@ and do not assume Phase 4 is ready without evidence.
   unknown executable target fields before creating outputs. Coverage:
   `build_zen_commands_reject_unknown_target_fields`.
 - Central stdlib core `Option`, `Result`, propagation, byte-buffer, iterator,
-  and pointer helpers no longer use the removed `return` keyword, guarded by
+  pointer, and slice helpers no longer use the removed `return` keyword,
+  guarded by
   `central_stdlib_core_modules_do_not_use_removed_return_keyword`, establishing
   the first small stdlib cleanup gate before broader stdlib compilation is
   promoted.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3085,7 +3085,8 @@ checked-in docs, tests, and commits only.
   unknown target fields before outputs are created, covered by
   `build_zen_commands_reject_unknown_target_fields`.
 - Central stdlib core `Option`, `Result`, propagation, byte-buffer, iterator,
-  and pointer helpers no longer use the removed `return` keyword, guarded by
+  pointer, and slice helpers no longer use the removed `return` keyword,
+  guarded by
   `central_stdlib_core_modules_do_not_use_removed_return_keyword`, so the
   first stdlib compilation cleanup point stays aligned with expression-tail
   returns before broader stdlib parsing/building is promoted.

--- a/stdlib/core/slice.zen
+++ b/stdlib/core/slice.zen
@@ -18,19 +18,19 @@ Slice<T>: {
 
 // Create a slice from a raw pointer and length
 Slice<T>.from_raw = (ptr: RawPtr<u8>, len: usize) Slice<T> {
-    return Slice<T> { ptr: ptr, len: len }
+    Slice<T> { ptr: ptr, len: len }
 }
 
 // Create an empty slice
 Slice<T>.empty = () Slice<T> {
-    return Slice<T> { ptr: compiler.null_ptr(), len: 0 }
+    Slice<T> { ptr: compiler.null_ptr(), len: 0 }
 }
 
 // Allocate a new slice using an allocator
 Slice<T>.alloc = (allocator: Allocator, count: usize) Slice<T> {
     alloc_size = count * compiler.sizeof<T>()
     alloc_ptr = allocator.allocate(alloc_size)
-    return Slice<T> { ptr: alloc_ptr, len: count }
+    Slice<T> { ptr: alloc_ptr, len: count }
 }
 
 // Allocate a zeroed slice using an allocator
@@ -38,7 +38,7 @@ Slice<T>.alloc_zeroed = (allocator: Allocator, count: usize) Slice<T> {
     zeroed_size = count * compiler.sizeof<T>()
     zeroed_ptr = allocator.allocate(zeroed_size)
     compiler.memset(zeroed_ptr, 0, zeroed_size)
-    return Slice<T> { ptr: zeroed_ptr, len: count }
+    Slice<T> { ptr: zeroed_ptr, len: count }
 }
 
 // Free the slice using an allocator (caller must ensure allocator matches!)
@@ -49,33 +49,33 @@ Slice<T>.free = (self: Slice<T>, allocator: Allocator) void {
 
 // Get length in elements
 Slice<T>.length = (self: Slice<T>) usize {
-    return self.len
+    self.len
 }
 
 // Get size in bytes
 Slice<T>.byte_size = (self: Slice<T>) usize {
-    return self.len * compiler.sizeof<T>()
+    self.len * compiler.sizeof<T>()
 }
 
 // Check if slice is empty
 Slice<T>.is_empty = (self: Slice<T>) bool {
-    return self.len == 0
+    self.len == 0
 }
 
 // Check if slice is valid (non-null pointer)
 Slice<T>.is_valid = (self: Slice<T>) bool {
     addr = compiler.ptr_to_int(self.ptr)
-    return addr != 0
+    addr != 0
 }
 
 // Get raw pointer (for syscalls or interop)
 Slice<T>.as_ptr = (self: Slice<T>) RawPtr<u8> {
-    return self.ptr
+    self.ptr
 }
 
 // Get raw pointer as integer address (for syscalls)
 Slice<T>.as_addr = (self: Slice<T>) i64 {
-    return compiler.ptr_to_int(self.ptr)
+    compiler.ptr_to_int(self.ptr)
 }
 
 // Read element at index with bounds check
@@ -86,7 +86,7 @@ Slice<T>.get = (self: Slice<T>, index: usize) T {
     }
     offset = cast(index * compiler.sizeof<T>(), i64)
     elem_ptr = compiler.gep(self.ptr, offset)
-    return compiler.load<T>(elem_ptr)
+    compiler.load<T>(elem_ptr)
 }
 
 // Write element at index with bounds check
@@ -103,13 +103,13 @@ Slice<T>.set = (self: Slice<T>, index: usize, value: T) void {
 // Get pointer to element at index (unsafe, no bounds check for performance)
 Slice<T>.ptr_at = (self: Slice<T>, index: usize) RawPtr<u8> {
     offset = cast(index * compiler.sizeof<T>(), i64)
-    return compiler.gep(self.ptr, offset)
+    compiler.gep(self.ptr, offset)
 }
 
 // Read first element (for convenience)
 Slice<T>.first = (self: Slice<T>) T {
     self.len == 0 ? { compiler.panic("Slice.first: empty slice") }
-    return compiler.load<T>(self.ptr)
+    compiler.load<T>(self.ptr)
 }
 
 // Read last element (for convenience)
@@ -117,7 +117,7 @@ Slice<T>.last = (self: Slice<T>) T {
     self.len == 0 ? { compiler.panic("Slice.last: empty slice") }
     offset = cast((self.len - 1) * compiler.sizeof<T>(), i64)
     elem_ptr = compiler.gep(self.ptr, offset)
-    return compiler.load<T>(elem_ptr)
+    compiler.load<T>(elem_ptr)
 }
 
 // Fill entire slice with a value
@@ -142,7 +142,7 @@ Slice<T>.copy_from = (self: Slice<T>, src: Slice<T>) usize {
     src.len < copy_count ? { copy_count = src.len }
     copy_size = copy_count * compiler.sizeof<T>()
     compiler.memcpy(self.ptr, src.ptr, copy_size)
-    return copy_count
+    copy_count
 }
 
 // Copy from raw pointer with explicit count
@@ -162,7 +162,7 @@ Slice<T>.subslice = (self: Slice<T>, start: usize, len: usize) Slice<T> {
     }
     offset = cast(start * compiler.sizeof<T>(), i64)
     new_ptr = compiler.gep(self.ptr, offset)
-    return Slice<T> { ptr: new_ptr, len: len }
+    Slice<T> { ptr: new_ptr, len: len }
 }
 
 // ============================================================================
@@ -173,7 +173,7 @@ Slice<T>.subslice = (self: Slice<T>, start: usize, len: usize) Slice<T> {
 byte_slice = (allocator: Allocator, count: usize) Slice<u8> {
     byte_size = count * compiler.sizeof<u8>()
     byte_ptr = allocator.allocate(byte_size)
-    return Slice<u8> { ptr: byte_ptr, len: count }
+    Slice<u8> { ptr: byte_ptr, len: count }
 }
 
 // Create a zeroed byte slice (Slice<u8>)
@@ -181,14 +181,14 @@ byte_slice_zeroed = (allocator: Allocator, count: usize) Slice<u8> {
     zeroed_byte_size = count * compiler.sizeof<u8>()
     zeroed_byte_ptr = allocator.allocate(zeroed_byte_size)
     compiler.memset(zeroed_byte_ptr, 0, zeroed_byte_size)
-    return Slice<u8> { ptr: zeroed_byte_ptr, len: count }
+    Slice<u8> { ptr: zeroed_byte_ptr, len: count }
 }
 
 // Create a slice of i64
 i64_slice = (allocator: Allocator, count: usize) Slice<i64> {
     i64_size = count * compiler.sizeof<i64>()
     i64_ptr = allocator.allocate(i64_size)
-    return Slice<i64> { ptr: i64_ptr, len: count }
+    Slice<i64> { ptr: i64_ptr, len: count }
 }
 
 // Create a zeroed slice of i64
@@ -196,7 +196,7 @@ i64_slice_zeroed = (allocator: Allocator, count: usize) Slice<i64> {
     zeroed_i64_size = count * compiler.sizeof<i64>()
     zeroed_i64_ptr = allocator.allocate(zeroed_i64_size)
     compiler.memset(zeroed_i64_ptr, 0, zeroed_i64_size)
-    return Slice<i64> { ptr: zeroed_i64_ptr, len: count }
+    Slice<i64> { ptr: zeroed_i64_ptr, len: count }
 }
 
 // ============================================================================
@@ -212,7 +212,7 @@ write_string_at = (slice: Slice<u8>, offset: usize, s: StaticString, slen: usize
     }
     dest = compiler.gep(slice.ptr, cast(offset, i64))
     compiler.memcpy(dest, s, slen)
-    return slen
+    slen
 }
 
 // Write a single byte at offset
@@ -230,5 +230,5 @@ read_byte_at = (slice: Slice<u8>, offset: usize) u8 {
         compiler.panic("read_byte_at: offset out of bounds")
     }
     src = compiler.gep(slice.ptr, cast(offset, i64))
-    return compiler.load<u8>(src)
+    compiler.load<u8>(src)
 }

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -128,6 +128,7 @@ fn central_stdlib_core_modules_do_not_use_removed_return_keyword() {
         "stdlib/core/buffer.zen",
         "stdlib/core/iterator.zen",
         "stdlib/core/ptr.zen",
+        "stdlib/core/slice.zen",
     ] {
         let source = read(path);
         assert!(


### PR DESCRIPTION
## Summary
- Convert `stdlib/core/slice.zen` helpers from the removed `return` keyword to tail expressions.
- Extend the core stdlib docs-truth guard to cover `stdlib/core/slice.zen`.
- Update the phase plan and completion audit evidence to include slice helpers.

## Validation
- `cargo test --test docs_truth central_stdlib_core_modules_do_not_use_removed_return_keyword -- --nocapture`
- `rg -n "\breturn\b" stdlib/core` returned no matches
- `cargo test --test docs_truth -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `gh run list --branch codex/stdlib-slice-no-return --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]` after branch push