### PR TITLE
[codex] Cover imported implements arity

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -900,6 +900,9 @@ and do not assume Phase 4 is ready without evidence.
 - Imported duplicate generic behavior impls are rejected through the module
   graph, covered by
   `integration::imported_duplicate_generic_behavior_impl_is_error`.
+- Imported generic behavior impl arity diagnostics are covered through the
+  module graph by
+  `integration::imported_generic_behavior_impl_type_arg_arity_is_error`.
 - Generic dispatch through an imported child behavior can call a method inherited
   from that behavior's imported parent, covered by
   `tests/zen/multi_file_imported_child_parent_dispatch/main.zen`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1111,6 +1111,9 @@ checked-in docs, tests, and commits only.
 - Imported duplicate generic behavior impls are rejected through the module
   graph, covered by
   `integration::imported_duplicate_generic_behavior_impl_is_error`.
+- Imported generic behavior impl arity diagnostics are covered through the
+  module graph by
+  `integration::imported_generic_behavior_impl_type_arg_arity_is_error`.
 - Generic dispatch through an imported child behavior can call a method inherited
   from that behavior's imported parent, covered by
   `tests/zen/multi_file_imported_child_parent_dispatch/main.zen`.

--- a/tests/integration/frontend_diagnostics.rs
+++ b/tests/integration/frontend_diagnostics.rs
@@ -288,6 +288,57 @@ main = () i32 {
 }
 
 #[test]
+fn imported_generic_behavior_impl_type_arg_arity_is_error() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let traits_path = tmp.path().join("traits.zen");
+    std::fs::write(
+        &traits_path,
+        r#"
+pub Json<T>: behavior {
+    encode: (Self) T
+}
+"#,
+    )
+    .expect("write traits module");
+
+    let main_path = tmp.path().join("main.zen");
+    std::fs::write(
+        &main_path,
+        r#"
+{ Json } = traits
+
+Point: {
+    x: i32
+}
+
+Point.implements(Json) {
+    encode = (value: Point) str {
+        "point"
+    }
+}
+
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write entry module");
+
+    let panic = std::panic::catch_unwind(|| compile_to_c(&main_path))
+        .expect_err("compile_to_c should reject imported behavior impl arity errors");
+    let message = panic
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| panic.downcast_ref::<&str>().copied())
+        .unwrap_or("<non-string panic>");
+
+    assert!(
+        message.contains("generic behavior `Json` expects 1 type arguments, found 0"),
+        "expected imported behavior impl arity diagnostic, panic={message}"
+    );
+}
+
+#[test]
 fn imported_generic_behavior_requires_type_arg_arity_is_error() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let traits_path = tmp.path().join("traits.zen");


### PR DESCRIPTION
## Summary
- Add module-graph diagnostic coverage for imported generic behavior `.implements` type-argument arity errors.
- Prove malformed `Point.implements(Json)` over imported `Json<T>` emits the hard arity diagnostic.
- Record the evidence in the phase plan and completion audit.

## Validation
- `cargo test --test integration imported_generic_behavior_impl_type_arg_arity_is_error -- --nocapture`
- `cargo test --test docs_truth phase_audit -- --nocapture`
- `git diff --check --cached`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch codex/cover-imported-implements-arity --limit 10 --json databaseId,status,conclusion,name,event,headSha,createdAt` returned `[]` before PR creation.