### PR TITLE
[codex] Remove return from stdlib actor system

### DIFF
--- a/stdlib/concurrency/actor/system.zen
+++ b/stdlib/concurrency/actor/system.zen
@@ -40,7 +40,7 @@ ActorSystem.new = (name_ptr: i64, allocator: Allocator) ActorSystem {
     // Create root supervisor with one-for-one strategy
     root_sup = Supervisor.new(0, 10, 60, allocator)  // STRATEGY_ONE_FOR_ONE
 
-    return ActorSystem {
+    ActorSystem {
         name: name_ptr,
         state: Atomic<i32>.new(SYSTEM_CREATED),
         actor_count: Atomic<i64>.new(0),
@@ -57,7 +57,7 @@ ActorSystem.start = (self: MutPtr<ActorSystem>) Result<(), i32> {
 
     // Start root supervisor
     root_sup: MutPtr<Supervisor> = cast(compiler.int_to_ptr(self.val.root_supervisor), MutPtr<Supervisor>)
-    return root_sup.start()
+    root_sup.start()
 }
 
 // Shutdown the actor system gracefully
@@ -73,12 +73,12 @@ ActorSystem.shutdown = (self: MutPtr<ActorSystem>) void {
 
 // Check if system is running
 ActorSystem.is_running = (self: Ptr<ActorSystem>) bool {
-    return self.val.state.load() == SYSTEM_RUNNING
+    self.val.state.load() == SYSTEM_RUNNING
 }
 
 // Get number of active actors
 ActorSystem.actor_count = (self: Ptr<ActorSystem>) i64 {
-    return self.val.actor_count.load()
+    self.val.actor_count.load()
 }
 
 // ============================================================================
@@ -87,11 +87,11 @@ ActorSystem.actor_count = (self: Ptr<ActorSystem>) i64 {
 // Note: Full spawning requires Thread integration.
 // This provides the framework; actual thread creation handled separately.
 
-// Spawn an actor (returns ActorRef)
+// Spawn an actor (yields ActorRef)
 // The actor runs in the current thread - for threaded actors, use spawn_threaded
 ActorSystem.spawn = (self: MutPtr<ActorSystem>, actor_ptr: i64) i64 {
     self.val.actor_count.fetch_add(1)
-    return actor_ptr
+    actor_ptr
 }
 
 // Spawn an actor on a dedicated OS thread
@@ -104,10 +104,10 @@ ActorSystem.spawn_threaded = (self: MutPtr<ActorSystem>, actor_ptr: i64) Result<
     result ? {
         | Err(e) {
             self.val.actor_count.fetch_sub(1)
-            return Result.Err(e)
+            Result.Err(e)
         }
         | Ok(handle) {
-            return Result.Ok(handle)
+            Result.Ok(handle)
         }
     }
 }
@@ -146,7 +146,7 @@ hash_name = (name_ptr: i64, len: usize) u64 {
         hash = ((hash << 5) + hash) + cast(c, u64)
         i = i + 1
     }
-    return hash
+    hash
 }
 
 // Register an actor by name
@@ -157,17 +157,15 @@ ActorSystem.register = (self: MutPtr<ActorSystem>, name_ptr: i64, name_len: usiz
 
     // Check if already exists
     existing = self.val.registry.get(hash)
-    existing ? {
-        | Some(_) {
-            self.val.registry_lock.unlock()
-            return Result.Err(-17)  // EEXIST
+    result = existing ? {
+        | Some(_) { Result.Err(-17) }  // EEXIST
+        | None {
+            self.val.registry.insert(hash, actor_ref)
+            Result.Ok(())
         }
-        | None { }
     }
-
-    self.val.registry.insert(hash, actor_ref)
     self.val.registry_lock.unlock()
-    return Result.Ok(())
+    result
 }
 
 // Lookup actor by name
@@ -178,7 +176,7 @@ ActorSystem.lookup = (self: MutPtr<ActorSystem>, name_ptr: i64, name_len: usize)
     result = self.val.registry.get(hash)
     self.val.registry_lock.unlock()
 
-    return result
+    result
 }
 
 // Unregister an actor

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -129,6 +129,7 @@ fn promoted_stdlib_modules_do_not_use_removed_return_keyword() {
         "stdlib/concurrency/actor/actor.zen",
         "stdlib/concurrency/actor/async_actor.zen",
         "stdlib/concurrency/actor/supervisor.zen",
+        "stdlib/concurrency/actor/system.zen",
         "stdlib/concurrency/primitives/atomic.zen",
         "stdlib/concurrency/primitives/futex.zen",
         "stdlib/concurrency/sync/barrier.zen",


### PR DESCRIPTION
## Summary
- remove the removed `return` keyword from `stdlib/concurrency/actor/system.zen`
- promote the actor system module into the docs-truth no-return guard

## Validation
- guard-first failure observed: `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `rg -n "\breturn\b" stdlib/concurrency/actor/system.zen` returned no matches
- `cargo test --test docs_truth -- --nocapture`
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- branch push Actions check: `[]`