### PR TITLE
Cover imported requires inherited behavior impl

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -898,8 +898,10 @@ and do not assume Phase 4 is ready without evidence.
   `tests/zen/multi_file_imported_child_parent_dispatch/main.zen`.
 - Entry-module `.requires` assertions over imported public types and imported
   generic behaviors are covered by
-  `tests/zen/multi_file_imported_behavior_requires/main.zen`, with missing
-  imported generic behavior impl diagnostics covered by
+  `tests/zen/multi_file_imported_behavior_requires/main.zen`. Imported
+  `.requires` assertions are also satisfied by inherited child behavior impls
+  through `tests/zen/multi_file_imported_behavior_requires_inherited/main.zen`,
+  with missing imported generic behavior impl diagnostics covered by
   `integration::imported_generic_behavior_requires_missing_impl_is_error`.
 - Imported public generic functions preserve behavior bounds whose behavior was
   imported by the source module, covered by

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1108,8 +1108,10 @@ checked-in docs, tests, and commits only.
   `tests/zen/multi_file_imported_child_parent_dispatch/main.zen`.
 - Entry-module `.requires` assertions over imported public types and imported
   generic behaviors are covered by
-  `tests/zen/multi_file_imported_behavior_requires/main.zen`, with missing
-  imported generic behavior impl diagnostics covered by
+  `tests/zen/multi_file_imported_behavior_requires/main.zen`. Imported
+  `.requires` assertions are also satisfied by inherited child behavior impls
+  through `tests/zen/multi_file_imported_behavior_requires_inherited/main.zen`,
+  with missing imported generic behavior impl diagnostics covered by
   `integration::imported_generic_behavior_requires_missing_impl_is_error`.
 - Imported public generic functions can use behavior bounds whose behavior was
   imported by the source module, covered by

--- a/tests/integration/multi_file_fixtures.rs
+++ b/tests/integration/multi_file_fixtures.rs
@@ -176,6 +176,13 @@ fn test_multi_file_imported_behavior_requires() {
 }
 
 #[test]
+fn test_multi_file_imported_behavior_requires_inherited() {
+    let zen_path = test_dir().join("multi_file_imported_behavior_requires_inherited/main.zen");
+    let actual = compile_and_run(&zen_path);
+    assert_eq!(actual, "inherited-required\n");
+}
+
+#[test]
 fn test_multi_file_imported_function_imported_behavior_bound() {
     let zen_path = test_dir().join("multi_file_imported_function_imported_behavior_bound/main.zen");
     let actual = compile_and_run(&zen_path);

--- a/tests/zen/multi_file_imported_behavior_requires_inherited/base.zen
+++ b/tests/zen/multi_file_imported_behavior_requires_inherited/base.zen
@@ -1,0 +1,3 @@
+pub Json<T>: behavior {
+    encode: (Self) T
+}

--- a/tests/zen/multi_file_imported_behavior_requires_inherited/main.zen
+++ b/tests/zen/multi_file_imported_behavior_requires_inherited/main.zen
@@ -1,0 +1,29 @@
+{ io } = std
+{ Json } = base
+{ PrettyJson } = traits
+
+Point: {
+    x: i32
+}
+
+Point.implements(PrettyJson) {
+    encode = (value: Point) str {
+        "inherited-required"
+    }
+
+    pretty = (value: Point) str {
+        "pretty"
+    }
+}
+
+Point.requires(Json<str>)
+
+encode<T: Json<str>> = (value: T) str {
+    value.encode()
+}
+
+main = () i32 {
+    point = Point { x: 41 }
+    io.println(encode(point))
+    0
+}

--- a/tests/zen/multi_file_imported_behavior_requires_inherited/traits.zen
+++ b/tests/zen/multi_file_imported_behavior_requires_inherited/traits.zen
@@ -1,0 +1,7 @@
+{ Json } = base
+
+pub PrettyJson: behavior {
+    pretty: (Self) str
+}
+
+PrettyJson.extends(Json<str>)


### PR DESCRIPTION
## Summary
- add a multi-file fixture proving imported `.requires(Json<str>)` is satisfied by an imported child behavior implementation
- record the inherited imported `.requires` evidence in the phase plan and completion audit

## Verification
- `cargo test --test integration test_multi_file_imported_behavior_requires -- --nocapture`
- `cargo test --test integration test_multi_file_imported_behavior_requires_inherited -- --nocapture`
- `cargo test --test docs_truth`
- `git diff --check && cargo fmt --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`