### PR TITLE
[codex] Share executable graph test fixtures

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3748,6 +3748,11 @@ and do not assume Phase 4 is ready without evidence.
   executable graph coverage from no-executable-target coverage under
   `tests/integration/cli_build/emit_direct_validation/target_selection/`,
   preserving diagnostic ordering checks without one mixed validation file.
+- Build-driver executable graph execution tests now share canonical single,
+  multi-target, and dependency-ordered fixtures through
+  `tests/integration/cli_build/support.rs`, preserving normal `zen build
+  build.zen`, direct `zen build.zen`, and legacy `zen build-graph` coverage
+  while removing duplicated graph setup.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3431,6 +3431,11 @@ checked-in docs, tests, and commits only.
   executable graph coverage from no-executable-target coverage under
   `tests/integration/cli_build/emit_direct_validation/target_selection/`,
   leaving shared emit-command helpers in the parent module.
+- Build-driver executable graph execution tests now share canonical single,
+  multi-target, and dependency-ordered fixtures through
+  `tests/integration/cli_build/support.rs`, preserving normal `zen build
+  build.zen`, direct `zen build.zen`, and legacy `zen build-graph` coverage
+  without triplicated graph setup.
 
 ## Current Phase
 

--- a/tests/integration/cli_build/build_command_execution.rs
+++ b/tests/integration/cli_build/build_command_execution.rs
@@ -1,169 +1,35 @@
-use std::process::Command;
-
 #[test]
 fn build_command_routes_build_zen_through_deterministic_graph() {
+    let args = ["build", "build.zen"];
     let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-    std::fs::write(
-        tmp.path().join("main.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write main.zen");
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["build", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen build build.zen");
+    super::support::write_single_executable_graph(&tmp);
+    let output = super::support::run_zen_in(&tmp, &args);
+    super::support::assert_zen_success(&args, &output);
 
-    assert!(
-        output.status.success(),
-        "zen build build.zen failed: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let bin_path = tmp.path().join("build").join("myapp");
-    assert!(
-        bin_path.exists(),
-        "expected {} to exist",
-        bin_path.display()
-    );
-    let run = Command::new(&bin_path).output().expect("run built binary");
-    assert!(
-        run.status.success(),
-        "built binary exited with {}",
-        run.status
-    );
+    super::support::assert_built_binaries_run(&[tmp.path().join("build").join("myapp")]);
 }
 
 #[test]
 fn build_command_build_zen_compiles_multiple_executable_targets() {
+    let args = ["build", "build.zen"];
     let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
-    b.add(Executable { name: "tool", main: "tool.zen", out_dir: "build/tool/" })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-    std::fs::write(
-        tmp.path().join("app.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write app.zen");
-    std::fs::write(
-        tmp.path().join("tool.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write tool.zen");
+    super::support::write_multiple_executable_graph(&tmp);
+    let output = super::support::run_zen_in(&tmp, &args);
+    super::support::assert_zen_success(&args, &output);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["build", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen build build.zen");
-
-    assert!(
-        output.status.success(),
-        "zen build build.zen failed: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    for bin_path in [
+    super::support::assert_built_binaries_run(&[
         tmp.path().join("build").join("app").join("app"),
         tmp.path().join("build").join("tool").join("tool"),
-    ] {
-        assert!(
-            bin_path.exists(),
-            "expected {} to exist",
-            bin_path.display()
-        );
-        let run = Command::new(&bin_path).output().expect("run built binary");
-        assert!(
-            run.status.success(),
-            "built binary {} exited with {}",
-            bin_path.display(),
-            run.status
-        );
-    }
+    ]);
 }
 
 #[test]
 fn build_command_build_zen_compiles_executable_dependencies_first() {
+    let args = ["build", "build.zen"];
     let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable {
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        dependencies: ["tool"],
-    })
-    b.add(Executable { name: "tool", main: "tool.zen", out_dir: "build/tool/" })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-    std::fs::write(
-        tmp.path().join("app.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write app.zen");
-    std::fs::write(
-        tmp.path().join("tool.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write tool.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["build", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen build build.zen");
-
-    assert!(
-        output.status.success(),
-        "zen build build.zen failed: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
+    super::support::write_dependent_executable_graph(&tmp);
+    let output = super::support::run_zen_in(&tmp, &args);
+    super::support::assert_zen_success(&args, &output);
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let tool_emit = stdout
@@ -177,21 +43,8 @@ main = () i32 {
         "expected dependency target to compile before dependent target, stdout={stdout}"
     );
 
-    for bin_path in [
+    super::support::assert_built_binaries_run(&[
         tmp.path().join("build").join("tool").join("tool"),
         tmp.path().join("build").join("app").join("app"),
-    ] {
-        assert!(
-            bin_path.exists(),
-            "expected {} to exist",
-            bin_path.display()
-        );
-        let run = Command::new(&bin_path).output().expect("run built binary");
-        assert!(
-            run.status.success(),
-            "built binary {} exited with {}",
-            bin_path.display(),
-            run.status
-        );
-    }
+    ]);
 }

--- a/tests/integration/cli_build/direct_build_graph_execution.rs
+++ b/tests/integration/cli_build/direct_build_graph_execution.rs
@@ -1,170 +1,35 @@
-use std::process::Command;
-
 #[test]
 fn direct_file_command_build_zen_routes_through_deterministic_graph() {
+    let args = ["build.zen"];
     let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-    std::fs::write(
-        tmp.path().join("main.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write main.zen");
+    super::support::write_single_executable_graph(&tmp);
+    let output = super::support::run_zen_in(&tmp, &args);
+    super::support::assert_zen_success(&args, &output);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .arg("build.zen")
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen build.zen");
-
-    assert!(
-        output.status.success(),
-        "zen build.zen failed: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let bin_path = tmp.path().join("build").join("myapp");
-    assert!(
-        bin_path.exists(),
-        "expected {} to exist",
-        bin_path.display()
-    );
-    let run = Command::new(&bin_path).output().expect("run built binary");
-    assert!(
-        run.status.success(),
-        "built binary exited with {}",
-        run.status
-    );
+    super::support::assert_built_binaries_run(&[tmp.path().join("build").join("myapp")]);
 }
 
 #[test]
 fn direct_file_command_build_zen_compiles_multiple_executable_targets() {
+    let args = ["build.zen"];
     let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
-    b.add(Executable { name: "tool", main: "tool.zen", out_dir: "build/tool/" })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-    std::fs::write(
-        tmp.path().join("app.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write app.zen");
-    std::fs::write(
-        tmp.path().join("tool.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write tool.zen");
+    super::support::write_multiple_executable_graph(&tmp);
+    let output = super::support::run_zen_in(&tmp, &args);
+    super::support::assert_zen_success(&args, &output);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .arg("build.zen")
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen build.zen");
-
-    assert!(
-        output.status.success(),
-        "zen build.zen failed: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    for bin_path in [
+    super::support::assert_built_binaries_run(&[
         tmp.path().join("build").join("app").join("app"),
         tmp.path().join("build").join("tool").join("tool"),
-    ] {
-        assert!(
-            bin_path.exists(),
-            "expected {} to exist",
-            bin_path.display()
-        );
-        let run = Command::new(&bin_path).output().expect("run built binary");
-        assert!(
-            run.status.success(),
-            "built binary {} exited with {}",
-            bin_path.display(),
-            run.status
-        );
-    }
+    ]);
 }
 
 #[test]
 fn direct_file_command_build_zen_compiles_executable_dependencies_first() {
+    let args = ["build.zen"];
     let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable {
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        dependencies: ["tool"],
-    })
-    b.add(Executable { name: "tool", main: "tool.zen", out_dir: "build/tool/" })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-    std::fs::write(
-        tmp.path().join("app.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write app.zen");
-    std::fs::write(
-        tmp.path().join("tool.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write tool.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .arg("build.zen")
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen build.zen");
-
-    assert!(
-        output.status.success(),
-        "zen build.zen failed: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
+    super::support::write_dependent_executable_graph(&tmp);
+    let output = super::support::run_zen_in(&tmp, &args);
+    super::support::assert_zen_success(&args, &output);
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let tool_emit = stdout
@@ -178,21 +43,8 @@ main = () i32 {
         "expected dependency target to compile before dependent target, stdout={stdout}"
     );
 
-    for bin_path in [
+    super::support::assert_built_binaries_run(&[
         tmp.path().join("build").join("tool").join("tool"),
         tmp.path().join("build").join("app").join("app"),
-    ] {
-        assert!(
-            bin_path.exists(),
-            "expected {} to exist",
-            bin_path.display()
-        );
-        let run = Command::new(&bin_path).output().expect("run built binary");
-        assert!(
-            run.status.success(),
-            "built binary {} exited with {}",
-            bin_path.display(),
-            run.status
-        );
-    }
+    ]);
 }

--- a/tests/integration/cli_build/legacy_graph_command/execution.rs
+++ b/tests/integration/cli_build/legacy_graph_command/execution.rs
@@ -1,170 +1,35 @@
-use std::process::Command;
-
 #[test]
 fn build_graph_command_compiles_single_executable_target() {
+    let args = ["build-graph", "build.zen"];
     let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-    std::fs::write(
-        tmp.path().join("main.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write main.zen");
+    super::super::support::write_single_executable_graph(&tmp);
+    let output = super::super::support::run_zen_in(&tmp, &args);
+    super::super::support::assert_zen_success(&args, &output);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["build-graph", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen build-graph");
-
-    assert!(
-        output.status.success(),
-        "zen build-graph failed: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let bin_path = tmp.path().join("build").join("myapp");
-    assert!(
-        bin_path.exists(),
-        "expected {} to exist",
-        bin_path.display()
-    );
-    let run = Command::new(&bin_path).output().expect("run built binary");
-    assert!(
-        run.status.success(),
-        "built binary exited with {}",
-        run.status
-    );
+    super::super::support::assert_built_binaries_run(&[tmp.path().join("build").join("myapp")]);
 }
 
 #[test]
 fn build_graph_command_compiles_multiple_executable_targets() {
+    let args = ["build-graph", "build.zen"];
     let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
-    b.add(Executable { name: "tool", main: "tool.zen", out_dir: "build/tool/" })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-    std::fs::write(
-        tmp.path().join("app.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write app.zen");
-    std::fs::write(
-        tmp.path().join("tool.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write tool.zen");
+    super::super::support::write_multiple_executable_graph(&tmp);
+    let output = super::super::support::run_zen_in(&tmp, &args);
+    super::super::support::assert_zen_success(&args, &output);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["build-graph", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen build-graph");
-
-    assert!(
-        output.status.success(),
-        "zen build-graph failed: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    for bin_path in [
+    super::super::support::assert_built_binaries_run(&[
         tmp.path().join("build").join("app").join("app"),
         tmp.path().join("build").join("tool").join("tool"),
-    ] {
-        assert!(
-            bin_path.exists(),
-            "expected {} to exist",
-            bin_path.display()
-        );
-        let run = Command::new(&bin_path).output().expect("run built binary");
-        assert!(
-            run.status.success(),
-            "built binary {} exited with {}",
-            bin_path.display(),
-            run.status
-        );
-    }
+    ]);
 }
 
 #[test]
 fn build_graph_command_compiles_executable_dependencies_first() {
+    let args = ["build-graph", "build.zen"];
     let tmp = tempfile::tempdir().expect("create temp dir");
-    std::fs::write(
-        tmp.path().join("build.zen"),
-        r#"
-build = (b: Builder) Result<BuildConfig, BuildError> {
-    b.add(Executable {
-        name: "app",
-        main: "app.zen",
-        out_dir: "build/app/",
-        dependencies: ["tool"],
-    })
-    b.add(Executable { name: "tool", main: "tool.zen", out_dir: "build/tool/" })
-    .Ok(b.config())
-}
-"#,
-    )
-    .expect("write build.zen");
-    std::fs::write(
-        tmp.path().join("app.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write app.zen");
-    std::fs::write(
-        tmp.path().join("tool.zen"),
-        r#"
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write tool.zen");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["build-graph", "build.zen"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("run zen build-graph");
-
-    assert!(
-        output.status.success(),
-        "zen build-graph failed: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
+    super::super::support::write_dependent_executable_graph(&tmp);
+    let output = super::super::support::run_zen_in(&tmp, &args);
+    super::super::support::assert_zen_success(&args, &output);
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let tool_emit = stdout
@@ -178,21 +43,8 @@ main = () i32 {
         "expected dependency target to compile before dependent target, stdout={stdout}"
     );
 
-    for bin_path in [
+    super::super::support::assert_built_binaries_run(&[
         tmp.path().join("build").join("tool").join("tool"),
         tmp.path().join("build").join("app").join("app"),
-    ] {
-        assert!(
-            bin_path.exists(),
-            "expected {} to exist",
-            bin_path.display()
-        );
-        let run = Command::new(&bin_path).output().expect("run built binary");
-        assert!(
-            run.status.success(),
-            "built binary {} exited with {}",
-            bin_path.display(),
-            run.status
-        );
-    }
+    ]);
 }

--- a/tests/integration/cli_build/support.rs
+++ b/tests/integration/cli_build/support.rs
@@ -1,3 +1,115 @@
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+pub(super) fn write_single_executable_graph(tmp: &tempfile::TempDir) {
+    write_file(
+        tmp,
+        "build.zen",
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable { name: "myapp", main: "main.zen", out_dir: "build/" })
+    .Ok(b.config())
+}
+"#,
+    );
+    write_file(
+        tmp,
+        "main.zen",
+        r#"
+main = () i32 {
+    0
+}
+"#,
+    );
+}
+
+pub(super) fn write_multiple_executable_graph(tmp: &tempfile::TempDir) {
+    write_file(
+        tmp,
+        "build.zen",
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable { name: "app", main: "app.zen", out_dir: "build/app/" })
+    b.add(Executable { name: "tool", main: "tool.zen", out_dir: "build/tool/" })
+    .Ok(b.config())
+}
+"#,
+    );
+    write_file(tmp, "app.zen", main_source("0").as_str());
+    write_file(tmp, "tool.zen", main_source("0").as_str());
+}
+
+pub(super) fn write_dependent_executable_graph(tmp: &tempfile::TempDir) {
+    write_file(
+        tmp,
+        "build.zen",
+        r#"
+build = (b: Builder) Result<BuildConfig, BuildError> {
+    b.add(Executable {
+        name: "app",
+        main: "app.zen",
+        out_dir: "build/app/",
+        dependencies: ["tool"],
+    })
+    b.add(Executable { name: "tool", main: "tool.zen", out_dir: "build/tool/" })
+    .Ok(b.config())
+}
+"#,
+    );
+    write_file(tmp, "app.zen", main_source("0").as_str());
+    write_file(tmp, "tool.zen", main_source("0").as_str());
+}
+
+pub(super) fn run_zen_in(tmp: &tempfile::TempDir, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(args)
+        .current_dir(tmp.path())
+        .output()
+        .expect("run zen command")
+}
+
+pub(super) fn assert_zen_success(args: &[&str], output: &Output) {
+    assert!(
+        output.status.success(),
+        "zen {args:?} failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+pub(super) fn assert_built_binaries_run(paths: &[PathBuf]) {
+    for bin_path in paths {
+        assert!(
+            bin_path.exists(),
+            "expected {} to exist",
+            bin_path.display()
+        );
+        let run = Command::new(bin_path).output().expect("run built binary");
+        assert!(
+            run.status.success(),
+            "built binary {} exited with {}",
+            bin_path.display(),
+            run.status
+        );
+    }
+}
+
+fn write_file(tmp: &tempfile::TempDir, path: &str, source: &str) {
+    std::fs::write(tmp.path().join(path), source).unwrap_or_else(|err| {
+        panic!("write {path}: {err}");
+    });
+}
+
+fn main_source(value: &str) -> String {
+    format!(
+        r#"
+main = () i32 {{
+    {value}
+}}
+"#,
+    )
+}
+
 pub(super) fn transitive_gated_test_dependency_graph() -> tempfile::TempDir {
     let tmp = tempfile::tempdir().expect("create temp dir");
     std::fs::write(


### PR DESCRIPTION
## Summary
- Added shared CLI build execution fixtures for single, multi-target, and dependency-ordered executable build graphs.
- Reused those fixtures across `zen build build.zen`, direct `zen build.zen`, and legacy `zen build-graph` execution tests.
- Updated phase/audit docs with the completed build-driver anti-slop slice.

## Validation
- `cargo test --test integration compiles_executable -- --nocapture`
- `cargo test --test integration deterministic_graph -- --nocapture`
- `cargo test --test integration multiple_executable_targets -- --nocapture`
- `cargo test --test integration build_graph_command_compiles_single_executable_target -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Branch push Actions check returned `[]`.