### PR TITLE
[codex] Cover imported generic constructor arity

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -103,6 +103,10 @@ and do not assume Phase 4 is ready without evidence.
   proving both `Result_unwrap_or_i32_str` and `Result_unwrap_or_bool_str`
   resolve to emitted definitions exactly once without unspecialized `Result_T`
   symbols.
+- Imported generic aggregate constructor arity diagnostics are covered by
+  `integration::imported_generic_aggregate_constructor_type_arg_arity_is_error`,
+  proving module-graph struct and enum constructors preserve hard generic arity
+  diagnostics without raw field or variant payload mismatch followups.
 - Loop-control parser dispatch now has repo hygiene coverage through
   `repo_hygiene::parser_loop_control_calls_use_owned_action_enum`, guarding the
   `LoopControlAction` parsing path against raw `done`/`next` spelling checks.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -138,6 +138,11 @@ checked-in docs, tests, and commits only.
 - Generic diagnostics now cover generic struct constructor arity failures
   without leaking raw type-parameter field mismatch followups, including
   `generic_struct_constructor_without_type_args_is_error`.
+- Imported generic struct and enum constructor arity diagnostics now have
+  module-graph coverage through
+  `imported_generic_aggregate_constructor_type_arg_arity_is_error`, preserving
+  the hard aggregate arity diagnostics without field or payload mismatch
+  followups.
 - Generic diagnostics now cover non-generic struct and enum constructors that
   receive type arguments, including
   `nongeneric_struct_constructor_type_args_are_error` and

--- a/tests/integration/frontend_diagnostics.rs
+++ b/tests/integration/frontend_diagnostics.rs
@@ -182,6 +182,65 @@ main = () i32 {
 }
 
 #[test]
+fn imported_generic_aggregate_constructor_type_arg_arity_is_error() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let types_path = tmp.path().join("types.zen");
+    std::fs::write(
+        &types_path,
+        r#"
+pub Box<T>: {
+    value: T
+}
+
+pub Option<T>:
+    Some(T),
+    None
+"#,
+    )
+    .expect("write types module");
+
+    let main_path = tmp.path().join("main.zen");
+    std::fs::write(
+        &main_path,
+        r#"
+{ Box, Option } = types
+
+main = () i32 {
+    boxed = Box<i32, str> { value: 1 }
+    value = Option<i32, str>.Some(1)
+    boxed.value
+}
+"#,
+    )
+    .expect("write entry module");
+
+    let panic = std::panic::catch_unwind(|| compile_to_c(&main_path))
+        .expect_err("compile_to_c should reject imported generic constructor arity errors");
+    let message = panic
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| panic.downcast_ref::<&str>().copied())
+        .unwrap_or("<non-string panic>");
+
+    assert!(
+        message.contains("generic struct `Box` expects 1 type arguments, found 2"),
+        "expected imported generic struct constructor arity diagnostic, panic={message}"
+    );
+    assert!(
+        message.contains("generic enum `Option` expects 1 type arguments, found 2"),
+        "expected imported generic enum constructor arity diagnostic, panic={message}"
+    );
+    assert!(
+        !message.contains("field `value` for struct `Box`"),
+        "imported generic struct constructor arity failure should not also report field mismatch, panic={message}"
+    );
+    assert!(
+        !message.contains("payload for enum variant"),
+        "imported generic enum constructor arity failure should not also report payload mismatch, panic={message}"
+    );
+}
+
+#[test]
 fn imported_generic_behavior_requires_missing_impl_is_error() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let traits_path = tmp.path().join("traits.zen");


### PR DESCRIPTION
## Summary

Add module-graph diagnostic coverage for imported generic struct and enum constructor type-argument arity errors.

The new test proves imported aggregate constructors keep the hard generic arity diagnostics and avoid noisy raw field/payload mismatch followups. Phase docs and the completion audit now record that evidence.

## Validation

- `cargo test --test integration imported_generic_aggregate_constructor_type_arg_arity_is_error -- --nocapture`
- `cargo fmt --check`
- `cargo test --test docs_truth phase_audit -- --nocapture`
- `git diff --check --cached`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Branch workflow check before PR creation: `gh run list --repo lantos1618/zenlang --branch codex/cover-imported-generic-constructor-arity --limit 10 --json ...` returned `[]`, so this push did not trigger branch Actions.