### PR TITLE
[codex] Remove return from stdlib build DSL

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3412,11 +3412,10 @@ and do not assume Phase 4 is ready without evidence.
 - All executing/checking `build.zen` command entrypoints now reject ordinary
   unknown executable target fields before creating outputs. Coverage:
   `build_zen_commands_reject_unknown_target_fields`.
-- The stdlib compiler bridge plus core `Option`, `Result`, propagation,
-  byte-buffer, iterator, pointer, and slice helpers no longer use the removed
-  `return` keyword, guarded by
-  `central_stdlib_bridge_and_core_modules_do_not_use_removed_return_keyword`,
-  establishing
+- The stdlib build DSL, compiler bridge, and core `Option`, `Result`,
+  propagation, byte-buffer, iterator, pointer, and slice helpers no longer use
+  the removed `return` keyword, guarded by
+  `promoted_stdlib_modules_do_not_use_removed_return_keyword`, establishing
   the first small stdlib cleanup gate before broader stdlib compilation is
   promoted.
 - Effect checking, typed allocator semantics, actors in std integration,

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3084,11 +3084,10 @@ checked-in docs, tests, and commits only.
 - All executing/checking `build.zen` command entrypoints now reject ordinary
   unknown target fields before outputs are created, covered by
   `build_zen_commands_reject_unknown_target_fields`.
-- The stdlib compiler bridge plus core `Option`, `Result`, propagation,
-  byte-buffer, iterator, pointer, and slice helpers no longer use the removed
-  `return` keyword, guarded by
-  `central_stdlib_bridge_and_core_modules_do_not_use_removed_return_keyword`,
-  so the
+- The stdlib build DSL, compiler bridge, and core `Option`, `Result`,
+  propagation, byte-buffer, iterator, pointer, and slice helpers no longer use
+  the removed `return` keyword, guarded by
+  `promoted_stdlib_modules_do_not_use_removed_return_keyword`, so the
   first stdlib compilation cleanup point stays aligned with expression-tail
   returns before broader stdlib parsing/building is promoted.
 

--- a/stdlib/build.zen
+++ b/stdlib/build.zen
@@ -119,7 +119,7 @@ Build: {
 
 // Create native target (current platform)
 native_target = () Target {
-    return Target {
+    Target {
         os_tag: OsTag.Native,
         cpu_arch: CpuArch.Native
     }
@@ -151,7 +151,7 @@ cpu_name = (t: Target) StaticString {
 
 // Create new build configuration
 new_build = () Build {
-    return Build {
+    Build {
         optimize: OptimizeMode.Debug,
         strip: false,
         enable_stack_traces: true,
@@ -164,18 +164,18 @@ new_build = () Build {
 
 // Get standard target options (returns native target)
 standard_target = (b: Build) Target {
-    return b.target
+    b.target
 }
 
 // Get standard optimize option
 standard_optimize = (b: Build) OptimizeMode {
-    return b.optimize
+    b.optimize
 }
 
 // Add an executable target
 add_executable = (b: Build, opts: ExeOptions) Executable {
     io.println("  Adding executable: ${opts.name}")
-    return Executable {
+    Executable {
         name: opts.name,
         root_source_file: opts.root_source_file,
         optimize: b.optimize,
@@ -187,7 +187,7 @@ add_executable = (b: Build, opts: ExeOptions) Executable {
 // Add a test target
 add_test = (b: Build, root_file: StaticString) Test {
     io.println("  Adding test: ${root_file}")
-    return Test {
+    Test {
         name: root_file,
         root_source_file: root_file
     }
@@ -196,7 +196,7 @@ add_test = (b: Build, root_file: StaticString) Test {
 // Add a static library target
 add_static_library = (b: Build, opts: LibOptions) StaticLibrary {
     io.println("  Adding static library: ${opts.name}")
-    return StaticLibrary {
+    StaticLibrary {
         name: opts.name,
         root_source_file: opts.root_source_file,
         optimize: b.optimize,
@@ -207,7 +207,7 @@ add_static_library = (b: Build, opts: LibOptions) StaticLibrary {
 // Add a dependency
 add_dependency = (b: Build, name: StaticString, opts: DepOptions) Dependency {
     io.println("  Adding dependency: ${name} from ${opts.url}")
-    return Dependency {
+    Dependency {
         name: name,
         url: opts.url
     }

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -120,8 +120,9 @@ fn source_ast_no_longer_has_return_expression_nodes() {
 }
 
 #[test]
-fn central_stdlib_bridge_and_core_modules_do_not_use_removed_return_keyword() {
+fn promoted_stdlib_modules_do_not_use_removed_return_keyword() {
     for path in [
+        "stdlib/build.zen",
         "stdlib/compiler.zen",
         "stdlib/core/option.zen",
         "stdlib/core/result.zen",


### PR DESCRIPTION
## Summary
- Convert `stdlib/build.zen` helpers from the removed `return` keyword to tail expressions.
- Expand the promoted stdlib no-return docs-truth guard to cover the build DSL, compiler bridge, and core helper modules.
- Update the phase plan and completion audit wording to match the expanded guard.

## Validation
- Failing first: `cargo test --test docs_truth central_stdlib_bridge_and_core_modules_do_not_use_removed_return_keyword -- --nocapture` failed on `stdlib/build.zen`
- `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- `rg -n "\breturn\b" stdlib/build.zen stdlib/compiler.zen stdlib/core` returned no matches
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `gh run list --branch codex/stdlib-build-no-return --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]` after branch push