### PR TITLE
[codex] Record stdlib no-return audit evidence

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3412,13 +3412,16 @@ and do not assume Phase 4 is ready without evidence.
 - All executing/checking `build.zen` command entrypoints now reject ordinary
   unknown executable target fields before creating outputs. Coverage:
   `build_zen_commands_reject_unknown_target_fields`.
-- The stdlib build DSL, compiler/FFI bridges, environment, filesystem, IO, math, random, time, and memory facades,
-  testing facade, memory allocator wrappers plus arena, async, heap, and mmap helpers, and
-  core `Option`, `Result`, propagation, byte-buffer, iterator, pointer, and
-  slice helpers no longer use the removed `return` keyword, guarded by
-  `promoted_stdlib_modules_do_not_use_removed_return_keyword`, establishing
-  the first small stdlib cleanup gate before broader stdlib compilation is
-  promoted.
+- The stdlib build DSL, compiler/FFI bridges, environment, filesystem, IO,
+  math, random, time, and memory facades, testing facade, memory allocator
+  wrappers plus arena, async, heap, and mmap helpers, and core `Option`,
+  `Result`, propagation, byte-buffer, iterator, pointer, and slice helpers no
+  longer use the removed `return` keyword. The final sweep includes
+  `stdlib/io/net/unix_socket.zen`, `stdlib/io/net/socket.zen`,
+  `stdlib/io/files/file.zen`, and `stdlib/sys/process/prctl.zen`, and is
+  guarded by `promoted_stdlib_modules_do_not_use_removed_return_keyword`,
+  establishing the first small stdlib cleanup gate before broader stdlib
+  compilation is promoted.
 - Root smoke fixtures under `tests/test_*.zen` no longer use the removed
   `return` keyword and are guarded by
   `root_smoke_fixtures_do_not_use_removed_return_keyword`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3084,13 +3084,16 @@ checked-in docs, tests, and commits only.
 - All executing/checking `build.zen` command entrypoints now reject ordinary
   unknown target fields before outputs are created, covered by
   `build_zen_commands_reject_unknown_target_fields`.
-- The stdlib build DSL, compiler/FFI bridges, environment, filesystem, IO, math, random, time, and memory facades,
-  testing facade, memory allocator wrappers plus arena, async, heap, and mmap helpers, and
-  core `Option`, `Result`, propagation, byte-buffer, iterator, pointer, and
-  slice helpers no longer use the removed `return` keyword, guarded by
-  `promoted_stdlib_modules_do_not_use_removed_return_keyword`, so the
-  first stdlib compilation cleanup point stays aligned with expression-tail
-  returns before broader stdlib parsing/building is promoted.
+- The stdlib build DSL, compiler/FFI bridges, environment, filesystem, IO,
+  math, random, time, and memory facades, testing facade, memory allocator
+  wrappers plus arena, async, heap, and mmap helpers, and core `Option`,
+  `Result`, propagation, byte-buffer, iterator, pointer, and slice helpers no
+  longer use the removed `return` keyword. The final sweep includes
+  `stdlib/io/net/unix_socket.zen`, `stdlib/io/net/socket.zen`,
+  `stdlib/io/files/file.zen`, and `stdlib/sys/process/prctl.zen`, guarded by
+  `promoted_stdlib_modules_do_not_use_removed_return_keyword`, so the first
+  stdlib compilation cleanup point stays aligned with expression-tail returns
+  before broader stdlib parsing/building is promoted.
 - Root smoke fixtures under `tests/test_*.zen` now use expression-tail returns
   instead of the removed `return` keyword, guarded by
   `root_smoke_fixtures_do_not_use_removed_return_keyword`.

--- a/tests/docs_truth/phase_audit.rs
+++ b/tests/docs_truth/phase_audit.rs
@@ -181,6 +181,11 @@ fn phase_plan_records_recovered_progress_and_next_slice() {
         "generic_bound_nongeneric_behavior_type_args_are_error",
         "generic_enum_constructor_without_type_args_is_error",
         "type_declaration_keyword_owns_text_spelling",
+        "promoted_stdlib_modules_do_not_use_removed_return_keyword",
+        "stdlib/io/net/unix_socket.zen",
+        "stdlib/io/net/socket.zen",
+        "stdlib/io/files/file.zen",
+        "stdlib/sys/process/prctl.zen",
     ] {
         assert!(
             plan.contains(required),
@@ -367,6 +372,11 @@ fn completion_audit_records_recovery_objective_evidence_and_gaps() {
         "behavior_extends_nongeneric_parent_type_args_are_error",
         "generic_bound_nongeneric_behavior_type_args_are_error",
         "generic_enum_constructor_without_type_args_is_error",
+        "promoted_stdlib_modules_do_not_use_removed_return_keyword",
+        "stdlib/io/net/unix_socket.zen",
+        "stdlib/io/net/socket.zen",
+        "stdlib/io/files/file.zen",
+        "stdlib/sys/process/prctl.zen",
     ] {
         assert!(
             audit.contains(required),


### PR DESCRIPTION
## Summary

- record the completed promoted-stdlib no-return sweep in the durable phase plan and completion audit
- require representative final-sweep stdlib paths in the docs-truth phase audit
- keep the cleanup evidence tied to `promoted_stdlib_modules_do_not_use_removed_return_keyword`

## Validation

- `cargo test --test docs_truth phase_audit -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Branch-push Actions stayed quiet: `gh run list --repo lantos1618/zenlang --branch codex/record-stdlib-no-return-audit --limit 10 --json databaseId,status,conclusion,name,event,headSha` returned `[]`.