### PR TITLE
Document generic method nested inference coverage

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -554,7 +554,8 @@ and do not assume Phase 4 is ready without evidence.
   shapes, so nested type parameters inside compound arguments can produce
   direct conflict diagnostics. Generic method inference conflicts now have
   matching compound-shape coverage for function, array, raw-pointer, and slice
-  parameter types in `tests/generic_diagnostics.rs`.
+  parameter types, plus nested generic struct and enum parameter types, in
+  `tests/generic_diagnostics.rs`.
   Resolver rejects duplicate generic type-parameter names across value, type,
   and behavior declarations, covered by
   `resolver_phase2::resolver_rejects_duplicate_type_parameter_names`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -907,8 +907,9 @@ checked-in docs, tests, and commits only.
   Generic inference now also walks function, array, and raw-pointer parameter
   shapes, so nested type parameters inside compound arguments can produce
   direct conflict diagnostics. Generic method inference conflict coverage now
-  mirrors those compound parameter shapes and includes slice parameters, so
-  method receiver inference cannot hide later nested argument conflicts.
+  mirrors those compound parameter shapes and includes slice parameters plus
+  nested generic struct and enum parameters, so method receiver inference
+  cannot hide later nested argument conflicts.
   Resolver now rejects duplicate generic type-parameter names across value,
   type, and behavior declarations, covered by
   `resolver_phase2::resolver_rejects_duplicate_type_parameter_names`.


### PR DESCRIPTION
## Summary
- record the nested generic struct/enum method inference conflict coverage in the phase plan
- mirror that evidence in the completion audit

## Verification
- cargo test --test docs_truth
- cargo test --test generic_diagnostics generic_method_inference_conflict_through_generic_ -- --nocapture
- git diff --check && cargo fmt --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests