### PR TITLE
[codex] Remove return from stdlib condvar

### DIFF
--- a/stdlib/concurrency/sync/condvar.zen
+++ b/stdlib/concurrency/sync/condvar.zen
@@ -22,7 +22,7 @@ CondVar: {
 }
 
 CondVar.new = () CondVar {
-    return CondVar { seq: 0 }
+    CondVar { seq: 0 }
 }
 
 // Wait for the condition to be signaled
@@ -79,7 +79,7 @@ CondVar.wait_timeout = (self: MutPtr<CondVar>, mutex: MutPtr<Mutex>, timeout_ns:
     mutex.lock()
 
     // ETIMEDOUT = -110
-    return result != -110
+    result != -110
 }
 
 // Signal one waiting thread

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -127,6 +127,7 @@ fn promoted_stdlib_modules_do_not_use_removed_return_keyword() {
         "stdlib/collections/queue.zen",
         "stdlib/compiler.zen",
         "stdlib/concurrency/sync/barrier.zen",
+        "stdlib/concurrency/sync/condvar.zen",
         "stdlib/concurrency/sync/semaphore.zen",
         "stdlib/ffi.zen",
         "stdlib/fs.zen",


### PR DESCRIPTION
## Summary
- remove the removed `return` keyword from `stdlib/concurrency/sync/condvar.zen`
- promote the condvar facade into the docs-truth no-return guard

## Validation
- guard-first failure observed: `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `rg -n "\breturn\b" stdlib/concurrency/sync/condvar.zen` returned no matches
- `cargo test --test docs_truth -- --nocapture`
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- branch push Actions check: `[]`