### PR TITLE
[codex] Remove return from stdlib async actor

### DIFF
--- a/stdlib/concurrency/actor/async_actor.zen
+++ b/stdlib/concurrency/actor/async_actor.zen
@@ -42,89 +42,95 @@ AsyncMailbox.new = (capacity: usize, allocator: Allocator) Result<AsyncMailbox<M
     // Allocate message buffer
     msg_size = compiler.sizeof<M>()
     buffer = allocator.allocate(capacity * msg_size)
-    buffer == 0 ? { return Result.Err(-12) }  // ENOMEM
-
-    // Create eventfd for notification
-    efd_result = Eventfd.new(0)
-    efd_result ? {
-        | Err(e) {
-            allocator.deallocate(buffer, capacity * msg_size)
-            return Result.Err(e.code)
+    buffer == 0 ?
+        | true { Result.Err(-12) }  // ENOMEM
+        | false {
+            // Create eventfd for notification
+            efd_result = Eventfd.new(0)
+            efd_result ? {
+                | Err(e) {
+                    allocator.deallocate(buffer, capacity * msg_size)
+                    Result.Err(e.code)
+                }
+                | Ok(efd) {
+                    Result.Ok(AsyncMailbox<M> {
+                        buffer: buffer,
+                        capacity: capacity,
+                        head: Atomic<i64>.new(0),
+                        tail: Atomic<i64>.new(0),
+                        count: Atomic<i32>.new(0),
+                        notify_fd: efd.fd,
+                        allocator: allocator
+                    })
+                }
+            }
         }
-        | Ok(efd) {
-            return Result.Ok(AsyncMailbox<M> {
-                buffer: buffer,
-                capacity: capacity,
-                head: Atomic<i64>.new(0),
-                tail: Atomic<i64>.new(0),
-                count: Atomic<i32>.new(0),
-                notify_fd: efd.fd,
-                allocator: allocator
-            })
-        }
-    }
 }
 
-// Send message (non-blocking, returns error if full)
+// Send message (non-blocking, yields error if full)
 AsyncMailbox.try_send = (self: MutPtr<AsyncMailbox<M>>, msg: M) Result<(), i32> {
     // Reserve slot atomically
     old_count = self.val.count.fetch_add(1)
-    old_count >= cast(self.val.capacity, i32) ? {
-        // Undo reservation
-        self.val.count.fetch_sub(1)
-        return Result.Err(-11)  // EAGAIN
-    }
+    old_count >= cast(self.val.capacity, i32) ?
+        | true {
+            // Undo reservation
+            self.val.count.fetch_sub(1)
+            Result.Err(-11)  // EAGAIN
+        }
+        | false {
+            // Slot reserved - safe to write
+            tail = self.val.tail.fetch_add(1)
+            idx = tail % cast(self.val.capacity, i64)
+            msg_size = compiler.sizeof<M>()
 
-    // Slot reserved - safe to write
-    tail = self.val.tail.fetch_add(1)
-    idx = tail % cast(self.val.capacity, i64)
-    msg_size = compiler.sizeof<M>()
+            // Write message
+            dest = compiler.int_to_ptr(self.val.buffer + idx * cast(msg_size, i64))
+            compiler.memcpy(dest, compiler.raw_ptr_cast(&msg.ref()), msg_size)
 
-    // Write message
-    dest = compiler.int_to_ptr(self.val.buffer + idx * cast(msg_size, i64))
-    compiler.memcpy(dest, compiler.raw_ptr_cast(&msg.ref()), msg_size)
+            // Signal if mailbox was empty
+            old_count == 0 ? {
+                // Write to eventfd to wake up waiting actor
+                val: u64 = 1
+                compiler.syscall3(SYS_WRITE, self.val.notify_fd, compiler.ptr_to_int(&val.ref()), 8)
+            }
 
-    // Signal if mailbox was empty
-    old_count == 0 ? {
-        // Write to eventfd to wake up waiting actor
-        val: u64 = 1
-        compiler.syscall3(SYS_WRITE, self.val.notify_fd, compiler.ptr_to_int(&val.ref()), 8)
-    }
-
-    return Result.Ok(())
+            Result.Ok(())
+        }
 }
 
 // Receive message (non-blocking)
 AsyncMailbox.try_recv = (self: MutPtr<AsyncMailbox<M>>) Option<M> {
     // Reserve slot atomically
     old_count = self.val.count.fetch_sub(1)
-    old_count <= 0 ? {
-        // Undo reservation
-        self.val.count.fetch_add(1)
-        return Option.None
-    }
+    old_count <= 0 ?
+        | true {
+            // Undo reservation
+            self.val.count.fetch_add(1)
+            Option.None
+        }
+        | false {
+            // Slot reserved - safe to read
+            head = self.val.head.fetch_add(1)
+            idx = head % cast(self.val.capacity, i64)
+            msg_size = compiler.sizeof<M>()
 
-    // Slot reserved - safe to read
-    head = self.val.head.fetch_add(1)
-    idx = head % cast(self.val.capacity, i64)
-    msg_size = compiler.sizeof<M>()
+            // Read message
+            src = compiler.int_to_ptr(self.val.buffer + idx * cast(msg_size, i64))
+            msg: M = compiler.zeroed<M>()
+            compiler.memcpy(compiler.raw_ptr_cast(&msg.mut_ref()), src, msg_size)
 
-    // Read message
-    src = compiler.int_to_ptr(self.val.buffer + idx * cast(msg_size, i64))
-    msg: M = compiler.zeroed<M>()
-    compiler.memcpy(compiler.raw_ptr_cast(&msg.mut_ref()), src, msg_size)
-
-    return Option.Some(msg)
+            Option.Some(msg)
+        }
 }
 
 // Get eventfd for async waiting
 AsyncMailbox.notify_fd = (self: Ptr<AsyncMailbox<M>>) i32 {
-    return self.val.notify_fd
+    self.val.notify_fd
 }
 
 // Check if has messages
 AsyncMailbox.has_messages = (self: Ptr<AsyncMailbox<M>>) bool {
-    return self.val.count.load() > 0
+    self.val.count.load() > 0
 }
 
 AsyncMailbox.free = (self: MutPtr<AsyncMailbox<M>>) void {
@@ -145,12 +151,12 @@ AsyncActorRef<M>: {
 
 AsyncActorRef.send = (self: AsyncActorRef<M>, msg: M) Result<(), i32> {
     mailbox: MutPtr<AsyncMailbox<M>> = cast(compiler.int_to_ptr(self.mailbox), MutPtr<AsyncMailbox<M>>)
-    return mailbox.try_send(msg)
+    mailbox.try_send(msg)
 }
 
 AsyncActorRef.is_alive = (self: AsyncActorRef<M>) bool {
     state_ptr: Ptr<Atomic<i32>> = cast(compiler.int_to_ptr(self.state), Ptr<Atomic<i32>>)
-    return state_ptr.val.load() == 1  // RUNNING
+    state_ptr.val.load() == 1  // RUNNING
 }
 
 // ============================================================================
@@ -186,7 +192,7 @@ AsyncActor<M, B>: {
 async_actor_id_counter: Atomic<i64> = Atomic<i64>.new(1)
 
 next_async_actor_id = () u64 {
-    return cast(async_actor_id_counter.fetch_add(1), u64)
+    cast(async_actor_id_counter.fetch_add(1), u64)
 }
 
 // Create async actor
@@ -195,9 +201,9 @@ AsyncActor.new = (behavior: B, mailbox_size: usize, async_pool: MutPtr<AsyncPool
 
     mailbox_result = AsyncMailbox<M>.new(mailbox_size, allocator)
     mailbox_result ? {
-        | Err(e) { return Result.Err(e) }
+        | Err(e) { Result.Err(e) }
         | Ok(mailbox) {
-            return Result.Ok(AsyncActor<M, B> {
+            Result.Ok(AsyncActor<M, B> {
                 id: next_async_actor_id(),
                 state: Atomic<i32>.new(ASYNC_ACTOR_CREATED),
                 mailbox: mailbox,
@@ -211,7 +217,7 @@ AsyncActor.new = (behavior: B, mailbox_size: usize, async_pool: MutPtr<AsyncPool
 
 // Get reference for message sending
 AsyncActor.ref = (self: Ptr<AsyncActor<M, B>>) AsyncActorRef<M> {
-    return AsyncActorRef<M> {
+    AsyncActorRef<M> {
         id: self.val.id,
         mailbox: compiler.ptr_to_int(compiler.raw_ptr_cast(&self.val.mailbox.ref())),
         state: compiler.ptr_to_int(compiler.raw_ptr_cast(&self.val.state.ref()))
@@ -284,7 +290,7 @@ AsyncActor.free = (self: MutPtr<AsyncActor<M, B>>) void {
 
 spawn_async_actor = (scheduler: MutPtr<Scheduler>, actor_ptr: i64) Result<u64, i32> {
     // The actor's run method becomes a task
-    return scheduler.spawn(actor_run_entry, actor_ptr)
+    scheduler.spawn(actor_run_entry, actor_ptr)
 }
 
 // Entry point for actor task

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -127,6 +127,7 @@ fn promoted_stdlib_modules_do_not_use_removed_return_keyword() {
         "stdlib/collections/queue.zen",
         "stdlib/compiler.zen",
         "stdlib/concurrency/actor/actor.zen",
+        "stdlib/concurrency/actor/async_actor.zen",
         "stdlib/concurrency/primitives/atomic.zen",
         "stdlib/concurrency/primitives/futex.zen",
         "stdlib/concurrency/sync/barrier.zen",


### PR DESCRIPTION
## Summary
- remove the removed `return` keyword from `stdlib/concurrency/actor/async_actor.zen`
- promote the async actor module into the docs-truth no-return guard

## Validation
- guard-first failure observed: `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `rg -n "\breturn\b" stdlib/concurrency/actor/async_actor.zen` returned no matches
- `cargo test --test docs_truth -- --nocapture`
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- branch push Actions check: `[]`