### PR TITLE
[codex] Remove return from stdlib process facade

### DIFF
--- a/stdlib/sys/process/process.zen
+++ b/stdlib/sys/process/process.zen
@@ -19,7 +19,7 @@ ProcessError: { code: i32, message: StaticString }
 
 ProcessError.from_errno = (errno: i64) ProcessError {
     code = cast(0 - errno, i32)
-    return ProcessError { code: code, message: "Process error" }
+    ProcessError { code: code, message: "Process error" }
 }
 
 // Process ID type
@@ -27,19 +27,20 @@ Pid: { value: i32 }
 
 Pid.current = () Pid {
     result = compiler.syscall0(SYS_GETPID)
-    return Pid { value: cast(result, i32) }
+    Pid { value: cast(result, i32) }
 }
 
 Pid.parent = () Pid {
     result = compiler.syscall0(SYS_GETPPID)
-    return Pid { value: cast(result, i32) }
+    Pid { value: cast(result, i32) }
 }
 
 // Fork the current process
 fork = () Result<Pid, ProcessError> {
     result = compiler.syscall0(SYS_FORK)
-    result < 0 ? { return Result.Err(ProcessError.from_errno(result)) }
-    return Result.Ok(Pid { value: cast(result, i32) })
+    result < 0 ?
+        | true { Result.Err(ProcessError.from_errno(result)) }
+        | false { Result.Ok(Pid { value: cast(result, i32) }) }
 }
 
 // Exit the current process
@@ -52,36 +53,39 @@ exit = (code: i32) void {
 wait = () Result<i32, ProcessError> {
     status: i32 = 0
     result = compiler.syscall4(SYS_WAIT4, -1, compiler.ptr_to_int(&status.ref()), 0, 0)
-    result < 0 ? { return Result.Err(ProcessError.from_errno(result)) }
-    return Result.Ok(status)
+    result < 0 ?
+        | true { Result.Err(ProcessError.from_errno(result)) }
+        | false { Result.Ok(status) }
 }
 
 // Wait for specific child (non-blocking)
 waitpid = (pid: Pid, options: i32) Result<i32, ProcessError> {
     status: i32 = 0
     result = compiler.syscall4(SYS_WAIT4, pid.value, compiler.ptr_to_int(&status.ref()), options, 0)
-    result < 0 ? { return Result.Err(ProcessError.from_errno(result)) }
-    return Result.Ok(status)
+    result < 0 ?
+        | true { Result.Err(ProcessError.from_errno(result)) }
+        | false { Result.Ok(status) }
 }
 
 // Send signal to process
 kill = (pid: Pid, signal: i32) Result<(), ProcessError> {
     result = compiler.syscall2(SYS_KILL, pid.value, signal)
-    result < 0 ? { return Result.Err(ProcessError.from_errno(result)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(ProcessError.from_errno(result)) }
+        | false { Result.Ok(()) }
 }
 
 // Extract exit status from wait status
 exit_status = (status: i32) i32 {
-    return (status >> 8) & 255
+    (status >> 8) & 255
 }
 
 // Check if process exited normally
 exited_normally = (status: i32) bool {
-    return (status & 127) == 0
+    (status & 127) == 0
 }
 
 // Check if process was signaled
 was_signaled = (status: i32) bool {
-    return (status & 127) != 0
+    (status & 127) != 0
 }

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -139,6 +139,7 @@ fn promoted_stdlib_modules_do_not_use_removed_return_keyword() {
         "stdlib/math/math.zen",
         "stdlib/sys/env.zen",
         "stdlib/sys/uname.zen",
+        "stdlib/sys/process/process.zen",
         "stdlib/sys/random/getrandom.zen",
         "stdlib/sys/random/prng.zen",
         "stdlib/memory/allocator.zen",


### PR DESCRIPTION
## Summary
- remove the removed `return` keyword from `stdlib/sys/process/process.zen`
- promote the process facade into the docs-truth no-return guard

## Validation
- guard-first failure observed: `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `rg -n "\breturn\b" stdlib/sys/process/process.zen` returned no matches
- `cargo test --test docs_truth -- --nocapture`
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- branch push Actions check: `[]`
