### PR TITLE
[codex] Remove return from memory mmap helpers

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3413,7 +3413,7 @@ and do not assume Phase 4 is ready without evidence.
   unknown executable target fields before creating outputs. Coverage:
   `build_zen_commands_reject_unknown_target_fields`.
 - The stdlib build DSL, compiler/FFI bridges, filesystem and memory facades,
-  testing facade, memory async helpers, and core `Option`, `Result`,
+  testing facade, memory async and mmap helpers, and core `Option`, `Result`,
   propagation, byte-buffer, iterator, pointer, and slice helpers no longer use
   the removed `return` keyword, guarded by
   `promoted_stdlib_modules_do_not_use_removed_return_keyword`, establishing

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3085,7 +3085,7 @@ checked-in docs, tests, and commits only.
   unknown target fields before outputs are created, covered by
   `build_zen_commands_reject_unknown_target_fields`.
 - The stdlib build DSL, compiler/FFI bridges, filesystem and memory facades,
-  testing facade, memory async helpers, and core `Option`, `Result`,
+  testing facade, memory async and mmap helpers, and core `Option`, `Result`,
   propagation, byte-buffer, iterator, pointer, and slice helpers no longer use
   the removed `return` keyword, guarded by
   `promoted_stdlib_modules_do_not_use_removed_return_keyword`, so the

--- a/stdlib/memory/mmap.zen
+++ b/stdlib/memory/mmap.zen
@@ -21,7 +21,7 @@ MmapError: { code: i32, message: StaticString }
 
 MmapError.from_errno = (errno: i64) MmapError {
     code = cast(0 - errno, i32)
-    return MmapError { code: code, message: "Mmap error" }
+    MmapError { code: code, message: "Mmap error" }
 }
 
 // Memory-mapped region
@@ -31,32 +31,37 @@ Mmap: { base_addr: i64, len: usize }
 Mmap.anonymous = (len: usize, prot: i32) Result<Mmap, MmapError> {
     flags = MAP_PRIVATE | MAP_ANONYMOUS
     result = compiler.syscall6(SYS_MMAP, 0, len, prot, flags, -1, 0)
-    result < 0 ? { return Result.Err(MmapError.from_errno(result)) }
-    return Result.Ok(Mmap { base_addr: result, len: len })
+    result < 0 ?
+        | true { Result.Err(MmapError.from_errno(result)) }
+        | false { Result.Ok(Mmap { base_addr: result, len: len }) }
 }
 
 // Map with read/write access
 Mmap.alloc = (len: usize) Result<Mmap, MmapError> {
-    return Mmap.anonymous(len, PROT_READ | PROT_WRITE)
+    Mmap.anonymous(len, PROT_READ | PROT_WRITE)
 }
 
 // Get pointer to mapped memory
 Mmap.ptr = (self: Mmap) Ptr<u8> {
-    return compiler.int_to_ptr(self.base_addr)
+    compiler.int_to_ptr(self.base_addr)
 }
 
 // Change protection
 Mmap.protect = (self: MutPtr<Mmap>, prot: i32) Result<(), MmapError> {
     result = compiler.syscall3(SYS_MPROTECT, self.val.base_addr, self.val.len, prot)
-    result < 0 ? { return Result.Err(MmapError.from_errno(result)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(MmapError.from_errno(result)) }
+        | false { Result.Ok(()) }
 }
 
 // Unmap memory
 Mmap.unmap = (self: MutPtr<Mmap>) Result<(), MmapError> {
     result = compiler.syscall2(SYS_MUNMAP, self.val.base_addr, self.val.len)
-    result < 0 ? { return Result.Err(MmapError.from_errno(result)) }
-    self.val.base_addr = 0
-    self.val.len = 0
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(MmapError.from_errno(result)) }
+        | false {
+            self.val.base_addr = 0
+            self.val.len = 0
+            Result.Ok(())
+        }
 }

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -131,6 +131,7 @@ fn promoted_stdlib_modules_do_not_use_removed_return_keyword() {
         "stdlib/memory/async_helpers.zen",
         "stdlib/memory/async_pool.zen",
         "stdlib/memory/memory.zen",
+        "stdlib/memory/mmap.zen",
         "stdlib/core/option.zen",
         "stdlib/core/result.zen",
         "stdlib/core/propagate.zen",


### PR DESCRIPTION
## Summary
- convert `stdlib/memory/mmap.zen` from removed `return` syntax to tail-expression conditionals
- add mmap helpers to the promoted stdlib no-return hygiene guard
- record the cleanup in phase/audit docs

## Verification
- `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture` failed before implementation
- `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- `rg -n "\breturn\b" stdlib/build.zen stdlib/compiler.zen stdlib/ffi.zen stdlib/fs.zen stdlib/testing.zen stdlib/memory/async_allocator.zen stdlib/memory/async_helpers.zen stdlib/memory/async_pool.zen stdlib/memory/memory.zen stdlib/memory/mmap.zen stdlib/core tests/test_*.zen` returned no matches
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`