### PR TITLE
[codex] Remove return from stdlib waitgroup

### DIFF
--- a/stdlib/concurrency/sync/waitgroup.zen
+++ b/stdlib/concurrency/sync/waitgroup.zen
@@ -27,7 +27,7 @@ WaitGroup: {
 }
 
 WaitGroup.new = () WaitGroup {
-    return WaitGroup { counter: 0 }
+    WaitGroup { counter: 0 }
 }
 
 // Add to the WaitGroup counter (can be negative to decrement)
@@ -60,44 +60,43 @@ WaitGroup.wait = (self: MutPtr<WaitGroup>) void {
     val = cast(compiler.atomic_load(compiler.raw_ptr_cast(&self.val.counter.ref())), i64)
     counter ::= cast(val >> 32, i32)
 
-    // Fast path: already done
-    counter == 0 ? { return }
+    counter != 0 ? {
+        // Increment waiter count (lower 32 bits)
+        compiler.atomic_add(compiler.raw_ptr_cast(&self.val.counter.ref()), 1)
 
-    // Increment waiter count (lower 32 bits)
-    compiler.atomic_add(compiler.raw_ptr_cast(&self.val.counter.ref()), 1)
-
-    // Wait loop
-    done ::= false
-    done == false ? {
-        raw_val = cast(compiler.atomic_load(compiler.raw_ptr_cast(&self.val.counter.ref())), i64)
-        counter = cast(raw_val >> 32, i32)
-
-        counter == 0 ? { done = true }
+        // Wait loop
+        done ::= false
         done == false ? {
-            futex_wait(&self.val.counter.ref(), cast(raw_val, i32))
-        }
-    }
+            raw_val = cast(compiler.atomic_load(compiler.raw_ptr_cast(&self.val.counter.ref())), i64)
+            counter = cast(raw_val >> 32, i32)
 
-    // Decrement waiter count
-    compiler.atomic_sub(compiler.raw_ptr_cast(&self.val.counter.ref()), 1)
+            counter == 0 ? { done = true }
+            done == false ? {
+                futex_wait(&self.val.counter.ref(), cast(raw_val, i32))
+            }
+        }
+
+        // Decrement waiter count
+        compiler.atomic_sub(compiler.raw_ptr_cast(&self.val.counter.ref()), 1)
+    }
 }
 
 // Get current counter value (for debugging)
 WaitGroup.counter = (self: Ptr<WaitGroup>) i32 {
     val = cast(compiler.atomic_load(compiler.raw_ptr_cast(&self.val.counter.ref())), i64)
-    return cast(val >> 32, i32)
+    cast(val >> 32, i32)
 }
 
 // Check if all tasks are done
 WaitGroup.is_done = (self: Ptr<WaitGroup>) bool {
-    return self.counter() == 0
+    self.counter() == 0
 }
 
 // ============================================================================
 // Latch - One-shot synchronization barrier
 // ============================================================================
 // Unlike WaitGroup, a Latch can only count down (never up) and
-// once triggered, all future wait() calls return immediately.
+// once triggered, all future wait() calls complete immediately.
 //
 // Useful for one-time initialization gates.
 
@@ -106,7 +105,7 @@ Latch: {
 }
 
 Latch.new = (count: i32) Latch {
-    return Latch { count: count }
+    Latch { count: count }
 }
 
 // Count down by one
@@ -122,9 +121,6 @@ Latch.count_down = (self: MutPtr<Latch>) void {
 // Wait until count reaches zero
 Latch.wait = (self: MutPtr<Latch>) void {
     count ::= cast(compiler.atomic_load(compiler.raw_ptr_cast(&self.val.count.ref())), i32)
-
-    // Fast path
-    count <= 0 ? { return }
 
     // Wait loop
     count > 0 ? {
@@ -142,7 +138,7 @@ Latch.arrive_and_wait = (self: MutPtr<Latch>) void {
 // Check if latch has triggered
 Latch.is_ready = (self: Ptr<Latch>) bool {
     count = cast(compiler.atomic_load(compiler.raw_ptr_cast(&self.val.count.ref())), i32)
-    return count <= 0
+    count <= 0
 }
 
 // ============================================================================
@@ -155,7 +151,7 @@ CountDownEvent: {
 }
 
 CountDownEvent.new = (count: i32) CountDownEvent {
-    return CountDownEvent { initial: count, current: count }
+    CountDownEvent { initial: count, current: count }
 }
 
 CountDownEvent.signal = (self: MutPtr<CountDownEvent>) void {
@@ -178,5 +174,5 @@ CountDownEvent.reset = (self: MutPtr<CountDownEvent>) void {
 
 CountDownEvent.is_set = (self: Ptr<CountDownEvent>) bool {
     count = cast(compiler.atomic_load(compiler.raw_ptr_cast(&self.val.current.ref())), i32)
-    return count <= 0
+    count <= 0
 }

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -132,6 +132,7 @@ fn promoted_stdlib_modules_do_not_use_removed_return_keyword() {
         "stdlib/concurrency/sync/mutex.zen",
         "stdlib/concurrency/sync/once.zen",
         "stdlib/concurrency/sync/semaphore.zen",
+        "stdlib/concurrency/sync/waitgroup.zen",
         "stdlib/ffi.zen",
         "stdlib/fs.zen",
         "stdlib/io/eventfd.zen",


### PR DESCRIPTION
## Summary
- remove the removed `return` keyword from `stdlib/concurrency/sync/waitgroup.zen`
- promote the waitgroup sync utilities into the docs-truth no-return guard

## Validation
- guard-first failure observed: `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `rg -n "\breturn\b" stdlib/concurrency/sync/waitgroup.zen` returned no matches
- `cargo test --test docs_truth -- --nocapture`
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- branch push Actions check: `[]`