### PR TITLE
Cover direct build graph file effects with unselected targets

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2895,6 +2895,11 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration direct_file_command_build_zen_accepts_declared_file_read_effects_for_multiple_targets`,
   `cargo test --test integration direct_file_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects_for_multiple_targets`,
   `cargo test --test integration direct_file_command_build_zen_accepts_identifier_fallback_declared_file_read_effects_for_multiple_targets`,
+  `cargo test --test integration direct_file_command_build_zen_accepts_declared_file_read_effects_with_unselected_targets`,
+  `cargo test --test integration direct_file_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects_with_unselected_targets`,
+  `cargo test --test integration direct_file_command_build_zen_accepts_identifier_fallback_declared_file_read_effects_with_unselected_targets`,
+  `cargo test --test integration direct_file_command_build_zen_rejects_undeclared_file_read_effects_before_unselected_targets`,
+  `cargo test --test integration direct_file_command_build_zen_rejects_file_read_without_fallback_before_unselected_targets`,
   `cargo test --test integration direct_file_command_multi_target_build_zen_rejects_file_read_without_fallback_before_execution`,
   and
   `cargo test --test integration direct_file_command_multi_target_build_zen_rejects_undeclared_file_read_effects`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2832,12 +2832,23 @@ checked-in docs, tests, and commits only.
   `direct_file_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects_for_multiple_targets`,
   and
   `direct_file_command_build_zen_accepts_identifier_fallback_declared_file_read_effects_for_multiple_targets`.
+  Direct build graphs with unselected test and library targets also keep
+  declared file-read fallback behavior through
+  `direct_file_command_build_zen_accepts_declared_file_read_effects_with_unselected_targets`,
+  `direct_file_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects_with_unselected_targets`,
+  and
+  `direct_file_command_build_zen_accepts_identifier_fallback_declared_file_read_effects_with_unselected_targets`.
   Undeclared file reads reject before execution through
   `direct_file_command_build_zen_rejects_undeclared_file_read_effects_before_execution`
+  and before unselected target source handling through
+  `direct_file_command_build_zen_rejects_undeclared_file_read_effects_before_unselected_targets`,
   and before multi-target execution through
   `direct_file_command_multi_target_build_zen_rejects_undeclared_file_read_effects`.
   File reads with `?` but no fallback arm also reject before execution through
   `direct_file_command_build_zen_rejects_file_read_without_fallback_before_execution`.
+  Direct build graphs with unselected test and library targets reject file
+  reads lacking a fallback arm before unselected target source handling through
+  `direct_file_command_build_zen_rejects_file_read_without_fallback_before_unselected_targets`.
   Multi-target executable graph execution keeps that rejection before execution
   through
   `direct_file_command_multi_target_build_zen_rejects_file_read_without_fallback_before_execution`.

--- a/tests/integration/cli_build/direct_build_graph_host_effects.rs
+++ b/tests/integration/cli_build/direct_build_graph_host_effects.rs
@@ -3,6 +3,9 @@ use std::process::Command;
 #[path = "direct_build_graph_host_effects/file_reads.rs"]
 mod file_reads;
 
+#[path = "direct_build_graph_host_effects/file_reads_unselected_targets.rs"]
+mod file_reads_unselected_targets;
+
 #[test]
 fn direct_file_command_multi_target_build_zen_rejects_undeclared_host_effects() {
     let tmp = tempfile::tempdir().expect("create temp dir");

--- a/tests/integration/cli_build/direct_build_graph_host_effects/file_reads_unselected_targets.rs
+++ b/tests/integration/cli_build/direct_build_graph_host_effects/file_reads_unselected_targets.rs
@@ -1,0 +1,167 @@
+use std::process::Command;
+
+#[test]
+fn direct_file_command_build_zen_accepts_declared_file_read_effects_with_unselected_targets() {
+    assert_direct_file_command_accepts_declared_file_read_effects_with_unselected_targets(
+        r#"| .Err { "default" }"#,
+        "direct_file_command_build_zen_accepts_declared_file_read_effects_with_unselected_targets",
+    );
+}
+
+#[test]
+fn direct_file_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects_with_unselected_targets(
+) {
+    assert_direct_file_command_accepts_declared_file_read_effects_with_unselected_targets(
+        r#"| _ { "default" }"#,
+        "direct_file_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects_with_unselected_targets",
+    );
+}
+
+#[test]
+fn direct_file_command_build_zen_accepts_identifier_fallback_declared_file_read_effects_with_unselected_targets(
+) {
+    assert_direct_file_command_accepts_declared_file_read_effects_with_unselected_targets(
+        r#"| err { "default" }"#,
+        "direct_file_command_build_zen_accepts_identifier_fallback_declared_file_read_effects_with_unselected_targets",
+    );
+}
+
+#[test]
+fn direct_file_command_build_zen_rejects_undeclared_file_read_effects_before_unselected_targets() {
+    assert_direct_file_command_rejects_file_read_before_unselected_targets(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets")
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    b.add(Test { name: "unit", root: "missing_unit.zen" })
+    b.add(Library { name: "core", exports: ["lib.zen"] })
+    .Ok(b.config())
+}
+"#,
+        "undeclared",
+    );
+}
+
+#[test]
+fn direct_file_command_build_zen_rejects_file_read_without_fallback_before_unselected_targets() {
+    assert_direct_file_command_rejects_file_read_before_unselected_targets(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets") ?
+        | .Ok(contents) { contents }
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    b.add(Test { name: "unit", root: "missing_unit.zen" })
+    b.add(Library { name: "core", exports: ["lib.zen"] })
+    .Ok(b.config())
+}
+"#,
+        "missing-fallback",
+    );
+}
+
+fn assert_direct_file_command_accepts_declared_file_read_effects_with_unselected_targets(
+    fallback_arm: &str,
+    case_name: &str,
+) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
+    manifest = b.os.read_file("build.targets") ?
+        | .Ok(contents) {{ contents }}
+        {fallback_arm}
+    b.add(Executable {{ name: "app", main: "app.zen", out_dir: "build/app/" }})
+    b.add(Test {{ name: "unit", root: "missing_unit.zen" }})
+    b.add(Library {{ name: "core", exports: ["lib.zen"] }})
+    .Ok(b.config())
+}}
+"#,
+        ),
+    )
+    .expect("write build.zen");
+    std::fs::write(tmp.path().join("build.targets"), "app\n").expect("write manifest");
+    write_zero_main(tmp.path().join("app.zen"));
+    write_library_source(&tmp);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .arg("build.zen")
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build.zen");
+
+    assert!(
+        output.status.success(),
+        "{case_name}: zen build.zen failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let bin_path = tmp.path().join("build").join("app").join("app");
+    assert!(
+        bin_path.exists(),
+        "expected {} to exist",
+        bin_path.display()
+    );
+}
+
+fn assert_direct_file_command_rejects_file_read_before_unselected_targets(
+    build_source: &str,
+    diagnostic_case: &str,
+) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(tmp.path().join("build.zen"), build_source).expect("write build.zen");
+    write_zero_main(tmp.path().join("app.zen"));
+    write_library_source(&tmp);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .arg("build.zen")
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("undeclared host effect: read file `build.targets`"),
+        "expected {diagnostic_case} file read diagnostic, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("missing_unit.zen"),
+        "host-effect validation should run before unrelated test source handling, stderr={stderr}"
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "direct build.zen command should reject file effects before selected target execution"
+    );
+}
+
+fn write_zero_main(path: impl AsRef<std::path::Path>) {
+    std::fs::write(
+        path,
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write main source");
+}
+
+fn write_library_source(tmp: &tempfile::TempDir) {
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    1
+}
+"#,
+    )
+    .expect("write lib.zen");
+}


### PR DESCRIPTION
## Summary

- add direct `zen build.zen` file-read coverage for unselected test/library targets
- add matching undeclared and missing-fallback rejection coverage before unselected target source handling
- split the new direct file-read tests into a focused module to keep files below hygiene thresholds
- record the direct build-driver evidence in phase/audit docs

## Verification

- `cargo test --test integration direct_file_command_build_zen_accepts_declared_file_read_effects_with_unselected_targets -- --nocapture`
- `cargo test --test integration direct_file_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects_with_unselected_targets -- --nocapture`
- `cargo test --test integration direct_file_command_build_zen_accepts_identifier_fallback_declared_file_read_effects_with_unselected_targets -- --nocapture`
- `cargo test --test integration direct_file_command_build_zen_rejects_undeclared_file_read_effects_before_unselected_targets -- --nocapture`
- `cargo test --test integration direct_file_command_build_zen_rejects_file_read_without_fallback_before_unselected_targets -- --nocapture`
- `cargo test --test docs_truth`
- `git diff --check && cargo fmt --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`