### PR TITLE
Cover build graph file effects with unselected targets

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2657,6 +2657,11 @@ and do not assume Phase 4 is ready without evidence.
   `cargo test --test integration build_command_build_zen_accepts_declared_file_read_effects_for_multiple_targets`,
   `cargo test --test integration build_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects_for_multiple_targets`,
   `cargo test --test integration build_command_build_zen_accepts_identifier_fallback_declared_file_read_effects_for_multiple_targets`,
+  `cargo test --test integration build_command_build_zen_accepts_declared_file_read_effects_with_unselected_targets`,
+  `cargo test --test integration build_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects_with_unselected_targets`,
+  `cargo test --test integration build_command_build_zen_accepts_identifier_fallback_declared_file_read_effects_with_unselected_targets`,
+  `cargo test --test integration build_command_build_zen_rejects_undeclared_file_read_effects_before_unselected_targets`,
+  `cargo test --test integration build_command_build_zen_rejects_file_read_without_fallback_before_unselected_targets`,
   `cargo test --test integration build_command_multi_target_build_zen_rejects_file_read_without_fallback_before_execution`,
   and
   `cargo test --test integration build_command_multi_target_build_zen_rejects_undeclared_file_read_effects`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -2554,11 +2554,22 @@ checked-in docs, tests, and commits only.
   `build_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects_for_multiple_targets`,
   and
   `build_command_build_zen_accepts_identifier_fallback_declared_file_read_effects_for_multiple_targets`.
+  Build graphs with unselected test and library targets also keep declared
+  file-read fallback behavior through
+  `build_command_build_zen_accepts_declared_file_read_effects_with_unselected_targets`,
+  `build_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects_with_unselected_targets`,
+  and
+  `build_command_build_zen_accepts_identifier_fallback_declared_file_read_effects_with_unselected_targets`.
   File reads with `?` but no fallback arm reject before multi-target execution
   through
   `build_command_multi_target_build_zen_rejects_file_read_without_fallback_before_execution`.
+  Build graphs with unselected test and library targets reject file reads
+  lacking a fallback arm before unselected target source handling through
+  `build_command_build_zen_rejects_file_read_without_fallback_before_unselected_targets`.
   Undeclared file reads reject before target execution through
   `build_command_build_zen_rejects_undeclared_file_read_effects_before_execution`
+  and before unselected target source handling through
+  `build_command_build_zen_rejects_undeclared_file_read_effects_before_unselected_targets`,
   and before multi-target execution through
   `build_command_multi_target_build_zen_rejects_undeclared_file_read_effects`.
 - Normal `zen check build.zen` validates the same constrained deterministic

--- a/tests/integration/cli_build/build_command_host_effects/file_reads.rs
+++ b/tests/integration/cli_build/build_command_host_effects/file_reads.rs
@@ -2,3 +2,5 @@
 mod declared;
 #[path = "file_reads/rejections.rs"]
 mod rejections;
+#[path = "file_reads/unselected_targets.rs"]
+mod unselected_targets;

--- a/tests/integration/cli_build/build_command_host_effects/file_reads/unselected_targets.rs
+++ b/tests/integration/cli_build/build_command_host_effects/file_reads/unselected_targets.rs
@@ -1,0 +1,167 @@
+use std::process::Command;
+
+#[test]
+fn build_command_build_zen_accepts_declared_file_read_effects_with_unselected_targets() {
+    assert_build_command_accepts_declared_file_read_effects_with_unselected_targets(
+        r#"| .Err { "default" }"#,
+        "build_command_build_zen_accepts_declared_file_read_effects_with_unselected_targets",
+    );
+}
+
+#[test]
+fn build_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects_with_unselected_targets(
+) {
+    assert_build_command_accepts_declared_file_read_effects_with_unselected_targets(
+        r#"| _ { "default" }"#,
+        "build_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects_with_unselected_targets",
+    );
+}
+
+#[test]
+fn build_command_build_zen_accepts_identifier_fallback_declared_file_read_effects_with_unselected_targets(
+) {
+    assert_build_command_accepts_declared_file_read_effects_with_unselected_targets(
+        r#"| err { "default" }"#,
+        "build_command_build_zen_accepts_identifier_fallback_declared_file_read_effects_with_unselected_targets",
+    );
+}
+
+#[test]
+fn build_command_build_zen_rejects_undeclared_file_read_effects_before_unselected_targets() {
+    assert_build_command_rejects_file_read_before_unselected_targets(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets")
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    b.add(Test { name: "unit", root: "missing_unit.zen" })
+    b.add(Library { name: "core", exports: ["lib.zen"] })
+    .Ok(b.config())
+}
+"#,
+        "undeclared",
+    );
+}
+
+#[test]
+fn build_command_build_zen_rejects_file_read_without_fallback_before_unselected_targets() {
+    assert_build_command_rejects_file_read_before_unselected_targets(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets") ?
+        | .Ok(contents) { contents }
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    b.add(Test { name: "unit", root: "missing_unit.zen" })
+    b.add(Library { name: "core", exports: ["lib.zen"] })
+    .Ok(b.config())
+}
+"#,
+        "missing-fallback",
+    );
+}
+
+fn assert_build_command_accepts_declared_file_read_effects_with_unselected_targets(
+    fallback_arm: &str,
+    case_name: &str,
+) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
+    manifest = b.os.read_file("build.targets") ?
+        | .Ok(contents) {{ contents }}
+        {fallback_arm}
+    b.add(Executable {{ name: "app", main: "app.zen", out_dir: "build/app/" }})
+    b.add(Test {{ name: "unit", root: "missing_unit.zen" }})
+    b.add(Library {{ name: "core", exports: ["lib.zen"] }})
+    .Ok(b.config())
+}}
+"#,
+        ),
+    )
+    .expect("write build.zen");
+    std::fs::write(tmp.path().join("build.targets"), "app\n").expect("write manifest");
+    write_zero_main(tmp.path().join("app.zen"));
+    write_library_source(&tmp);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build build.zen");
+
+    assert!(
+        output.status.success(),
+        "{case_name}: zen build build.zen failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let bin_path = tmp.path().join("build").join("app").join("app");
+    assert!(
+        bin_path.exists(),
+        "expected {} to exist",
+        bin_path.display()
+    );
+}
+
+fn assert_build_command_rejects_file_read_before_unselected_targets(
+    build_source: &str,
+    diagnostic_case: &str,
+) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(tmp.path().join("build.zen"), build_source).expect("write build.zen");
+    write_zero_main(tmp.path().join("app.zen"));
+    write_library_source(&tmp);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen build build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("undeclared host effect: read file `build.targets`"),
+        "expected {diagnostic_case} file read diagnostic, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("missing_unit.zen"),
+        "host-effect validation should run before unrelated test source handling, stderr={stderr}"
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "build command should reject file effects before selected target execution"
+    );
+}
+
+fn write_zero_main(path: impl AsRef<std::path::Path>) {
+    std::fs::write(
+        path,
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write main source");
+}
+
+fn write_library_source(tmp: &tempfile::TempDir) {
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    1
+}
+"#,
+    )
+    .expect("write lib.zen");
+}


### PR DESCRIPTION
## Summary

- add normal `zen build build.zen` file-read coverage for unselected test/library targets
- add matching undeclared and missing-fallback rejection coverage before unselected target source handling
- keep the new cases in a focused file-read module to preserve test file hygiene
- record the normal build-driver evidence in phase/audit docs

## Verification

- `cargo test --test integration build_command_build_zen_accepts_declared_file_read_effects_with_unselected_targets -- --nocapture`
- `cargo test --test integration build_command_build_zen_accepts_wildcard_fallback_declared_file_read_effects_with_unselected_targets -- --nocapture`
- `cargo test --test integration build_command_build_zen_accepts_identifier_fallback_declared_file_read_effects_with_unselected_targets -- --nocapture`
- `cargo test --test integration build_command_build_zen_rejects_undeclared_file_read_effects_before_unselected_targets -- --nocapture`
- `cargo test --test integration build_command_build_zen_rejects_file_read_without_fallback_before_unselected_targets -- --nocapture`
- `cargo test --test docs_truth`
- `git diff --check && cargo fmt --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`