### PR TITLE
[codex] Remove return from stdlib epoll facade

### DIFF
--- a/stdlib/io/mux/epoll.zen
+++ b/stdlib/io/mux/epoll.zen
@@ -24,40 +24,44 @@ EpollError: { code: i32, message: StaticString }
 
 EpollError.from_errno = (errno: i64) EpollError {
     code = cast(0 - errno, i32)
-    return EpollError { code: code, message: "Epoll error" }
+    EpollError { code: code, message: "Epoll error" }
 }
 
 EpollEvent: { events: u32, data: u64 }
 
 EpollEvent.for_fd = (events: u32, fd: i32) EpollEvent {
-    return EpollEvent { events: events, data: cast(fd, u64) }
+    EpollEvent { events: events, data: cast(fd, u64) }
 }
 
 Epoll: { fd: i32 }
 
 Epoll.new = () Result<Epoll, EpollError> {
     result = compiler.syscall1(SYS_EPOLL_CREATE1, EPOLL_CLOEXEC)
-    result < 0 ? { return Result.Err(EpollError.from_errno(result)) }
-    return Result.Ok(Epoll { fd: cast(result, i32) })
+    result < 0 ?
+        | true { Result.Err(EpollError.from_errno(result)) }
+        | false { Result.Ok(Epoll { fd: cast(result, i32) }) }
 }
 
 Epoll.add = (self: MutPtr<Epoll>, fd: i32, events: u32) Result<(), EpollError> {
     event = EpollEvent.for_fd(events, fd)
     result = compiler.syscall4(SYS_EPOLL_CTL, self.val.fd, EPOLL_CTL_ADD, fd, compiler.ptr_to_int(&event.ref()))
-    result < 0 ? { return Result.Err(EpollError.from_errno(result)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(EpollError.from_errno(result)) }
+        | false { Result.Ok(()) }
 }
 
 Epoll.remove = (self: MutPtr<Epoll>, fd: i32) Result<(), EpollError> {
     result = compiler.syscall4(SYS_EPOLL_CTL, self.val.fd, EPOLL_CTL_DEL, fd, 0)
-    result < 0 ? { return Result.Err(EpollError.from_errno(result)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(EpollError.from_errno(result)) }
+        | false { Result.Ok(()) }
 }
 
 Epoll.wait = (self: MutPtr<Epoll>, events: Ptr<EpollEvent>, max: i32, timeout_ms: i32) Result<i32, EpollError> {
     result = compiler.syscall4(SYS_EPOLL_WAIT, self.val.fd, compiler.ptr_to_int(events), max, timeout_ms)
-    result < 0 ? { return Result.Err(EpollError.from_errno(result)) }
-    return Result.Ok(cast(result, i32))
+    result < 0 ?
+        | true { Result.Err(EpollError.from_errno(result)) }
+        | false { Result.Ok(cast(result, i32)) }
 }
 
 Epoll.close = (self: MutPtr<Epoll>) void {

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -128,6 +128,7 @@ fn promoted_stdlib_modules_do_not_use_removed_return_keyword() {
         "stdlib/fs.zen",
         "stdlib/io/eventfd.zen",
         "stdlib/io/inotify.zen",
+        "stdlib/io/mux/epoll.zen",
         "stdlib/io/mux/poll.zen",
         "stdlib/io/net/pipe.zen",
         "stdlib/io/signal.zen",


### PR DESCRIPTION
## Summary
- remove the removed `return` keyword from `stdlib/io/mux/epoll.zen`
- promote the epoll facade into the docs-truth no-return guard

## Validation
- guard-first failure observed: `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- promoted no-return `rg -n "\breturn\b" ...` scan returned no matches
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- branch push Actions check: `[]`
