### PR TITLE
[codex] Gate generic association targets explicitly

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -72,6 +72,12 @@ and do not assume Phase 4 is ready without evidence.
   `integration::generic_specializations_do_not_emit_unspecialized_c_symbols`,
   proving `Box<T>.wrap_result` can infer `T` from the concrete receiver and
   specialize `Result<Option<T>, str>` without unresolved generated C calls.
+- Generic association targets remain gated deliberately. The parser now has
+  focused coverage for `Box<T>.implements`, `Box<T>.requires`, and
+  `Box<T>.extends` through
+  `parser::tests::generic_type_association_keywords_are_explicitly_gated`,
+  avoiding accidental partial promotion before the behavior solver can model
+  generic target templates.
 - Generic method specializations that call generic functions have executable
   and generated-C coverage in `tests/zen/generic_method_worklist.zen`, including
   call-resolution assertions for the reached generic function dependency.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -94,6 +94,12 @@ checked-in docs, tests, and commits only.
   parameter parsing in a focused declaration-types module, leaving the main
   declaration parser responsible for dispatch, imports, functions, and
   top-level bindings.
+- Generic association target syntax such as `Box<T>.implements(Json<T>)`,
+  `Box<T>.requires(Json<T>)`, and `Box<T>.extends(Json<T>)` now has an explicit
+  parser gate through
+  `parser::tests::generic_type_association_keywords_are_explicitly_gated`,
+  keeping the unsupported behavior-solver boundary separate from supported
+  generic non-behavior `Type<T>.impl` blocks.
 - Resolver symbol table data-model definitions now live in a focused core
   include, leaving symbol-table lookup and definition behavior in the parent
   implementation file.

--- a/src/parser/declarations.rs
+++ b/src/parser/declarations.rs
@@ -60,12 +60,7 @@ impl Parser {
                                     name_span,
                                 );
                             }
-                            return Err(CompileError::Syntax(
-                                format!(
-                                    "gated v1 feature '{keyword}': type association and behavior constraints are specified in docs/V1_SPEC.md but are not implemented"
-                                ),
-                                Some(self.peek_span()),
-                            ));
+                            return self.reject_gated_generic_association_target(keyword);
                         }
 
                         let mut all_type_params = type_params;
@@ -174,6 +169,18 @@ impl Parser {
     }
 
     // ── Function ──────────────────────────────────────────────
+
+    fn reject_gated_generic_association_target<T>(
+        &self,
+        keyword: TypeDeclarationKeyword,
+    ) -> Result<T, CompileError> {
+        Err(CompileError::Syntax(
+            format!(
+                "generic association target `Type<T>.{keyword}` is gated; use non-generic `{keyword}` associations or keep the generic behavior target deferred to docs/V1_SPEC.md"
+            ),
+            Some(self.peek_span()),
+        ))
+    }
 
     fn parse_function_def(
         &mut self,

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -15,6 +15,10 @@ fn parse_ok(src: &str) -> Program {
     })
 }
 
+fn parse_err(src: &str) -> Vec<CompileError> {
+    parse_str(src).expect_err("expected parse to fail")
+}
+
 mod behaviors;
 mod declarations;
 mod examples_types_errors;

--- a/src/parser/tests/behaviors.rs
+++ b/src/parser/tests/behaviors.rs
@@ -158,6 +158,28 @@ fn parse_generic_impl_block_hoists_receiver_type_params_to_methods() {
 }
 
 #[test]
+fn generic_type_association_keywords_are_explicitly_gated() {
+    for (keyword, source) in [
+        ("implements", "Box<T>.implements(Json<T>) { }"),
+        ("requires", "Box<T>.requires(Json<T>)"),
+        ("extends", "Box<T>.extends(Json<T>)"),
+    ] {
+        let errors = parse_err(source);
+        let message = errors
+            .first()
+            .map(ToString::to_string)
+            .unwrap_or_else(|| "missing parser error".to_string());
+
+        assert!(
+            message.contains(&format!(
+                "generic association target `Type<T>.{keyword}` is gated"
+            )),
+            "expected explicit generic association gate for {keyword}, got {errors:?}"
+        );
+    }
+}
+
+#[test]
 fn parse_behavior_impl_with_generic_behavior_args() {
     let prog = parse_ok("Point.implements(Json<i32>) { }");
     match &prog.declarations[0] {


### PR DESCRIPTION
## Summary

- Add parser coverage for generic association target syntax across `implements`, `requires`, and `extends`.
- Replace the broad generic association parser message with a focused gate helper using `TypeDeclarationKeyword` display.
- Record the boundary in the phase plan and completion audit so it stays distinct from supported `Type<T>.impl` blocks.

## Why

Generic behavior target templates need behavior-solver support, not just parser support. This keeps `Box<T>.implements(Json<T>)` and related forms explicitly gated until that solver work is implemented, while preserving the accepted generic non-behavior impl syntax.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test parser::tests::behaviors::generic_type_association_keywords_are_explicitly_gated --lib -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`