### PR TITLE
[codex] Remove return from stdlib io facade

### DIFF
--- a/stdlib/io/io.zen
+++ b/stdlib/io/io.zen
@@ -43,19 +43,19 @@ eprintln = (message: String) void {
 // Use this when you need to avoid libc entirely
 sys_write = (msg: StaticString, len: i64) i64 {
     msg_ptr = compiler.ptr_to_int(msg)
-    return compiler.syscall3(1, 1, msg_ptr, len)
+    compiler.syscall3(1, 1, msg_ptr, len)
 }
 
 // Write to stderr using raw syscall
 sys_ewrite = (msg: StaticString, len: i64) i64 {
     msg_ptr = compiler.ptr_to_int(msg)
-    return compiler.syscall3(1, 2, msg_ptr, len)
+    compiler.syscall3(1, 2, msg_ptr, len)
 }
 
 // Raw syscall write to any file descriptor
 sys_write_raw = (fd: i64, buf: RawPtr<u8>, count: i64) i64 {
     buf_addr = compiler.ptr_to_int(buf)
-    return compiler.syscall3(1, fd, buf_addr, count)
+    compiler.syscall3(1, fd, buf_addr, count)
 }
 
 // =============================================================================
@@ -64,10 +64,10 @@ sys_write_raw = (fd: i64, buf: RawPtr<u8>, count: i64) i64 {
 
 // Read line from stdin (not yet implemented)
 read_line = () Result<String, String> {
-    return Result.Err("Not implemented")
+    Result.Err("Not implemented")
 }
 
 // Read with prompt (not yet implemented)
 read_input = (prompt: String) Result<String, String> {
-    return Result.Err("Not implemented")
+    Result.Err("Not implemented")
 }

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -128,6 +128,7 @@ fn promoted_stdlib_modules_do_not_use_removed_return_keyword() {
         "stdlib/fs.zen",
         "stdlib/io/eventfd.zen",
         "stdlib/io/inotify.zen",
+        "stdlib/io/io.zen",
         "stdlib/io/mux/epoll.zen",
         "stdlib/io/mux/poll.zen",
         "stdlib/io/net/pipe.zen",


### PR DESCRIPTION
## Summary
- remove the removed `return` keyword from `stdlib/io/io.zen`
- promote the IO facade into the docs-truth no-return guard

## Validation
- guard-first failure observed: `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `rg -n "\breturn\b" stdlib/io/io.zen` returned no matches
- `cargo test --test docs_truth -- --nocapture`
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- branch push Actions check: `[]`
