### PR TITLE
[codex] Gate result raise diagnostics

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3335,6 +3335,10 @@ and do not assume Phase 4 is ready without evidence.
   `typechecker::tests::core_semantics::literals::range_expression_is_rejected_until_range_type_exists`,
   so parser-accepted range syntax no longer succeeds with an unknown typed
   placeholder before range semantics exist.
+- Planned Result propagation through `.raise()` remains gated deliberately. It
+  now has a focused typechecker diagnostic instead of an ordinary unknown-method
+  error, covered by
+  `typechecker::tests::core_semantics::literals::result_raise_is_rejected_until_propagation_lowering_exists`.
 - Type declaration suffix parsing now uses enum-backed `impl`/`implements`/
   `requires`/`extends` spellings, keeping parser dispatch and diagnostics off
   ad hoc string comparisons. Coverage:

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3119,6 +3119,10 @@ checked-in docs, tests, and commits only.
 - Range expressions now produce an explicit gated typechecker diagnostic until
   a concrete range type is designed, instead of silently carrying an unknown
   placeholder through function return checking.
+- Planned Result propagation through `.raise()` now produces an explicit gated
+  typechecker diagnostic instead of falling through to ordinary missing-method
+  lookup, covered by
+  `typechecker::tests::core_semantics::literals::result_raise_is_rejected_until_propagation_lowering_exists`.
 - Dead char-literal AST support has been removed because no lexer/parser
   surface produces it. The cleanup removes the stale typechecker `Unknown`
   fallback and is guarded by

--- a/src/typechecker/expressions/method_call_support.rs
+++ b/src/typechecker/expressions/method_call_support.rs
@@ -3,6 +3,8 @@ use crate::typechecker::FuncInfo;
 
 mod module_calls;
 
+const RESULT_PROPAGATION_METHOD: &str = "raise";
+
 impl TypeChecker {
     pub(super) fn check_method_call_expr(
         &mut self,
@@ -19,6 +21,14 @@ impl TypeChecker {
         }
 
         let typed_receiver = self.check_expr(receiver)?;
+
+        if method == RESULT_PROPAGATION_METHOD {
+            return Err(Diagnostic::error(
+                "E3054",
+                "`.raise()` is gated until Result propagation typing and lowering are implemented",
+                span,
+            ));
+        }
 
         // Build args: receiver as first arg (for methods/UFC)
         let mut typed_args = vec![typed_receiver.clone()];

--- a/src/typechecker/tests/core_semantics/literals.rs
+++ b/src/typechecker/tests/core_semantics/literals.rs
@@ -21,3 +21,35 @@ main = () i32 {
         "expected range diagnostic, got {err:?}"
     );
 }
+
+#[test]
+fn result_raise_is_rejected_until_propagation_lowering_exists() {
+    let program = parse_program(
+        r#"
+Result<T, E>:
+    Ok(T),
+    Err(E)
+
+main = () i32 {
+    value = Result<i32, str>.Ok(1)
+    value.raise()
+}
+"#,
+    );
+    let mut tc = TypeChecker::new();
+
+    let err = tc
+        .check_program(&program)
+        .expect_err("raise propagation should stay gated until lowering exists");
+
+    assert!(
+        err.iter()
+            .any(|d| d.message.contains("`.raise()` is gated")),
+        "expected raise gate diagnostic, got {err:?}"
+    );
+    assert!(
+        err.iter()
+            .all(|d| !d.message.contains("has no method `raise`")),
+        "raise gate should not be reported as an ordinary missing method, got {err:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Add an explicit typechecker gate for planned `.raise()` Result propagation.
- Cover the gate with a unit test that proves `.raise()` no longer falls through to an ordinary missing-method error.
- Record the gated boundary in the phase plan and completion audit.

## Why

`.raise()` is documented as a v1 design goal, but propagation typing and lowering are not implemented yet. The compiler should reject it deliberately instead of reporting `Result_* has no method raise`.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test typechecker::tests::core_semantics::literals::result_raise_is_rejected_until_propagation_lowering_exists --lib -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`