### PR TITLE
Cover imported behavior impl overlap

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -888,6 +888,9 @@ and do not assume Phase 4 is ready without evidence.
 - Imported behavior inheritance follows parent behavior imports from the defining
   module, with negative coverage in
   `integration::imported_behavior_extends_imported_parent_requires_parent_methods`.
+- Imported behavior impl coherence rejects entry-module implementations of
+  both an imported generic parent behavior and an imported child behavior,
+  covered by `integration::imported_behavior_extends_parent_impl_overlap_is_error`.
 - Generic dispatch through an imported child behavior can call a method inherited
   from that behavior's imported parent, covered by
   `tests/zen/multi_file_imported_child_parent_dispatch/main.zen`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1098,6 +1098,9 @@ checked-in docs, tests, and commits only.
 - Imported behavior inheritance now follows parent behavior imports from the
   defining module, with negative coverage in
   `integration::imported_behavior_extends_imported_parent_requires_parent_methods`.
+- Imported behavior impl coherence rejects entry-module implementations of
+  both an imported generic parent behavior and an imported child behavior,
+  covered by `integration::imported_behavior_extends_parent_impl_overlap_is_error`.
 - Generic dispatch through an imported child behavior can call a method inherited
   from that behavior's imported parent, covered by
   `tests/zen/multi_file_imported_child_parent_dispatch/main.zen`.

--- a/tests/integration/frontend_diagnostics/behavior_extends.rs
+++ b/tests/integration/frontend_diagnostics/behavior_extends.rs
@@ -124,6 +124,75 @@ main = () i32 {
 }
 
 #[test]
+fn imported_behavior_extends_parent_impl_overlap_is_error() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let traits_path = tmp.path().join("traits.zen");
+    std::fs::write(
+        &traits_path,
+        r#"
+pub Json<T>: behavior {
+    encode: (Self) T
+}
+
+pub PrettyJson: behavior {
+    pretty: (Self) str
+}
+
+PrettyJson.extends(Json<str>)
+"#,
+    )
+    .expect("write traits module");
+
+    let main_path = tmp.path().join("main.zen");
+    std::fs::write(
+        &main_path,
+        r#"
+{ Json, PrettyJson } = traits
+
+Point: {
+    x: i32
+}
+
+Point.implements(Json<str>) {
+    encode = (value: Point) str {
+        "point"
+    }
+}
+
+Point.implements(PrettyJson) {
+    encode = (value: Point) str {
+        "point"
+    }
+
+    pretty = (value: Point) str {
+        "pretty"
+    }
+}
+
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write entry module");
+
+    let panic = std::panic::catch_unwind(|| compile_to_c(&main_path))
+        .expect_err("compile_to_c should reject imported overlapping behavior impls");
+    let message = panic
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| panic.downcast_ref::<&str>().copied())
+        .unwrap_or("<non-string panic>");
+
+    assert!(
+        message.contains(
+            "overlapping implementations of behaviors `Json_str` and `PrettyJson` for type `Point`"
+        ),
+        "expected imported behavior impl overlap diagnostic, panic={message}"
+    );
+}
+
+#[test]
 fn imported_behavior_extends_requires_transitive_parent_methods() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let traits_path = tmp.path().join("traits.zen");


### PR DESCRIPTION
## Summary
- add imported behavior inheritance overlap coverage for implementing both a generic parent behavior and child behavior
- record the imported coherence evidence in the phase plan and completion audit

## Verification
- cargo test --test integration imported_behavior_extends_parent_impl_overlap_is_error -- --nocapture
- cargo test --test integration frontend_diagnostics::behavior_extends -- --nocapture
- cargo test --test docs_truth
- git diff --check && cargo fmt --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests