### PR TITLE
Cover imported behavior requires missing impl

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -898,7 +898,9 @@ and do not assume Phase 4 is ready without evidence.
   `tests/zen/multi_file_imported_child_parent_dispatch/main.zen`.
 - Entry-module `.requires` assertions over imported public types and imported
   generic behaviors are covered by
-  `tests/zen/multi_file_imported_behavior_requires/main.zen`.
+  `tests/zen/multi_file_imported_behavior_requires/main.zen`, with missing
+  imported generic behavior impl diagnostics covered by
+  `integration::imported_generic_behavior_requires_missing_impl_is_error`.
 - Imported public generic functions preserve behavior bounds whose behavior was
   imported by the source module, covered by
   `tests/zen/multi_file_imported_function_imported_behavior_bound/main.zen`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1108,7 +1108,9 @@ checked-in docs, tests, and commits only.
   `tests/zen/multi_file_imported_child_parent_dispatch/main.zen`.
 - Entry-module `.requires` assertions over imported public types and imported
   generic behaviors are covered by
-  `tests/zen/multi_file_imported_behavior_requires/main.zen`.
+  `tests/zen/multi_file_imported_behavior_requires/main.zen`, with missing
+  imported generic behavior impl diagnostics covered by
+  `integration::imported_generic_behavior_requires_missing_impl_is_error`.
 - Imported public generic functions can use behavior bounds whose behavior was
   imported by the source module, covered by
   `tests/zen/multi_file_imported_function_imported_behavior_bound/main.zen`.

--- a/tests/integration/frontend_diagnostics.rs
+++ b/tests/integration/frontend_diagnostics.rs
@@ -180,3 +180,50 @@ main = () i32 {
         "imported generic function arity failure should not also report argument mismatch, panic={message}"
     );
 }
+
+#[test]
+fn imported_generic_behavior_requires_missing_impl_is_error() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let traits_path = tmp.path().join("traits.zen");
+    std::fs::write(
+        &traits_path,
+        r#"
+pub Json<T>: behavior {
+    encode: (Self) T
+}
+"#,
+    )
+    .expect("write traits module");
+
+    let main_path = tmp.path().join("main.zen");
+    std::fs::write(
+        &main_path,
+        r#"
+{ Json } = traits
+
+Point: {
+    x: i32
+}
+
+Point.requires(Json<str>)
+
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write entry module");
+
+    let panic = std::panic::catch_unwind(|| compile_to_c(&main_path))
+        .expect_err("compile_to_c should reject missing imported behavior requires impl");
+    let message = panic
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| panic.downcast_ref::<&str>().copied())
+        .unwrap_or("<non-string panic>");
+
+    assert!(
+        message.contains("type `Point` does not implement required behavior `Json_str`"),
+        "expected imported generic behavior requires diagnostic, panic={message}"
+    );
+}


### PR DESCRIPTION
## Summary
- add frontend diagnostic coverage for missing imported generic behavior `.requires` implementations
- update phase and audit docs to record the imported `.requires` negative path

## Verification
- cargo test --test integration imported_generic_behavior_requires_missing_impl_is_error -- --nocapture
- cargo test --test integration test_multi_file_imported_behavior_requires -- --nocapture
- cargo test --test docs_truth
- git diff --check && cargo fmt --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests