### PR TITLE
[codex] Clarify build zen v1 backlog

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3781,6 +3781,12 @@ and do not assume Phase 4 is ready without evidence.
   `tests/integration/cli_build/legacy_graph_command_host_effects/env_reads/`,
   preserving undeclared env-read and validation-order checks while keeping
   file-read coverage wired separately from the parent module.
+- `docs/V1_SPEC.md` now separates constrained `build.zen` execution evidence
+  from the remaining required-test backlog. Deterministic graph execution has
+  positive executable/test coverage and negative undeclared-host-effect
+  coverage, so `build.zen` is no longer listed as only planned backlog. This is
+  guarded by
+  `docs_truth::v1_spec_records_phase_one_feature_gates_and_test_backlog`.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3462,6 +3462,11 @@ checked-in docs, tests, and commits only.
   coverage into focused basic and ordering modules under
   `tests/integration/cli_build/legacy_graph_command_host_effects/env_reads/`,
   leaving file-read coverage wired separately from the parent module.
+- `docs/V1_SPEC.md` now separates constrained `build.zen` evidence from the
+  remaining required-test backlog: deterministic graph execution already has
+  positive executable/test coverage and negative undeclared-host-effect
+  coverage, so the backlog is reserved for v1 areas that still lack minimum
+  positive/negative proof.
 
 ## Current Phase
 
@@ -3487,7 +3492,7 @@ exist and pass through the same compiler path advertised in `docs/V1_SPEC.md`.
 
 ## Next Small Slice
 
-Continue the next smallest build-driver slice by expanding graph execution only
-when a new positive graph fixture and a matching negative deterministic-effect
-fixture exist first. Preserve the constrained accepted `build.zen` subset until
-multi-target or richer build-script semantics are specified and tested.
+Continue the next smallest gated-feature slice with tests first. For
+`build.zen`, expand beyond the constrained subset only when a new positive graph
+fixture and a matching negative deterministic-effect fixture exist first. For
+non-build v1 areas, start with the Required Test Backlog in `docs/V1_SPEC.md`.

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -139,9 +139,14 @@ Generic behavior inheritance with child type-parameter parent args is covered by
 | Existing broad stdlib files | experimental | Must compile before promotion |
 | Formatter, package manager, alternate backends | removed from v1 claims | Reintroduce only with tests and binaries |
 
+Constrained `build.zen` execution already has positive and negative evidence:
+Deterministic build graph compiles executable and test targets, while build
+scripts using undeclared host side effects are rejected. The remaining backlog
+below is for v1 areas without that minimum positive/negative proof.
+
 ## Required Test Backlog
 
-Every v1 effect/type-match/allocator/actor/build-system claim needs at least one
+Every remaining v1 effect/type-match/allocator/actor/IR claim needs at least one
 planned positive test and one planned negative test before implementation.
 
 | Area | Planned Positive Test | Planned Negative Test |
@@ -153,7 +158,6 @@ planned positive test and one planned negative test before implementation.
 | AST traversal | Tooling can read AST JSON for a parsed source fixture | AST traversal cannot bypass semantic checks for a core language feature |
 | Actors in std | Actor mailbox send/receive works with scheduler and allocator integration | Actor using async mailbox from sync-only context is rejected |
 | JSON/YAML IR boundaries | Checked MIR JSON and target YAML validate against schemas | Hand-authored JSON IR cannot override compiler-owned types or layouts |
-| `build.zen` | Deterministic build graph compiles executable and test targets | Build script using undeclared host side effects is rejected |
 
 ## Stdlib Gate
 

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -218,4 +218,13 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         !spec.contains("Deterministic build graph creates one executable target"),
         "docs/V1_SPEC.md still describes the build.zen backlog as single-executable only"
     );
+
+    let backlog = spec
+        .split("## Required Test Backlog")
+        .nth(1)
+        .expect("V1 spec should contain required test backlog");
+    assert!(
+        !backlog.contains("| `build.zen` |"),
+        "docs/V1_SPEC.md should not list constrained build.zen execution as only planned backlog"
+    );
 }


### PR DESCRIPTION
## Summary
- Move constrained `build.zen` execution out of the V1 required-test backlog now that it has positive executable/test coverage and negative undeclared-host-effect coverage.
- Add a docs-truth assertion so `build.zen` is not reintroduced as only planned backlog while the feature matrix marks it constrained.
- Update the phase plan and completion audit to point remaining gated work at the V1 backlog.

## Validation
- `cargo test --test docs_truth v1_spec_records_phase_one_feature_gates_and_test_backlog -- --nocapture` failed before the spec edit and passed after it.
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Branch-push Actions check returned `[]`.