### PR TITLE
Cover generic function slice inference conflicts

### DIFF
--- a/tests/generic_diagnostics/inference_conflicts.rs
+++ b/tests/generic_diagnostics/inference_conflicts.rs
@@ -106,3 +106,26 @@ main = () i32 {
         "expected generic function raw-pointer inference conflict diagnostic, got {errors:?}"
     );
 }
+
+#[test]
+fn generic_function_inference_conflict_through_slice_type_is_error() {
+    let errors = typecheck_errors(
+        r#"
+choose_slice<T> = (left: T, items: Slice<T>) T {
+    left
+}
+
+main = () i32 {
+    items = cast("bad", Slice<str>)
+    choose_slice(1, items)
+}
+"#,
+    );
+
+    assert!(
+        errors.iter().any(|d| d.message.contains(
+            "conflicting inferred type argument `T` for generic function `choose_slice`: inferred `i32` and `str`"
+        )),
+        "expected generic function slice inference conflict diagnostic, got {errors:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Add Phase 5 diagnostic coverage for generic function inference conflicts through `Slice<T>` parameters.
- Align generic function conflict coverage with the existing generic method slice conflict case.

## Validation

- `cargo test --test generic_diagnostics generic_function_inference_conflict_through_slice_type_is_error -- --nocapture`
- `git diff --check && cargo fmt --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`

Branch-push Actions check: `gh run list --repo lantos1618/zenlang --branch codex/cover-generic-function-slice-inference --limit 10 --json databaseId,status,conclusion,name,event,headSha,createdAt` returned `[]`.