### PR TITLE
Cover test graph env effects with unselected targets

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2732,9 +2732,17 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration test_command_build_zen_accepts_wildcard_fallback_declared_env_read_for_multiple_targets`,
   and
   `cargo test --test integration test_command_build_zen_accepts_identifier_fallback_declared_env_read_for_multiple_targets`.
+  Test graphs with unselected executable and library targets keep declared
+  env-read fallback handling through
+  `cargo test --test integration test_command_build_zen_accepts_declared_env_read_with_unselected_targets`,
+  `cargo test --test integration test_command_build_zen_accepts_wildcard_fallback_declared_env_read_with_unselected_targets`,
+  and
+  `cargo test --test integration test_command_build_zen_accepts_identifier_fallback_declared_env_read_with_unselected_targets`.
   Missing fallback arms on deterministic env reads reject before test
   execution through
   `cargo test --test integration test_command_build_zen_rejects_env_read_without_fallback_before_execution`
+  and before unselected-target source handling through
+  `cargo test --test integration test_command_build_zen_rejects_env_read_without_fallback_before_unselected_targets`,
   and before multi-target test execution through
   `cargo test --test integration test_command_multi_target_build_zen_rejects_env_read_without_fallback_before_execution`.
 - Build/test/emit graph execution validates non-executed graph-only library

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2649,8 +2649,16 @@ checked-in docs, tests, and commits only.
   `test_command_build_zen_accepts_wildcard_fallback_declared_env_read_for_multiple_targets`,
   and
   `test_command_build_zen_accepts_identifier_fallback_declared_env_read_for_multiple_targets`.
+  Test graphs with unselected executable and library targets also keep
+  declared env-read fallback behavior through
+  `test_command_build_zen_accepts_declared_env_read_with_unselected_targets`,
+  `test_command_build_zen_accepts_wildcard_fallback_declared_env_read_with_unselected_targets`,
+  and
+  `test_command_build_zen_accepts_identifier_fallback_declared_env_read_with_unselected_targets`.
   Env reads with `?` but no fallback arm reject before test execution through
   `test_command_build_zen_rejects_env_read_without_fallback_before_execution`
+  and before unselected executable/library target handling through
+  `test_command_build_zen_rejects_env_read_without_fallback_before_unselected_targets`,
   and before multi-target test execution through
   `test_command_multi_target_build_zen_rejects_env_read_without_fallback_before_execution`.
   Declared deterministic file-read effects are accepted on the normal test

--- a/tests/integration/cli_build/declared_env_effects/rejections.rs
+++ b/tests/integration/cli_build/declared_env_effects/rejections.rs
@@ -273,6 +273,60 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
 }
 
 #[test]
+fn test_command_build_zen_rejects_env_read_without_fallback_before_unselected_targets() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    std_path = b.os.env("ZEN_STD") ?
+        | .Ok(value) { value }
+    b.add(Executable { name: "app", main: "missing_app.zen", out_dir: "build/app/" })
+    b.add(Test { name: "unit", root: "unit.zen" })
+    b.add(Library { name: "core", exports: ["lib.zen"] })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("unit.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write unit.zen");
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    1
+}
+"#,
+    )
+    .expect("write lib.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["test", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen test build.zen");
+
+    assert_env_read_without_fallback_failed(&output);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("missing_app.zen"),
+        "host-effect validation should run before unrelated executable source handling, stderr={stderr}"
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "test command should not start after graph validation fails"
+    );
+}
+
+#[test]
 fn test_command_multi_target_build_zen_rejects_env_read_without_fallback_before_execution() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(

--- a/tests/integration/cli_build/declared_env_effects/test_command.rs
+++ b/tests/integration/cli_build/declared_env_effects/test_command.rs
@@ -48,6 +48,90 @@ fn test_command_build_zen_accepts_identifier_fallback_declared_env_read_for_mult
     );
 }
 
+#[test]
+fn test_command_build_zen_accepts_declared_env_read_with_unselected_targets() {
+    assert_test_command_accepts_declared_env_read_with_unselected_targets(
+        r#"| .Err { "default" }"#,
+        "test_command_build_zen_accepts_declared_env_read_with_unselected_targets",
+    );
+}
+
+#[test]
+fn test_command_build_zen_accepts_wildcard_fallback_declared_env_read_with_unselected_targets() {
+    assert_test_command_accepts_declared_env_read_with_unselected_targets(
+        r#"| _ { "default" }"#,
+        "test_command_build_zen_accepts_wildcard_fallback_declared_env_read_with_unselected_targets",
+    );
+}
+
+#[test]
+fn test_command_build_zen_accepts_identifier_fallback_declared_env_read_with_unselected_targets() {
+    assert_test_command_accepts_declared_env_read_with_unselected_targets(
+        r#"| err { "default" }"#,
+        "test_command_build_zen_accepts_identifier_fallback_declared_env_read_with_unselected_targets",
+    );
+}
+
+fn assert_test_command_accepts_declared_env_read_with_unselected_targets(
+    fallback_arm: &str,
+    case_name: &str,
+) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
+    std_path = b.os.env("ZEN_STD") ?
+        | .Ok(value) {{ value }}
+        {fallback_arm}
+    b.add(Executable {{ name: "app", main: "missing_app.zen", out_dir: "build/app/" }})
+    b.add(Test {{ name: "unit", root: "unit.zen" }})
+    b.add(Library {{ name: "core", exports: ["lib.zen"] }})
+    .Ok(b.config())
+}}
+"#,
+        ),
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("unit.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write unit.zen");
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    1
+}
+"#,
+    )
+    .expect("write lib.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["test", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen test build.zen");
+
+    assert!(
+        output.status.success(),
+        "{case_name}: zen test build.zen failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("test unit passed"),
+        "expected selected test target to pass, stdout={stdout}"
+    );
+}
+
 fn assert_test_command_accepts_declared_env_read_for_multiple_targets(
     fallback_arm: &str,
     case_name: &str,


### PR DESCRIPTION
## Summary
- add `zen test build.zen` coverage for declared env reads when executable/library targets are present but unselected
- add the matching missing-fallback env-read rejection before unselected executable source handling
- record the new build-driver evidence in the phase plan and completion audit

## Verification
- `cargo test --test integration test_command_build_zen_accepts_declared_env_read_with_unselected_targets -- --nocapture`
- `cargo test --test integration test_command_build_zen_accepts_wildcard_fallback_declared_env_read_with_unselected_targets -- --nocapture`
- `cargo test --test integration test_command_build_zen_accepts_identifier_fallback_declared_env_read_with_unselected_targets -- --nocapture`
- `cargo test --test integration test_command_build_zen_rejects_env_read_without_fallback_before_unselected_targets -- --nocapture`
- `cargo test --test docs_truth`
- `git diff --check && cargo fmt --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`