### PR TITLE
Cover imported transitive behavior impl overlap

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -890,7 +890,9 @@ and do not assume Phase 4 is ready without evidence.
   `integration::imported_behavior_extends_imported_parent_requires_parent_methods`.
 - Imported behavior impl coherence rejects entry-module implementations of
   both an imported generic parent behavior and an imported child behavior,
-  covered by `integration::imported_behavior_extends_parent_impl_overlap_is_error`.
+  including transitive imported parent chains, covered by
+  `integration::imported_behavior_extends_parent_impl_overlap_is_error` and
+  `integration::imported_behavior_extends_transitive_parent_impl_overlap_is_error`.
 - Generic dispatch through an imported child behavior can call a method inherited
   from that behavior's imported parent, covered by
   `tests/zen/multi_file_imported_child_parent_dispatch/main.zen`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1100,7 +1100,9 @@ checked-in docs, tests, and commits only.
   `integration::imported_behavior_extends_imported_parent_requires_parent_methods`.
 - Imported behavior impl coherence rejects entry-module implementations of
   both an imported generic parent behavior and an imported child behavior,
-  covered by `integration::imported_behavior_extends_parent_impl_overlap_is_error`.
+  including transitive imported parent chains, covered by
+  `integration::imported_behavior_extends_parent_impl_overlap_is_error` and
+  `integration::imported_behavior_extends_transitive_parent_impl_overlap_is_error`.
 - Generic dispatch through an imported child behavior can call a method inherited
   from that behavior's imported parent, covered by
   `tests/zen/multi_file_imported_child_parent_dispatch/main.zen`.

--- a/tests/integration/frontend_diagnostics/behavior_extends.rs
+++ b/tests/integration/frontend_diagnostics/behavior_extends.rs
@@ -193,6 +193,84 @@ main = () i32 {
 }
 
 #[test]
+fn imported_behavior_extends_transitive_parent_impl_overlap_is_error() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let traits_path = tmp.path().join("traits.zen");
+    std::fs::write(
+        &traits_path,
+        r#"
+pub Json<T>: behavior {
+    encode: (Self) T
+}
+
+pub CompactJson: behavior {
+    compact: (Self) str
+}
+
+pub PrettyJson: behavior {
+    pretty: (Self) str
+}
+
+CompactJson.extends(Json<str>)
+PrettyJson.extends(CompactJson)
+"#,
+    )
+    .expect("write traits module");
+
+    let main_path = tmp.path().join("main.zen");
+    std::fs::write(
+        &main_path,
+        r#"
+{ Json, PrettyJson } = traits
+
+Point: {
+    x: i32
+}
+
+Point.implements(Json<str>) {
+    encode = (value: Point) str {
+        "point"
+    }
+}
+
+Point.implements(PrettyJson) {
+    encode = (value: Point) str {
+        "point"
+    }
+
+    compact = (value: Point) str {
+        "compact"
+    }
+
+    pretty = (value: Point) str {
+        "pretty"
+    }
+}
+
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write entry module");
+
+    let panic = std::panic::catch_unwind(|| compile_to_c(&main_path))
+        .expect_err("compile_to_c should reject imported transitive overlapping behavior impls");
+    let message = panic
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| panic.downcast_ref::<&str>().copied())
+        .unwrap_or("<non-string panic>");
+
+    assert!(
+        message.contains(
+            "overlapping implementations of behaviors `Json_str` and `PrettyJson` for type `Point`"
+        ),
+        "expected imported transitive behavior impl overlap diagnostic, panic={message}"
+    );
+}
+
+#[test]
 fn imported_behavior_extends_requires_transitive_parent_methods() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let traits_path = tmp.path().join("traits.zen");


### PR DESCRIPTION
## Summary
- add frontend diagnostic coverage for imported transitive behavior impl overlap
- update phase and audit docs to record imported direct and transitive coherence evidence

## Verification
- cargo test --test integration imported_behavior_extends_transitive_parent_impl_overlap_is_error -- --nocapture
- cargo test --test integration frontend_diagnostics::behavior_extends -- --nocapture
- cargo test --test docs_truth
- git diff --check && cargo fmt --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests