### PR TITLE
[codex] Split emit direct validation tests

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3727,6 +3727,10 @@ and do not assume Phase 4 is ready without evidence.
   `tests/integration/cli_build/build_command_host_effects/file_reads/declared/`,
   preserving declared `.Err`, wildcard, and identifier fallback-arm coverage
   without one mixed test file.
+- `zen emit build.zen` validation tests now keep dependency-shape diagnostics
+  and executable target-metadata diagnostics in focused modules under
+  `tests/integration/cli_build/emit_direct_validation/`, preserving the same
+  rejection coverage while avoiding a mixed parent validation file.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3410,6 +3410,11 @@ checked-in docs, tests, and commits only.
   single-target and multi-target positive cases under
   `tests/integration/cli_build/build_command_host_effects/file_reads/declared/`,
   preserving the same fallback-arm coverage while keeping each module focused.
+- `zen emit build.zen` validation tests now keep dependency-shape diagnostics
+  and executable target-metadata diagnostics in focused modules under
+  `tests/integration/cli_build/emit_direct_validation/`, leaving the parent
+  file to wire submodules and cover the unrelated gated-test-source positive
+  path.
 
 ## Current Phase
 

--- a/tests/integration/cli_build/emit_direct_validation.rs
+++ b/tests/integration/cli_build/emit_direct_validation.rs
@@ -1,9 +1,13 @@
 use std::process::Command;
 
+#[path = "emit_direct_validation/dependencies.rs"]
+mod dependencies;
 #[path = "emit_direct_validation/gated_dependencies.rs"]
 mod gated_dependencies;
 #[path = "emit_direct_validation/graph_only_libraries.rs"]
 mod graph_only_libraries;
+#[path = "emit_direct_validation/target_metadata.rs"]
+mod target_metadata;
 #[path = "emit_direct_validation/target_selection.rs"]
 mod target_selection;
 
@@ -51,134 +55,6 @@ main = () i32 {
     assert!(
         !tmp.path().join("build").join("app").exists(),
         "zen emit build.zen should not compile the target binary"
-    );
-}
-
-#[test]
-fn emit_command_build_zen_rejects_unknown_target_dependencies() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable {
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        dependencies: ["core"],
-    })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-    assert_emit_command_rejects_dependency_shape(
-        tmp.path(),
-        "build target `app` depends on unknown target `core`",
-    );
-}
-
-#[test]
-fn emit_command_build_zen_rejects_self_target_dependencies() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable {
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        dependencies: ["app"],
-    })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-    assert_emit_command_rejects_dependency_shape(
-        tmp.path(),
-        "build target `app` cannot depend on itself",
-    );
-}
-
-#[test]
-fn emit_command_build_zen_rejects_cyclic_target_dependencies() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Library {
-        name: "core",
-        exports: ["lib.zen"],
-        dependencies: ["app"],
-    })
-    b.add(Executable {
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        dependencies: ["core"],
-    })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-    assert_emit_command_rejects_dependency_shape(
-        tmp.path(),
-        "build target dependency cycle includes `app`",
-    );
-}
-
-#[test]
-fn emit_command_build_zen_rejects_duplicate_target_fields() {
-    assert_emit_command_rejects_target_metadata(
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable {
-        name: "app",
-        name: "tool",
-        main: "app.zen",
-        out_dir: "build/app/",
-    })
-    .Ok(b.config())
-}
-"#,
-        "duplicate field `name` in `Executable` build target",
-    );
-}
-
-#[test]
-fn emit_command_build_zen_rejects_missing_required_target_fields() {
-    assert_emit_command_rejects_target_metadata(
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable {
-        name: "app",
-        main: "app.zen",
-    })
-    .Ok(b.config())
-}
-"#,
-        "missing required field `out_dir` in `Executable` build target",
-    );
-}
-
-#[test]
-fn emit_command_build_zen_rejects_invalid_target_field_types() {
-    assert_emit_command_rejects_target_metadata(
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable {
-        name: "app",
-        main: "app.zen",
-        out_dir: 42,
-    })
-    .Ok(b.config())
-}
-"#,
-        "field `out_dir` in `Executable` build target must be a string",
     );
 }
 

--- a/tests/integration/cli_build/emit_direct_validation/dependencies.rs
+++ b/tests/integration/cli_build/emit_direct_validation/dependencies.rs
@@ -1,0 +1,76 @@
+#[test]
+fn emit_command_build_zen_rejects_unknown_target_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["core"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    super::assert_emit_command_rejects_dependency_shape(
+        tmp.path(),
+        "build target `app` depends on unknown target `core`",
+    );
+}
+
+#[test]
+fn emit_command_build_zen_rejects_self_target_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["app"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    super::assert_emit_command_rejects_dependency_shape(
+        tmp.path(),
+        "build target `app` cannot depend on itself",
+    );
+}
+
+#[test]
+fn emit_command_build_zen_rejects_cyclic_target_dependencies() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        tmp.path().join("build.zen"),
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Library {
+        name: "core",
+        exports: ["lib.zen"],
+        dependencies: ["app"],
+    })
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["core"],
+    })
+    .Ok(b.config())
+}
+"#,
+    )
+    .expect("write build.zen");
+    super::assert_emit_command_rejects_dependency_shape(
+        tmp.path(),
+        "build target dependency cycle includes `app`",
+    );
+}

--- a/tests/integration/cli_build/emit_direct_validation/target_metadata.rs
+++ b/tests/integration/cli_build/emit_direct_validation/target_metadata.rs
@@ -1,0 +1,50 @@
+#[test]
+fn emit_command_build_zen_rejects_duplicate_target_fields() {
+    super::assert_emit_command_rejects_target_metadata(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        name: "tool",
+        main: "app.zen",
+        out_dir: "build/app/",
+    })
+    .Ok(b.config())
+}
+"#,
+        "duplicate field `name` in `Executable` build target",
+    );
+}
+
+#[test]
+fn emit_command_build_zen_rejects_missing_required_target_fields() {
+    super::assert_emit_command_rejects_target_metadata(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+    })
+    .Ok(b.config())
+}
+"#,
+        "missing required field `out_dir` in `Executable` build target",
+    );
+}
+
+#[test]
+fn emit_command_build_zen_rejects_invalid_target_field_types() {
+    super::assert_emit_command_rejects_target_metadata(
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: 42,
+    })
+    .Ok(b.config())
+}
+"#,
+        "field `out_dir` in `Executable` build target must be a string",
+    );
+}


### PR DESCRIPTION
## Summary

Split `zen emit build.zen` validation coverage into focused dependency-shape and executable target-metadata modules. The parent module now wires the validation submodules and keeps only the unrelated gated-test-source positive path plus shared assertion helpers.

## Validation

- `cargo test --test integration emit_command_build_zen_rejects -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Branch push Actions check: `gh run list --repo lantos1618/zenlang --branch codex/split-emit-direct-validation --limit 10 --json ...` returned `[]`, so the push itself stayed quiet.