### PR TITLE
[codex] Cover imported requires arity

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -911,7 +911,9 @@ and do not assume Phase 4 is ready without evidence.
   with generated-C assertions proving concrete inherited dispatch emission
   without unspecialized `T_encode` placeholders. Missing imported generic
   behavior impl diagnostics are covered by
-  `integration::imported_generic_behavior_requires_missing_impl_is_error`, and
+  `integration::imported_generic_behavior_requires_missing_impl_is_error`,
+  imported generic `.requires` arity diagnostics are covered by
+  `integration::imported_generic_behavior_requires_type_arg_arity_is_error`, and
   duplicate imported generic `.requires` edges are covered by
   `integration::imported_duplicate_generic_behavior_requires_is_error`.
 - Imported public generic functions preserve behavior bounds whose behavior was

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1122,7 +1122,9 @@ checked-in docs, tests, and commits only.
   with generated-C assertions proving concrete inherited dispatch emission
   without unspecialized `T_encode` placeholders. Missing imported generic
   behavior impl diagnostics are covered by
-  `integration::imported_generic_behavior_requires_missing_impl_is_error`, and
+  `integration::imported_generic_behavior_requires_missing_impl_is_error`,
+  imported generic `.requires` arity diagnostics are covered by
+  `integration::imported_generic_behavior_requires_type_arg_arity_is_error`, and
   duplicate imported generic `.requires` edges are covered by
   `integration::imported_duplicate_generic_behavior_requires_is_error`.
 - Imported public generic functions can use behavior bounds whose behavior was

--- a/tests/integration/frontend_diagnostics.rs
+++ b/tests/integration/frontend_diagnostics.rs
@@ -288,6 +288,53 @@ main = () i32 {
 }
 
 #[test]
+fn imported_generic_behavior_requires_type_arg_arity_is_error() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let traits_path = tmp.path().join("traits.zen");
+    std::fs::write(
+        &traits_path,
+        r#"
+pub Json<T>: behavior {
+    encode: (Self) T
+}
+"#,
+    )
+    .expect("write traits module");
+
+    let main_path = tmp.path().join("main.zen");
+    std::fs::write(
+        &main_path,
+        r#"
+{ Json } = traits
+
+Point: {
+    x: i32
+}
+
+Point.requires(Json<i32, str>)
+
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write entry module");
+
+    let panic = std::panic::catch_unwind(|| compile_to_c(&main_path))
+        .expect_err("compile_to_c should reject imported behavior requires arity errors");
+    let message = panic
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| panic.downcast_ref::<&str>().copied())
+        .unwrap_or("<non-string panic>");
+
+    assert!(
+        message.contains("generic behavior `Json` expects 1 type arguments, found 2"),
+        "expected imported behavior requires arity diagnostic, panic={message}"
+    );
+}
+
+#[test]
 fn imported_duplicate_generic_behavior_requires_is_error() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let traits_path = tmp.path().join("traits.zen");


### PR DESCRIPTION
## Summary

Add module-graph diagnostic coverage for imported generic behavior `.requires` type-argument arity errors.

The new integration test proves malformed `Point.requires(Json<i32, str>)` assertions over imported generic behaviors produce the hard arity diagnostic. Phase docs and the completion audit now record that evidence.

## Validation

- `cargo test --test integration imported_generic_behavior_requires_type_arg_arity_is_error -- --nocapture`
- `cargo test --test docs_truth phase_audit -- --nocapture`
- `git diff --check --cached`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Branch workflow check before PR creation: `gh run list --repo lantos1618/zenlang --branch codex/cover-imported-requires-arity --limit 10 --json ...` returned `[]`, so this push did not trigger branch Actions.