### PR TITLE
Cover generic function nested type inference conflicts

### DIFF
--- a/tests/generic_diagnostics/inference_conflicts.rs
+++ b/tests/generic_diagnostics/inference_conflicts.rs
@@ -175,3 +175,57 @@ main = () i32 {
         "expected generic function slice inference conflict diagnostic, got {errors:?}"
     );
 }
+
+#[test]
+fn generic_function_inference_conflict_through_generic_struct_type_is_error() {
+    let errors = typecheck_errors(
+        r#"
+Box<T>: {
+    value: T
+}
+
+choose_box<T> = (left: T, box: Box<T>) T {
+    left
+}
+
+main = () i32 {
+    box = Box<str> { value: "bad" }
+    choose_box(1, box)
+}
+"#,
+    );
+
+    assert!(
+        errors.iter().any(|d| d.message.contains(
+            "conflicting inferred type argument `T` for generic function `choose_box`: inferred `i32` and `str`"
+        )),
+        "expected generic function struct inference conflict diagnostic, got {errors:?}"
+    );
+}
+
+#[test]
+fn generic_function_inference_conflict_through_generic_enum_type_is_error() {
+    let errors = typecheck_errors(
+        r#"
+Option<T>:
+    None,
+    Some(T)
+
+choose_option<T> = (left: T, value: Option<T>) T {
+    left
+}
+
+main = () i32 {
+    value = Option<str>.Some("bad")
+    choose_option(1, value)
+}
+"#,
+    );
+
+    assert!(
+        errors.iter().any(|d| d.message.contains(
+            "conflicting inferred type argument `T` for generic function `choose_option`: inferred `i32` and `str`"
+        )),
+        "expected generic function enum inference conflict diagnostic, got {errors:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Add Phase 5 hard-diagnostic coverage for generic function inference conflicts through generic struct parameters like `Box<T>`.
- Add matching coverage for generic enum parameters like `Option<T>`, exercising the `AstType::Generic` inference path.

## Validation

- `cargo test --test generic_diagnostics generic_function_inference_conflict_through_generic_struct_type_is_error -- --nocapture`
- `cargo test --test generic_diagnostics generic_function_inference_conflict_through_generic_enum_type_is_error -- --nocapture`
- `git diff --check && cargo fmt --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`

Branch-push Actions check: `gh run list --repo lantos1618/zenlang --branch codex/cover-generic-function-nested-type-inference --limit 10 --json databaseId,status,conclusion,name,event,headSha,createdAt` returned `[]`.