### PR TITLE
[codex] Cover imported duplicate requires

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -911,7 +911,9 @@ and do not assume Phase 4 is ready without evidence.
   with generated-C assertions proving concrete inherited dispatch emission
   without unspecialized `T_encode` placeholders. Missing imported generic
   behavior impl diagnostics are covered by
-  `integration::imported_generic_behavior_requires_missing_impl_is_error`.
+  `integration::imported_generic_behavior_requires_missing_impl_is_error`, and
+  duplicate imported generic `.requires` edges are covered by
+  `integration::imported_duplicate_generic_behavior_requires_is_error`.
 - Imported public generic functions preserve behavior bounds whose behavior was
   imported by the source module, covered by
   `tests/zen/multi_file_imported_function_imported_behavior_bound/main.zen`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1122,7 +1122,9 @@ checked-in docs, tests, and commits only.
   with generated-C assertions proving concrete inherited dispatch emission
   without unspecialized `T_encode` placeholders. Missing imported generic
   behavior impl diagnostics are covered by
-  `integration::imported_generic_behavior_requires_missing_impl_is_error`.
+  `integration::imported_generic_behavior_requires_missing_impl_is_error`, and
+  duplicate imported generic `.requires` edges are covered by
+  `integration::imported_duplicate_generic_behavior_requires_is_error`.
 - Imported public generic functions can use behavior bounds whose behavior was
   imported by the source module, covered by
   `tests/zen/multi_file_imported_function_imported_behavior_bound/main.zen`.

--- a/tests/integration/frontend_diagnostics.rs
+++ b/tests/integration/frontend_diagnostics.rs
@@ -286,3 +286,57 @@ main = () i32 {
         "expected imported generic behavior requires diagnostic, panic={message}"
     );
 }
+
+#[test]
+fn imported_duplicate_generic_behavior_requires_is_error() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let traits_path = tmp.path().join("traits.zen");
+    std::fs::write(
+        &traits_path,
+        r#"
+pub Json<T>: behavior {
+    encode: (Self) T
+}
+"#,
+    )
+    .expect("write traits module");
+
+    let main_path = tmp.path().join("main.zen");
+    std::fs::write(
+        &main_path,
+        r#"
+{ Json } = traits
+
+Point: {
+    x: i32
+}
+
+Point.implements(Json<str>) {
+    encode = (value: Point) str {
+        "point"
+    }
+}
+
+Point.requires(Json<str>)
+Point.requires(Json<str>)
+
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write entry module");
+
+    let panic = std::panic::catch_unwind(|| compile_to_c(&main_path))
+        .expect_err("compile_to_c should reject duplicate imported behavior requires");
+    let message = panic
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| panic.downcast_ref::<&str>().copied())
+        .unwrap_or("<non-string panic>");
+
+    assert!(
+        message.contains("duplicate required behavior `Json<str>` for `Point`"),
+        "expected imported duplicate behavior requires diagnostic, panic={message}"
+    );
+}


### PR DESCRIPTION
## Summary

Add module-graph diagnostic coverage for duplicate imported generic `.requires` edges.

The new integration test proves duplicate `Point.requires(Json<str>)` assertions are rejected through the resolver/frontend path before they can become ambiguous behavior-association state. Phase docs and the completion audit now record that evidence.

## Validation

- `cargo test --test integration imported_duplicate_generic_behavior_requires_is_error -- --nocapture`
- `cargo test --test docs_truth phase_audit -- --nocapture`
- `git diff --check --cached`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Branch workflow check before PR creation: `gh run list --repo lantos1618/zenlang --branch codex/cover-imported-duplicate-requires --limit 10 --json ...` returned `[]`, so this push did not trigger branch Actions.