### PR TITLE
Cover legacy graph env effects

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3687,6 +3687,17 @@ and do not assume Phase 4 is ready without evidence.
   `build_graph_command_rejects_undeclared_file_read_effects_before_unselected_targets`,
   and
   `build_graph_command_rejects_file_read_without_fallback_before_unselected_targets`.
+- Legacy `zen build-graph build.zen` env-read host-effect validation now also
+  matches the unselected-target coverage on the newer graph execution
+  entrypoints: declared fallback arms allow selected executable targets to build
+  while unrelated missing test sources are ignored, and missing-fallback env
+  reads are rejected before unrelated target handling or output creation.
+  Coverage:
+  `build_graph_command_accepts_declared_env_read_with_unselected_targets`,
+  `build_graph_command_accepts_wildcard_fallback_declared_env_read_with_unselected_targets`,
+  `build_graph_command_accepts_identifier_fallback_declared_env_read_with_unselected_targets`,
+  and
+  `build_graph_command_rejects_env_read_without_fallback_before_unselected_targets`.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3376,6 +3376,16 @@ checked-in docs, tests, and commits only.
   `build_graph_command_rejects_undeclared_file_read_effects_before_unselected_targets`,
   and
   `build_graph_command_rejects_file_read_without_fallback_before_unselected_targets`.
+- Legacy `zen build-graph build.zen` now also has matching declared env-read
+  unselected-target coverage: declared fallback arms allow selected executable
+  targets to build while unrelated missing test sources are ignored, and
+  missing-fallback env reads are rejected before unrelated target handling or
+  output creation. Coverage:
+  `build_graph_command_accepts_declared_env_read_with_unselected_targets`,
+  `build_graph_command_accepts_wildcard_fallback_declared_env_read_with_unselected_targets`,
+  `build_graph_command_accepts_identifier_fallback_declared_env_read_with_unselected_targets`,
+  and
+  `build_graph_command_rejects_env_read_without_fallback_before_unselected_targets`.
 
 ## Current Phase
 

--- a/tests/integration/cli_build/declared_env_effects/build_graph.rs
+++ b/tests/integration/cli_build/declared_env_effects/build_graph.rs
@@ -56,6 +56,30 @@ fn build_graph_command_accepts_identifier_fallback_declared_env_read_for_multipl
     );
 }
 
+#[test]
+fn build_graph_command_accepts_declared_env_read_with_unselected_targets() {
+    assert_build_graph_command_accepts_declared_env_read_with_unselected_targets(
+        r#"| .Err { "default" }"#,
+        "build_graph_command_accepts_declared_env_read_with_unselected_targets",
+    );
+}
+
+#[test]
+fn build_graph_command_accepts_wildcard_fallback_declared_env_read_with_unselected_targets() {
+    assert_build_graph_command_accepts_declared_env_read_with_unselected_targets(
+        r#"| _ { "default" }"#,
+        "build_graph_command_accepts_wildcard_fallback_declared_env_read_with_unselected_targets",
+    );
+}
+
+#[test]
+fn build_graph_command_accepts_identifier_fallback_declared_env_read_with_unselected_targets() {
+    assert_build_graph_command_accepts_declared_env_read_with_unselected_targets(
+        r#"| err { "default" }"#,
+        "build_graph_command_accepts_identifier_fallback_declared_env_read_with_unselected_targets",
+    );
+}
+
 fn assert_build_graph_command_accepts_declared_env_read_for_multiple_targets(
     fallback_arm: &str,
     case_name: &str,
@@ -119,4 +143,66 @@ main = () i32 {
             bin_path.display()
         );
     }
+}
+
+fn assert_build_graph_command_accepts_declared_env_read_with_unselected_targets(
+    fallback_arm: &str,
+    case_name: &str,
+) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
+    std_path = b.os.env("ZEN_STD") ?
+        | .Ok(value) {{ value }}
+        {fallback_arm}
+    b.add(Executable {{ name: "app", main: "app.zen", out_dir: "build/app/" }})
+    b.add(Test {{ name: "unit", root: "missing_unit.zen" }})
+    b.add(Library {{ name: "core", exports: ["lib.zen"] }})
+    .Ok(b.config())
+}}
+"#,
+        ),
+    )
+    .expect("write build.zen");
+    std::fs::write(
+        tmp.path().join("app.zen"),
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write app.zen");
+    std::fs::write(
+        tmp.path().join("lib.zen"),
+        r#"
+value = () i32 {
+    1
+}
+"#,
+    )
+    .expect("write lib.zen");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["build-graph", "build.zen"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen build-graph build.zen");
+
+    assert!(
+        output.status.success(),
+        "{case_name}: zen build-graph build.zen failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let bin_path = tmp.path().join("build").join("app").join("app");
+    assert!(
+        bin_path.exists(),
+        "expected {} to exist",
+        bin_path.display()
+    );
 }

--- a/tests/integration/cli_build/declared_env_effects/rejections/build_graph.rs
+++ b/tests/integration/cli_build/declared_env_effects/rejections/build_graph.rs
@@ -37,3 +37,11 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
         "build-graph command should reject env effects before target execution"
     );
 }
+
+#[test]
+fn build_graph_command_rejects_env_read_without_fallback_before_unselected_targets() {
+    assert_env_read_without_fallback_before_unselected_targets(
+        &["build-graph", "build.zen"],
+        "build-graph command should reject env effects before selected target execution",
+    );
+}


### PR DESCRIPTION
## Summary
- add legacy `zen build-graph build.zen` env-read host-effect coverage for unselected targets
- document the matching positive/negative coverage in the phase plan and completion audit

## Verification
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`