### PR TITLE
[codex] Remove return from stdlib timerfd facade

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3412,7 +3412,7 @@ and do not assume Phase 4 is ready without evidence.
 - All executing/checking `build.zen` command entrypoints now reject ordinary
   unknown executable target fields before creating outputs. Coverage:
   `build_zen_commands_reject_unknown_target_fields`.
-- The stdlib build DSL, compiler/FFI bridges, environment, filesystem, math, random, time, and memory facades,
+- The stdlib build DSL, compiler/FFI bridges, environment, filesystem, IO, math, random, time, and memory facades,
   testing facade, memory allocator wrappers plus arena, async, heap, and mmap helpers, and
   core `Option`, `Result`, propagation, byte-buffer, iterator, pointer, and
   slice helpers no longer use the removed `return` keyword, guarded by

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3084,7 +3084,7 @@ checked-in docs, tests, and commits only.
 - All executing/checking `build.zen` command entrypoints now reject ordinary
   unknown target fields before outputs are created, covered by
   `build_zen_commands_reject_unknown_target_fields`.
-- The stdlib build DSL, compiler/FFI bridges, environment, filesystem, math, random, time, and memory facades,
+- The stdlib build DSL, compiler/FFI bridges, environment, filesystem, IO, math, random, time, and memory facades,
   testing facade, memory allocator wrappers plus arena, async, heap, and mmap helpers, and
   core `Option`, `Result`, propagation, byte-buffer, iterator, pointer, and
   slice helpers no longer use the removed `return` keyword, guarded by

--- a/stdlib/io/timerfd.zen
+++ b/stdlib/io/timerfd.zen
@@ -11,7 +11,7 @@ TFD_CLOEXEC = 524288
 TFD_NONBLOCK = 2048
 
 TimerError: { code: i32 }
-TimerError.from_errno = (errno: i64) TimerError { return TimerError { code: cast(0 - errno, i32) } }
+TimerError.from_errno = (errno: i64) TimerError { TimerError { code: cast(0 - errno, i32) } }
 
 Itimerspec: { interval_sec: i64, interval_nsec: i64, value_sec: i64, value_nsec: i64 }
 
@@ -19,15 +19,17 @@ Timerfd: { fd: i32 }
 
 Timerfd.new = () Result<Timerfd, TimerError> {
     result = compiler.syscall2(SYS_TIMERFD_CREATE, CLOCK_MONOTONIC, TFD_CLOEXEC)
-    result < 0 ? { return Result.Err(TimerError.from_errno(result)) }
-    return Result.Ok(Timerfd { fd: cast(result, i32) })
+    result < 0 ?
+        | true { Result.Err(TimerError.from_errno(result)) }
+        | false { Result.Ok(Timerfd { fd: cast(result, i32) }) }
 }
 
 Timerfd.set_oneshot_ms = (self: MutPtr<Timerfd>, ms: i64) Result<(), TimerError> {
     spec = Itimerspec { interval_sec: 0, interval_nsec: 0, value_sec: ms / 1000, value_nsec: (ms % 1000) * 1000000 }
     result = compiler.syscall4(SYS_TIMERFD_SETTIME, self.val.fd, 0, compiler.ptr_to_int(&spec.ref()), 0)
-    result < 0 ? { return Result.Err(TimerError.from_errno(result)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(TimerError.from_errno(result)) }
+        | false { Result.Ok(()) }
 }
 
 Timerfd.set_interval_ms = (self: MutPtr<Timerfd>, ms: i64) Result<(), TimerError> {
@@ -35,15 +37,17 @@ Timerfd.set_interval_ms = (self: MutPtr<Timerfd>, ms: i64) Result<(), TimerError
     nsec = (ms % 1000) * 1000000
     spec = Itimerspec { interval_sec: sec, interval_nsec: nsec, value_sec: sec, value_nsec: nsec }
     result = compiler.syscall4(SYS_TIMERFD_SETTIME, self.val.fd, 0, compiler.ptr_to_int(&spec.ref()), 0)
-    result < 0 ? { return Result.Err(TimerError.from_errno(result)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(TimerError.from_errno(result)) }
+        | false { Result.Ok(()) }
 }
 
 Timerfd.wait = (self: MutPtr<Timerfd>) Result<u64, TimerError> {
     expirations: u64 = 0
     result = compiler.syscall3(SYS_READ, self.val.fd, compiler.ptr_to_int(&expirations.ref()), 8)
-    result < 0 ? { return Result.Err(TimerError.from_errno(result)) }
-    return Result.Ok(expirations)
+    result < 0 ?
+        | true { Result.Err(TimerError.from_errno(result)) }
+        | false { Result.Ok(expirations) }
 }
 
 Timerfd.close = (self: MutPtr<Timerfd>) void { compiler.syscall1(SYS_CLOSE, self.val.fd) }

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -126,6 +126,7 @@ fn promoted_stdlib_modules_do_not_use_removed_return_keyword() {
         "stdlib/compiler.zen",
         "stdlib/ffi.zen",
         "stdlib/fs.zen",
+        "stdlib/io/timerfd.zen",
         "stdlib/testing.zen",
         "stdlib/time.zen",
         "stdlib/math/math.zen",


### PR DESCRIPTION
## Summary
- remove the removed `return` keyword from `stdlib/io/timerfd.zen`
- promote timerfd into the docs-truth no-return guard
- update phase/audit docs to include IO in the promoted stdlib cleanup list

## Validation
- guard-first failure observed: `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- promoted no-return `rg -n "\breturn\b" ...` scan returned no matches
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- branch push Actions check: `[]`