### PR TITLE
Cover generic function pointer inference conflicts

### DIFF
--- a/tests/generic_diagnostics/inference_conflicts.rs
+++ b/tests/generic_diagnostics/inference_conflicts.rs
@@ -108,6 +108,52 @@ main = () i32 {
 }
 
 #[test]
+fn generic_function_inference_conflict_through_pointer_type_is_error() {
+    let errors = typecheck_errors(
+        r#"
+choose_ptr<T> = (left: T, ptr: Ptr<T>) T {
+    left
+}
+
+main = () i32 {
+    ptr = cast("bad", Ptr<str>)
+    choose_ptr(1, ptr)
+}
+"#,
+    );
+
+    assert!(
+        errors.iter().any(|d| d.message.contains(
+            "conflicting inferred type argument `T` for generic function `choose_ptr`: inferred `i32` and `str`"
+        )),
+        "expected generic function pointer inference conflict diagnostic, got {errors:?}"
+    );
+}
+
+#[test]
+fn generic_function_inference_conflict_through_mut_pointer_type_is_error() {
+    let errors = typecheck_errors(
+        r#"
+choose_mut_ptr<T> = (left: T, ptr: MutPtr<T>) T {
+    left
+}
+
+main = () i32 {
+    ptr = cast("bad", MutPtr<str>)
+    choose_mut_ptr(1, ptr)
+}
+"#,
+    );
+
+    assert!(
+        errors.iter().any(|d| d.message.contains(
+            "conflicting inferred type argument `T` for generic function `choose_mut_ptr`: inferred `i32` and `str`"
+        )),
+        "expected generic function mutable pointer inference conflict diagnostic, got {errors:?}"
+    );
+}
+
+#[test]
 fn generic_function_inference_conflict_through_slice_type_is_error() {
     let errors = typecheck_errors(
         r#"


### PR DESCRIPTION
## Summary

- Add Phase 5 hard-diagnostic coverage for generic function inference conflicts through `Ptr<T>` parameters.
- Add matching coverage for `MutPtr<T>` parameters so generic function inference has explicit pointer-shape coverage alongside raw pointer and slice cases.

## Validation

- `cargo test --test generic_diagnostics generic_function_inference_conflict_through_pointer_type_is_error -- --nocapture`
- `cargo test --test generic_diagnostics generic_function_inference_conflict_through_mut_pointer_type_is_error -- --nocapture`
- `git diff --check && cargo fmt --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`

Branch-push Actions check: `gh run list --repo lantos1618/zenlang --branch codex/cover-generic-function-pointer-inference --limit 10 --json databaseId,status,conclusion,name,event,headSha,createdAt` returned `[]`.