### PR TITLE
[codex] Remove return from stdlib uname facade

### DIFF
--- a/stdlib/sys/uname.zen
+++ b/stdlib/sys/uname.zen
@@ -8,30 +8,30 @@
 SysError: { code: i32 }
 
 SysError.from_errno = (errno: i64) SysError {
-    return SysError { code: cast(0 - errno, i32) }
+    SysError { code: cast(0 - errno, i32) }
 }
 
 // Get user ID
 getuid = () u32 {
-    return cast(compiler.syscall0(SYS_GETUID), u32)
+    cast(compiler.syscall0(SYS_GETUID), u32)
 }
 
 // Get group ID
 getgid = () u32 {
-    return cast(compiler.syscall0(SYS_GETGID), u32)
+    cast(compiler.syscall0(SYS_GETGID), u32)
 }
 
 // Get effective user ID
 geteuid = () u32 {
-    return cast(compiler.syscall0(SYS_GETEUID), u32)
+    cast(compiler.syscall0(SYS_GETEUID), u32)
 }
 
 // Get effective group ID
 getegid = () u32 {
-    return cast(compiler.syscall0(SYS_GETEGID), u32)
+    cast(compiler.syscall0(SYS_GETEGID), u32)
 }
 
 // Check if running as root
 is_root = () bool {
-    return geteuid() == 0
+    geteuid() == 0
 }

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -138,6 +138,7 @@ fn promoted_stdlib_modules_do_not_use_removed_return_keyword() {
         "stdlib/time.zen",
         "stdlib/math/math.zen",
         "stdlib/sys/env.zen",
+        "stdlib/sys/uname.zen",
         "stdlib/sys/random/getrandom.zen",
         "stdlib/sys/random/prng.zen",
         "stdlib/memory/allocator.zen",


### PR DESCRIPTION
## Summary
- remove the removed `return` keyword from `stdlib/sys/uname.zen`
- promote the uname facade into the docs-truth no-return guard

## Validation
- guard-first failure observed: `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `rg -n "\breturn\b" stdlib/sys/uname.zen` returned no matches
- `cargo test --test docs_truth -- --nocapture`
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- branch push Actions check: `[]`
