### PR TITLE
[codex] Split CLI diagnostics tests

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3731,6 +3731,10 @@ and do not assume Phase 4 is ready without evidence.
   and executable target-metadata diagnostics in focused modules under
   `tests/integration/cli_build/emit_direct_validation/`, preserving the same
   rejection coverage while avoiding a mixed parent validation file.
+- CLI diagnostic integration tests now split check-command diagnostics,
+  diagnostic de-duplication, and emit-command diagnostics under
+  `tests/integration/cli_build/diagnostics/`, preserving imported module
+  resolver/type diagnostic coverage while keeping each module focused.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3415,6 +3415,10 @@ checked-in docs, tests, and commits only.
   `tests/integration/cli_build/emit_direct_validation/`, leaving the parent
   file to wire submodules and cover the unrelated gated-test-source positive
   path.
+- CLI diagnostic integration tests now split check-command diagnostics,
+  diagnostic de-duplication, and emit-command diagnostics under
+  `tests/integration/cli_build/diagnostics/`, keeping shared imported-module
+  fixtures in the parent module.
 
 ## Current Phase
 

--- a/tests/integration/cli_build/diagnostics.rs
+++ b/tests/integration/cli_build/diagnostics.rs
@@ -1,90 +1,11 @@
-use std::process::Command;
+#[path = "diagnostics/check_command.rs"]
+mod check_command;
+#[path = "diagnostics/dedup.rs"]
+mod dedup;
+#[path = "diagnostics/emit_command.rs"]
+mod emit_command;
 
-#[test]
-fn check_command_runs_resolver_diagnostics() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let zen_path = tmp.path().join("bad_resolver_ref.zen");
-    std::fs::write(
-        &zen_path,
-        r#"
-main = () i32 {
-    missing_local
-}
-"#,
-    )
-    .expect("write test file");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["check", zen_path.to_str().unwrap()])
-        .output()
-        .expect("run zen check");
-
-    assert!(
-        !output.status.success(),
-        "zen check unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr).contains("unknown value symbol 'missing_local'"),
-        "expected resolver diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-}
-
-#[test]
-fn check_command_reports_imported_module_resolver_diagnostics() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let math_path = tmp.path().join("math.zen");
-    std::fs::write(
-        &math_path,
-        r#"
-pub add = (a: i32, b: i32) i32 {
-    a + b
-}
-
-pub broken = () i32 {
-    missing_dep_local
-}
-"#,
-    )
-    .expect("write imported module");
-
-    let main_path = tmp.path().join("main.zen");
-    std::fs::write(
-        &main_path,
-        r#"
-{ add } = math
-
-main = () i32 {
-    add(1, 2)
-}
-"#,
-    )
-    .expect("write entry module");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["check", main_path.to_str().unwrap()])
-        .output()
-        .expect("run zen check");
-
-    assert!(
-        !output.status.success(),
-        "zen check unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("unknown value symbol 'missing_dep_local'"),
-        "expected imported module resolver diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-}
-
-#[test]
-fn check_command_reports_imported_module_type_diagnostics() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
+fn write_imported_module_type_error_fixture(tmp: &tempfile::TempDir) -> std::path::PathBuf {
     let math_path = tmp.path().join("math.zen");
     std::fs::write(
         &math_path,
@@ -112,130 +33,19 @@ main = () i32 {
 "#,
     )
     .expect("write entry module");
+    main_path
+}
 
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["check", main_path.to_str().unwrap()])
-        .output()
-        .expect("run zen check");
-
+fn assert_fails_with(output: &std::process::Output, command_name: &str, expected: &str) {
     assert!(
         !output.status.success(),
-        "zen check unexpectedly succeeded: stdout={}, stderr={}",
+        "{command_name} unexpectedly succeeded: stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("return type mismatch: expected `i32`, found `bool`"),
-        "expected imported module type diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-}
-
-#[test]
-fn check_command_deduplicates_typechecker_diagnostics() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let traits_path = tmp.path().join("traits.zen");
-    std::fs::write(
-        &traits_path,
-        r#"
-pub Json<T>: behavior {
-    encode: (Self) T
-}
-
-pub Point: {
-    x: i32
-}
-"#,
-    )
-    .expect("write traits module");
-
-    let main_path = tmp.path().join("main.zen");
-    std::fs::write(
-        &main_path,
-        r#"
-{ Json, Point } = traits
-
-Point.requires(Json<str>)
-
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write entry module");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["check", main_path.to_str().unwrap()])
-        .output()
-        .expect("run zen check");
-
-    assert!(
-        !output.status.success(),
-        "zen check unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    let diagnostic = "type `Point` does not implement required behavior `Json_str`";
-    assert!(
-        stderr.contains(diagnostic),
-        "expected missing behavior diagnostic, stderr={stderr}"
-    );
-    assert_eq!(
-        stderr.matches(diagnostic).count(),
-        1,
-        "expected missing behavior diagnostic once, stderr={stderr}"
-    );
-}
-
-#[test]
-fn emit_command_reports_imported_module_type_diagnostics() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let math_path = tmp.path().join("math.zen");
-    std::fs::write(
-        &math_path,
-        r#"
-pub add = (a: i32, b: i32) i32 {
-    a + b
-}
-
-pub broken = () i32 {
-    true
-}
-"#,
-    )
-    .expect("write imported module");
-
-    let main_path = tmp.path().join("main.zen");
-    std::fs::write(
-        &main_path,
-        r#"
-{ add } = math
-
-main = () i32 {
-    add(1, 2)
-}
-"#,
-    )
-    .expect("write entry module");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit", main_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit");
-
-    assert!(
-        !output.status.success(),
-        "zen emit unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("return type mismatch: expected `i32`, found `bool`"),
-        "expected imported module type diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr).contains(expected),
+        "expected diagnostic `{expected}`, stderr={}",
         String::from_utf8_lossy(&output.stderr)
     );
 }

--- a/tests/integration/cli_build/diagnostics/check_command.rs
+++ b/tests/integration/cli_build/diagnostics/check_command.rs
@@ -1,0 +1,83 @@
+use std::process::Command;
+
+#[test]
+fn check_command_runs_resolver_diagnostics() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let zen_path = tmp.path().join("bad_resolver_ref.zen");
+    std::fs::write(
+        &zen_path,
+        r#"
+main = () i32 {
+    missing_local
+}
+"#,
+    )
+    .expect("write test file");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["check", zen_path.to_str().unwrap()])
+        .output()
+        .expect("run zen check");
+
+    super::assert_fails_with(&output, "zen check", "unknown value symbol 'missing_local'");
+}
+
+#[test]
+fn check_command_reports_imported_module_resolver_diagnostics() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let math_path = tmp.path().join("math.zen");
+    std::fs::write(
+        &math_path,
+        r#"
+pub add = (a: i32, b: i32) i32 {
+    a + b
+}
+
+pub broken = () i32 {
+    missing_dep_local
+}
+"#,
+    )
+    .expect("write imported module");
+
+    let main_path = tmp.path().join("main.zen");
+    std::fs::write(
+        &main_path,
+        r#"
+{ add } = math
+
+main = () i32 {
+    add(1, 2)
+}
+"#,
+    )
+    .expect("write entry module");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["check", main_path.to_str().unwrap()])
+        .output()
+        .expect("run zen check");
+
+    super::assert_fails_with(
+        &output,
+        "zen check",
+        "unknown value symbol 'missing_dep_local'",
+    );
+}
+
+#[test]
+fn check_command_reports_imported_module_type_diagnostics() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let main_path = super::write_imported_module_type_error_fixture(&tmp);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["check", main_path.to_str().unwrap()])
+        .output()
+        .expect("run zen check");
+
+    super::assert_fails_with(
+        &output,
+        "zen check",
+        "return type mismatch: expected `i32`, found `bool`",
+    );
+}

--- a/tests/integration/cli_build/diagnostics/dedup.rs
+++ b/tests/integration/cli_build/diagnostics/dedup.rs
@@ -1,0 +1,59 @@
+use std::process::Command;
+
+#[test]
+fn check_command_deduplicates_typechecker_diagnostics() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let traits_path = tmp.path().join("traits.zen");
+    std::fs::write(
+        &traits_path,
+        r#"
+pub Json<T>: behavior {
+    encode: (Self) T
+}
+
+pub Point: {
+    x: i32
+}
+"#,
+    )
+    .expect("write traits module");
+
+    let main_path = tmp.path().join("main.zen");
+    std::fs::write(
+        &main_path,
+        r#"
+{ Json, Point } = traits
+
+Point.requires(Json<str>)
+
+main = () i32 {
+    0
+}
+"#,
+    )
+    .expect("write entry module");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["check", main_path.to_str().unwrap()])
+        .output()
+        .expect("run zen check");
+
+    assert!(
+        !output.status.success(),
+        "zen check unexpectedly succeeded: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let diagnostic = "type `Point` does not implement required behavior `Json_str`";
+    assert!(
+        stderr.contains(diagnostic),
+        "expected missing behavior diagnostic, stderr={stderr}"
+    );
+    assert_eq!(
+        stderr.matches(diagnostic).count(),
+        1,
+        "expected missing behavior diagnostic once, stderr={stderr}"
+    );
+}

--- a/tests/integration/cli_build/diagnostics/emit_command.rs
+++ b/tests/integration/cli_build/diagnostics/emit_command.rs
@@ -1,0 +1,18 @@
+use std::process::Command;
+
+#[test]
+fn emit_command_reports_imported_module_type_diagnostics() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let main_path = super::write_imported_module_type_error_fixture(&tmp);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit", main_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit");
+
+    super::assert_fails_with(
+        &output,
+        "zen emit",
+        "return type mismatch: expected `i32`, found `bool`",
+    );
+}


### PR DESCRIPTION
## Summary

Split CLI diagnostic integration coverage into focused check-command, diagnostic de-duplication, and emit-command modules. Shared imported-module fixture setup and failure assertions now live in the parent diagnostics module.

## Validation

- `cargo test --test integration diagnostics -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Branch push Actions check: `gh run list --repo lantos1618/zenlang --branch codex/split-cli-diagnostics-tests --limit 10 --json ...` returned `[]`, so the push itself stayed quiet.