### PR TITLE
[codex] Remove return from stdlib fs facade

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3412,9 +3412,9 @@ and do not assume Phase 4 is ready without evidence.
 - All executing/checking `build.zen` command entrypoints now reject ordinary
   unknown executable target fields before creating outputs. Coverage:
   `build_zen_commands_reject_unknown_target_fields`.
-- The stdlib build DSL, compiler/FFI bridges, and core `Option`, `Result`,
-  propagation, byte-buffer, iterator, pointer, and slice helpers no longer use
-  the removed `return` keyword, guarded by
+- The stdlib build DSL, compiler/FFI bridges, filesystem facade, and core
+  `Option`, `Result`, propagation, byte-buffer, iterator, pointer, and slice
+  helpers no longer use the removed `return` keyword, guarded by
   `promoted_stdlib_modules_do_not_use_removed_return_keyword`, establishing
   the first small stdlib cleanup gate before broader stdlib compilation is
   promoted.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3084,9 +3084,9 @@ checked-in docs, tests, and commits only.
 - All executing/checking `build.zen` command entrypoints now reject ordinary
   unknown target fields before outputs are created, covered by
   `build_zen_commands_reject_unknown_target_fields`.
-- The stdlib build DSL, compiler/FFI bridges, and core `Option`, `Result`,
-  propagation, byte-buffer, iterator, pointer, and slice helpers no longer use
-  the removed `return` keyword, guarded by
+- The stdlib build DSL, compiler/FFI bridges, filesystem facade, and core
+  `Option`, `Result`, propagation, byte-buffer, iterator, pointer, and slice
+  helpers no longer use the removed `return` keyword, guarded by
   `promoted_stdlib_modules_do_not_use_removed_return_keyword`, so the
   first stdlib compilation cleanup point stays aligned with expression-tail
   returns before broader stdlib parsing/building is promoted.

--- a/stdlib/fs.zen
+++ b/stdlib/fs.zen
@@ -8,5 +8,5 @@
 
 // Convenience: create a directory with default permissions (0755)
 create_dir = (path: i64) Result<(), i32> {
-    return mkdir_default(path)
+    mkdir_default(path)
 }

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -125,6 +125,7 @@ fn promoted_stdlib_modules_do_not_use_removed_return_keyword() {
         "stdlib/build.zen",
         "stdlib/compiler.zen",
         "stdlib/ffi.zen",
+        "stdlib/fs.zen",
         "stdlib/core/option.zen",
         "stdlib/core/result.zen",
         "stdlib/core/propagate.zen",


### PR DESCRIPTION
## Summary
- Convert the `stdlib/fs.zen` facade helper from the removed `return` keyword to a tail expression.
- Extend the promoted stdlib no-return docs-truth guard to cover the filesystem facade.
- Update phase/audit wording to include the filesystem facade in the guarded promoted surface.

## Validation
- Failing first: `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture` failed on `stdlib/fs.zen`
- `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- `rg -n "\breturn\b" stdlib/build.zen stdlib/compiler.zen stdlib/ffi.zen stdlib/fs.zen stdlib/core` returned no matches
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `gh run list --branch codex/stdlib-fs-no-return --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]` after branch push