### PR TITLE
[codex] Remove return from stdlib memory facade

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3412,9 +3412,9 @@ and do not assume Phase 4 is ready without evidence.
 - All executing/checking `build.zen` command entrypoints now reject ordinary
   unknown executable target fields before creating outputs. Coverage:
   `build_zen_commands_reject_unknown_target_fields`.
-- The stdlib build DSL, compiler/FFI bridges, filesystem facade, and core
-  `Option`, `Result`, propagation, byte-buffer, iterator, pointer, and slice
-  helpers no longer use the removed `return` keyword, guarded by
+- The stdlib build DSL, compiler/FFI bridges, filesystem and memory facades,
+  and core `Option`, `Result`, propagation, byte-buffer, iterator, pointer,
+  and slice helpers no longer use the removed `return` keyword, guarded by
   `promoted_stdlib_modules_do_not_use_removed_return_keyword`, establishing
   the first small stdlib cleanup gate before broader stdlib compilation is
   promoted.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3084,9 +3084,9 @@ checked-in docs, tests, and commits only.
 - All executing/checking `build.zen` command entrypoints now reject ordinary
   unknown target fields before outputs are created, covered by
   `build_zen_commands_reject_unknown_target_fields`.
-- The stdlib build DSL, compiler/FFI bridges, filesystem facade, and core
-  `Option`, `Result`, propagation, byte-buffer, iterator, pointer, and slice
-  helpers no longer use the removed `return` keyword, guarded by
+- The stdlib build DSL, compiler/FFI bridges, filesystem and memory facades,
+  and core `Option`, `Result`, propagation, byte-buffer, iterator, pointer,
+  and slice helpers no longer use the removed `return` keyword, guarded by
   `promoted_stdlib_modules_do_not_use_removed_return_keyword`, so the
   first stdlib compilation cleanup point stays aligned with expression-tail
   returns before broader stdlib parsing/building is promoted.

--- a/stdlib/memory/memory.zen
+++ b/stdlib/memory/memory.zen
@@ -4,7 +4,7 @@
 { Allocator, ExecutionMode, CompletionFn } = @std.memory.allocator
 { Heap, HeapSync } = @std.memory.heap
 
-// Convenience function: returns a default blocking heap allocator
+// Convenience function: produces a default blocking heap allocator
 get_default_allocator = () Allocator {
-    return Heap.sync()
+    Heap.sync()
 }

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -126,6 +126,7 @@ fn promoted_stdlib_modules_do_not_use_removed_return_keyword() {
         "stdlib/compiler.zen",
         "stdlib/ffi.zen",
         "stdlib/fs.zen",
+        "stdlib/memory/memory.zen",
         "stdlib/core/option.zen",
         "stdlib/core/result.zen",
         "stdlib/core/propagate.zen",


### PR DESCRIPTION
## Summary
- Convert `stdlib/memory/memory.zen` from the removed `return` keyword to a tail expression.
- Extend the promoted stdlib no-return docs-truth guard to cover the memory facade.
- Update phase/audit wording to include the filesystem and memory facades in the guarded promoted surface.

## Validation
- Failing first: `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture` failed on `stdlib/memory/memory.zen`
- `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- `rg -n "\breturn\b" stdlib/build.zen stdlib/compiler.zen stdlib/ffi.zen stdlib/fs.zen stdlib/memory/memory.zen stdlib/core` returned no matches
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `gh run list --branch codex/stdlib-memory-facade-no-return --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]` after branch push