### PR TITLE
Cover generic method nested type inference conflicts

### DIFF
--- a/tests/generic_diagnostics/inference_conflicts/methods.rs
+++ b/tests/generic_diagnostics/inference_conflicts/methods.rs
@@ -272,3 +272,67 @@ main = () i32 {
         "expected generic method slice inference conflict diagnostic, got {errors:?}"
     );
 }
+
+#[test]
+fn generic_method_inference_conflict_through_generic_struct_type_is_error() {
+    let errors = typecheck_errors(
+        r#"
+Box<T>: {
+    value: T
+}
+
+Holder: {
+    value: i32
+}
+
+Holder.choose_box<T> = (self: Holder, left: T, box: Box<T>) T {
+    left
+}
+
+main = () i32 {
+    holder = Holder { value: 0 }
+    box = Box<str> { value: "bad" }
+    holder.choose_box(1, box)
+}
+"#,
+    );
+
+    assert!(
+        errors.iter().any(|d| d.message.contains(
+            "conflicting inferred type argument `T` for generic method `Holder.choose_box`: inferred `i32` and `str`"
+        )),
+        "expected generic method struct inference conflict diagnostic, got {errors:?}"
+    );
+}
+
+#[test]
+fn generic_method_inference_conflict_through_generic_enum_type_is_error() {
+    let errors = typecheck_errors(
+        r#"
+Option<T>:
+    None,
+    Some(T)
+
+Holder: {
+    value: i32
+}
+
+Holder.choose_option<T> = (self: Holder, left: T, value: Option<T>) T {
+    left
+}
+
+main = () i32 {
+    holder = Holder { value: 0 }
+    value = Option<str>.Some("bad")
+    holder.choose_option(1, value)
+}
+"#,
+    );
+
+    assert!(
+        errors.iter().any(|d| d.message.contains(
+            "conflicting inferred type argument `T` for generic method `Holder.choose_option`: inferred `i32` and `str`"
+        )),
+        "expected generic method enum inference conflict diagnostic, got {errors:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- add generic method inference conflict coverage through nested generic struct parameters
- add generic method inference conflict coverage through nested generic enum parameters

## Verification
- cargo test --test generic_diagnostics generic_method_inference_conflict_through_generic_struct_type_is_error -- --nocapture
- cargo test --test generic_diagnostics generic_method_inference_conflict_through_generic_enum_type_is_error -- --nocapture
- git diff --check && cargo fmt --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests