### PR TITLE
[codex] Remove return from stdlib random facade

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3412,7 +3412,7 @@ and do not assume Phase 4 is ready without evidence.
 - All executing/checking `build.zen` command entrypoints now reject ordinary
   unknown executable target fields before creating outputs. Coverage:
   `build_zen_commands_reject_unknown_target_fields`.
-- The stdlib build DSL, compiler/FFI bridges, environment, filesystem, math, time, and memory facades,
+- The stdlib build DSL, compiler/FFI bridges, environment, filesystem, math, random, time, and memory facades,
   testing facade, memory allocator wrappers plus arena, async, heap, and mmap helpers, and
   core `Option`, `Result`, propagation, byte-buffer, iterator, pointer, and
   slice helpers no longer use the removed `return` keyword, guarded by

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3084,7 +3084,7 @@ checked-in docs, tests, and commits only.
 - All executing/checking `build.zen` command entrypoints now reject ordinary
   unknown target fields before outputs are created, covered by
   `build_zen_commands_reject_unknown_target_fields`.
-- The stdlib build DSL, compiler/FFI bridges, environment, filesystem, math, time, and memory facades,
+- The stdlib build DSL, compiler/FFI bridges, environment, filesystem, math, random, time, and memory facades,
   testing facade, memory allocator wrappers plus arena, async, heap, and mmap helpers, and
   core `Option`, `Result`, propagation, byte-buffer, iterator, pointer, and
   slice helpers no longer use the removed `return` keyword, guarded by

--- a/stdlib/sys/random/getrandom.zen
+++ b/stdlib/sys/random/getrandom.zen
@@ -9,37 +9,38 @@ GRND_NONBLOCK = 1
 GRND_RANDOM = 2
 
 RandomError: { code: i32 }
-RandomError.from_errno = (errno: i64) RandomError { return RandomError { code: cast(0 - errno, i32) } }
+RandomError.from_errno = (errno: i64) RandomError { RandomError { code: cast(0 - errno, i32) } }
 
 // Get random bytes from kernel
 getrandom = (buf: Ptr<u8>, len: usize, flags: u32) Result<usize, RandomError> {
     result = compiler.syscall3(SYS_GETRANDOM, compiler.ptr_to_int(buf), len, flags)
-    result < 0 ? { return Result.Err(RandomError.from_errno(result)) }
-    return Result.Ok(cast(result, usize))
+    result < 0 ?
+        | true { Result.Err(RandomError.from_errno(result)) }
+        | false { Result.Ok(cast(result, usize)) }
 }
 
 // Get random u64
 random_u64 = () Result<u64, RandomError> {
     value: u64 = 0
     getrandom(compiler.raw_ptr_cast(&value.ref()), 8, 0).raise()
-    return Result.Ok(value)
+    Result.Ok(value)
 }
 
 // Get random u32
 random_u32 = () Result<u32, RandomError> {
     value: u32 = 0
     getrandom(compiler.raw_ptr_cast(&value.ref()), 4, 0).raise()
-    return Result.Ok(value)
+    Result.Ok(value)
 }
 
 // Get random in range [0, max)
 random_range = (max: u64) Result<u64, RandomError> {
     value = random_u64().raise()
-    return Result.Ok(value % max)
+    Result.Ok(value % max)
 }
 
 // Fill buffer with random bytes
 fill_random = (buf: Ptr<u8>, len: usize) Result<(), RandomError> {
     getrandom(buf, len, 0).raise()
-    return Result.Ok(())
+    Result.Ok(())
 }

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -130,6 +130,7 @@ fn promoted_stdlib_modules_do_not_use_removed_return_keyword() {
         "stdlib/time.zen",
         "stdlib/math/math.zen",
         "stdlib/sys/env.zen",
+        "stdlib/sys/random/getrandom.zen",
         "stdlib/memory/allocator.zen",
         "stdlib/memory/arena.zen",
         "stdlib/memory/async_allocator.zen",


### PR DESCRIPTION
## Summary
- remove the removed `return` keyword from `stdlib/sys/random/getrandom.zen`
- promote the random facade into the docs-truth no-return guard
- update the phase/audit docs to list random with the returnless promoted stdlib modules

## Validation
- guard-first failure observed: `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- promoted no-return `rg -n "\breturn\b" ...` scan returned no matches
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- branch push Actions check: `[]`