### PR TITLE
[codex] Split build graph declared env tests

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3720,6 +3720,11 @@ and do not assume Phase 4 is ready without evidence.
   `tests/integration/cli_build/legacy_graph_command_host_effects/file_reads/`,
   preserving deterministic-effect coverage while avoiding one large mixed test
   file.
+- Legacy `zen build-graph build.zen` declared env-read positive tests now split
+  single-target, multi-target, and unselected-target cases under
+  `tests/integration/cli_build/declared_env_effects/build_graph/`, preserving
+  declared `.Err`, wildcard, and identifier fallback-arm coverage without one
+  mixed test file.
 - Declared env-read executable graph tests now split normal
   `zen build build.zen` coverage from direct `zen build.zen` coverage under
   `tests/integration/cli_build/declared_env_effects/executable/`, preserving

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3398,6 +3398,11 @@ checked-in docs, tests, and commits only.
   `build_graph_command_accepts_identifier_fallback_declared_env_read_with_unselected_targets`,
   and
   `build_graph_command_rejects_env_read_without_fallback_before_unselected_targets`.
+- Legacy `zen build-graph build.zen` declared env-read positive tests now split
+  single-target, multi-target, and unselected-target cases under
+  `tests/integration/cli_build/declared_env_effects/build_graph/`, preserving
+  declared `.Err`, wildcard, and identifier fallback-arm coverage without one
+  mixed test file.
 - Legacy `zen build-graph build.zen` file-read host-effect tests now live in
   focused `declared`, `rejections`, and `unselected_targets` modules under
   `tests/integration/cli_build/legacy_graph_command_host_effects/file_reads/`,

--- a/tests/integration/cli_build/declared_env_effects/build_graph.rs
+++ b/tests/integration/cli_build/declared_env_effects/build_graph.rs
@@ -1,84 +1,11 @@
+#[path = "build_graph/multiple_targets.rs"]
+mod multiple_targets;
+#[path = "build_graph/single_target.rs"]
+mod single_target;
+#[path = "build_graph/unselected_targets.rs"]
+mod unselected_targets;
+
 use std::process::Command;
-
-use super::{assert_executable_command_accepts_declared_env_read, ExecutableCommandExpectation};
-
-#[test]
-fn build_graph_command_accepts_declared_env_read_with_fallback() {
-    assert_executable_command_accepts_declared_env_read(
-        &["build-graph", "build.zen"],
-        r#"| .Err { "default" }"#,
-        "build_graph_command_accepts_declared_env_read_with_fallback",
-        ExecutableCommandExpectation::BuildOutput,
-    );
-}
-
-#[test]
-fn build_graph_command_accepts_wildcard_fallback_declared_env_read() {
-    assert_executable_command_accepts_declared_env_read(
-        &["build-graph", "build.zen"],
-        r#"| _ { "default" }"#,
-        "build_graph_command_accepts_wildcard_fallback_declared_env_read",
-        ExecutableCommandExpectation::BuildOutput,
-    );
-}
-
-#[test]
-fn build_graph_command_accepts_identifier_fallback_declared_env_read() {
-    assert_executable_command_accepts_declared_env_read(
-        &["build-graph", "build.zen"],
-        r#"| err { "default" }"#,
-        "build_graph_command_accepts_identifier_fallback_declared_env_read",
-        ExecutableCommandExpectation::BuildOutput,
-    );
-}
-
-#[test]
-fn build_graph_command_accepts_declared_env_read_for_multiple_targets() {
-    assert_build_graph_command_accepts_declared_env_read_for_multiple_targets(
-        r#"| .Err { "default" }"#,
-        "build_graph_command_accepts_declared_env_read_for_multiple_targets",
-    );
-}
-
-#[test]
-fn build_graph_command_accepts_wildcard_fallback_declared_env_read_for_multiple_targets() {
-    assert_build_graph_command_accepts_declared_env_read_for_multiple_targets(
-        r#"| _ { "default" }"#,
-        "build_graph_command_accepts_wildcard_fallback_declared_env_read_for_multiple_targets",
-    );
-}
-
-#[test]
-fn build_graph_command_accepts_identifier_fallback_declared_env_read_for_multiple_targets() {
-    assert_build_graph_command_accepts_declared_env_read_for_multiple_targets(
-        r#"| err { "default" }"#,
-        "build_graph_command_accepts_identifier_fallback_declared_env_read_for_multiple_targets",
-    );
-}
-
-#[test]
-fn build_graph_command_accepts_declared_env_read_with_unselected_targets() {
-    assert_build_graph_command_accepts_declared_env_read_with_unselected_targets(
-        r#"| .Err { "default" }"#,
-        "build_graph_command_accepts_declared_env_read_with_unselected_targets",
-    );
-}
-
-#[test]
-fn build_graph_command_accepts_wildcard_fallback_declared_env_read_with_unselected_targets() {
-    assert_build_graph_command_accepts_declared_env_read_with_unselected_targets(
-        r#"| _ { "default" }"#,
-        "build_graph_command_accepts_wildcard_fallback_declared_env_read_with_unselected_targets",
-    );
-}
-
-#[test]
-fn build_graph_command_accepts_identifier_fallback_declared_env_read_with_unselected_targets() {
-    assert_build_graph_command_accepts_declared_env_read_with_unselected_targets(
-        r#"| err { "default" }"#,
-        "build_graph_command_accepts_identifier_fallback_declared_env_read_with_unselected_targets",
-    );
-}
 
 fn assert_build_graph_command_accepts_declared_env_read_for_multiple_targets(
     fallback_arm: &str,

--- a/tests/integration/cli_build/declared_env_effects/build_graph/multiple_targets.rs
+++ b/tests/integration/cli_build/declared_env_effects/build_graph/multiple_targets.rs
@@ -1,0 +1,25 @@
+use super::assert_build_graph_command_accepts_declared_env_read_for_multiple_targets;
+
+#[test]
+fn build_graph_command_accepts_declared_env_read_for_multiple_targets() {
+    assert_build_graph_command_accepts_declared_env_read_for_multiple_targets(
+        r#"| .Err { "default" }"#,
+        "build_graph_command_accepts_declared_env_read_for_multiple_targets",
+    );
+}
+
+#[test]
+fn build_graph_command_accepts_wildcard_fallback_declared_env_read_for_multiple_targets() {
+    assert_build_graph_command_accepts_declared_env_read_for_multiple_targets(
+        r#"| _ { "default" }"#,
+        "build_graph_command_accepts_wildcard_fallback_declared_env_read_for_multiple_targets",
+    );
+}
+
+#[test]
+fn build_graph_command_accepts_identifier_fallback_declared_env_read_for_multiple_targets() {
+    assert_build_graph_command_accepts_declared_env_read_for_multiple_targets(
+        r#"| err { "default" }"#,
+        "build_graph_command_accepts_identifier_fallback_declared_env_read_for_multiple_targets",
+    );
+}

--- a/tests/integration/cli_build/declared_env_effects/build_graph/single_target.rs
+++ b/tests/integration/cli_build/declared_env_effects/build_graph/single_target.rs
@@ -1,0 +1,33 @@
+use super::super::{
+    assert_executable_command_accepts_declared_env_read, ExecutableCommandExpectation,
+};
+
+#[test]
+fn build_graph_command_accepts_declared_env_read_with_fallback() {
+    assert_executable_command_accepts_declared_env_read(
+        &["build-graph", "build.zen"],
+        r#"| .Err { "default" }"#,
+        "build_graph_command_accepts_declared_env_read_with_fallback",
+        ExecutableCommandExpectation::BuildOutput,
+    );
+}
+
+#[test]
+fn build_graph_command_accepts_wildcard_fallback_declared_env_read() {
+    assert_executable_command_accepts_declared_env_read(
+        &["build-graph", "build.zen"],
+        r#"| _ { "default" }"#,
+        "build_graph_command_accepts_wildcard_fallback_declared_env_read",
+        ExecutableCommandExpectation::BuildOutput,
+    );
+}
+
+#[test]
+fn build_graph_command_accepts_identifier_fallback_declared_env_read() {
+    assert_executable_command_accepts_declared_env_read(
+        &["build-graph", "build.zen"],
+        r#"| err { "default" }"#,
+        "build_graph_command_accepts_identifier_fallback_declared_env_read",
+        ExecutableCommandExpectation::BuildOutput,
+    );
+}

--- a/tests/integration/cli_build/declared_env_effects/build_graph/unselected_targets.rs
+++ b/tests/integration/cli_build/declared_env_effects/build_graph/unselected_targets.rs
@@ -1,0 +1,25 @@
+use super::assert_build_graph_command_accepts_declared_env_read_with_unselected_targets;
+
+#[test]
+fn build_graph_command_accepts_declared_env_read_with_unselected_targets() {
+    assert_build_graph_command_accepts_declared_env_read_with_unselected_targets(
+        r#"| .Err { "default" }"#,
+        "build_graph_command_accepts_declared_env_read_with_unselected_targets",
+    );
+}
+
+#[test]
+fn build_graph_command_accepts_wildcard_fallback_declared_env_read_with_unselected_targets() {
+    assert_build_graph_command_accepts_declared_env_read_with_unselected_targets(
+        r#"| _ { "default" }"#,
+        "build_graph_command_accepts_wildcard_fallback_declared_env_read_with_unselected_targets",
+    );
+}
+
+#[test]
+fn build_graph_command_accepts_identifier_fallback_declared_env_read_with_unselected_targets() {
+    assert_build_graph_command_accepts_declared_env_read_with_unselected_targets(
+        r#"| err { "default" }"#,
+        "build_graph_command_accepts_identifier_fallback_declared_env_read_with_unselected_targets",
+    );
+}


### PR DESCRIPTION
## Summary

- Split legacy `zen build-graph build.zen` declared env-read positive coverage into `single_target`, `multiple_targets`, and `unselected_targets` modules.
- Kept shared build-graph helpers in the parent module.
- Updated phase/audit docs with the new test layout evidence.

## Validation

- `cargo test --test integration build_graph_command_accepts_declared_env_read_with -- --nocapture`
- `cargo test --test integration build_graph_command_accepts_wildcard_fallback_declared_env_read -- --nocapture`
- `cargo test --test integration build_graph_command_accepts_identifier_fallback_declared_env_read -- --nocapture`
- `cargo test --test integration build_graph_command_accepts_declared_env_read_for_multiple_targets -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Branch-push Actions noise check: `gh run list --repo lantos1618/zenlang --branch codex/split-declared-env-build-graph-tests --limit 10 --json databaseId,status,conclusion,name,event,headSha,createdAt` returned `[]`.