### PR TITLE
[codex] Remove return from memory arena helpers

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3413,7 +3413,7 @@ and do not assume Phase 4 is ready without evidence.
   unknown executable target fields before creating outputs. Coverage:
   `build_zen_commands_reject_unknown_target_fields`.
 - The stdlib build DSL, compiler/FFI bridges, filesystem and memory facades,
-  testing facade, memory allocator wrappers plus async, heap, and mmap helpers, and
+  testing facade, memory allocator wrappers plus arena, async, heap, and mmap helpers, and
   core `Option`, `Result`, propagation, byte-buffer, iterator, pointer, and
   slice helpers no longer use the removed `return` keyword, guarded by
   `promoted_stdlib_modules_do_not_use_removed_return_keyword`, establishing

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3085,7 +3085,7 @@ checked-in docs, tests, and commits only.
   unknown target fields before outputs are created, covered by
   `build_zen_commands_reject_unknown_target_fields`.
 - The stdlib build DSL, compiler/FFI bridges, filesystem and memory facades,
-  testing facade, memory allocator wrappers plus async, heap, and mmap helpers, and
+  testing facade, memory allocator wrappers plus arena, async, heap, and mmap helpers, and
   core `Option`, `Result`, propagation, byte-buffer, iterator, pointer, and
   slice helpers no longer use the removed `return` keyword, guarded by
   `promoted_stdlib_modules_do_not_use_removed_return_keyword`, so the

--- a/stdlib/memory/arena.zen
+++ b/stdlib/memory/arena.zen
@@ -38,7 +38,7 @@ ArenaAsync: {
 arena_async_allocate = (ctx: RawPtr<u8>, size: usize) RawPtr<u8> {
     // For now, just use raw_allocate as a placeholder
     // Real implementation would use bump allocation from arena memory
-    return compiler.raw_allocate(size)
+    compiler.raw_allocate(size)
 }
 
 arena_async_deallocate = (ctx: RawPtr<u8>, ptr: RawPtr<u8>, size: usize) void {
@@ -46,11 +46,11 @@ arena_async_deallocate = (ctx: RawPtr<u8>, ptr: RawPtr<u8>, size: usize) void {
 }
 
 arena_async_reallocate = (ctx: RawPtr<u8>, ptr: RawPtr<u8>, old_size: usize, new_size: usize) RawPtr<u8> {
-    return compiler.raw_reallocate(ptr, old_size, new_size)
+    compiler.raw_reallocate(ptr, old_size, new_size)
 }
 
 arena_async_mode = (ctx: RawPtr<u8>) ExecutionMode {
-    return ExecutionMode.Async
+    ExecutionMode.Async
 }
 
 arena_async_schedule_read = (ctx: RawPtr<u8>, fd: i32, buf: RawPtr<u8>, len: usize, offset: i64, callback: CompletionFn, user_data: u64) i64 {
@@ -62,7 +62,7 @@ arena_async_schedule_read = (ctx: RawPtr<u8>, fd: i32, buf: RawPtr<u8>, len: usi
         { compiler.syscall4(17, fd, buf_i64, len, offset) }
     callback(user_data, result)
     zero: i64 = 0
-    return zero
+    zero
 }
 
 arena_async_schedule_write = (ctx: RawPtr<u8>, fd: i32, buf: RawPtr<u8>, len: usize, offset: i64, callback: CompletionFn, user_data: u64) i64 {
@@ -74,15 +74,15 @@ arena_async_schedule_write = (ctx: RawPtr<u8>, fd: i32, buf: RawPtr<u8>, len: us
         { compiler.syscall4(18, fd, buf_i64, len, offset) }
     callback(user_data, result)
     zero: i64 = 0
-    return zero
+    zero
 }
 
 arena_async_poll = (ctx: RawPtr<u8>) i32 {
-    return 0  // Placeholder - real impl would poll io_uring
+    0  // Placeholder - real impl would poll io_uring
 }
 
 arena_async_wait = (ctx: RawPtr<u8>) i32 {
-    return 0  // Placeholder - real impl would wait on io_uring
+    0  // Placeholder - real impl would wait on io_uring
 }
 
 // ============================================================================
@@ -98,8 +98,8 @@ Arena.async = () Allocator {
     ctx = compiler.raw_allocate(4)
     compiler.store<i32>(ctx, 1)  // mode = async
 
-    // Build and return Allocator with function pointers
-    return Allocator {
+    // Build Allocator with function pointers
+    Allocator {
         ctx: ctx,
         allocate_fn: arena_async_allocate,
         deallocate_fn: arena_async_deallocate,

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -128,6 +128,7 @@ fn promoted_stdlib_modules_do_not_use_removed_return_keyword() {
         "stdlib/fs.zen",
         "stdlib/testing.zen",
         "stdlib/memory/allocator.zen",
+        "stdlib/memory/arena.zen",
         "stdlib/memory/async_allocator.zen",
         "stdlib/memory/async_helpers.zen",
         "stdlib/memory/async_pool.zen",


### PR DESCRIPTION
## Summary
- Promotes `stdlib/memory/arena.zen` into the docs-truth no-`return` stdlib guard.
- Converts arena allocator helper tail results from removed `return` keyword syntax to expression-tail syntax.
- Updates the phase plan and completion audit evidence to include arena helpers.

## Validation
- First ran `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture` after adding the guard and confirmed it failed on `stdlib/memory/arena.zen`.
- `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- `rg -n "\breturn\b" stdlib/build.zen stdlib/compiler.zen stdlib/ffi.zen stdlib/fs.zen stdlib/testing.zen stdlib/memory/allocator.zen stdlib/memory/arena.zen stdlib/memory/async_allocator.zen stdlib/memory/async_helpers.zen stdlib/memory/async_pool.zen stdlib/memory/heap.zen stdlib/memory/memory.zen stdlib/memory/mmap.zen stdlib/core tests/test_*.zen`
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Branch push Actions check: `gh run list --branch codex/stdlib-memory-arena-no-return --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]`.