### PR TITLE
Align build zen backlog wording

### DIFF
--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -26,7 +26,8 @@ Unsupported spec-like constructs must stay gated until parser and semantic tests
 exist. This includes unspecialized generic behavior bounds such as `T: Json`,
 unspecialized generic type association targets such as `Box.implements(Json)`,
 comptime execution, type matching, async operations, actor syntax, package
-manifests, and `build.zen` execution.
+manifests, and `build.zen` execution beyond the constrained deterministic
+graph surface.
 
 ## Accepted Syntax Forms
 
@@ -152,7 +153,7 @@ planned positive test and one planned negative test before implementation.
 | AST traversal | Tooling can read AST JSON for a parsed source fixture | AST traversal cannot bypass semantic checks for a core language feature |
 | Actors in std | Actor mailbox send/receive works with scheduler and allocator integration | Actor using async mailbox from sync-only context is rejected |
 | JSON/YAML IR boundaries | Checked MIR JSON and target YAML validate against schemas | Hand-authored JSON IR cannot override compiler-owned types or layouts |
-| `build.zen` | Deterministic build graph creates one executable target | Build script using undeclared host side effects is rejected |
+| `build.zen` | Deterministic build graph compiles executable and test targets | Build script using undeclared host side effects is rejected |
 
 ## Stdlib Gate
 

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -60,6 +60,7 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "Executable target dependencies compile",
         "dependency cycles",
         "dependency-ordered multi-executable build tests",
+        "Deterministic build graph compiles executable and test targets",
         "Accepted Syntax Forms",
         "Test Evidence",
         "Planned Positive Test",
@@ -212,4 +213,9 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
             "docs/V1_SPEC.md is missing Phase 1 requirement: {required}"
         );
     }
+
+    assert!(
+        !spec.contains("Deterministic build graph creates one executable target"),
+        "docs/V1_SPEC.md still describes the build.zen backlog as single-executable only"
+    );
 }


### PR DESCRIPTION
## Summary

- Update the V1 spec syntax contract so only `build.zen` execution beyond the constrained deterministic graph surface remains gated.
- Update the required build-system backlog positive test wording from single-executable-only to executable and test target compilation.
- Add a docs-truth guard against reintroducing the stale single-executable backlog claim.

## Validation

- `cargo test --test docs_truth v1_spec_records_phase_one_feature_gates_and_test_backlog` failed before the spec wording update and passed after it.
- `git diff --check && cargo fmt --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- Branch push Actions check returned `[]`.