### PR TITLE
Cover transitive generic behavior impl overlap

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -973,8 +973,9 @@ and do not assume Phase 4 is ready without evidence.
   validation.
 - Behavior impl coherence rejects overlapping parent/child behavior impls for
   the same type.
-- Behavior impl coherence is covered for specialized generic parent/child
-  overlap and for distinct generic specializations that must remain independent.
+- Behavior impl coherence is covered for direct and transitive specialized
+  generic parent/child overlap and for distinct generic specializations that
+  must remain independent.
   Resolver-restored generic impl refs also drive overlap diagnostics when
   AST-only impl type arguments are stale, covered by
   `typechecker::tests::collect_declarations_with_symbols_reports_overlap_from_restored_impl_type_args`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1208,8 +1208,9 @@ checked-in docs, tests, and commits only.
   validation.
 - Behavior impl coherence rejects overlapping parent/child behavior impls for
   the same type.
-- Behavior impl coherence is now covered for specialized generic parent/child
-  overlap and for distinct generic specializations that must remain independent.
+- Behavior impl coherence is now covered for direct and transitive specialized
+  generic parent/child overlap and for distinct generic specializations that
+  must remain independent.
 - Inherited behavior default methods have executable coverage through
   `tests/zen/behavior_inherited_default_method.zen`.
 - Resolver Phase 2 has started with symbol IDs, separate namespaces, duplicate

--- a/src/typechecker/tests/generic_behaviors/extends/diagnostics.rs
+++ b/src/typechecker/tests/generic_behaviors/extends/diagnostics.rs
@@ -39,6 +39,50 @@ Point.implements(PrettyJson) {
 }
 
 #[test]
+fn behavior_impl_transitive_generic_parent_overlap_is_error() {
+    let program = parse_program(
+        r#"
+Point: { x: i32 }
+
+Json<T>: behavior {
+    encode: (Self) T
+}
+
+CompactJson: behavior {
+    compact: (Self) str
+}
+
+PrettyJson: behavior {
+    pretty: (Self) str
+}
+
+CompactJson.extends(Json<str>)
+PrettyJson.extends(CompactJson)
+
+Point.implements(Json<str>) {
+    encode = (value: Point) str { "point" }
+}
+
+Point.implements(PrettyJson) {
+    encode = (value: Point) str { "point" }
+    compact = (value: Point) str { "compact" }
+    pretty = (value: Point) str { "pretty" }
+}
+"#,
+    );
+
+    let errors = TypeChecker::new()
+        .check_program(&program)
+        .expect_err("transitive specialized parent and child behavior impls should overlap");
+    assert!(
+        errors.iter().any(|d| d.message.contains(
+            "overlapping implementations of behaviors `Json_str` and `PrettyJson` for type `Point`"
+        )),
+        "expected transitive specialized behavior impl overlap diagnostic, got {errors:?}"
+    );
+}
+
+#[test]
 fn behavior_extends_cycle_is_error() {
     let program = parse_program(
         r#"


### PR DESCRIPTION
## Summary
- add behavior coherence coverage for transitive specialized generic parent/child impl overlap
- record the transitive overlap evidence in the phase plan and completion audit

## Verification
- cargo test --lib behavior_impl_transitive_generic_parent_overlap_is_error -- --nocapture
- cargo test --lib generic_behaviors::extends::diagnostics -- --nocapture
- cargo test --test docs_truth
- git diff --check && cargo fmt --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests