### PR TITLE
[codex] Remove return from stdlib ffi bridge

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3412,7 +3412,7 @@ and do not assume Phase 4 is ready without evidence.
 - All executing/checking `build.zen` command entrypoints now reject ordinary
   unknown executable target fields before creating outputs. Coverage:
   `build_zen_commands_reject_unknown_target_fields`.
-- The stdlib build DSL, compiler bridge, and core `Option`, `Result`,
+- The stdlib build DSL, compiler/FFI bridges, and core `Option`, `Result`,
   propagation, byte-buffer, iterator, pointer, and slice helpers no longer use
   the removed `return` keyword, guarded by
   `promoted_stdlib_modules_do_not_use_removed_return_keyword`, establishing

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3084,7 +3084,7 @@ checked-in docs, tests, and commits only.
 - All executing/checking `build.zen` command entrypoints now reject ordinary
   unknown target fields before outputs are created, covered by
   `build_zen_commands_reject_unknown_target_fields`.
-- The stdlib build DSL, compiler bridge, and core `Option`, `Result`,
+- The stdlib build DSL, compiler/FFI bridges, and core `Option`, `Result`,
   propagation, byte-buffer, iterator, pointer, and slice helpers no longer use
   the removed `return` keyword, guarded by
   `promoted_stdlib_modules_do_not_use_removed_return_keyword`, so the

--- a/stdlib/ffi.zen
+++ b/stdlib/ffi.zen
@@ -29,13 +29,13 @@ CLibrary: {
 // Returns library handle or null on failure
 // Use dlerror() via compiler.dlerror() for error messages
 load_library_raw = (path: String) RawPtr<u8> {
-    return compiler.load_library(path)
+    compiler.load_library(path)
 }
 
 // Get symbol from library (low-level)
 // Returns symbol pointer or null if not found
 get_symbol_raw = (handle: RawPtr<u8>, symbol: String) RawPtr<u8> {
-    return compiler.get_symbol(handle, symbol)
+    compiler.get_symbol(handle, symbol)
 }
 
 // Unload library (low-level)
@@ -47,33 +47,33 @@ unload_library_raw = (handle: RawPtr<u8>) void {
 // LIBRARY LOADING (Wrapped)
 // =============================================================================
 
-// Load a C library and return a CLibrary wrapper
+// Load a C library into a CLibrary wrapper
 // Returns CLibrary with null handle on failure
 load_library = (path: String) CLibrary {
     handle = compiler.load_library(path)
-    return CLibrary { handle: handle }
+    CLibrary { handle: handle }
 }
 
 // Get function pointer from library
 // Returns CFuncPtr with null ptr on failure
 get_function = (lib: CLibrary, symbol: String) CFuncPtr {
     fn_ptr = compiler.get_symbol(lib.handle, symbol)
-    return CFuncPtr { ptr: fn_ptr }
+    CFuncPtr { ptr: fn_ptr }
 }
 
 // Get raw symbol pointer from library
 get_symbol = (lib: CLibrary, symbol: String) RawPtr<u8> {
-    return compiler.get_symbol(lib.handle, symbol)
+    compiler.get_symbol(lib.handle, symbol)
 }
 
 // Check if library was loaded successfully
 is_loaded = (lib: CLibrary) bool {
-    return compiler.ptr_to_int(lib.handle) != 0
+    compiler.ptr_to_int(lib.handle) != 0
 }
 
 // Check if function pointer is valid
 is_valid = (func: CFuncPtr) bool {
-    return compiler.ptr_to_int(func.ptr) != 0
+    compiler.ptr_to_int(func.ptr) != 0
 }
 
 // Unload library

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -124,6 +124,7 @@ fn promoted_stdlib_modules_do_not_use_removed_return_keyword() {
     for path in [
         "stdlib/build.zen",
         "stdlib/compiler.zen",
+        "stdlib/ffi.zen",
         "stdlib/core/option.zen",
         "stdlib/core/result.zen",
         "stdlib/core/propagate.zen",


### PR DESCRIPTION
## Summary
- Convert `stdlib/ffi.zen` wrappers from the removed `return` keyword to tail expressions.
- Extend the promoted stdlib no-return docs-truth guard to cover the FFI bridge.
- Update phase/audit wording to reflect the compiler and FFI bridge coverage.

## Validation
- Failing first: `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture` failed on `stdlib/ffi.zen`
- `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- `rg -n "\breturn\b" stdlib/build.zen stdlib/compiler.zen stdlib/ffi.zen stdlib/core` returned no matches
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `gh run list --branch codex/stdlib-ffi-no-return --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]` after branch push