### PR TITLE
[codex] Remove return from memory smoke fixtures

### DIFF
--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -146,12 +146,17 @@ fn promoted_stdlib_modules_do_not_use_removed_return_keyword() {
 #[test]
 fn root_smoke_fixtures_do_not_use_removed_return_keyword() {
     for path in [
+        "tests/test_arena_async.zen",
+        "tests/test_gpa_trait.zen",
+        "tests/test_heap_sync.zen",
         "tests/test_io_import.zen",
         "tests/test_minimal.zen",
         "tests/test_nested_import.zen",
         "tests/test_no_import.zen",
+        "tests/test_panic.zen",
         "tests/test_raw_alloc.zen",
         "tests/test_simple_allocator.zen",
+        "tests/test_unified_allocator.zen",
     ] {
         let source = read(path);
         assert!(

--- a/tests/test_arena_async.zen
+++ b/tests/test_arena_async.zen
@@ -12,22 +12,25 @@ main = () i32 {
     // Test memory allocation
     ptr = alloc.allocate(128)
     ptr_val = compiler.ptr_to_int(ptr)
-    ptr_val == 0 ? {
-        io.println("ERROR: Allocation failed!")
-        return 1
-    }
-    io.println("Allocated 128 bytes")
+    ptr_val == 0 ?
+        | true {
+            io.println("ERROR: Allocation failed!")
+            1
+        }
+        | false {
+            io.println("Allocated 128 bytes")
 
-    // Verify mode is Async
-    mode = alloc.mode()
-    mode ?
-        | Async { io.println("Mode: Async (correct!)") }
-        | Sync { io.println("ERROR: Mode should be Async!") }
+            // Verify mode is Async
+            mode = alloc.mode()
+            mode ?
+                | Async { io.println("Mode: Async (correct!)") }
+                | Sync { io.println("ERROR: Mode should be Async!") }
 
-    // Test poll (non-blocking)
-    poll_result = alloc.poll()
-    io.println("Poll returned: ${poll_result}")
+            // Test poll (non-blocking)
+            poll_result = alloc.poll()
+            io.println("Poll returned: ${poll_result}")
 
-    io.println("ArenaAsync test passed!")
-    return 0
+            io.println("ArenaAsync test passed!")
+            0
+        }
 }

--- a/tests/test_gpa_trait.zen
+++ b/tests/test_gpa_trait.zen
@@ -18,5 +18,5 @@ main = () i32 {
 
     io.println("Deallocated")
     io.println("Success!")
-    return 0
+    0
 }

--- a/tests/test_heap_sync.zen
+++ b/tests/test_heap_sync.zen
@@ -31,5 +31,5 @@ main = () i32 {
     io.println("Wait returned: ${wait_result}")
 
     io.println("HeapSync test passed!")
-    return 0
+    0
 }

--- a/tests/test_unified_allocator.zen
+++ b/tests/test_unified_allocator.zen
@@ -49,28 +49,31 @@ process_data = (alloc: Allocator, size: usize) i32 {
     // Memory allocation - works through function pointer!
     buf = alloc.allocate(size)
     buf_val = compiler.ptr_to_int(buf)
-    buf_val == 0 ? {
-        io.println("  ERROR: Allocation failed!")
-        return -1
-    }
-    io.println("  Allocated buffer successfully")
+    buf_val == 0 ?
+        | true {
+            io.println("  ERROR: Allocation failed!")
+            -1
+        }
+        | false {
+            io.println("  Allocated buffer successfully")
 
-    // Check execution mode - determined by the allocator
-    mode = alloc.mode()
-    mode ?
-        | Sync { io.println("  Mode: Sync (blocking I/O)") }
-        | Async { io.println("  Mode: Async (non-blocking I/O)") }
+            // Check execution mode - determined by the allocator
+            mode = alloc.mode()
+            mode ?
+                | Sync { io.println("  Mode: Sync (blocking I/O)") }
+                | Async { io.println("  Mode: Async (non-blocking I/O)") }
 
-    // Store and read back a value
-    compiler.store<i64>(buf, 42)
-    value = compiler.load<i64>(buf)
-    io.println("  Stored and read back: ${value}")
+            // Store and read back a value
+            compiler.store<i64>(buf, 42)
+            value = compiler.load<i64>(buf)
+            io.println("  Stored and read back: ${value}")
 
-    // Cleanup - works through function pointer!
-    alloc.deallocate(buf, size)
-    io.println("  Deallocated buffer")
+            // Cleanup - works through function pointer!
+            alloc.deallocate(buf, size)
+            io.println("  Deallocated buffer")
 
-    return 0
+            0
+        }
 }
 
 // ============================================================================
@@ -90,34 +93,40 @@ main = () i32 {
     io.println("-----------------------------------")
     sync_alloc = Heap.sync()
     result1 = process_data(sync_alloc, 256)
-    result1 != 0 ? { return 1 }
-    io.println("")
+    result1 != 0 ?
+        | true { 1 }
+        | false {
+            io.println("")
 
-    // -------------------------------------------------------------------------
-    // Test 2: Using Arena.async() (async I/O)
-    // -------------------------------------------------------------------------
-    io.println("Test 2: Arena.async() - Async I/O")
-    io.println("----------------------------------")
-    async_alloc = Arena.async()
-    result2 = process_data(async_alloc, 256)
-    result2 != 0 ? { return 1 }
-    io.println("")
+            // -------------------------------------------------------------------------
+            // Test 2: Using Arena.async() (async I/O)
+            // -------------------------------------------------------------------------
+            io.println("Test 2: Arena.async() - Async I/O")
+            io.println("----------------------------------")
+            async_alloc = Arena.async()
+            result2 = process_data(async_alloc, 256)
+            result2 != 0 ?
+                | true { 1 }
+                | false {
+                    io.println("")
 
-    // -------------------------------------------------------------------------
-    // Success!
-    // -------------------------------------------------------------------------
-    io.println("==============================================")
-    io.println("   SUCCESS!")
-    io.println("==============================================")
-    io.println("")
-    io.println("The SAME process_data() function worked with:")
-    io.println("  - Heap.sync()  (blocking I/O)")
-    io.println("  - Arena.async() (async I/O)")
-    io.println("")
-    io.println("KEY INSIGHT:")
-    io.println("  Allocator is a struct with function pointers.")
-    io.println("  This enables true polymorphism without traits-as-types!")
-    io.println("  NO async/await! NO function coloring!")
+                    // -------------------------------------------------------------------------
+                    // Success!
+                    // -------------------------------------------------------------------------
+                    io.println("==============================================")
+                    io.println("   SUCCESS!")
+                    io.println("==============================================")
+                    io.println("")
+                    io.println("The SAME process_data() function worked with:")
+                    io.println("  - Heap.sync()  (blocking I/O)")
+                    io.println("  - Arena.async() (async I/O)")
+                    io.println("")
+                    io.println("KEY INSIGHT:")
+                    io.println("  Allocator is a struct with function pointers.")
+                    io.println("  This enables true polymorphism without traits-as-types!")
+                    io.println("  NO async/await! NO function coloring!")
 
-    return 0
+                    0
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- extend the root smoke fixture hygiene guard to all tracked `tests/test_*.zen` smoke files
- convert memory allocator smoke fixtures from removed `return` syntax to tail-expression conditionals

## Verification
- `cargo test --test docs_truth root_smoke_fixtures_do_not_use_removed_return_keyword -- --nocapture` failed before implementation
- `cargo test --test docs_truth root_smoke_fixtures_do_not_use_removed_return_keyword -- --nocapture`
- `rg -n "\breturn\b" tests/test_*.zen` returned no matches
- `cargo test --test docs_truth -- --nocapture`
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`