### PR TITLE
Split build graph JSON validation tests

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -286,6 +286,13 @@ and do not assume Phase 4 is ready without evidence.
   package/link field diagnostics into
   `tests/integration/cli_build/build_graph_json/validation/unsupported_targets.rs`,
   leaving target field and dependency graph diagnostics in the parent module.
+- Build-graph JSON validation tests now split dependency graph diagnostics and
+  deterministic-body rejection coverage into
+  `tests/integration/cli_build/build_graph_json/validation/dependencies.rs`
+  and
+  `tests/integration/cli_build/build_graph_json/validation/deterministic_body.rs`,
+  leaving the parent module on target field diagnostics and the shared CLI
+  assertion helper.
 - Emit-command build graph validation tests now split target-selection
   diagnostics into
   `tests/integration/cli_build/emit_direct_validation/target_selection.rs`,

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -474,6 +474,10 @@ checked-in docs, tests, and commits only.
 - Build-graph JSON validation tests now keep unsupported target kind and gated
   package/link field diagnostics in a focused child module, leaving target
   field and dependency graph diagnostics in the parent module.
+- Build-graph JSON validation tests now also keep dependency graph diagnostics
+  and deterministic-body rejection coverage in focused child modules, leaving
+  the parent module on target field diagnostics and the shared CLI assertion
+  helper.
 - Emit-command build graph validation tests now keep target-selection
   diagnostics in a focused child module, leaving unrelated gated test source
   skip coverage in the parent module.

--- a/tests/integration/cli_build/build_graph_json/validation.rs
+++ b/tests/integration/cli_build/build_graph_json/validation.rs
@@ -1,5 +1,9 @@
 use std::process::Command;
 
+#[path = "validation/dependencies.rs"]
+mod dependencies;
+#[path = "validation/deterministic_body.rs"]
+mod deterministic_body;
 #[path = "validation/unsupported_targets.rs"]
 mod unsupported_targets;
 
@@ -150,86 +154,6 @@ build = (b: Builder) Result<BuildConfig, BuildError> {
 }
 "#,
         "field `exports` in `Library` build target must contain at least one source",
-    );
-}
-
-#[test]
-fn emit_json_build_graph_rejects_unknown_target_dependencies() {
-    assert_emit_json_build_graph_error_contains(
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable {
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        dependencies: ["core"],
-    })
-    .Ok(b.config())
-}
-"#,
-        "build target `app` depends on unknown target `core`",
-    );
-}
-
-#[test]
-fn emit_json_build_graph_rejects_self_target_dependencies() {
-    assert_emit_json_build_graph_error_contains(
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable {
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        dependencies: ["app"],
-    })
-    .Ok(b.config())
-}
-"#,
-        "build target `app` cannot depend on itself",
-    );
-}
-
-#[test]
-fn emit_json_build_graph_rejects_cyclic_target_dependencies() {
-    assert_emit_json_build_graph_error_contains(
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable {
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        dependencies: ["tool"],
-    })
-    b.add(Executable {
-        name: "tool",
-        main: "tool.zen",
-        out_dir: "build/tool/",
-        dependencies: ["app"],
-    })
-    .Ok(b.config())
-}
-"#,
-        "build target dependency cycle includes `app`",
-    );
-}
-
-#[test]
-fn emit_json_build_graph_rejects_dynamic_target_adds() {
-    assert_emit_json_build_graph_error_contains(
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    enabled = true
-    enabled ?
-        | true {
-            b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
-        }
-        | false {
-            b.add(Executable { name: "tool", main: "tool.zen", out_dir: "build/tool/" })
-        }
-    .Ok(b.config())
-}
-"#,
-        "build targets must be added in the deterministic build graph body",
     );
 }
 

--- a/tests/integration/cli_build/build_graph_json/validation/dependencies.rs
+++ b/tests/integration/cli_build/build_graph_json/validation/dependencies.rs
@@ -1,0 +1,59 @@
+#[test]
+fn emit_json_build_graph_rejects_unknown_target_dependencies() {
+    super::assert_emit_json_build_graph_error_contains(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["core"],
+    })
+    .Ok(b.config())
+}
+"#,
+        "build target `app` depends on unknown target `core`",
+    );
+}
+
+#[test]
+fn emit_json_build_graph_rejects_self_target_dependencies() {
+    super::assert_emit_json_build_graph_error_contains(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["app"],
+    })
+    .Ok(b.config())
+}
+"#,
+        "build target `app` cannot depend on itself",
+    );
+}
+
+#[test]
+fn emit_json_build_graph_rejects_cyclic_target_dependencies() {
+    super::assert_emit_json_build_graph_error_contains(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["tool"],
+    })
+    b.add(Executable {
+        name: "tool",
+        main: "tool.zen",
+        out_dir: "build/tool/",
+        dependencies: ["app"],
+    })
+    .Ok(b.config())
+}
+"#,
+        "build target dependency cycle includes `app`",
+    );
+}

--- a/tests/integration/cli_build/build_graph_json/validation/deterministic_body.rs
+++ b/tests/integration/cli_build/build_graph_json/validation/deterministic_body.rs
@@ -1,0 +1,19 @@
+#[test]
+fn emit_json_build_graph_rejects_dynamic_target_adds() {
+    super::assert_emit_json_build_graph_error_contains(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    enabled = true
+    enabled ?
+        | true {
+            b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+        }
+        | false {
+            b.add(Executable { name: "tool", main: "tool.zen", out_dir: "build/tool/" })
+        }
+    .Ok(b.config())
+}
+"#,
+        "build targets must be added in the deterministic build graph body",
+    );
+}


### PR DESCRIPTION
## Summary

- Move `emit-json build-graph` dependency diagnostics into `build_graph_json/validation/dependencies.rs`.
- Move deterministic-body rejection coverage into `build_graph_json/validation/deterministic_body.rs`.
- Keep the parent validation module focused on target field diagnostics and the shared CLI assertion helper.
- Update phase/audit docs with the split evidence.

## Validation

- `cargo test --test integration build_graph_json::validation`
- `git diff --check && cargo fmt --check && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- Branch Actions query did not show a run for current head `dc07c0c6`; only an older PR run for a different SHA was returned.