### PR TITLE
[codex] Remove return from memory heap helpers

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3413,7 +3413,7 @@ and do not assume Phase 4 is ready without evidence.
   unknown executable target fields before creating outputs. Coverage:
   `build_zen_commands_reject_unknown_target_fields`.
 - The stdlib build DSL, compiler/FFI bridges, filesystem and memory facades,
-  testing facade, memory allocator wrappers plus async and mmap helpers, and
+  testing facade, memory allocator wrappers plus async, heap, and mmap helpers, and
   core `Option`, `Result`, propagation, byte-buffer, iterator, pointer, and
   slice helpers no longer use the removed `return` keyword, guarded by
   `promoted_stdlib_modules_do_not_use_removed_return_keyword`, establishing

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3085,7 +3085,7 @@ checked-in docs, tests, and commits only.
   unknown target fields before outputs are created, covered by
   `build_zen_commands_reject_unknown_target_fields`.
 - The stdlib build DSL, compiler/FFI bridges, filesystem and memory facades,
-  testing facade, memory allocator wrappers plus async and mmap helpers, and
+  testing facade, memory allocator wrappers plus async, heap, and mmap helpers, and
   core `Option`, `Result`, propagation, byte-buffer, iterator, pointer, and
   slice helpers no longer use the removed `return` keyword, guarded by
   `promoted_stdlib_modules_do_not_use_removed_return_keyword`, so the

--- a/stdlib/memory/heap.zen
+++ b/stdlib/memory/heap.zen
@@ -33,7 +33,7 @@ HeapSync: {
 // ============================================================================
 
 heap_sync_allocate = (ctx: RawPtr<u8>, size: usize) RawPtr<u8> {
-    return compiler.raw_allocate(size)
+    compiler.raw_allocate(size)
 }
 
 heap_sync_deallocate = (ctx: RawPtr<u8>, ptr: RawPtr<u8>, size: usize) void {
@@ -41,11 +41,11 @@ heap_sync_deallocate = (ctx: RawPtr<u8>, ptr: RawPtr<u8>, size: usize) void {
 }
 
 heap_sync_reallocate = (ctx: RawPtr<u8>, ptr: RawPtr<u8>, old_size: usize, new_size: usize) RawPtr<u8> {
-    return compiler.raw_reallocate(ptr, old_size, new_size)
+    compiler.raw_reallocate(ptr, old_size, new_size)
 }
 
 heap_sync_mode = (ctx: RawPtr<u8>) ExecutionMode {
-    return ExecutionMode.Sync
+    ExecutionMode.Sync
 }
 
 heap_sync_schedule_read = (ctx: RawPtr<u8>, fd: i32, buf: RawPtr<u8>, len: usize, offset: i64, callback: CompletionFn, user_data: u64) i64 {
@@ -56,7 +56,7 @@ heap_sync_schedule_read = (ctx: RawPtr<u8>, fd: i32, buf: RawPtr<u8>, len: usize
         { compiler.syscall4(17, fd, buf_i64, len, offset) }
     callback(user_data, result)
     zero: i64 = 0
-    return zero
+    zero
 }
 
 heap_sync_schedule_write = (ctx: RawPtr<u8>, fd: i32, buf: RawPtr<u8>, len: usize, offset: i64, callback: CompletionFn, user_data: u64) i64 {
@@ -67,15 +67,15 @@ heap_sync_schedule_write = (ctx: RawPtr<u8>, fd: i32, buf: RawPtr<u8>, len: usiz
         { compiler.syscall4(18, fd, buf_i64, len, offset) }
     callback(user_data, result)
     zero: i64 = 0
-    return zero
+    zero
 }
 
 heap_sync_poll = (ctx: RawPtr<u8>) i32 {
-    return 0  // No-op for sync - operations complete immediately
+    0  // No-op for sync - operations complete immediately
 }
 
 heap_sync_wait = (ctx: RawPtr<u8>) i32 {
-    return 0  // No-op for sync - nothing to wait for
+    0  // No-op for sync - nothing to wait for
 }
 
 // ============================================================================
@@ -93,8 +93,8 @@ Heap.sync = () Allocator {
     // Initialize the placeholder field
     compiler.store<i32>(ctx, 0)
 
-    // Build and return Allocator with function pointers
-    return Allocator {
+    // Build Allocator with function pointers
+    Allocator {
         ctx: ctx,
         allocate_fn: heap_sync_allocate,
         deallocate_fn: heap_sync_deallocate,
@@ -113,5 +113,5 @@ Heap.sync = () Allocator {
 
 // Default allocator for most use cases
 default_allocator = () Allocator {
-    return Heap.sync()
+    Heap.sync()
 }

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -131,6 +131,7 @@ fn promoted_stdlib_modules_do_not_use_removed_return_keyword() {
         "stdlib/memory/async_allocator.zen",
         "stdlib/memory/async_helpers.zen",
         "stdlib/memory/async_pool.zen",
+        "stdlib/memory/heap.zen",
         "stdlib/memory/memory.zen",
         "stdlib/memory/mmap.zen",
         "stdlib/core/option.zen",


### PR DESCRIPTION
## Summary
- Promotes `stdlib/memory/heap.zen` into the docs-truth no-`return` stdlib guard.
- Converts heap allocator helper tail results from removed `return` keyword syntax to expression-tail syntax.
- Updates the phase plan and completion audit evidence to include heap helpers.

## Validation
- First ran `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture` after adding the guard and confirmed it failed on `stdlib/memory/heap.zen`.
- `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- `rg -n "\breturn\b" stdlib/build.zen stdlib/compiler.zen stdlib/ffi.zen stdlib/fs.zen stdlib/testing.zen stdlib/memory/allocator.zen stdlib/memory/async_allocator.zen stdlib/memory/async_helpers.zen stdlib/memory/async_pool.zen stdlib/memory/heap.zen stdlib/memory/memory.zen stdlib/memory/mmap.zen stdlib/core tests/test_*.zen`
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Branch push Actions check: `gh run list --branch codex/stdlib-memory-heap-no-return --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]`.