### PR TITLE
Cover build graph env effects with unselected targets

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2672,9 +2672,18 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration build_command_build_zen_accepts_wildcard_fallback_declared_env_read_for_multiple_targets`,
   and
   `cargo test --test integration build_command_build_zen_accepts_identifier_fallback_declared_env_read_for_multiple_targets`.
+  Build graphs with unselected test and library targets keep declared env-read
+  fallback behavior through
+  `cargo test --test integration build_command_build_zen_accepts_declared_env_read_with_unselected_targets`,
+  `cargo test --test integration build_command_build_zen_accepts_wildcard_fallback_declared_env_read_with_unselected_targets`,
+  and
+  `cargo test --test integration build_command_build_zen_accepts_identifier_fallback_declared_env_read_with_unselected_targets`.
   Missing fallback arms on deterministic env reads reject before execution
   through
   `cargo test --test integration build_command_build_zen_rejects_env_read_without_fallback_before_execution`.
+  Build graphs with unselected test and library targets keep that rejection
+  before unselected-target source handling through
+  `cargo test --test integration build_command_build_zen_rejects_env_read_without_fallback_before_unselected_targets`.
   Multi-target executable graph execution keeps that rejection before target
   execution through
   `cargo test --test integration build_command_multi_target_build_zen_rejects_env_read_without_fallback_before_execution`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2532,8 +2532,17 @@ checked-in docs, tests, and commits only.
   `build_command_build_zen_accepts_wildcard_fallback_declared_env_read_for_multiple_targets`,
   and
   `build_command_build_zen_accepts_identifier_fallback_declared_env_read_for_multiple_targets`.
+  Build graphs with unselected test and library targets also keep declared
+  env-read fallback behavior through
+  `build_command_build_zen_accepts_declared_env_read_with_unselected_targets`,
+  `build_command_build_zen_accepts_wildcard_fallback_declared_env_read_with_unselected_targets`,
+  and
+  `build_command_build_zen_accepts_identifier_fallback_declared_env_read_with_unselected_targets`.
   Env reads with `?` but no fallback arm reject before execution through
   `build_command_build_zen_rejects_env_read_without_fallback_before_execution`.
+  Build graphs with unselected test and library targets keep that rejection
+  before unselected target source handling through
+  `build_command_build_zen_rejects_env_read_without_fallback_before_unselected_targets`.
   Multi-target executable graph execution keeps that rejection before target
   execution through
   `build_command_multi_target_build_zen_rejects_env_read_without_fallback_before_execution`.

--- a/tests/integration/cli_build/declared_env_effects/executable.rs
+++ b/tests/integration/cli_build/declared_env_effects/executable.rs
@@ -60,6 +60,30 @@ fn build_command_build_zen_accepts_identifier_fallback_declared_env_read_for_mul
 }
 
 #[test]
+fn build_command_build_zen_accepts_declared_env_read_with_unselected_targets() {
+    assert_build_command_accepts_declared_env_read_with_unselected_targets(
+        r#"| .Err { "default" }"#,
+        "build_command_build_zen_accepts_declared_env_read_with_unselected_targets",
+    );
+}
+
+#[test]
+fn build_command_build_zen_accepts_wildcard_fallback_declared_env_read_with_unselected_targets() {
+    assert_build_command_accepts_declared_env_read_with_unselected_targets(
+        r#"| _ { "default" }"#,
+        "build_command_build_zen_accepts_wildcard_fallback_declared_env_read_with_unselected_targets",
+    );
+}
+
+#[test]
+fn build_command_build_zen_accepts_identifier_fallback_declared_env_read_with_unselected_targets() {
+    assert_build_command_accepts_declared_env_read_with_unselected_targets(
+        r#"| err { "default" }"#,
+        "build_command_build_zen_accepts_identifier_fallback_declared_env_read_with_unselected_targets",
+    );
+}
+
+#[test]
 fn direct_file_command_build_zen_accepts_declared_env_read_with_fallback() {
     assert_executable_command_accepts_declared_env_read(
         &["build.zen"],
@@ -115,6 +139,68 @@ fn direct_file_command_build_zen_accepts_identifier_fallback_declared_env_read_f
         &["build.zen"],
         r#"| err { "default" }"#,
         "direct_file_command_build_zen_accepts_identifier_fallback_declared_env_read_for_multiple_targets",
+    );
+}
+
+fn assert_build_command_accepts_declared_env_read_with_unselected_targets(
+    fallback_arm: &str,
+    case_name: &str,
+) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
+    std_path = b.os.env("ZEN_STD") ?
+        | .Ok(value) {{ value }}
+        {fallback_arm}
+    b.add(Executable {{ name: "app", main: "app.zen", out_dir: "build/app/" }})
+    b.add(Test {{ name: "unit", root: "missing_unit.zen" }})
+    b.add(Library {{ name: "core", exports: ["lib.zen"] }})
+    .Ok(b.config())
+}}
+"#,
+        ),
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    1
+}
+"#,
+    )
+    .expect("write lib.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build build.zen");
+
+    assert!(
+        output.status.success(),
+        "{case_name}: zen build build.zen failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let bin_path = tmp.path().join("build").join("app").join("app");
+    assert!(
+        bin_path.exists(),
+        "expected {} to exist",
+        bin_path.display()
     );
 }
 

--- a/tests/integration/cli_build/declared_env_effects/rejections.rs
+++ b/tests/integration/cli_build/declared_env_effects/rejections.rs
@@ -41,6 +41,60 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
 }
 
 #[test]
+fn build_command_build_zen_rejects_env_read_without_fallback_before_unselected_targets() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    std_path = b.os.env("ZEN_STD") ?
+        | .Ok(value) { value }
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    b.add(Test { name: "unit", root: "missing_unit.zen" })
+    b.add(Library { name: "core", exports: ["lib.zen"] })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    1
+}
+"#,
+    )
+    .expect("write lib.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build build.zen");
+
+    assert_env_read_without_fallback_failed(&output);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("missing_unit.zen"),
+        "host-effect validation should run before unrelated test source handling, stderr={stderr}"
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "build command should reject env effects before selected target execution"
+    );
+}
+
+#[test]
 fn direct_file_command_build_zen_rejects_env_read_without_fallback_before_execution() {
     assert_env_read_without_fallback_is_rejected(
         &["build.zen"],


### PR DESCRIPTION
## Summary
- add normal `zen build build.zen` coverage for declared env reads with unselected test/library targets
- add the matching missing-fallback env-read rejection before unselected test source handling
- record the new build-driver evidence in the phase plan and completion audit

## Verification
- `cargo test --test integration build_command_build_zen_accepts_declared_env_read_with_unselected_targets -- --nocapture`
- `cargo test --test integration build_command_build_zen_accepts_wildcard_fallback_declared_env_read_with_unselected_targets -- --nocapture`
- `cargo test --test integration build_command_build_zen_accepts_identifier_fallback_declared_env_read_with_unselected_targets -- --nocapture`
- `cargo test --test integration build_command_build_zen_rejects_env_read_without_fallback_before_unselected_targets -- --nocapture`
- `cargo test --test docs_truth`
- `git diff --check && cargo fmt --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`