### PR TITLE
[codex] Cover imported duplicate behavior impls

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -897,6 +897,9 @@ and do not assume Phase 4 is ready without evidence.
   including transitive imported parent chains, covered by
   `integration::imported_behavior_extends_parent_impl_overlap_is_error` and
   `integration::imported_behavior_extends_transitive_parent_impl_overlap_is_error`.
+- Imported duplicate generic behavior impls are rejected through the module
+  graph, covered by
+  `integration::imported_duplicate_generic_behavior_impl_is_error`.
 - Generic dispatch through an imported child behavior can call a method inherited
   from that behavior's imported parent, covered by
   `tests/zen/multi_file_imported_child_parent_dispatch/main.zen`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1108,6 +1108,9 @@ checked-in docs, tests, and commits only.
   including transitive imported parent chains, covered by
   `integration::imported_behavior_extends_parent_impl_overlap_is_error` and
   `integration::imported_behavior_extends_transitive_parent_impl_overlap_is_error`.
+- Imported duplicate generic behavior impls are rejected through the module
+  graph, covered by
+  `integration::imported_duplicate_generic_behavior_impl_is_error`.
 - Generic dispatch through an imported child behavior can call a method inherited
   from that behavior's imported parent, covered by
   `tests/zen/multi_file_imported_child_parent_dispatch/main.zen`.

--- a/tests/integration/frontend_diagnostics/behavior_extends/overlaps.rs
+++ b/tests/integration/frontend_diagnostics/behavior_extends/overlaps.rs
@@ -146,3 +146,60 @@ main = () i32 {
         "expected imported transitive behavior impl overlap diagnostic, panic={message}"
     );
 }
+
+#[test]
+fn imported_duplicate_generic_behavior_impl_is_error() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let traits_path = tmp.path().join("traits.zen");
+    std::fs::write(
+        &traits_path,
+        r#"
+pub Json<T>: behavior {
+    encode: (Self) T
+}
+"#,
+    )
+    .expect("write traits module");
+
+    let main_path = tmp.path().join("main.zen");
+    std::fs::write(
+        &main_path,
+        r#"
+{ Json } = traits
+
+Point: {
+    x: i32
+}
+
+Point.implements(Json<str>) {
+    encode = (value: Point) str {
+        "point"
+    }
+}
+
+Point.implements(Json<str>) {
+    encode = (value: Point) str {
+        "point-again"
+    }
+}
+
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write entry module");
+
+    let panic = std::panic::catch_unwind(|| compile_to_c(&main_path))
+        .expect_err("compile_to_c should reject duplicate imported behavior impls");
+    let message = panic
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| panic.downcast_ref::<&str>().copied())
+        .unwrap_or("<non-string panic>");
+
+    assert!(
+        message.contains("duplicate behavior implementation `Json<str>` for `Point`"),
+        "expected imported duplicate behavior impl diagnostic, panic={message}"
+    );
+}


### PR DESCRIPTION
## Summary

Add module-graph diagnostic coverage for duplicate implementations of an imported generic behavior.

The new integration test proves imported `Json<str>` duplicate behavior impls are rejected by the resolver/frontend path, and the phase plan plus completion audit now record that evidence.

## Validation

- `cargo test --test integration imported_duplicate_generic_behavior_impl_is_error -- --nocapture`
- `cargo test --test docs_truth phase_audit -- --nocapture`
- `git diff --check --cached`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Branch workflow check before PR creation: `gh run list --repo lantos1618/zenlang --branch codex/cover-imported-duplicate-behavior-impl --limit 10 --json ...` returned `[]`, so this push did not trigger branch Actions.