### PR TITLE
[codex] Split test command validation fixtures

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3476,11 +3476,12 @@ and do not assume Phase 4 is ready without evidence.
   preserving missing source, valid source, and library typecheck coverage while
   keeping executable-target, gated-dependency, and missing-root validation
   checks focused.
-- `zen test build.zen` graph-only library validation tests now live in
-  `tests/integration/cli_build/graph_validation_test_command_validation/graph_only_libraries.rs`,
-  preserving missing source, valid source, and library typecheck coverage while
-  keeping test-target, gated-dependency, and skipped-source validation checks
-  focused.
+- `zen test build.zen` graph validation tests now live in
+  `tests/integration/cli_build/graph_validation_test_command_validation.rs` and
+  `tests/integration/cli_build/graph_validation_test_command_validation/`,
+  preserving execution-scope, dependency-shape, target-metadata,
+  gated-dependency, and graph-only-library validation checks in focused
+  modules.
 - Build-graph JSON validation tests now live in
   `tests/integration/cli_build/build_graph_json/validation.rs`, preserving
   target field, dependency, unsupported target, and gated package/link

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3182,10 +3182,11 @@ checked-in docs, tests, and commits only.
   checks in focused modules under
   `tests/integration/cli_build/legacy_graph_command_validation/`, preserving
   the same command behavior coverage while keeping the module index compact.
-- `zen test build.zen` graph-only library validation tests now live in
-  `tests/integration/cli_build/graph_validation_test_command_validation/graph_only_libraries.rs`,
-  keeping missing source, valid source, and library typecheck coverage separate
-  from test-target, gated-dependency, and skipped-source validation checks.
+- `zen test build.zen` graph validation tests now live in
+  `tests/integration/cli_build/graph_validation_test_command_validation.rs` and
+  `tests/integration/cli_build/graph_validation_test_command_validation/`,
+  keeping execution-scope, dependency-shape, target-metadata,
+  gated-dependency, and graph-only-library validation checks focused.
 - Build-graph JSON validation tests now live in
   `tests/integration/cli_build/build_graph_json/validation.rs`, keeping target
   field, dependency, unsupported target, and gated package/link diagnostics

--- a/tests/integration/cli_build/graph_validation_test_command_validation.rs
+++ b/tests/integration/cli_build/graph_validation_test_command_validation.rs
@@ -1,9 +1,13 @@
 use std::process::Command;
 
+#[path = "graph_validation_test_command_validation/dependency_shapes.rs"]
+mod dependency_shapes;
 #[path = "graph_validation_test_command_validation/gated_dependencies.rs"]
 mod gated_dependencies;
 #[path = "graph_validation_test_command_validation/graph_only_libraries.rs"]
 mod graph_only_libraries;
+#[path = "graph_validation_test_command_validation/target_metadata.rs"]
+mod target_metadata;
 
 #[test]
 fn test_command_build_zen_rejects_graph_without_test_targets() {
@@ -105,181 +109,6 @@ main = () i32 {
         String::from_utf8_lossy(&output.stdout).contains("test unit passed"),
         "expected test pass output, stdout={}",
         String::from_utf8_lossy(&output.stdout)
-    );
-}
-
-#[test]
-fn test_command_build_zen_rejects_unknown_target_dependencies() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Test {
-        name: "unit",
-        root: "test.zen",
-        dependencies: ["core"],
-    })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-    assert_test_command_rejects_dependency_shape(
-        tmp.path(),
-        "build target `unit` depends on unknown target `core`",
-    );
-}
-
-#[test]
-fn test_command_build_zen_rejects_self_target_dependencies() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Test {
-        name: "unit",
-        root: "test.zen",
-        dependencies: ["unit"],
-    })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-    assert_test_command_rejects_dependency_shape(
-        tmp.path(),
-        "build target `unit` cannot depend on itself",
-    );
-}
-
-#[test]
-fn test_command_build_zen_rejects_cyclic_target_dependencies() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Test {
-        name: "unit",
-        root: "unit.zen",
-        dependencies: ["integration"],
-    })
-    b.add(Test {
-        name: "integration",
-        root: "integration.zen",
-        dependencies: ["unit"],
-    })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-    assert_test_command_rejects_dependency_shape(
-        tmp.path(),
-        "build target dependency cycle includes `integration`",
-    );
-}
-
-#[test]
-fn test_command_build_zen_rejects_duplicate_test_target_fields() {
-    assert_test_command_rejects_target_metadata(
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Test {
-        name: "unit",
-        name: "integration",
-        root: "test.zen",
-    })
-    .Ok(b.config())
-}
-"#,
-        "duplicate field `name` in `Test` build target",
-    );
-}
-
-#[test]
-fn test_command_build_zen_rejects_missing_required_test_target_fields() {
-    assert_test_command_rejects_target_metadata(
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Test {
-        name: "unit",
-    })
-    .Ok(b.config())
-}
-"#,
-        "missing required field `root` or `root_source_file` in `Test` build target",
-    );
-}
-
-#[test]
-fn test_command_build_zen_rejects_invalid_test_target_field_types() {
-    assert_test_command_rejects_target_metadata(
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Test {
-        name: "unit",
-        root: 42,
-    })
-    .Ok(b.config())
-}
-"#,
-        "field `root` in `Test` build target must be a string",
-    );
-}
-
-fn assert_test_command_rejects_target_metadata(build_source: &str, expected_diagnostic: &str) {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(tmp.path().join("build.zen"), build_source).expect("write build.zen");
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["test", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen test build.zen");
-
-    assert!(
-        !output.status.success(),
-        "zen test build.zen unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains(expected_diagnostic),
-        "expected target metadata diagnostic `{expected_diagnostic}`, stderr={stderr}"
-    );
-    assert!(
-        !tmp.path().join("build").exists(),
-        "test command should not create outputs after target metadata validation fails"
-    );
-}
-
-fn assert_test_command_rejects_dependency_shape(
-    project_dir: &std::path::Path,
-    expected_diagnostic: &str,
-) {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["test", "build.zen"])
-        .current_dir(project_dir)
-        .output()
-        .expect("run zen test build.zen");
-
-    assert!(
-        !output.status.success(),
-        "zen test build.zen unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr).contains(expected_diagnostic),
-        "expected dependency diagnostic `{expected_diagnostic}`, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        !project_dir.join("build").exists(),
-        "test command should not create outputs after dependency validation fails"
     );
 }
 

--- a/tests/integration/cli_build/graph_validation_test_command_validation/dependency_shapes.rs
+++ b/tests/integration/cli_build/graph_validation_test_command_validation/dependency_shapes.rs
@@ -1,0 +1,102 @@
+use std::process::Command;
+
+#[test]
+fn test_command_build_zen_rejects_unknown_target_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Test {
+        name: "unit",
+        root: "test.zen",
+        dependencies: ["core"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    assert_test_command_rejects_dependency_shape(
+        tmp.path(),
+        "build target `unit` depends on unknown target `core`",
+    );
+}
+
+#[test]
+fn test_command_build_zen_rejects_self_target_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Test {
+        name: "unit",
+        root: "test.zen",
+        dependencies: ["unit"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    assert_test_command_rejects_dependency_shape(
+        tmp.path(),
+        "build target `unit` cannot depend on itself",
+    );
+}
+
+#[test]
+fn test_command_build_zen_rejects_cyclic_target_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Test {
+        name: "unit",
+        root: "unit.zen",
+        dependencies: ["integration"],
+    })
+    b.add(Test {
+        name: "integration",
+        root: "integration.zen",
+        dependencies: ["unit"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    assert_test_command_rejects_dependency_shape(
+        tmp.path(),
+        "build target dependency cycle includes `integration`",
+    );
+}
+
+fn assert_test_command_rejects_dependency_shape(
+    project_dir: &std::path::Path,
+    expected_diagnostic: &str,
+) {
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["test", "build.zen"])
+        .current_dir(project_dir)
+        .output()
+        .expect("run zen test build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen test build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains(expected_diagnostic),
+        "expected dependency diagnostic `{expected_diagnostic}`, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !project_dir.join("build").exists(),
+        "test command should not create outputs after dependency validation fails"
+    );
+}

--- a/tests/integration/cli_build/graph_validation_test_command_validation/target_metadata.rs
+++ b/tests/integration/cli_build/graph_validation_test_command_validation/target_metadata.rs
@@ -1,0 +1,75 @@
+use std::process::Command;
+
+#[test]
+fn test_command_build_zen_rejects_duplicate_test_target_fields() {
+    assert_test_command_rejects_target_metadata(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Test {
+        name: "unit",
+        name: "integration",
+        root: "test.zen",
+    })
+    .Ok(b.config())
+}
+"#,
+        "duplicate field `name` in `Test` build target",
+    );
+}
+
+#[test]
+fn test_command_build_zen_rejects_missing_required_test_target_fields() {
+    assert_test_command_rejects_target_metadata(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Test {
+        name: "unit",
+    })
+    .Ok(b.config())
+}
+"#,
+        "missing required field `root` or `root_source_file` in `Test` build target",
+    );
+}
+
+#[test]
+fn test_command_build_zen_rejects_invalid_test_target_field_types() {
+    assert_test_command_rejects_target_metadata(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Test {
+        name: "unit",
+        root: 42,
+    })
+    .Ok(b.config())
+}
+"#,
+        "field `root` in `Test` build target must be a string",
+    );
+}
+
+fn assert_test_command_rejects_target_metadata(build_source: &str, expected_diagnostic: &str) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(tmp.path().join("build.zen"), build_source).expect("write build.zen");
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["test", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen test build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen test build.zen unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(expected_diagnostic),
+        "expected target metadata diagnostic `{expected_diagnostic}`, stderr={stderr}"
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "test command should not create outputs after target metadata validation fails"
+    );
+}


### PR DESCRIPTION
## Summary

Split `zen test build.zen` graph validation fixtures into focused dependency-shape and target-metadata modules, leaving execution-scope cases in the parent module.

## Validation

- `cargo fmt --check`
- `cargo test --test integration graph_validation_test_command_validation -- --nocapture`
- `cargo test --test docs_truth phase_audit`
- `git diff --check --cached`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`