### PR TITLE
[codex] Split unsupported target tests

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3735,6 +3735,10 @@ and do not assume Phase 4 is ready without evidence.
   diagnostic de-duplication, and emit-command diagnostics under
   `tests/integration/cli_build/diagnostics/`, preserving imported module
   resolver/type diagnostic coverage while keeping each module focused.
+- Unsupported `build.zen` target tests now split unsupported target-kind
+  coverage from gated/unknown executable-field coverage under
+  `tests/integration/cli_build/unsupported_targets/`, preserving the same
+  command matrix without one mixed rejection file.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3419,6 +3419,10 @@ checked-in docs, tests, and commits only.
   diagnostic de-duplication, and emit-command diagnostics under
   `tests/integration/cli_build/diagnostics/`, keeping shared imported-module
   fixtures in the parent module.
+- Unsupported `build.zen` target tests now split unsupported target-kind
+  coverage from gated/unknown executable-field coverage under
+  `tests/integration/cli_build/unsupported_targets/`, preserving the same
+  command matrix while keeping the parent module to shared helpers.
 
 ## Current Phase
 

--- a/tests/integration/cli_build/unsupported_targets.rs
+++ b/tests/integration/cli_build/unsupported_targets.rs
@@ -1,155 +1,27 @@
 use std::process::Command;
 
-#[test]
-fn build_command_build_zen_rejects_unsupported_package_targets() {
-    assert_build_zen_command_rejects_unsupported_target_kind(&["build", "build.zen"], "Package");
-}
+#[path = "unsupported_targets/fields.rs"]
+mod fields;
+#[path = "unsupported_targets/kinds.rs"]
+mod kinds;
 
-#[test]
-fn build_command_build_zen_rejects_unsupported_link_targets() {
-    assert_build_zen_command_rejects_unsupported_target_kind(&["build", "build.zen"], "Link");
-}
-
-#[test]
-fn direct_file_command_build_zen_rejects_unsupported_package_targets() {
-    assert_build_zen_command_rejects_unsupported_target_kind(&["build.zen"], "Package");
-}
-
-#[test]
-fn direct_file_command_build_zen_rejects_unsupported_link_targets() {
-    assert_build_zen_command_rejects_unsupported_target_kind(&["build.zen"], "Link");
-}
-
-#[test]
-fn check_command_build_zen_rejects_unsupported_package_targets() {
-    assert_build_zen_command_rejects_unsupported_target_kind(&["check", "build.zen"], "Package");
-}
-
-#[test]
-fn check_command_build_zen_rejects_unsupported_link_targets() {
-    assert_build_zen_command_rejects_unsupported_target_kind(&["check", "build.zen"], "Link");
-}
-
-#[test]
-fn test_command_build_zen_rejects_unsupported_package_targets() {
-    assert_build_zen_command_rejects_unsupported_target_kind(&["test", "build.zen"], "Package");
-}
-
-#[test]
-fn test_command_build_zen_rejects_unsupported_link_targets() {
-    assert_build_zen_command_rejects_unsupported_target_kind(&["test", "build.zen"], "Link");
-}
-
-#[test]
-fn emit_command_build_zen_rejects_unsupported_package_targets() {
-    assert_build_zen_command_rejects_unsupported_target_kind(&["emit", "build.zen"], "Package");
-}
-
-#[test]
-fn emit_command_build_zen_rejects_unsupported_link_targets() {
-    assert_build_zen_command_rejects_unsupported_target_kind(&["emit", "build.zen"], "Link");
-}
-
-#[test]
-fn build_graph_command_rejects_unsupported_package_targets() {
-    assert_build_zen_command_rejects_unsupported_target_kind(
-        &["build-graph", "build.zen"],
-        "Package",
-    );
-}
-
-#[test]
-fn build_graph_command_rejects_unsupported_link_targets() {
-    assert_build_zen_command_rejects_unsupported_target_kind(&["build-graph", "build.zen"], "Link");
-}
-
-#[test]
-fn build_zen_commands_reject_package_fields() {
-    assert_build_zen_commands_reject_gated_target_field("packages", r#"["std"]"#);
-}
-
-#[test]
-fn build_zen_commands_reject_link_fields() {
-    assert_build_zen_commands_reject_gated_target_field("link", r#"["m"]"#);
-}
-
-#[test]
-fn build_zen_commands_reject_unknown_target_fields() {
-    assert_build_zen_commands_reject_unknown_target_field("output_dir", r#""build/app/""#);
-}
-
-fn assert_build_zen_command_rejects_unsupported_target_kind(args: &[&str], target_kind: &str) {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        format!(
-            r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {{
-    b.add({target_kind} {{ name: "core", root: "src/lib.zen" }})
-    .Ok(b.config())
-}}
-"#
-        ),
-    )
-    .expect("write build.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(args)
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen build.zen command");
-
-    assert!(
-        !output.status.success(),
-        "zen {args:?} unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr).contains(&format!(
-            "unsupported build target kind `{target_kind}`; supported target kinds are `Executable`, `Test`, and `Library`"
-        )),
-        "expected unsupported target diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        !tmp.path().join("build").exists(),
-        "zen {args:?} should reject unsupported target kinds before creating build outputs"
-    );
-}
-
-fn assert_build_zen_commands_reject_gated_target_field(field: &str, value: &str) {
-    for args in [
+fn all_build_zen_command_args() -> [&'static [&'static str]; 6] {
+    [
         &["build", "build.zen"][..],
         &["build.zen"][..],
         &["check", "build.zen"][..],
         &["test", "build.zen"][..],
         &["emit", "build.zen"][..],
         &["build-graph", "build.zen"][..],
-    ] {
-        assert_build_zen_command_rejects_gated_target_field(args, field, value);
-    }
+    ]
 }
 
-fn assert_build_zen_command_rejects_gated_target_field(args: &[&str], field: &str, value: &str) {
+fn run_build_zen_command(
+    args: &[&str],
+    build_source: String,
+) -> (tempfile::TempDir, std::process::Output) {
     let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        format!(
-            r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {{
-    b.add(Executable {{
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        {field}: {value},
-    }})
-    .Ok(b.config())
-}}
-"#
-        ),
-    )
-    .expect("write build.zen");
+    std::fs::write(tmp.path().join("build.zen"), build_source).expect("write build.zen");
 
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
         .args(args)
@@ -157,6 +29,16 @@ build = (b: Builder) Result<BuildConfig, BuildError> {{
         .output()
         .expect("run zen build.zen command");
 
+    (tmp, output)
+}
+
+fn assert_rejected_without_outputs(
+    tmp: &tempfile::TempDir,
+    output: &std::process::Output,
+    args: &[&str],
+    expected: String,
+    reason: &str,
+) {
     assert!(
         !output.status.success(),
         "zen {args:?} unexpectedly succeeded: stdout={}, stderr={}",
@@ -164,72 +46,12 @@ build = (b: Builder) Result<BuildConfig, BuildError> {{
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(
-        String::from_utf8_lossy(&output.stderr).contains(&format!(
-            "unsupported field `{field}` in `Executable` build target; package/link semantics are gated"
-        )),
-        "expected gated field diagnostic, stderr={}",
+        String::from_utf8_lossy(&output.stderr).contains(&expected),
+        "expected {reason} diagnostic, stderr={}",
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(
         !tmp.path().join("build").exists(),
-        "zen {args:?} should reject gated target fields before creating build outputs"
-    );
-}
-
-fn assert_build_zen_commands_reject_unknown_target_field(field: &str, value: &str) {
-    for args in [
-        &["build", "build.zen"][..],
-        &["build.zen"][..],
-        &["check", "build.zen"][..],
-        &["test", "build.zen"][..],
-        &["emit", "build.zen"][..],
-        &["build-graph", "build.zen"][..],
-    ] {
-        assert_build_zen_command_rejects_unknown_target_field(args, field, value);
-    }
-}
-
-fn assert_build_zen_command_rejects_unknown_target_field(args: &[&str], field: &str, value: &str) {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        format!(
-            r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {{
-    b.add(Executable {{
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        {field}: {value},
-    }})
-    .Ok(b.config())
-}}
-"#
-        ),
-    )
-    .expect("write build.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(args)
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen build.zen command");
-
-    assert!(
-        !output.status.success(),
-        "zen {args:?} unexpectedly succeeded: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr).contains(&format!(
-            "unknown field `{field}` in `Executable` build target"
-        )),
-        "expected unknown field diagnostic, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        !tmp.path().join("build").exists(),
-        "zen {args:?} should reject unknown target fields before creating build outputs"
+        "zen {args:?} should reject {reason} before creating build outputs"
     );
 }

--- a/tests/integration/cli_build/unsupported_targets/fields.rs
+++ b/tests/integration/cli_build/unsupported_targets/fields.rs
@@ -1,0 +1,80 @@
+#[test]
+fn build_zen_commands_reject_package_fields() {
+    assert_build_zen_commands_reject_gated_target_field("packages", r#"["std"]"#);
+}
+
+#[test]
+fn build_zen_commands_reject_link_fields() {
+    assert_build_zen_commands_reject_gated_target_field("link", r#"["m"]"#);
+}
+
+#[test]
+fn build_zen_commands_reject_unknown_target_fields() {
+    assert_build_zen_commands_reject_unknown_target_field("output_dir", r#""build/app/""#);
+}
+
+fn assert_build_zen_commands_reject_gated_target_field(field: &str, value: &str) {
+    for args in super::all_build_zen_command_args() {
+        assert_build_zen_command_rejects_gated_target_field(args, field, value);
+    }
+}
+
+fn assert_build_zen_command_rejects_gated_target_field(args: &[&str], field: &str, value: &str) {
+    let (tmp, output) = super::run_build_zen_command(
+        args,
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
+    b.add(Executable {{
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        {field}: {value},
+    }})
+    .Ok(b.config())
+}}
+"#
+        ),
+    );
+
+    super::assert_rejected_without_outputs(
+        &tmp,
+        &output,
+        args,
+        format!("unsupported field `{field}` in `Executable` build target; package/link semantics are gated"),
+        "gated target field",
+    );
+}
+
+fn assert_build_zen_commands_reject_unknown_target_field(field: &str, value: &str) {
+    for args in super::all_build_zen_command_args() {
+        assert_build_zen_command_rejects_unknown_target_field(args, field, value);
+    }
+}
+
+fn assert_build_zen_command_rejects_unknown_target_field(args: &[&str], field: &str, value: &str) {
+    let (tmp, output) = super::run_build_zen_command(
+        args,
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
+    b.add(Executable {{
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        {field}: {value},
+    }})
+    .Ok(b.config())
+}}
+"#
+        ),
+    );
+
+    super::assert_rejected_without_outputs(
+        &tmp,
+        &output,
+        args,
+        format!("unknown field `{field}` in `Executable` build target"),
+        "unknown target field",
+    );
+}

--- a/tests/integration/cli_build/unsupported_targets/kinds.rs
+++ b/tests/integration/cli_build/unsupported_targets/kinds.rs
@@ -1,0 +1,86 @@
+#[test]
+fn build_command_build_zen_rejects_unsupported_package_targets() {
+    assert_build_zen_command_rejects_unsupported_target_kind(&["build", "build.zen"], "Package");
+}
+
+#[test]
+fn build_command_build_zen_rejects_unsupported_link_targets() {
+    assert_build_zen_command_rejects_unsupported_target_kind(&["build", "build.zen"], "Link");
+}
+
+#[test]
+fn direct_file_command_build_zen_rejects_unsupported_package_targets() {
+    assert_build_zen_command_rejects_unsupported_target_kind(&["build.zen"], "Package");
+}
+
+#[test]
+fn direct_file_command_build_zen_rejects_unsupported_link_targets() {
+    assert_build_zen_command_rejects_unsupported_target_kind(&["build.zen"], "Link");
+}
+
+#[test]
+fn check_command_build_zen_rejects_unsupported_package_targets() {
+    assert_build_zen_command_rejects_unsupported_target_kind(&["check", "build.zen"], "Package");
+}
+
+#[test]
+fn check_command_build_zen_rejects_unsupported_link_targets() {
+    assert_build_zen_command_rejects_unsupported_target_kind(&["check", "build.zen"], "Link");
+}
+
+#[test]
+fn test_command_build_zen_rejects_unsupported_package_targets() {
+    assert_build_zen_command_rejects_unsupported_target_kind(&["test", "build.zen"], "Package");
+}
+
+#[test]
+fn test_command_build_zen_rejects_unsupported_link_targets() {
+    assert_build_zen_command_rejects_unsupported_target_kind(&["test", "build.zen"], "Link");
+}
+
+#[test]
+fn emit_command_build_zen_rejects_unsupported_package_targets() {
+    assert_build_zen_command_rejects_unsupported_target_kind(&["emit", "build.zen"], "Package");
+}
+
+#[test]
+fn emit_command_build_zen_rejects_unsupported_link_targets() {
+    assert_build_zen_command_rejects_unsupported_target_kind(&["emit", "build.zen"], "Link");
+}
+
+#[test]
+fn build_graph_command_rejects_unsupported_package_targets() {
+    assert_build_zen_command_rejects_unsupported_target_kind(
+        &["build-graph", "build.zen"],
+        "Package",
+    );
+}
+
+#[test]
+fn build_graph_command_rejects_unsupported_link_targets() {
+    assert_build_zen_command_rejects_unsupported_target_kind(&["build-graph", "build.zen"], "Link");
+}
+
+fn assert_build_zen_command_rejects_unsupported_target_kind(args: &[&str], target_kind: &str) {
+    let (tmp, output) = super::run_build_zen_command(
+        args,
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
+    b.add({target_kind} {{ name: "core", root: "src/lib.zen" }})
+    .Ok(b.config())
+}}
+"#
+        ),
+    );
+
+    super::assert_rejected_without_outputs(
+        &tmp,
+        &output,
+        args,
+        format!(
+            "unsupported build target kind `{target_kind}`; supported target kinds are `Executable`, `Test`, and `Library`"
+        ),
+        "unsupported target kind",
+    );
+}


### PR DESCRIPTION
## Summary

Split unsupported `build.zen` target integration tests into focused unsupported target-kind and gated/unknown executable-field modules. The parent module now owns the shared build.zen command matrix and rejection helpers.

## Validation

- `cargo test --test integration unsupported_targets -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Branch push Actions check: `gh run list --repo lantos1618/zenlang --branch codex/split-unsupported-target-tests --limit 10 --json ...` returned `[]`, so the push itself stayed quiet.