### PR TITLE
[codex] Remove return from stdlib file link

### DIFF
--- a/stdlib/io/files/link.zen
+++ b/stdlib/io/files/link.zen
@@ -26,15 +26,17 @@ RENAME_WHITEOUT = 4          // Whiteout source (overlay fs)
 // Create a hard link
 link = (old_path: i64, new_path: i64) Result<(), i32> {
     result = compiler.syscall2(SYS_LINK, old_path, new_path)
-    result < 0 ? { return Result.Err(cast(result, i32)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(cast(result, i32)) }
+        | false { Result.Ok(()) }
 }
 
 // Create hard link relative to directory fds
 linkat = (old_dirfd: i32, old_path: i64, new_dirfd: i32, new_path: i64, flags: i32) Result<(), i32> {
     result = compiler.syscall5(SYS_LINKAT, old_dirfd, old_path, new_dirfd, new_path, flags)
-    result < 0 ? { return Result.Err(cast(result, i32)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(cast(result, i32)) }
+        | false { Result.Ok(()) }
 }
 
 // ============================================================================
@@ -44,30 +46,34 @@ linkat = (old_dirfd: i32, old_path: i64, new_dirfd: i32, new_path: i64, flags: i
 // Create a symbolic link
 symlink = (target: i64, link_path: i64) Result<(), i32> {
     result = compiler.syscall2(SYS_SYMLINK, target, link_path)
-    result < 0 ? { return Result.Err(cast(result, i32)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(cast(result, i32)) }
+        | false { Result.Ok(()) }
 }
 
 // Create symbolic link relative to directory fd
 symlinkat = (target: i64, dirfd: i32, link_path: i64) Result<(), i32> {
     result = compiler.syscall3(SYS_SYMLINKAT, target, dirfd, link_path)
-    result < 0 ? { return Result.Err(cast(result, i32)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(cast(result, i32)) }
+        | false { Result.Ok(()) }
 }
 
 // Read the target of a symbolic link
 // Returns number of bytes written to buf (not null-terminated)
 readlink = (path: i64, buf: i64, buf_size: usize) Result<usize, i32> {
     result = compiler.syscall3(SYS_READLINK, path, buf, buf_size)
-    result < 0 ? { return Result.Err(cast(result, i32)) }
-    return Result.Ok(cast(result, usize))
+    result < 0 ?
+        | true { Result.Err(cast(result, i32)) }
+        | false { Result.Ok(cast(result, usize)) }
 }
 
 // Read symlink relative to directory fd
 readlinkat = (dirfd: i32, path: i64, buf: i64, buf_size: usize) Result<usize, i32> {
     result = compiler.syscall4(SYS_READLINKAT, dirfd, path, buf, buf_size)
-    result < 0 ? { return Result.Err(cast(result, i32)) }
-    return Result.Ok(cast(result, usize))
+    result < 0 ?
+        | true { Result.Err(cast(result, i32)) }
+        | false { Result.Ok(cast(result, usize)) }
 }
 
 // ============================================================================
@@ -77,25 +83,27 @@ readlinkat = (dirfd: i32, path: i64, buf: i64, buf_size: usize) Result<usize, i3
 // Remove a file
 unlink = (path: i64) Result<(), i32> {
     result = compiler.syscall1(SYS_UNLINK, path)
-    result < 0 ? { return Result.Err(cast(result, i32)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(cast(result, i32)) }
+        | false { Result.Ok(()) }
 }
 
 // Remove file or directory relative to directory fd
 unlinkat = (dirfd: i32, path: i64, flags: i32) Result<(), i32> {
     result = compiler.syscall3(SYS_UNLINKAT, dirfd, path, flags)
-    result < 0 ? { return Result.Err(cast(result, i32)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(cast(result, i32)) }
+        | false { Result.Ok(()) }
 }
 
 // Remove a file (convenience - alias for unlink)
 remove_file = (path: i64) Result<(), i32> {
-    return unlink(path)
+    unlink(path)
 }
 
 // Remove an empty directory
 remove_dir = (path: i64) Result<(), i32> {
-    return unlinkat(AT_FDCWD, path, AT_REMOVEDIR)
+    unlinkat(AT_FDCWD, path, AT_REMOVEDIR)
 }
 
 // ============================================================================
@@ -105,32 +113,35 @@ remove_dir = (path: i64) Result<(), i32> {
 // Rename/move a file or directory
 rename = (old_path: i64, new_path: i64) Result<(), i32> {
     result = compiler.syscall2(SYS_RENAME, old_path, new_path)
-    result < 0 ? { return Result.Err(cast(result, i32)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(cast(result, i32)) }
+        | false { Result.Ok(()) }
 }
 
 // Rename relative to directory fds
 renameat = (old_dirfd: i32, old_path: i64, new_dirfd: i32, new_path: i64) Result<(), i32> {
     result = compiler.syscall4(SYS_RENAMEAT, old_dirfd, old_path, new_dirfd, new_path)
-    result < 0 ? { return Result.Err(cast(result, i32)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(cast(result, i32)) }
+        | false { Result.Ok(()) }
 }
 
 // Rename with flags (RENAME_NOREPLACE, RENAME_EXCHANGE)
 renameat2 = (old_dirfd: i32, old_path: i64, new_dirfd: i32, new_path: i64, flags: u32) Result<(), i32> {
     result = compiler.syscall5(SYS_RENAMEAT2, old_dirfd, old_path, new_dirfd, new_path, flags)
-    result < 0 ? { return Result.Err(cast(result, i32)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(cast(result, i32)) }
+        | false { Result.Ok(()) }
 }
 
 // Rename without overwriting existing target
 rename_noreplace = (old_path: i64, new_path: i64) Result<(), i32> {
-    return renameat2(AT_FDCWD, old_path, AT_FDCWD, new_path, RENAME_NOREPLACE)
+    renameat2(AT_FDCWD, old_path, AT_FDCWD, new_path, RENAME_NOREPLACE)
 }
 
 // Atomically exchange two paths
 rename_exchange = (path_a: i64, path_b: i64) Result<(), i32> {
-    return renameat2(AT_FDCWD, path_a, AT_FDCWD, path_b, RENAME_EXCHANGE)
+    renameat2(AT_FDCWD, path_a, AT_FDCWD, path_b, RENAME_EXCHANGE)
 }
 
 // ============================================================================
@@ -139,22 +150,24 @@ rename_exchange = (path_a: i64, path_b: i64) Result<(), i32> {
 
 // Move a file (alias for rename)
 move_file = (from: i64, to: i64) Result<(), i32> {
-    return rename(from, to)
+    rename(from, to)
 }
 
 // Copy symlink target to buffer and null-terminate
 // Returns length of target (not including null)
 readlink_z = (path: i64, buf: i64, buf_size: usize) Result<usize, i32> {
-    buf_size == 0 ? { return Result.Err(-22) }  // EINVAL
-
-    // Read with one less byte for null terminator
-    result = readlink(path, buf, buf_size - 1)
-    result ? {
-        | Ok(len) {
-            // Null terminate
-            compiler.store<u8>(compiler.int_to_ptr(buf + cast(len, i64)), 0)
-            return Result.Ok(len)
+    buf_size == 0 ?
+        | true { Result.Err(-22) }  // EINVAL
+        | false {
+            // Read with one less byte for null terminator
+            result = readlink(path, buf, buf_size - 1)
+            result ? {
+                | Ok(len) {
+                    // Null terminate
+                    compiler.store<u8>(compiler.int_to_ptr(buf + cast(len, i64)), 0)
+                    Result.Ok(len)
+                }
+                | Err(e) { Result.Err(e) }
+            }
         }
-        | Err(e) { return Result.Err(e) }
-    }
 }

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -154,6 +154,7 @@ fn promoted_stdlib_modules_do_not_use_removed_return_keyword() {
         "stdlib/io/eventfd.zen",
         "stdlib/io/files/copy.zen",
         "stdlib/io/files/dir.zen",
+        "stdlib/io/files/link.zen",
         "stdlib/io/files/splice.zen",
         "stdlib/io/inotify.zen",
         "stdlib/io/io.zen",


### PR DESCRIPTION
## Summary
- remove the removed `return` keyword from `stdlib/io/files/link.zen`
- preserve link/unlink/rename/readlink wrapper behavior with expression branches
- promote file link into the docs-truth no-return guard

## Validation
- guard-first failure observed: `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `rg -n "return " stdlib/io/files/link.zen` returned no matches
- `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- branch push Actions check: `[]`