### PR TITLE
[codex] Split direct build validation fixtures

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -2992,9 +2992,10 @@ and do not assume Phase 4 is ready without evidence.
   graph-only-library modules while preserving coverage through
   `cargo test --test integration legacy_graph_command_validation`.
 - Direct build.zen integration tests now keep graph validation cases in
-  `tests/integration/cli_build/direct_build_graph_validation.rs`, reducing
-  `tests/integration/cli_build/direct_build_graph_execution.rs` from 417 to
-  198 lines while preserving coverage through
+  `tests/integration/cli_build/direct_build_graph_validation.rs` and
+  `tests/integration/cli_build/direct_build_graph_validation/`, split across
+  execution-scope, dependency-shape, target-metadata, gated-dependency, and
+  graph-only-library modules while preserving coverage through
   `cargo test --test integration direct_file_command_build_zen`.
 - Check-command build.zen integration tests now keep graph validation cases in
   `tests/integration/cli_build/graph_validation/`, split across basic

--- a/tests/integration/cli_build/direct_build_graph_validation.rs
+++ b/tests/integration/cli_build/direct_build_graph_validation.rs
@@ -1,9 +1,13 @@
 use std::process::Command;
 
+#[path = "direct_build_graph_validation/dependency_shapes.rs"]
+mod dependency_shapes;
 #[path = "direct_build_graph_validation/gated_dependencies.rs"]
 mod gated_dependencies;
 #[path = "direct_build_graph_validation/graph_only_libraries.rs"]
 mod graph_only_libraries;
+#[path = "direct_build_graph_validation/target_metadata.rs"]
+mod target_metadata;
 
 #[test]
 fn direct_file_command_build_zen_rejects_graph_without_executable_targets() {
@@ -105,191 +109,6 @@ main = () i32 {
     assert!(
         tmp.path().join("build").join("app").join("app").exists(),
         "expected executable output to exist"
-    );
-}
-
-#[test]
-fn direct_file_command_build_zen_rejects_unknown_target_dependencies() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable {
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        dependencies: ["core"],
-    })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-    assert_direct_file_command_rejects_dependency_shape(
-        tmp.path(),
-        "build target `app` depends on unknown target `core`",
-    );
-}
-
-#[test]
-fn direct_file_command_build_zen_rejects_self_target_dependencies() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable {
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        dependencies: ["app"],
-    })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-    assert_direct_file_command_rejects_dependency_shape(
-        tmp.path(),
-        "build target `app` cannot depend on itself",
-    );
-}
-
-#[test]
-fn direct_file_command_build_zen_rejects_cyclic_target_dependencies() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable {
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        dependencies: ["tool"],
-    })
-    b.add(Executable {
-        name: "tool",
-        main: "tool.zen",
-        out_dir: "build/tool/",
-        dependencies: ["app"],
-    })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-    assert_direct_file_command_rejects_dependency_shape(
-        tmp.path(),
-        "build target dependency cycle includes `app`",
-    );
-}
-
-#[test]
-fn direct_file_command_build_zen_rejects_duplicate_target_fields() {
-    assert_direct_file_command_rejects_target_metadata(
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable {
-        name: "app",
-        name: "tool",
-        main: "app.zen",
-        out_dir: "build/app/",
-    })
-    .Ok(b.config())
-}
-"#,
-        "duplicate field `name` in `Executable` build target",
-    );
-}
-
-#[test]
-fn direct_file_command_build_zen_rejects_missing_required_target_fields() {
-    assert_direct_file_command_rejects_target_metadata(
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable {
-        name: "app",
-        main: "app.zen",
-    })
-    .Ok(b.config())
-}
-"#,
-        "missing required field `out_dir` in `Executable` build target",
-    );
-}
-
-#[test]
-fn direct_file_command_build_zen_rejects_invalid_target_field_types() {
-    assert_direct_file_command_rejects_target_metadata(
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable {
-        name: "app",
-        main: "app.zen",
-        out_dir: 42,
-    })
-    .Ok(b.config())
-}
-"#,
-        "field `out_dir` in `Executable` build target must be a string",
-    );
-}
-
-fn assert_direct_file_command_rejects_target_metadata(
-    build_source: &str,
-    expected_diagnostic: &str,
-) {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(tmp.path().join("build.zen"), build_source).expect("write build.zen");
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .arg("build.zen")
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen build.zen");
-
-    assert!(
-        !output.status.success(),
-        "zen build.zen unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains(expected_diagnostic),
-        "expected target metadata diagnostic `{expected_diagnostic}`, stderr={stderr}"
-    );
-    assert!(
-        !tmp.path().join("build").exists(),
-        "direct build.zen command should not create outputs after target metadata validation fails"
-    );
-}
-
-fn assert_direct_file_command_rejects_dependency_shape(
-    project_dir: &std::path::Path,
-    expected_diagnostic: &str,
-) {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .arg("build.zen")
-        .current_dir(project_dir)
-        .output()
-        .expect("run zen build.zen");
-
-    assert!(
-        !output.status.success(),
-        "zen build.zen unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr).contains(expected_diagnostic),
-        "expected dependency diagnostic `{expected_diagnostic}`, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        !project_dir.join("build").exists(),
-        "direct build.zen command should not create outputs after dependency validation fails"
     );
 }
 

--- a/tests/integration/cli_build/direct_build_graph_validation/dependency_shapes.rs
+++ b/tests/integration/cli_build/direct_build_graph_validation/dependency_shapes.rs
@@ -1,0 +1,106 @@
+use std::process::Command;
+
+#[test]
+fn direct_file_command_build_zen_rejects_unknown_target_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["core"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    assert_direct_file_command_rejects_dependency_shape(
+        tmp.path(),
+        "build target `app` depends on unknown target `core`",
+    );
+}
+
+#[test]
+fn direct_file_command_build_zen_rejects_self_target_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["app"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    assert_direct_file_command_rejects_dependency_shape(
+        tmp.path(),
+        "build target `app` cannot depend on itself",
+    );
+}
+
+#[test]
+fn direct_file_command_build_zen_rejects_cyclic_target_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["tool"],
+    })
+    b.add(Executable {
+        name: "tool",
+        main: "tool.zen",
+        out_dir: "build/tool/",
+        dependencies: ["app"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    assert_direct_file_command_rejects_dependency_shape(
+        tmp.path(),
+        "build target dependency cycle includes `app`",
+    );
+}
+
+fn assert_direct_file_command_rejects_dependency_shape(
+    project_dir: &std::path::Path,
+    expected_diagnostic: &str,
+) {
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .arg("build.zen")
+        .current_dir(project_dir)
+        .output()
+        .expect("run zen build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains(expected_diagnostic),
+        "expected dependency diagnostic `{expected_diagnostic}`, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !project_dir.join("build").exists(),
+        "direct build.zen command should not create outputs after dependency validation fails"
+    );
+}

--- a/tests/integration/cli_build/direct_build_graph_validation/target_metadata.rs
+++ b/tests/integration/cli_build/direct_build_graph_validation/target_metadata.rs
@@ -1,0 +1,81 @@
+use std::process::Command;
+
+#[test]
+fn direct_file_command_build_zen_rejects_duplicate_target_fields() {
+    assert_direct_file_command_rejects_target_metadata(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        name: "tool",
+        main: "app.zen",
+        out_dir: "build/app/",
+    })
+    .Ok(b.config())
+}
+"#,
+        "duplicate field `name` in `Executable` build target",
+    );
+}
+
+#[test]
+fn direct_file_command_build_zen_rejects_missing_required_target_fields() {
+    assert_direct_file_command_rejects_target_metadata(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+    })
+    .Ok(b.config())
+}
+"#,
+        "missing required field `out_dir` in `Executable` build target",
+    );
+}
+
+#[test]
+fn direct_file_command_build_zen_rejects_invalid_target_field_types() {
+    assert_direct_file_command_rejects_target_metadata(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: 42,
+    })
+    .Ok(b.config())
+}
+"#,
+        "field `out_dir` in `Executable` build target must be a string",
+    );
+}
+
+fn assert_direct_file_command_rejects_target_metadata(
+    build_source: &str,
+    expected_diagnostic: &str,
+) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(tmp.path().join("build.zen"), build_source).expect("write build.zen");
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .arg("build.zen")
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(expected_diagnostic),
+        "expected target metadata diagnostic `{expected_diagnostic}`, stderr={stderr}"
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "direct build.zen command should not create outputs after target metadata validation fails"
+    );
+}


### PR DESCRIPTION
## Summary

Split direct `zen build.zen` graph validation fixtures into focused dependency-shape and target-metadata modules, leaving execution-scope cases in the parent module.

## Validation

- `cargo fmt --check`
- `cargo test --test integration direct_build_graph_validation -- --nocapture`
- `cargo test --test docs_truth phase_audit`
- `git diff --check --cached`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`