### PR TITLE
[codex] Remove return from stdlib env facade

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3412,7 +3412,7 @@ and do not assume Phase 4 is ready without evidence.
 - All executing/checking `build.zen` command entrypoints now reject ordinary
   unknown executable target fields before creating outputs. Coverage:
   `build_zen_commands_reject_unknown_target_fields`.
-- The stdlib build DSL, compiler/FFI bridges, filesystem, math, time, and memory facades,
+- The stdlib build DSL, compiler/FFI bridges, environment, filesystem, math, time, and memory facades,
   testing facade, memory allocator wrappers plus arena, async, heap, and mmap helpers, and
   core `Option`, `Result`, propagation, byte-buffer, iterator, pointer, and
   slice helpers no longer use the removed `return` keyword, guarded by

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3084,7 +3084,7 @@ checked-in docs, tests, and commits only.
 - All executing/checking `build.zen` command entrypoints now reject ordinary
   unknown target fields before outputs are created, covered by
   `build_zen_commands_reject_unknown_target_fields`.
-- The stdlib build DSL, compiler/FFI bridges, filesystem, math, time, and memory facades,
+- The stdlib build DSL, compiler/FFI bridges, environment, filesystem, math, time, and memory facades,
   testing facade, memory allocator wrappers plus arena, async, heap, and mmap helpers, and
   core `Option`, `Result`, propagation, byte-buffer, iterator, pointer, and
   slice helpers no longer use the removed `return` keyword, guarded by

--- a/stdlib/sys/env.zen
+++ b/stdlib/sys/env.zen
@@ -6,28 +6,30 @@
 { SYS_GETCWD, SYS_CHDIR, SYS_GETPID, SYS_GETPPID } = @std.sys.syscall
 
 EnvError: { code: i32 }
-EnvError.from_errno = (errno: i64) EnvError { return EnvError { code: cast(0 - errno, i32) } }
+EnvError.from_errno = (errno: i64) EnvError { EnvError { code: cast(0 - errno, i32) } }
 
 // Get current working directory into buffer
 getcwd = (buf: Ptr<u8>, size: usize) Result<usize, EnvError> {
     result = compiler.syscall2(SYS_GETCWD, compiler.ptr_to_int(buf), size)
-    result < 0 ? { return Result.Err(EnvError.from_errno(result)) }
-    return Result.Ok(cast(result, usize))
+    result < 0 ?
+        | true { Result.Err(EnvError.from_errno(result)) }
+        | false { Result.Ok(cast(result, usize)) }
 }
 
 // Change current working directory
 chdir = (path_ptr: i64) Result<(), EnvError> {
     result = compiler.syscall1(SYS_CHDIR, path_ptr)
-    result < 0 ? { return Result.Err(EnvError.from_errno(result)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(EnvError.from_errno(result)) }
+        | false { Result.Ok(()) }
 }
 
 // Get process ID
 getpid = () i32 {
-    return cast(compiler.syscall0(SYS_GETPID), i32)
+    cast(compiler.syscall0(SYS_GETPID), i32)
 }
 
 // Get parent process ID
 getppid = () i32 {
-    return cast(compiler.syscall0(SYS_GETPPID), i32)
+    cast(compiler.syscall0(SYS_GETPPID), i32)
 }

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -129,6 +129,7 @@ fn promoted_stdlib_modules_do_not_use_removed_return_keyword() {
         "stdlib/testing.zen",
         "stdlib/time.zen",
         "stdlib/math/math.zen",
+        "stdlib/sys/env.zen",
         "stdlib/memory/allocator.zen",
         "stdlib/memory/arena.zen",
         "stdlib/memory/async_allocator.zen",


### PR DESCRIPTION
## Summary
- Promotes `stdlib/sys/env.zen` into the docs-truth no-`return` stdlib guard.
- Converts environment syscall helpers from removed `return` keyword syntax to expression-tail syntax.
- Updates the phase plan and completion audit evidence to include the environment facade.

## Validation
- First ran `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture` after adding the guard and confirmed it failed on `stdlib/sys/env.zen`.
- `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- `rg -n "\breturn\b" stdlib/build.zen stdlib/compiler.zen stdlib/ffi.zen stdlib/fs.zen stdlib/testing.zen stdlib/time.zen stdlib/math/math.zen stdlib/sys/env.zen stdlib/memory/allocator.zen stdlib/memory/arena.zen stdlib/memory/async_allocator.zen stdlib/memory/async_helpers.zen stdlib/memory/async_pool.zen stdlib/memory/heap.zen stdlib/memory/memory.zen stdlib/memory/mmap.zen stdlib/core tests/test_*.zen`
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Branch push Actions check: `gh run list --branch codex/stdlib-sys-env-no-return --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]`.