### PR TITLE
Cover legacy graph file effects

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3675,6 +3675,18 @@ and do not assume Phase 4 is ready without evidence.
 - Root smoke fixtures under `tests/test_*.zen` no longer use the removed
   `return` keyword and are guarded by
   `root_smoke_fixtures_do_not_use_removed_return_keyword`.
+- Legacy `zen build-graph build.zen` file-read host-effect validation now
+  matches the unselected-target coverage on `zen build build.zen` and direct
+  `zen build.zen`: declared fallback arms allow selected executable targets to
+  build while unrelated missing test sources are ignored, and undeclared or
+  missing-fallback file reads are rejected before unrelated target handling or
+  output creation. Coverage:
+  `build_graph_command_accepts_declared_file_read_effects_with_unselected_targets`,
+  `build_graph_command_accepts_wildcard_fallback_declared_file_read_effects_with_unselected_targets`,
+  `build_graph_command_accepts_identifier_fallback_declared_file_read_effects_with_unselected_targets`,
+  `build_graph_command_rejects_undeclared_file_read_effects_before_unselected_targets`,
+  and
+  `build_graph_command_rejects_file_read_without_fallback_before_unselected_targets`.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3364,6 +3364,18 @@ checked-in docs, tests, and commits only.
 - Root smoke fixtures under `tests/test_*.zen` now use expression-tail returns
   instead of the removed `return` keyword, guarded by
   `root_smoke_fixtures_do_not_use_removed_return_keyword`.
+- Legacy `zen build-graph build.zen` now has the same declared file-read
+  unselected-target coverage as the newer graph execution entrypoints: declared
+  fallback arms allow selected executable targets to build while unrelated
+  missing test sources are ignored, and undeclared or missing-fallback file
+  reads are rejected before unrelated target handling or output creation.
+  Coverage:
+  `build_graph_command_accepts_declared_file_read_effects_with_unselected_targets`,
+  `build_graph_command_accepts_wildcard_fallback_declared_file_read_effects_with_unselected_targets`,
+  `build_graph_command_accepts_identifier_fallback_declared_file_read_effects_with_unselected_targets`,
+  `build_graph_command_rejects_undeclared_file_read_effects_before_unselected_targets`,
+  and
+  `build_graph_command_rejects_file_read_without_fallback_before_unselected_targets`.
 
 ## Current Phase
 

--- a/tests/integration/cli_build/legacy_graph_command_host_effects/file_reads.rs
+++ b/tests/integration/cli_build/legacy_graph_command_host_effects/file_reads.rs
@@ -49,6 +49,32 @@ fn build_graph_command_accepts_identifier_fallback_declared_file_read_effects_fo
     );
 }
 
+#[test]
+fn build_graph_command_accepts_declared_file_read_effects_with_unselected_targets() {
+    assert_build_graph_command_accepts_declared_file_read_effects_with_unselected_targets(
+        r#"| .Err { "default" }"#,
+        "build_graph_command_accepts_declared_file_read_effects_with_unselected_targets",
+    );
+}
+
+#[test]
+fn build_graph_command_accepts_wildcard_fallback_declared_file_read_effects_with_unselected_targets(
+) {
+    assert_build_graph_command_accepts_declared_file_read_effects_with_unselected_targets(
+        r#"| _ { "default" }"#,
+        "build_graph_command_accepts_wildcard_fallback_declared_file_read_effects_with_unselected_targets",
+    );
+}
+
+#[test]
+fn build_graph_command_accepts_identifier_fallback_declared_file_read_effects_with_unselected_targets(
+) {
+    assert_build_graph_command_accepts_declared_file_read_effects_with_unselected_targets(
+        r#"| err { "default" }"#,
+        "build_graph_command_accepts_identifier_fallback_declared_file_read_effects_with_unselected_targets",
+    );
+}
+
 fn assert_build_graph_command_accepts_declared_file_read_effects_for_multiple_targets(
     fallback_arm: &str,
     case_name: &str,
@@ -173,6 +199,53 @@ main = () i32 {
     );
 }
 
+fn assert_build_graph_command_accepts_declared_file_read_effects_with_unselected_targets(
+    fallback_arm: &str,
+    case_name: &str,
+) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
+    manifest = b.os.read_file("build.targets") ?
+        | .Ok(contents) {{ contents }}
+        {fallback_arm}
+    b.add(Executable {{ name: "app", main: "app.zen", out_dir: "build/app/" }})
+    b.add(Test {{ name: "unit", root: "missing_unit.zen" }})
+    b.add(Library {{ name: "core", exports: ["lib.zen"] }})
+    .Ok(b.config())
+}}
+"#,
+        ),
+    )
+    .expect("write build.zen");
+    std::fs::write(tmp.path().join("build.targets"), "app\n").expect("write manifest");
+    write_zero_main(tmp.path().join("app.zen"));
+    write_library_source(&tmp);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build-graph", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build-graph build.zen");
+
+    assert!(
+        output.status.success(),
+        "{case_name}: zen build-graph build.zen failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let bin_path = tmp.path().join("build").join("app").join("app");
+    assert!(
+        bin_path.exists(),
+        "expected {} to exist",
+        bin_path.display()
+    );
+}
+
 #[test]
 fn build_graph_command_rejects_undeclared_file_read_effects_before_execution() {
     let tmp = tempfile::tempdir().expect("create temp dir");
@@ -291,4 +364,97 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
         !tmp.path().join("build").exists(),
         "build-graph command should reject file effects before target execution"
     );
+}
+
+#[test]
+fn build_graph_command_rejects_undeclared_file_read_effects_before_unselected_targets() {
+    assert_build_graph_command_rejects_file_read_before_unselected_targets(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets")
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    b.add(Test { name: "unit", root: "missing_unit.zen" })
+    b.add(Library { name: "core", exports: ["lib.zen"] })
+    .Ok(b.config())
+}
+"#,
+        "undeclared",
+    );
+}
+
+#[test]
+fn build_graph_command_rejects_file_read_without_fallback_before_unselected_targets() {
+    assert_build_graph_command_rejects_file_read_before_unselected_targets(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    manifest = b.os.read_file("build.targets") ?
+        | .Ok(contents) { contents }
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    b.add(Test { name: "unit", root: "missing_unit.zen" })
+    b.add(Library { name: "core", exports: ["lib.zen"] })
+    .Ok(b.config())
+}
+"#,
+        "missing-fallback",
+    );
+}
+
+fn assert_build_graph_command_rejects_file_read_before_unselected_targets(
+    build_source: &str,
+    diagnostic_case: &str,
+) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(tmp.path().join("build.zen"), build_source).expect("write build.zen");
+    write_zero_main(tmp.path().join("app.zen"));
+    write_library_source(&tmp);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build-graph", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build-graph build.zen");
+
+    assert!(
+        !output.status.success(),
+        "zen build-graph unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("undeclared host effect: read file `build.targets`"),
+        "expected {diagnostic_case} file read diagnostic, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("missing_unit.zen"),
+        "host-effect validation should run before unrelated test source handling, stderr={stderr}"
+    );
+    assert!(
+        !tmp.path().join("build").exists(),
+        "build-graph command should reject file effects before selected target execution"
+    );
+}
+
+fn write_zero_main(path: impl AsRef<std::path::Path>) {
+    std::fs::write(
+        path,
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write main source");
+}
+
+fn write_library_source(tmp: &tempfile::TempDir) {
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    1
+}
+"#,
+    )
+    .expect("write lib.zen");
 }


### PR DESCRIPTION
## Summary
- add legacy `zen build-graph build.zen` file-read host-effect coverage for unselected targets
- document the matching positive/negative coverage in the phase plan and completion audit

## Verification
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`