### PR TITLE
[codex] Remove return from stdlib signal facade

### DIFF
--- a/stdlib/io/signal.zen
+++ b/stdlib/io/signal.zen
@@ -38,20 +38,22 @@ SIG_SETMASK = 2
 SignalError: { code: i32 }
 
 SignalError.from_errno = (errno: i64) SignalError {
-    return SignalError { code: cast(0 - errno, i32) }
+    SignalError { code: cast(0 - errno, i32) }
 }
 
 // Send signal to current process
 raise_signal = (sig: i32) Result<(), SignalError> {
     pid = compiler.syscall0(SYS_GETPID)
     result = compiler.syscall2(SYS_KILL, pid, sig)
-    result < 0 ? { return Result.Err(SignalError.from_errno(result)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(SignalError.from_errno(result)) }
+        | false { Result.Ok(()) }
 }
 
 // Send signal to process
 kill = (pid: i32, sig: i32) Result<(), SignalError> {
     result = compiler.syscall2(SYS_KILL, pid, sig)
-    result < 0 ? { return Result.Err(SignalError.from_errno(result)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(SignalError.from_errno(result)) }
+        | false { Result.Ok(()) }
 }

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -126,6 +126,7 @@ fn promoted_stdlib_modules_do_not_use_removed_return_keyword() {
         "stdlib/compiler.zen",
         "stdlib/ffi.zen",
         "stdlib/fs.zen",
+        "stdlib/io/signal.zen",
         "stdlib/io/timerfd.zen",
         "stdlib/testing.zen",
         "stdlib/time.zen",


### PR DESCRIPTION
## Summary
- remove the removed `return` keyword from `stdlib/io/signal.zen`
- promote the signal facade into the docs-truth no-return guard

## Validation
- guard-first failure observed: `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- promoted no-return `rg -n "\breturn\b" ...` scan returned no matches
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- branch push Actions check: `[]`