### PR TITLE
[codex] Remove return from stdlib file fs

### DIFF
--- a/stdlib/io/files/fs.zen
+++ b/stdlib/io/files/fs.zen
@@ -31,22 +31,25 @@ UTIME_OMIT = 1073741822  // Don't change (0x3ffffffe)
 // Change file mode bits
 chmod = (path: i64, mode: u32) Result<(), i32> {
     result = compiler.syscall2(SYS_CHMOD, path, mode)
-    result < 0 ? { return Result.Err(cast(result, i32)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(cast(result, i32)) }
+        | false { Result.Ok(()) }
 }
 
 // Change mode on open file descriptor
 fchmod = (fd: i32, mode: u32) Result<(), i32> {
     result = compiler.syscall2(SYS_FCHMOD, fd, mode)
-    result < 0 ? { return Result.Err(cast(result, i32)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(cast(result, i32)) }
+        | false { Result.Ok(()) }
 }
 
 // Change mode relative to directory fd
 fchmodat = (dirfd: i32, path: i64, mode: u32, flags: i32) Result<(), i32> {
     result = compiler.syscall4(SYS_FCHMODAT, dirfd, path, mode, flags)
-    result < 0 ? { return Result.Err(cast(result, i32)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(cast(result, i32)) }
+        | false { Result.Ok(()) }
 }
 
 // ============================================================================
@@ -57,29 +60,33 @@ fchmodat = (dirfd: i32, path: i64, mode: u32, flags: i32) Result<(), i32> {
 // Use -1 for uid/gid to leave unchanged
 chown = (path: i64, uid: u32, gid: u32) Result<(), i32> {
     result = compiler.syscall3(SYS_CHOWN, path, uid, gid)
-    result < 0 ? { return Result.Err(cast(result, i32)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(cast(result, i32)) }
+        | false { Result.Ok(()) }
 }
 
 // Change ownership on open file descriptor
 fchown = (fd: i32, uid: u32, gid: u32) Result<(), i32> {
     result = compiler.syscall3(SYS_FCHOWN, fd, uid, gid)
-    result < 0 ? { return Result.Err(cast(result, i32)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(cast(result, i32)) }
+        | false { Result.Ok(()) }
 }
 
 // Change ownership of symlink itself (not target)
 lchown = (path: i64, uid: u32, gid: u32) Result<(), i32> {
     result = compiler.syscall3(SYS_LCHOWN, path, uid, gid)
-    result < 0 ? { return Result.Err(cast(result, i32)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(cast(result, i32)) }
+        | false { Result.Ok(()) }
 }
 
 // Change ownership relative to directory fd
 fchownat = (dirfd: i32, path: i64, uid: u32, gid: u32, flags: i32) Result<(), i32> {
     result = compiler.syscall5(SYS_FCHOWNAT, dirfd, path, uid, gid, flags)
-    result < 0 ? { return Result.Err(cast(result, i32)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(cast(result, i32)) }
+        | false { Result.Ok(()) }
 }
 
 // ============================================================================
@@ -90,23 +97,25 @@ fchownat = (dirfd: i32, path: i64, uid: u32, gid: u32, flags: i32) Result<(), i3
 // mode: F_OK, R_OK, W_OK, X_OK (can be ORed together)
 access = (path: i64, mode: i32) Result<(), i32> {
     result = compiler.syscall2(SYS_ACCESS, path, mode)
-    result < 0 ? { return Result.Err(cast(result, i32)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(cast(result, i32)) }
+        | false { Result.Ok(()) }
 }
 
 // Check access relative to directory fd
 faccessat = (dirfd: i32, path: i64, mode: i32, flags: i32) Result<(), i32> {
     result = compiler.syscall4(SYS_FACCESSAT, dirfd, path, mode, flags)
-    result < 0 ? { return Result.Err(cast(result, i32)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(cast(result, i32)) }
+        | false { Result.Ok(()) }
 }
 
 // Check if file exists
 exists = (path: i64) bool {
     result = access(path, F_OK)
     result ? {
-        | Ok(_) { return true }
-        | Err(_) { return false }
+        | Ok(_) { true }
+        | Err(_) { false }
     }
 }
 
@@ -114,8 +123,8 @@ exists = (path: i64) bool {
 is_readable = (path: i64) bool {
     result = access(path, R_OK)
     result ? {
-        | Ok(_) { return true }
-        | Err(_) { return false }
+        | Ok(_) { true }
+        | Err(_) { false }
     }
 }
 
@@ -123,8 +132,8 @@ is_readable = (path: i64) bool {
 is_writable = (path: i64) bool {
     result = access(path, W_OK)
     result ? {
-        | Ok(_) { return true }
-        | Err(_) { return false }
+        | Ok(_) { true }
+        | Err(_) { false }
     }
 }
 
@@ -132,8 +141,8 @@ is_writable = (path: i64) bool {
 is_executable = (path: i64) bool {
     result = access(path, X_OK)
     result ? {
-        | Ok(_) { return true }
-        | Err(_) { return false }
+        | Ok(_) { true }
+        | Err(_) { false }
     }
 }
 
@@ -144,15 +153,17 @@ is_executable = (path: i64) bool {
 // Truncate file to specified length
 truncate = (path: i64, length: i64) Result<(), i32> {
     result = compiler.syscall2(SYS_TRUNCATE, path, length)
-    result < 0 ? { return Result.Err(cast(result, i32)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(cast(result, i32)) }
+        | false { Result.Ok(()) }
 }
 
 // Truncate open file descriptor
 ftruncate = (fd: i32, length: i64) Result<(), i32> {
     result = compiler.syscall2(SYS_FTRUNCATE, fd, length)
-    result < 0 ? { return Result.Err(cast(result, i32)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(cast(result, i32)) }
+        | false { Result.Ok(()) }
 }
 
 // ============================================================================
@@ -167,22 +178,25 @@ sync = () void {
 // Sync filesystem containing fd
 syncfs = (fd: i32) Result<(), i32> {
     result = compiler.syscall1(SYS_SYNCFS, fd)
-    result < 0 ? { return Result.Err(cast(result, i32)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(cast(result, i32)) }
+        | false { Result.Ok(()) }
 }
 
 // Sync file data and metadata to disk
 fsync = (fd: i32) Result<(), i32> {
     result = compiler.syscall1(SYS_FSYNC, fd)
-    result < 0 ? { return Result.Err(cast(result, i32)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(cast(result, i32)) }
+        | false { Result.Ok(()) }
 }
 
 // Sync only file data (not metadata)
 fdatasync = (fd: i32) Result<(), i32> {
     result = compiler.syscall1(SYS_FDATASYNC, fd)
-    result < 0 ? { return Result.Err(cast(result, i32)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(cast(result, i32)) }
+        | false { Result.Ok(()) }
 }
 
 // ============================================================================
@@ -199,8 +213,9 @@ Timespec: {
 // Use UTIME_NOW or UTIME_OMIT for special handling
 utimensat = (dirfd: i32, path: i64, times_ptr: i64, flags: i32) Result<(), i32> {
     result = compiler.syscall4(SYS_UTIMENSAT, dirfd, path, times_ptr, flags)
-    result < 0 ? { return Result.Err(cast(result, i32)) }
-    return Result.Ok(())
+    result < 0 ?
+        | true { Result.Err(cast(result, i32)) }
+        | false { Result.Ok(()) }
 }
 
 // Touch file (update timestamps to now)
@@ -209,7 +224,7 @@ touch = (path: i64) Result<(), i32> {
         Timespec { tv_sec: 0, tv_nsec: UTIME_NOW },
         Timespec { tv_sec: 0, tv_nsec: UTIME_NOW }
     ]
-    return utimensat(AT_FDCWD, path, compiler.ptr_to_int(compiler.raw_ptr_cast(&times.ref())), 0)
+    utimensat(AT_FDCWD, path, compiler.ptr_to_int(compiler.raw_ptr_cast(&times.ref())), 0)
 }
 
 // Touch via file descriptor (update timestamps to now)
@@ -218,5 +233,5 @@ ftouch = (fd: i32) Result<(), i32> {
         Timespec { tv_sec: 0, tv_nsec: UTIME_NOW },
         Timespec { tv_sec: 0, tv_nsec: UTIME_NOW }
     ]
-    return utimensat(fd, 0, compiler.ptr_to_int(compiler.raw_ptr_cast(&times.ref())), AT_EMPTY_PATH)
+    utimensat(fd, 0, compiler.ptr_to_int(compiler.raw_ptr_cast(&times.ref())), AT_EMPTY_PATH)
 }

--- a/tests/docs_truth/repo_hygiene.rs
+++ b/tests/docs_truth/repo_hygiene.rs
@@ -154,6 +154,7 @@ fn promoted_stdlib_modules_do_not_use_removed_return_keyword() {
         "stdlib/io/eventfd.zen",
         "stdlib/io/files/copy.zen",
         "stdlib/io/files/dir.zen",
+        "stdlib/io/files/fs.zen",
         "stdlib/io/files/link.zen",
         "stdlib/io/files/splice.zen",
         "stdlib/io/files/stat.zen",


### PR DESCRIPTION
## Summary
- remove the removed `return` keyword from `stdlib/io/files/fs.zen`
- preserve filesystem syscall wrapper behavior with expression branches and tail expressions
- promote file fs into the docs-truth no-return guard

## Validation
- guard-first failure observed: `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `rg -n "return " stdlib/io/files/fs.zen` returned no matches
- `cargo test --test docs_truth promoted_stdlib_modules_do_not_use_removed_return_keyword -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- branch push Actions check: `[]`
