### PR TITLE
[codex] Remove return from stdlib testing facade

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3413,8 +3413,9 @@ and do not assume Phase 4 is ready without evidence.
   unknown executable target fields before creating outputs. Coverage:
   `build_zen_commands_reject_unknown_target_fields`.
 - The stdlib build DSL, compiler/FFI bridges, filesystem and memory facades,
-  and core `Option`, `Result`, propagation, byte-buffer, iterator, pointer,
-  and slice helpers no longer use the removed `return` keyword, guarded by
+  testing facade, and core `Option`, `Result`, propagation, byte-buffer,
+  iterator, pointer, and slice helpers no longer use the removed `return`
+  keyword, guarded by
   `promoted_stdlib_modules_do_not_use_removed_return_keyword`, establishing
   the first small stdlib cleanup gate before broader stdlib compilation is
   promoted.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3085,8 +3085,9 @@ checked-in docs, tests, and commits only.
   unknown target fields before outputs are created, covered by
   `build_zen_commands_reject_unknown_target_fields`.
 - The stdlib build DSL, compiler/FFI bridges, filesystem and memory facades,
-  and core `Option`, `Result`, propagation, byte-buffer, iterator, pointer,
-  and slice helpers no longer use the removed `return` keyword, guarded by
+  testing facade, and core `Option`, `Result`, propagation, byte-buffer,
+  iterator, pointer, and slice helpers no longer use the removed `return`
+  keyword, guarded by
   `promoted_stdlib_modules_do_not_use_removed_return_keyword`, so the
   first stdlib compilation cleanup point stays aligned with expression-tail
   returns before broader stdlib parsing/building is promoted.

--- a/stdlib/testing.zen
+++ b/stdlib/testing.zen
@@ -15,11 +15,11 @@ TestResult:
 
 // Convenience constructors
 pass = () TestResult {
-    return TestResult.Pass
+    TestResult.Pass
 }
 
 fail_with = (message: String) TestResult {
-    return TestResult.Fail(message)
+    TestResult.Fail(message)
 }
 
 // ============================================================================
@@ -47,7 +47,7 @@ TestSuite: {
 
 // Create a new test suite
 new_test_suite = (name: String, allocator: memory.Allocator) TestSuite {
-    return TestSuite {
+    TestSuite {
         name: name,
         tests: DynVec<TestCase>.new(allocator),
         passed: 0,
@@ -114,35 +114,35 @@ fail = (message: String) void {
 }
 
 // ============================================================================
-// Assertions (return TestResult for use in test functions)
+// Assertions (produce TestResult for use in test functions)
 // ============================================================================
 
 // Assert that a condition is true
 expect = (condition: bool, message: String) TestResult {
     condition ?
-        | true { return TestResult.Pass }
-        | false { return TestResult.Fail(message) }
+        | true { TestResult.Pass }
+        | false { TestResult.Fail(message) }
 }
 
 // Assert equality
 expect_eq<T> = (actual: T, expected: T, message: String) TestResult {
     actual == expected ?
-        | true { return TestResult.Pass }
-        | false { return TestResult.Fail(message) }
+        | true { TestResult.Pass }
+        | false { TestResult.Fail(message) }
 }
 
 // Assert inequality
 expect_ne<T> = (actual: T, expected: T, message: String) TestResult {
     actual != expected ?
-        | true { return TestResult.Pass }
-        | false { return TestResult.Fail(message) }
+        | true { TestResult.Pass }
+        | false { TestResult.Fail(message) }
 }
 
 // Assert that a condition is false
 expect_not = (condition: bool, message: String) TestResult {
     condition ?
-        | false { return TestResult.Pass }
-        | true { return TestResult.Fail(message) }
+        | false { TestResult.Pass }
+        | true { TestResult.Fail(message) }
 }
 
 // ============================================================================

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -126,6 +126,7 @@ fn promoted_stdlib_modules_do_not_use_removed_return_keyword() {
         "stdlib/compiler.zen",
         "stdlib/ffi.zen",
         "stdlib/fs.zen",
+        "stdlib/testing.zen",
         "stdlib/memory/memory.zen",
         "stdlib/core/option.zen",
         "stdlib/core/result.zen",


### PR DESCRIPTION
## Summary
- convert `stdlib/testing.zen` helpers and assertions from removed `return` syntax to tail expressions
- add the testing facade to the promoted stdlib no-return hygiene guard
- record the testing facade cleanup in phase/audit docs

## Verification
- `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture` failed before implementation
- `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- `rg -n "\breturn\b" stdlib/build.zen stdlib/compiler.zen stdlib/ffi.zen stdlib/fs.zen stdlib/testing.zen stdlib/memory/memory.zen stdlib/core tests/test_*.zen` returned no matches
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`