### PR TITLE
[codex] Remove return from memory allocator wrappers

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3413,9 +3413,9 @@ and do not assume Phase 4 is ready without evidence.
   unknown executable target fields before creating outputs. Coverage:
   `build_zen_commands_reject_unknown_target_fields`.
 - The stdlib build DSL, compiler/FFI bridges, filesystem and memory facades,
-  testing facade, memory async and mmap helpers, and core `Option`, `Result`,
-  propagation, byte-buffer, iterator, pointer, and slice helpers no longer use
-  the removed `return` keyword, guarded by
+  testing facade, memory allocator wrappers plus async and mmap helpers, and
+  core `Option`, `Result`, propagation, byte-buffer, iterator, pointer, and
+  slice helpers no longer use the removed `return` keyword, guarded by
   `promoted_stdlib_modules_do_not_use_removed_return_keyword`, establishing
   the first small stdlib cleanup gate before broader stdlib compilation is
   promoted.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3085,9 +3085,9 @@ checked-in docs, tests, and commits only.
   unknown target fields before outputs are created, covered by
   `build_zen_commands_reject_unknown_target_fields`.
 - The stdlib build DSL, compiler/FFI bridges, filesystem and memory facades,
-  testing facade, memory async and mmap helpers, and core `Option`, `Result`,
-  propagation, byte-buffer, iterator, pointer, and slice helpers no longer use
-  the removed `return` keyword, guarded by
+  testing facade, memory allocator wrappers plus async and mmap helpers, and
+  core `Option`, `Result`, propagation, byte-buffer, iterator, pointer, and
+  slice helpers no longer use the removed `return` keyword, guarded by
   `promoted_stdlib_modules_do_not_use_removed_return_keyword`, so the
   first stdlib compilation cleanup point stays aligned with expression-tail
   returns before broader stdlib parsing/building is promoted.

--- a/stdlib/memory/allocator.zen
+++ b/stdlib/memory/allocator.zen
@@ -67,7 +67,7 @@ Allocator: {
 
 Allocator.allocate = (self: Allocator, size: usize) RawPtr<u8> {
     f = self.allocate_fn
-    return f(self.ctx, size)
+    f(self.ctx, size)
 }
 
 Allocator.deallocate = (self: Allocator, ptr: RawPtr<u8>, size: usize) void {
@@ -77,30 +77,30 @@ Allocator.deallocate = (self: Allocator, ptr: RawPtr<u8>, size: usize) void {
 
 Allocator.reallocate = (self: Allocator, ptr: RawPtr<u8>, old_size: usize, new_size: usize) RawPtr<u8> {
     f = self.reallocate_fn
-    return f(self.ctx, ptr, old_size, new_size)
+    f(self.ctx, ptr, old_size, new_size)
 }
 
 Allocator.mode = (self: Allocator) ExecutionMode {
     f = self.mode_fn
-    return f(self.ctx)
+    f(self.ctx)
 }
 
 Allocator.schedule_read = (self: Allocator, fd: i32, buf: RawPtr<u8>, len: usize, offset: i64, callback: CompletionFn, user_data: u64) i64 {
     f = self.schedule_read_fn
-    return f(self.ctx, fd, buf, len, offset, callback, user_data)
+    f(self.ctx, fd, buf, len, offset, callback, user_data)
 }
 
 Allocator.schedule_write = (self: Allocator, fd: i32, buf: RawPtr<u8>, len: usize, offset: i64, callback: CompletionFn, user_data: u64) i64 {
     f = self.schedule_write_fn
-    return f(self.ctx, fd, buf, len, offset, callback, user_data)
+    f(self.ctx, fd, buf, len, offset, callback, user_data)
 }
 
 Allocator.poll = (self: Allocator) i32 {
     f = self.poll_fn
-    return f(self.ctx)
+    f(self.ctx)
 }
 
 Allocator.wait = (self: Allocator) i32 {
     f = self.wait_fn
-    return f(self.ctx)
+    f(self.ctx)
 }

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -127,6 +127,7 @@ fn promoted_stdlib_modules_do_not_use_removed_return_keyword() {
         "stdlib/ffi.zen",
         "stdlib/fs.zen",
         "stdlib/testing.zen",
+        "stdlib/memory/allocator.zen",
         "stdlib/memory/async_allocator.zen",
         "stdlib/memory/async_helpers.zen",
         "stdlib/memory/async_pool.zen",


### PR DESCRIPTION
## Summary
- convert `stdlib/memory/allocator.zen` wrapper methods from removed `return` syntax to tail expressions
- add allocator wrappers to the promoted stdlib no-return hygiene guard
- record the cleanup in phase/audit docs

## Verification
- `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture` failed before implementation
- `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- `rg -n "\breturn\b" stdlib/build.zen stdlib/compiler.zen stdlib/ffi.zen stdlib/fs.zen stdlib/testing.zen stdlib/memory/allocator.zen stdlib/memory/async_allocator.zen stdlib/memory/async_helpers.zen stdlib/memory/async_pool.zen stdlib/memory/memory.zen stdlib/memory/mmap.zen stdlib/core tests/test_*.zen` returned no matches
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`