### PR TITLE
[codex] Cover imported extends arity

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -903,6 +903,9 @@ and do not assume Phase 4 is ready without evidence.
 - Imported generic behavior impl arity diagnostics are covered through the
   module graph by
   `integration::imported_generic_behavior_impl_type_arg_arity_is_error`.
+- Imported generic behavior inheritance arity diagnostics are covered through
+  the module graph by
+  `integration::imported_generic_behavior_extends_type_arg_arity_is_error`.
 - Generic dispatch through an imported child behavior can call a method inherited
   from that behavior's imported parent, covered by
   `tests/zen/multi_file_imported_child_parent_dispatch/main.zen`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1114,6 +1114,9 @@ checked-in docs, tests, and commits only.
 - Imported generic behavior impl arity diagnostics are covered through the
   module graph by
   `integration::imported_generic_behavior_impl_type_arg_arity_is_error`.
+- Imported generic behavior inheritance arity diagnostics are covered through
+  the module graph by
+  `integration::imported_generic_behavior_extends_type_arg_arity_is_error`.
 - Generic dispatch through an imported child behavior can call a method inherited
   from that behavior's imported parent, covered by
   `tests/zen/multi_file_imported_child_parent_dispatch/main.zen`.

--- a/tests/integration/frontend_diagnostics.rs
+++ b/tests/integration/frontend_diagnostics.rs
@@ -339,6 +339,53 @@ main = () i32 {
 }
 
 #[test]
+fn imported_generic_behavior_extends_type_arg_arity_is_error() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let traits_path = tmp.path().join("traits.zen");
+    std::fs::write(
+        &traits_path,
+        r#"
+pub Json<T>: behavior {
+    encode: (Self) T
+}
+"#,
+    )
+    .expect("write traits module");
+
+    let main_path = tmp.path().join("main.zen");
+    std::fs::write(
+        &main_path,
+        r#"
+{ Json } = traits
+
+PrettyJson: behavior {
+    pretty: (Self) str
+}
+
+PrettyJson.extends(Json)
+
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write entry module");
+
+    let panic = std::panic::catch_unwind(|| compile_to_c(&main_path))
+        .expect_err("compile_to_c should reject imported behavior extends arity errors");
+    let message = panic
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| panic.downcast_ref::<&str>().copied())
+        .unwrap_or("<non-string panic>");
+
+    assert!(
+        message.contains("generic behavior `Json` expects 1 type arguments, found 0"),
+        "expected imported behavior extends arity diagnostic, panic={message}"
+    );
+}
+
+#[test]
 fn imported_generic_behavior_requires_type_arg_arity_is_error() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let traits_path = tmp.path().join("traits.zen");


### PR DESCRIPTION
## Summary
- Add module-graph diagnostic coverage for imported generic behavior `.extends` type-argument arity errors.
- Prove malformed `PrettyJson.extends(Json)` over imported `Json<T>` emits the hard arity diagnostic.
- Record the evidence in the phase plan and completion audit.

## Validation
- `cargo test --test integration imported_generic_behavior_extends_type_arg_arity_is_error -- --nocapture`
- `cargo test --test docs_truth phase_audit -- --nocapture`
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch codex/cover-imported-extends-arity --limit 10 --json databaseId,status,conclusion,name,event,headSha,createdAt` returned `[]` before PR creation.