### PR TITLE
[codex] Cover inherited requires behavior emission

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -905,7 +905,9 @@ and do not assume Phase 4 is ready without evidence.
   `tests/zen/multi_file_imported_behavior_requires/main.zen`. Imported
   `.requires` assertions are also satisfied by inherited child behavior impls
   through `tests/zen/multi_file_imported_behavior_requires_inherited/main.zen`,
-  with missing imported generic behavior impl diagnostics covered by
+  with generated-C assertions proving concrete inherited dispatch emission
+  without unspecialized `T_encode` placeholders. Missing imported generic
+  behavior impl diagnostics are covered by
   `integration::imported_generic_behavior_requires_missing_impl_is_error`.
 - Imported public generic functions preserve behavior bounds whose behavior was
   imported by the source module, covered by

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1116,7 +1116,9 @@ checked-in docs, tests, and commits only.
   `tests/zen/multi_file_imported_behavior_requires/main.zen`. Imported
   `.requires` assertions are also satisfied by inherited child behavior impls
   through `tests/zen/multi_file_imported_behavior_requires_inherited/main.zen`,
-  with missing imported generic behavior impl diagnostics covered by
+  with generated-C assertions proving concrete inherited dispatch emission
+  without unspecialized `T_encode` placeholders. Missing imported generic
+  behavior impl diagnostics are covered by
   `integration::imported_generic_behavior_requires_missing_impl_is_error`.
 - Imported public generic functions can use behavior bounds whose behavior was
   imported by the source module, covered by

--- a/tests/integration/generic_specializations/behavior_bounds.rs
+++ b/tests/integration/generic_specializations/behavior_bounds.rs
@@ -118,6 +118,16 @@ fn behavior_bound_specializations_do_not_emit_unspecialized_c_symbols() {
     assert!(!c_source.contains("T_encode"));
 
     let c_source = compile_to_c_with_generated_call_check(
+        &test_dir().join("multi_file_imported_behavior_requires_inherited/main.zen"),
+    );
+    assert!(c_source.contains("zen_str Point_encode(Point value)"));
+    assert!(c_source.contains("zen_str encode_Point(Point value)"));
+    assert!(c_source.contains("Point_encode(value)"));
+    assert_c_call_resolves_to_definition(&c_source, "Point_encode");
+    assert_c_call_resolves_to_definition(&c_source, "encode_Point");
+    assert!(!c_source.contains("T_encode"));
+
+    let c_source = compile_to_c_with_generated_call_check(
         &test_dir().join("multi_file_imported_function_imported_behavior_bound/main.zen"),
     );
     assert!(c_source.contains("int32_t Point_encode__Json_i32(Point value)"));


### PR DESCRIPTION
## Summary

Add generated-C assertions for the imported `.requires` fixture where the required generic parent behavior is satisfied through an imported child behavior implementation.

The test now proves the inherited dispatch path emits concrete `Point_encode` and `encode_Point` call/definition pairs and does not leave unspecialized `T_encode` placeholders. Phase docs and the completion audit now record that evidence.

## Validation

- `cargo test --test integration behavior_bound_specializations_do_not_emit_unspecialized_c_symbols -- --nocapture`
- `cargo test --test docs_truth phase_audit -- --nocapture`
- `git diff --check --cached`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Branch workflow check before PR creation: `gh run list --repo lantos1618/zenlang --branch codex/cover-imported-inherited-requires-cgen --limit 10 --json ...` returned `[]`, so this push did not trigger branch Actions.