### PR TITLE
[codex] Remove return from root smoke fixtures

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3418,6 +3418,9 @@ and do not assume Phase 4 is ready without evidence.
   `promoted_stdlib_modules_do_not_use_removed_return_keyword`, establishing
   the first small stdlib cleanup gate before broader stdlib compilation is
   promoted.
+- Root smoke fixtures under `tests/test_*.zen` no longer use the removed
+  `return` keyword and are guarded by
+  `root_smoke_fixtures_do_not_use_removed_return_keyword`.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3090,6 +3090,9 @@ checked-in docs, tests, and commits only.
   `promoted_stdlib_modules_do_not_use_removed_return_keyword`, so the
   first stdlib compilation cleanup point stays aligned with expression-tail
   returns before broader stdlib parsing/building is promoted.
+- Root smoke fixtures under `tests/test_*.zen` now use expression-tail returns
+  instead of the removed `return` keyword, guarded by
+  `root_smoke_fixtures_do_not_use_removed_return_keyword`.
 
 ## Current Phase
 

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -144,6 +144,24 @@ fn promoted_stdlib_modules_do_not_use_removed_return_keyword() {
 }
 
 #[test]
+fn root_smoke_fixtures_do_not_use_removed_return_keyword() {
+    for path in [
+        "tests/test_io_import.zen",
+        "tests/test_minimal.zen",
+        "tests/test_nested_import.zen",
+        "tests/test_no_import.zen",
+        "tests/test_raw_alloc.zen",
+        "tests/test_simple_allocator.zen",
+    ] {
+        let source = read(path);
+        assert!(
+            !source.contains("return "),
+            "{path} still uses the removed return keyword"
+        );
+    }
+}
+
+#[test]
 fn source_ast_does_not_carry_dead_char_literal_nodes() {
     for path in [
         "src/ast/expressions.rs",

--- a/tests/test_io_import.zen
+++ b/tests/test_io_import.zen
@@ -3,5 +3,5 @@
 
 main = () i32 {
     println("Hello from io!")
-    return 0
+    0
 }

--- a/tests/test_minimal.zen
+++ b/tests/test_minimal.zen
@@ -2,5 +2,5 @@
 
 main = () i32 {
     io.println("Hello")
-    return 0
+    0
 }

--- a/tests/test_nested_import.zen
+++ b/tests/test_nested_import.zen
@@ -10,5 +10,5 @@ main = () i32 {
     alloc = GPA { id: 0 }
 
     io.println("Success!")
-    return 0
+    0
 }

--- a/tests/test_no_import.zen
+++ b/tests/test_no_import.zen
@@ -1,3 +1,3 @@
 main = () i32 {
-    return 0
+    0
 }

--- a/tests/test_raw_alloc.zen
+++ b/tests/test_raw_alloc.zen
@@ -12,5 +12,5 @@ main = () i32 {
     io.println("Deallocated")
 
     io.println("Success!")
-    return 0
+    0
 }

--- a/tests/test_simple_allocator.zen
+++ b/tests/test_simple_allocator.zen
@@ -7,5 +7,5 @@ main = () i32 {
     io.println("Creating allocator...")
     alloc = Heap.sync()
     io.println("Done!")
-    return 0
+    0
 }


### PR DESCRIPTION
## Summary
- convert root smoke fixtures from removed `return` syntax to tail expressions
- add a docs-truth hygiene guard for those root fixtures
- record the cleanup in the durable phase/audit docs

## Verification
- `cargo test --test docs_truth root_smoke_fixtures_do_not_use_removed_return_keyword -- --nocapture` failed before implementation
- `cargo test --test docs_truth -- --nocapture`
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `rg -n "\breturn\b" tests/test_io_import.zen tests/test_minimal.zen tests/test_nested_import.zen tests/test_no_import.zen tests/test_raw_alloc.zen tests/test_simple_allocator.zen stdlib/build.zen stdlib/compiler.zen stdlib/ffi.zen stdlib/fs.zen stdlib/memory/memory.zen stdlib/core` returned no matches