### PR TITLE
[codex] Remove return from stdlib math helpers

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3412,7 +3412,7 @@ and do not assume Phase 4 is ready without evidence.
 - All executing/checking `build.zen` command entrypoints now reject ordinary
   unknown executable target fields before creating outputs. Coverage:
   `build_zen_commands_reject_unknown_target_fields`.
-- The stdlib build DSL, compiler/FFI bridges, filesystem, time, and memory facades,
+- The stdlib build DSL, compiler/FFI bridges, filesystem, math, time, and memory facades,
   testing facade, memory allocator wrappers plus arena, async, heap, and mmap helpers, and
   core `Option`, `Result`, propagation, byte-buffer, iterator, pointer, and
   slice helpers no longer use the removed `return` keyword, guarded by

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3084,7 +3084,7 @@ checked-in docs, tests, and commits only.
 - All executing/checking `build.zen` command entrypoints now reject ordinary
   unknown target fields before outputs are created, covered by
   `build_zen_commands_reject_unknown_target_fields`.
-- The stdlib build DSL, compiler/FFI bridges, filesystem, time, and memory facades,
+- The stdlib build DSL, compiler/FFI bridges, filesystem, math, time, and memory facades,
   testing facade, memory allocator wrappers plus arena, async, heap, and mmap helpers, and
   core `Option`, `Result`, propagation, byte-buffer, iterator, pointer, and
   slice helpers no longer use the removed `return` keyword, guarded by

--- a/stdlib/math/math.zen
+++ b/stdlib/math/math.zen
@@ -9,15 +9,15 @@ E = 2.71828182845904523536
 // Absolute value (generic)
 abs<T> = (n: T) T {
     n < 0 ?
-        | true { return -n }
-        | false { return n }
+        | true { -n }
+        | false { n }
 }
 
 // Factorial (u32 -> u64 to avoid overflow)
 factorial = (n: u32) u64 {
     n == 0 ?
-        | true { return 1 }
-        | false { return cast(n, u64) * factorial(n - 1) }
+        | true { 1 }
+        | false { cast(n, u64) * factorial(n - 1) }
 }
 
 // Check if even
@@ -33,25 +33,25 @@ is_odd = (n: i32) bool {
 // Max of two values (generic)
 max<T> = (a: T, b: T) T {
     a > b ?
-        | true { return a }
-        | false { return b }
+        | true { a }
+        | false { b }
 }
 
 // Min of two values (generic)
 min<T> = (a: T, b: T) T {
     a < b ?
-        | true { return a }
-        | false { return b }
+        | true { a }
+        | false { b }
 }
 
 // Clamp value to range
 clamp = (n: i32, low: i32, high: i32) i32 {
     n < low ?
-        | true { return low }
+        | true { low }
         | false {
             n > high ?
-                | true { return high }
-                | false { return n }
+                | true { high }
+                | false { n }
         }
 }
 

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -128,6 +128,7 @@ fn promoted_stdlib_modules_do_not_use_removed_return_keyword() {
         "stdlib/fs.zen",
         "stdlib/testing.zen",
         "stdlib/time.zen",
+        "stdlib/math/math.zen",
         "stdlib/memory/allocator.zen",
         "stdlib/memory/arena.zen",
         "stdlib/memory/async_allocator.zen",


### PR DESCRIPTION
## Summary
- Promotes `stdlib/math/math.zen` into the docs-truth no-`return` stdlib guard.
- Converts math conditional arms from removed `return` keyword syntax to expression-tail syntax.
- Updates the phase plan and completion audit evidence to include math helpers.

## Validation
- First ran `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture` after adding the guard and confirmed it failed on `stdlib/math/math.zen`.
- `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- `rg -n "\breturn\b" stdlib/build.zen stdlib/compiler.zen stdlib/ffi.zen stdlib/fs.zen stdlib/testing.zen stdlib/time.zen stdlib/math/math.zen stdlib/memory/allocator.zen stdlib/memory/arena.zen stdlib/memory/async_allocator.zen stdlib/memory/async_helpers.zen stdlib/memory/async_pool.zen stdlib/memory/heap.zen stdlib/memory/memory.zen stdlib/memory/mmap.zen stdlib/core tests/test_*.zen`
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Branch push Actions check: `gh run list --branch codex/stdlib-math-no-return --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]`.