### PR TITLE
[codex] Split test command declared env tests

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3739,6 +3739,11 @@ and do not assume Phase 4 is ready without evidence.
   coverage from gated/unknown executable-field coverage under
   `tests/integration/cli_build/unsupported_targets/`, preserving the same
   command matrix without one mixed rejection file.
+- `zen test build.zen` declared env-read positive tests now split single-target,
+  multi-target, and unselected-target cases under
+  `tests/integration/cli_build/declared_env_effects/runner_command/`, preserving
+  declared `.Err`, wildcard, and identifier fallback-arm coverage without using
+  ignored `test_*` child paths.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3423,6 +3423,10 @@ checked-in docs, tests, and commits only.
   coverage from gated/unknown executable-field coverage under
   `tests/integration/cli_build/unsupported_targets/`, preserving the same
   command matrix while keeping the parent module to shared helpers.
+- `zen test build.zen` declared env-read positive tests now split single-target,
+  multi-target, and unselected-target cases under
+  `tests/integration/cli_build/declared_env_effects/runner_command/`, avoiding
+  ignored `test_*` child paths while preserving the same fallback-arm coverage.
 
 ## Current Phase
 

--- a/tests/integration/cli_build/declared_env_effects/runner_command/multiple_targets.rs
+++ b/tests/integration/cli_build/declared_env_effects/runner_command/multiple_targets.rs
@@ -1,0 +1,54 @@
+#[test]
+fn test_command_build_zen_accepts_declared_env_read_for_multiple_targets() {
+    assert_test_command_accepts_declared_env_read_for_multiple_targets(
+        r#"| .Err { "default" }"#,
+        "test_command_build_zen_accepts_declared_env_read_for_multiple_targets",
+    );
+}
+
+#[test]
+fn test_command_build_zen_accepts_wildcard_fallback_declared_env_read_for_multiple_targets() {
+    assert_test_command_accepts_declared_env_read_for_multiple_targets(
+        r#"| _ { "default" }"#,
+        "test_command_build_zen_accepts_wildcard_fallback_declared_env_read_for_multiple_targets",
+    );
+}
+
+#[test]
+fn test_command_build_zen_accepts_identifier_fallback_declared_env_read_for_multiple_targets() {
+    assert_test_command_accepts_declared_env_read_for_multiple_targets(
+        r#"| err { "default" }"#,
+        "test_command_build_zen_accepts_identifier_fallback_declared_env_read_for_multiple_targets",
+    );
+}
+
+fn assert_test_command_accepts_declared_env_read_for_multiple_targets(
+    fallback_arm: &str,
+    case_name: &str,
+) {
+    let (_tmp, output) = super::run_test_command_build_zen(
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
+    std_path = b.os.env("ZEN_STD") ?
+        | .Ok(value) {{ value }}
+        {fallback_arm}
+    b.add(Test {{ name: "unit", root: "unit.zen" }})
+    b.add(Test {{ name: "integration", root: "integration.zen" }})
+    .Ok(b.config())
+}}
+"#,
+        ),
+        &[
+            ("unit.zen", &super::passing_main_source(0)),
+            ("integration.zen", &super::passing_main_source(0)),
+        ],
+    );
+
+    super::assert_test_command_succeeded(&output, case_name);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("test unit passed") && stdout.contains("test integration passed"),
+        "expected both test targets to pass, stdout={stdout}"
+    );
+}

--- a/tests/integration/cli_build/declared_env_effects/runner_command/single_target.rs
+++ b/tests/integration/cli_build/declared_env_effects/runner_command/single_target.rs
@@ -1,0 +1,42 @@
+#[test]
+fn test_command_build_zen_accepts_declared_env_read_with_fallback() {
+    assert_test_command_accepts_declared_env_read(
+        r#"| .Err { "default" }"#,
+        "test_command_build_zen_accepts_declared_env_read_with_fallback",
+    );
+}
+
+#[test]
+fn test_command_build_zen_accepts_wildcard_fallback_declared_env_read() {
+    assert_test_command_accepts_declared_env_read(
+        r#"| _ { "default" }"#,
+        "test_command_build_zen_accepts_wildcard_fallback_declared_env_read",
+    );
+}
+
+#[test]
+fn test_command_build_zen_accepts_identifier_fallback_declared_env_read() {
+    assert_test_command_accepts_declared_env_read(
+        r#"| err { "default" }"#,
+        "test_command_build_zen_accepts_identifier_fallback_declared_env_read",
+    );
+}
+
+fn assert_test_command_accepts_declared_env_read(fallback_arm: &str, case_name: &str) {
+    let (_tmp, output) = super::run_test_command_build_zen(
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
+    std_path = b.os.env("ZEN_STD") ?
+        | .Ok(value) {{ value }}
+        {fallback_arm}
+    b.add(Test {{ name: "unit", root: "unit.zen" }})
+    .Ok(b.config())
+}}
+"#,
+        ),
+        &[("unit.zen", &super::passing_main_source(0))],
+    );
+
+    super::assert_test_command_succeeded(&output, case_name);
+}

--- a/tests/integration/cli_build/declared_env_effects/runner_command/unselected_targets.rs
+++ b/tests/integration/cli_build/declared_env_effects/runner_command/unselected_targets.rs
@@ -1,0 +1,55 @@
+#[test]
+fn test_command_build_zen_accepts_declared_env_read_with_unselected_targets() {
+    assert_test_command_accepts_declared_env_read_with_unselected_targets(
+        r#"| .Err { "default" }"#,
+        "test_command_build_zen_accepts_declared_env_read_with_unselected_targets",
+    );
+}
+
+#[test]
+fn test_command_build_zen_accepts_wildcard_fallback_declared_env_read_with_unselected_targets() {
+    assert_test_command_accepts_declared_env_read_with_unselected_targets(
+        r#"| _ { "default" }"#,
+        "test_command_build_zen_accepts_wildcard_fallback_declared_env_read_with_unselected_targets",
+    );
+}
+
+#[test]
+fn test_command_build_zen_accepts_identifier_fallback_declared_env_read_with_unselected_targets() {
+    assert_test_command_accepts_declared_env_read_with_unselected_targets(
+        r#"| err { "default" }"#,
+        "test_command_build_zen_accepts_identifier_fallback_declared_env_read_with_unselected_targets",
+    );
+}
+
+fn assert_test_command_accepts_declared_env_read_with_unselected_targets(
+    fallback_arm: &str,
+    case_name: &str,
+) {
+    let (_tmp, output) = super::run_test_command_build_zen(
+        format!(
+            r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {{
+    std_path = b.os.env("ZEN_STD") ?
+        | .Ok(value) {{ value }}
+        {fallback_arm}
+    b.add(Executable {{ name: "app", main: "missing_app.zen", out_dir: "build/app/" }})
+    b.add(Test {{ name: "unit", root: "unit.zen" }})
+    b.add(Library {{ name: "core", exports: ["lib.zen"] }})
+    .Ok(b.config())
+}}
+"#,
+        ),
+        &[
+            ("unit.zen", &super::passing_main_source(0)),
+            ("lib.zen", &super::passing_main_source(1)),
+        ],
+    );
+
+    super::assert_test_command_succeeded(&output, case_name);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("test unit passed"),
+        "expected selected test target to pass, stdout={stdout}"
+    );
+}

--- a/tests/integration/cli_build/declared_env_effects/test_command.rs
+++ b/tests/integration/cli_build/declared_env_effects/test_command.rs
@@ -1,233 +1,45 @@
 use std::process::Command;
 
-#[test]
-fn test_command_build_zen_accepts_declared_env_read_with_fallback() {
-    assert_test_command_accepts_declared_env_read(
-        r#"| .Err { "default" }"#,
-        "test_command_build_zen_accepts_declared_env_read_with_fallback",
-    );
-}
+#[path = "runner_command/multiple_targets.rs"]
+mod multiple_targets;
+#[path = "runner_command/single_target.rs"]
+mod single_target;
+#[path = "runner_command/unselected_targets.rs"]
+mod unselected_targets;
 
-#[test]
-fn test_command_build_zen_accepts_wildcard_fallback_declared_env_read() {
-    assert_test_command_accepts_declared_env_read(
-        r#"| _ { "default" }"#,
-        "test_command_build_zen_accepts_wildcard_fallback_declared_env_read",
-    );
-}
-
-#[test]
-fn test_command_build_zen_accepts_identifier_fallback_declared_env_read() {
-    assert_test_command_accepts_declared_env_read(
-        r#"| err { "default" }"#,
-        "test_command_build_zen_accepts_identifier_fallback_declared_env_read",
-    );
-}
-
-#[test]
-fn test_command_build_zen_accepts_declared_env_read_for_multiple_targets() {
-    assert_test_command_accepts_declared_env_read_for_multiple_targets(
-        r#"| .Err { "default" }"#,
-        "test_command_build_zen_accepts_declared_env_read_for_multiple_targets",
-    );
-}
-
-#[test]
-fn test_command_build_zen_accepts_wildcard_fallback_declared_env_read_for_multiple_targets() {
-    assert_test_command_accepts_declared_env_read_for_multiple_targets(
-        r#"| _ { "default" }"#,
-        "test_command_build_zen_accepts_wildcard_fallback_declared_env_read_for_multiple_targets",
-    );
-}
-
-#[test]
-fn test_command_build_zen_accepts_identifier_fallback_declared_env_read_for_multiple_targets() {
-    assert_test_command_accepts_declared_env_read_for_multiple_targets(
-        r#"| err { "default" }"#,
-        "test_command_build_zen_accepts_identifier_fallback_declared_env_read_for_multiple_targets",
-    );
-}
-
-#[test]
-fn test_command_build_zen_accepts_declared_env_read_with_unselected_targets() {
-    assert_test_command_accepts_declared_env_read_with_unselected_targets(
-        r#"| .Err { "default" }"#,
-        "test_command_build_zen_accepts_declared_env_read_with_unselected_targets",
-    );
-}
-
-#[test]
-fn test_command_build_zen_accepts_wildcard_fallback_declared_env_read_with_unselected_targets() {
-    assert_test_command_accepts_declared_env_read_with_unselected_targets(
-        r#"| _ { "default" }"#,
-        "test_command_build_zen_accepts_wildcard_fallback_declared_env_read_with_unselected_targets",
-    );
-}
-
-#[test]
-fn test_command_build_zen_accepts_identifier_fallback_declared_env_read_with_unselected_targets() {
-    assert_test_command_accepts_declared_env_read_with_unselected_targets(
-        r#"| err { "default" }"#,
-        "test_command_build_zen_accepts_identifier_fallback_declared_env_read_with_unselected_targets",
-    );
-}
-
-fn assert_test_command_accepts_declared_env_read_with_unselected_targets(
-    fallback_arm: &str,
-    case_name: &str,
-) {
+fn run_test_command_build_zen(
+    build_source: String,
+    files: &[(&str, &str)],
+) -> (tempfile::TempDir, std::process::Output) {
     let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        format!(
-            r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {{
-    std_path = b.os.env("ZEN_STD") ?
-        | .Ok(value) {{ value }}
-        {fallback_arm}
-    b.add(Executable {{ name: "app", main: "missing_app.zen", out_dir: "build/app/" }})
-    b.add(Test {{ name: "unit", root: "unit.zen" }})
-    b.add(Library {{ name: "core", exports: ["lib.zen"] }})
-    .Ok(b.config())
-}}
-"#,
-        ),
-    )
-    .expect("write build.zen");
-    std::fs::write(
-        tmp.path().join("unit.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write unit.zen");
-    std::fs::write(
-        tmp.path().join("lib.zen"),
-        r#"
-value = () i32 {
-    1
-}
-"#,
-    )
-    .expect("write lib.zen");
+    std::fs::write(tmp.path().join("build.zen"), build_source).expect("write build.zen");
+    for (path, source) in files {
+        std::fs::write(tmp.path().join(path), source).expect("write source file");
+    }
 
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
         .args(["test", "build.zen"])
         .current_dir(tmp.path())
         .output()
         .expect("run zen test build.zen");
+    (tmp, output)
+}
 
+fn assert_test_command_succeeded(output: &std::process::Output, case_name: &str) {
     assert!(
         output.status.success(),
         "{case_name}: zen test build.zen failed: stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        stdout.contains("test unit passed"),
-        "expected selected test target to pass, stdout={stdout}"
-    );
 }
 
-fn assert_test_command_accepts_declared_env_read_for_multiple_targets(
-    fallback_arm: &str,
-    case_name: &str,
-) {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        format!(
-            r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {{
-    std_path = b.os.env("ZEN_STD") ?
-        | .Ok(value) {{ value }}
-        {fallback_arm}
-    b.add(Test {{ name: "unit", root: "unit.zen" }})
-    b.add(Test {{ name: "integration", root: "integration.zen" }})
-    .Ok(b.config())
+fn passing_main_source(value: i32) -> String {
+    format!(
+        r#"
+main = () i32 {{
+    {value}
 }}
 "#,
-        ),
     )
-    .expect("write build.zen");
-    std::fs::write(
-        tmp.path().join("unit.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write unit.zen");
-    std::fs::write(
-        tmp.path().join("integration.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write integration.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["test", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen test build.zen");
-
-    assert!(
-        output.status.success(),
-        "{case_name}: zen test build.zen failed: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        stdout.contains("test unit passed") && stdout.contains("test integration passed"),
-        "expected both test targets to pass, stdout={stdout}"
-    );
-}
-
-fn assert_test_command_accepts_declared_env_read(fallback_arm: &str, case_name: &str) {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        format!(
-            r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {{
-    std_path = b.os.env("ZEN_STD") ?
-        | .Ok(value) {{ value }}
-        {fallback_arm}
-    b.add(Test {{ name: "unit", root: "test.zen" }})
-    .Ok(b.config())
-}}
-"#,
-        ),
-    )
-    .expect("write build.zen");
-    std::fs::write(
-        tmp.path().join("test.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write test.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["test", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen test build.zen");
-
-    assert!(
-        output.status.success(),
-        "{case_name}: zen test build.zen failed: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
 }


### PR DESCRIPTION
## Summary

Split `zen test build.zen` declared env-read positive coverage into focused single-target, multi-target, and unselected-target modules. The parent module now only wires those groups and owns shared command/source helpers. Child modules live under `runner_command/` to avoid the repo's ignored `test_*` path pattern.

## Validation

- `cargo test --test integration test_command_build_zen_accepts_declared_env_read -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Branch push Actions check: `gh run list --repo lantos1618/zenlang --branch codex/split-declared-env-test-command --limit 10 --json ...` returned `[]`, so the push itself stayed quiet.