### PR TITLE
Cover test graph file effects with unselected targets

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2709,6 +2709,14 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration test_command_multi_target_build_zen_rejects_file_read_without_fallback_before_execution`,
   and
   `cargo test --test integration test_command_multi_target_build_zen_rejects_undeclared_file_read_effects`.
+  Test graphs with unselected executable and library targets keep declared
+  file-read fallback handling and reject undeclared file reads before
+  unselected-target source handling through
+  `cargo test --test integration test_command_build_zen_accepts_declared_file_read_effects_with_unselected_targets`,
+  `cargo test --test integration test_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects_with_unselected_targets`,
+  `cargo test --test integration test_command_build_zen_accepts_identifier_fallback_declared_file_read_effects_with_unselected_targets`,
+  and
+  `cargo test --test integration test_command_build_zen_rejects_undeclared_file_read_effects_before_unselected_targets`.
   Declared deterministic env reads with `.Err`, wildcard, and identifier
   fallback arms are accepted on the same test execution path through
   `cargo test --test integration test_command_build_zen_accepts_declared_env_read_with_fallback`,
@@ -3118,7 +3126,11 @@ and do not assume Phase 4 is ready without evidence.
   `test_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects`,
   `test_command_build_zen_accepts_identifier_fallback_declared_file_read_effects`,
   `test_command_build_zen_accepts_declared_file_read_effects_for_multiple_targets`,
+  `test_command_build_zen_accepts_declared_file_read_effects_with_unselected_targets`,
+  `test_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects_with_unselected_targets`,
+  `test_command_build_zen_accepts_identifier_fallback_declared_file_read_effects_with_unselected_targets`,
   `test_command_build_zen_rejects_undeclared_file_read_effects_before_execution`,
+  `test_command_build_zen_rejects_undeclared_file_read_effects_before_unselected_targets`,
   `test_command_multi_target_build_zen_rejects_undeclared_file_read_effects`,
   `test_command_build_zen_rejects_file_read_without_fallback_before_execution`,
   and

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2661,8 +2661,16 @@ checked-in docs, tests, and commits only.
   `test_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects_for_multiple_targets`,
   and
   `test_command_build_zen_accepts_identifier_fallback_declared_file_read_effects_for_multiple_targets`.
+  Test graphs with unselected executable and library targets also keep
+  declared file-read fallback behavior through
+  `test_command_build_zen_accepts_declared_file_read_effects_with_unselected_targets`,
+  `test_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects_with_unselected_targets`,
+  and
+  `test_command_build_zen_accepts_identifier_fallback_declared_file_read_effects_with_unselected_targets`.
   Undeclared file reads reject before test execution through
   `test_command_build_zen_rejects_undeclared_file_read_effects_before_execution`
+  and before unselected executable/library target handling through
+  `test_command_build_zen_rejects_undeclared_file_read_effects_before_unselected_targets`,
   and before multi-target test execution through
   `test_command_multi_target_build_zen_rejects_undeclared_file_read_effects`.
   File reads with `?` but no fallback arm also reject before test execution

--- a/tests/integration/cli_build/graph_validation_test_command_host_effects/file_reads.rs
+++ b/tests/integration/cli_build/graph_validation_test_command_host_effects/file_reads.rs
@@ -174,6 +174,100 @@ main = () i32 {
 }
 
 #[test]
+fn test_command_build_zen_accepts_declared_file_read_effects_with_unselected_targets() {
+    assert_test_command_accepts_declared_file_read_effects_with_unselected_targets(
+        r#"| .Err { "default" }"#,
+        "test_command_build_zen_accepts_declared_file_read_effects_with_unselected_targets",
+    );
+}
+
+#[test]
+fn test_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects_with_unselected_targets(
+) {
+    assert_test_command_accepts_declared_file_read_effects_with_unselected_targets(
+        r#"| _ { "default" }"#,
+        "test_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects_with_unselected_targets",
+    );
+}
+
+#[test]
+fn test_command_build_zen_accepts_identifier_fallback_declared_file_read_effects_with_unselected_targets(
+) {
+    assert_test_command_accepts_declared_file_read_effects_with_unselected_targets(
+        r#"| err { "default" }"#,
+        "test_command_build_zen_accepts_identifier_fallback_declared_file_read_effects_with_unselected_targets",
+    );
+}
+
+fn assert_test_command_accepts_declared_file_read_effects_with_unselected_targets(
+    fallback_arm: &str,
+    case_name: &str,
+) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
+    manifest = b.os.read_file("test.targets") ?
+        | .Ok(contents) {{ contents }}
+        {fallback_arm}
+    b.add(Executable {{ name: "app", main: "missing_app.zen", out_dir: "build/app/" }})
+    b.add(Test {{ name: "unit", root: "unit.zen" }})
+    b.add(Library {{ name: "core", exports: ["lib.zen"] }})
+    .Ok(b.config())
+}}
+"#,
+        ),
+    )
+    .expect("write build.zen");
+    std::fs::write(tmp.path().join("test.targets"), "unit\n").expect("write manifest");
+    std::fs::write(
+        tmp.path().join("unit.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write unit.zen");
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    1
+}
+"#,
+    )
+    .expect("write lib.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["test", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen test build.zen");
+
+    assert!(
+        output.status.success(),
+        "{case_name}: zen test build.zen failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let bin_path = tmp.path().join("build").join("tests").join("unit");
+    assert!(
+        bin_path.exists(),
+        "expected {} to exist",
+        bin_path.display()
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("test unit passed"),
+        "{case_name}: expected test pass output, stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
 fn test_command_build_zen_rejects_undeclared_file_read_effects_before_execution() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(
@@ -205,6 +299,68 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
             .contains("undeclared host effect: read file `test.targets`"),
         "expected undeclared file read diagnostic, stderr={}",
         String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "test command should not start after graph validation fails"
+    );
+}
+
+#[test]
+fn test_command_build_zen_rejects_undeclared_file_read_effects_before_unselected_targets() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("test.targets")
+    b.add(Executable { name: "app", main: "missing_app.zen", out_dir: "build/app/" })
+    b.add(Test { name: "unit", root: "unit.zen" })
+    b.add(Library { name: "core", exports: ["lib.zen"] })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("unit.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write unit.zen");
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    1
+}
+"#,
+    )
+    .expect("write lib.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["test", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen test build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen test build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("undeclared host effect: read file `test.targets`"),
+        "expected undeclared file read diagnostic, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("missing_app.zen"),
+        "host-effect validation should run before unrelated executable source handling, stderr={stderr}"
     );
     assert!(
         !tmp.path().join("build").exists(),


### PR DESCRIPTION
## Summary
- add `zen test build.zen` coverage for declared file-read effects when executable and library targets are present but unselected
- add a matching negative fixture proving undeclared file reads fail before unselected executable source handling
- record the new build-driver evidence in the phase plan and completion audit

## Verification
- `cargo test --test integration test_command_build_zen_accepts_declared_file_read_effects_with_unselected_targets -- --nocapture`
- `cargo test --test integration test_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects_with_unselected_targets -- --nocapture`
- `cargo test --test integration test_command_build_zen_accepts_identifier_fallback_declared_file_read_effects_with_unselected_targets -- --nocapture`
- `cargo test --test integration test_command_build_zen_rejects_undeclared_file_read_effects_before_unselected_targets -- --nocapture`
- `cargo test --test docs_truth`
- `git diff --check && cargo fmt --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`