### PR TITLE
Cover direct build graph env effects with unselected targets

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2910,9 +2910,17 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration direct_file_command_build_zen_accepts_wildcard_fallback_declared_env_read_for_multiple_targets`,
   and
   `cargo test --test integration direct_file_command_build_zen_accepts_identifier_fallback_declared_env_read_for_multiple_targets`.
+  Direct build graphs with unselected test and library targets keep declared
+  env-read fallback behavior through
+  `cargo test --test integration direct_file_command_build_zen_accepts_declared_env_read_with_unselected_targets`,
+  `cargo test --test integration direct_file_command_build_zen_accepts_wildcard_fallback_declared_env_read_with_unselected_targets`,
+  and
+  `cargo test --test integration direct_file_command_build_zen_accepts_identifier_fallback_declared_env_read_with_unselected_targets`.
   Missing fallback arms on deterministic env reads reject before execution
   through
   `cargo test --test integration direct_file_command_build_zen_rejects_env_read_without_fallback_before_execution`
+  and before unselected-target source handling through
+  `cargo test --test integration direct_file_command_build_zen_rejects_env_read_without_fallback_before_unselected_targets`,
   and before multi-target direct execution through
   `cargo test --test integration direct_file_command_multi_target_build_zen_rejects_env_read_without_fallback_before_execution`.
 - Direct `zen build.zen` validates and typechecks graph-only library exports

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2812,8 +2812,16 @@ checked-in docs, tests, and commits only.
   `direct_file_command_build_zen_accepts_wildcard_fallback_declared_env_read_for_multiple_targets`,
   and
   `direct_file_command_build_zen_accepts_identifier_fallback_declared_env_read_for_multiple_targets`.
+  Direct build graphs with unselected test and library targets also keep
+  declared env-read fallback behavior through
+  `direct_file_command_build_zen_accepts_declared_env_read_with_unselected_targets`,
+  `direct_file_command_build_zen_accepts_wildcard_fallback_declared_env_read_with_unselected_targets`,
+  and
+  `direct_file_command_build_zen_accepts_identifier_fallback_declared_env_read_with_unselected_targets`.
   Env reads with `?` but no fallback arm reject before execution through
   `direct_file_command_build_zen_rejects_env_read_without_fallback_before_execution`
+  and before unselected target source handling through
+  `direct_file_command_build_zen_rejects_env_read_without_fallback_before_unselected_targets`,
   and before multi-target direct execution through
   `direct_file_command_multi_target_build_zen_rejects_env_read_without_fallback_before_execution`.
   Declared deterministic file-read effects are accepted through

--- a/tests/integration/cli_build/declared_env_effects/executable.rs
+++ b/tests/integration/cli_build/declared_env_effects/executable.rs
@@ -61,7 +61,8 @@ fn build_command_build_zen_accepts_identifier_fallback_declared_env_read_for_mul
 
 #[test]
 fn build_command_build_zen_accepts_declared_env_read_with_unselected_targets() {
-    assert_build_command_accepts_declared_env_read_with_unselected_targets(
+    assert_executable_command_accepts_declared_env_read_with_unselected_targets(
+        &["build", "build.zen"],
         r#"| .Err { "default" }"#,
         "build_command_build_zen_accepts_declared_env_read_with_unselected_targets",
     );
@@ -69,7 +70,8 @@ fn build_command_build_zen_accepts_declared_env_read_with_unselected_targets() {
 
 #[test]
 fn build_command_build_zen_accepts_wildcard_fallback_declared_env_read_with_unselected_targets() {
-    assert_build_command_accepts_declared_env_read_with_unselected_targets(
+    assert_executable_command_accepts_declared_env_read_with_unselected_targets(
+        &["build", "build.zen"],
         r#"| _ { "default" }"#,
         "build_command_build_zen_accepts_wildcard_fallback_declared_env_read_with_unselected_targets",
     );
@@ -77,7 +79,8 @@ fn build_command_build_zen_accepts_wildcard_fallback_declared_env_read_with_unse
 
 #[test]
 fn build_command_build_zen_accepts_identifier_fallback_declared_env_read_with_unselected_targets() {
-    assert_build_command_accepts_declared_env_read_with_unselected_targets(
+    assert_executable_command_accepts_declared_env_read_with_unselected_targets(
+        &["build", "build.zen"],
         r#"| err { "default" }"#,
         "build_command_build_zen_accepts_identifier_fallback_declared_env_read_with_unselected_targets",
     );
@@ -142,7 +145,37 @@ fn direct_file_command_build_zen_accepts_identifier_fallback_declared_env_read_f
     );
 }
 
-fn assert_build_command_accepts_declared_env_read_with_unselected_targets(
+#[test]
+fn direct_file_command_build_zen_accepts_declared_env_read_with_unselected_targets() {
+    assert_executable_command_accepts_declared_env_read_with_unselected_targets(
+        &["build.zen"],
+        r#"| .Err { "default" }"#,
+        "direct_file_command_build_zen_accepts_declared_env_read_with_unselected_targets",
+    );
+}
+
+#[test]
+fn direct_file_command_build_zen_accepts_wildcard_fallback_declared_env_read_with_unselected_targets(
+) {
+    assert_executable_command_accepts_declared_env_read_with_unselected_targets(
+        &["build.zen"],
+        r#"| _ { "default" }"#,
+        "direct_file_command_build_zen_accepts_wildcard_fallback_declared_env_read_with_unselected_targets",
+    );
+}
+
+#[test]
+fn direct_file_command_build_zen_accepts_identifier_fallback_declared_env_read_with_unselected_targets(
+) {
+    assert_executable_command_accepts_declared_env_read_with_unselected_targets(
+        &["build.zen"],
+        r#"| err { "default" }"#,
+        "direct_file_command_build_zen_accepts_identifier_fallback_declared_env_read_with_unselected_targets",
+    );
+}
+
+fn assert_executable_command_accepts_declared_env_read_with_unselected_targets(
+    args: &[&str],
     fallback_arm: &str,
     case_name: &str,
 ) {
@@ -184,14 +217,14 @@ value = () i32 {
     .expect("write lib.zen");
 
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["build", "build.zen"])
+        .args(args)
         .current_dir(tmp.path())
         .output()
-        .expect("run zen build build.zen");
+        .expect("run zen executable build graph command");
 
     assert!(
         output.status.success(),
-        "{case_name}: zen build build.zen failed: stdout={}, stderr={}",
+        "{case_name}: zen executable build graph command failed: stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );

--- a/tests/integration/cli_build/declared_env_effects/rejections.rs
+++ b/tests/integration/cli_build/declared_env_effects/rejections.rs
@@ -42,6 +42,13 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
 
 #[test]
 fn build_command_build_zen_rejects_env_read_without_fallback_before_unselected_targets() {
+    assert_env_read_without_fallback_before_unselected_targets(
+        &["build", "build.zen"],
+        "build command should reject env effects before selected target execution",
+    );
+}
+
+fn assert_env_read_without_fallback_before_unselected_targets(args: &[&str], build_message: &str) {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(
         tmp.path().join("build.zen"),
@@ -77,10 +84,10 @@ value = () i32 {
     .expect("write lib.zen");
 
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["build", "build.zen"])
+        .args(args)
         .current_dir(tmp.path())
         .output()
-        .expect("run zen build build.zen");
+        .expect("run zen executable build graph command");
 
     assert_env_read_without_fallback_failed(&output);
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -88,10 +95,7 @@ value = () i32 {
         !stderr.contains("missing_unit.zen"),
         "host-effect validation should run before unrelated test source handling, stderr={stderr}"
     );
-    assert!(
-        !tmp.path().join("build").exists(),
-        "build command should reject env effects before selected target execution"
-    );
+    assert!(!tmp.path().join("build").exists(), "{build_message}");
 }
 
 #[test]
@@ -99,6 +103,14 @@ fn direct_file_command_build_zen_rejects_env_read_without_fallback_before_execut
     assert_env_read_without_fallback_is_rejected(
         &["build.zen"],
         "direct build.zen command should not start after graph validation fails",
+    );
+}
+
+#[test]
+fn direct_file_command_build_zen_rejects_env_read_without_fallback_before_unselected_targets() {
+    assert_env_read_without_fallback_before_unselected_targets(
+        &["build.zen"],
+        "direct build.zen command should reject env effects before selected target execution",
     );
 }
 


### PR DESCRIPTION
## Summary

- add direct `zen build.zen` coverage for declared env reads with unselected test/library targets
- add matching missing-fallback env-read rejection before unselected target source handling
- record the direct build-driver evidence in phase/audit docs

## Verification

- `cargo test --test integration direct_file_command_build_zen_accepts_declared_env_read_with_unselected_targets -- --nocapture`
- `cargo test --test integration direct_file_command_build_zen_accepts_wildcard_fallback_declared_env_read_with_unselected_targets -- --nocapture`
- `cargo test --test integration direct_file_command_build_zen_accepts_identifier_fallback_declared_env_read_with_unselected_targets -- --nocapture`
- `cargo test --test integration direct_file_command_build_zen_rejects_env_read_without_fallback_before_unselected_targets -- --nocapture`
- `cargo test --test docs_truth`
- `git diff --check && cargo fmt --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`