### PR TITLE
[codex] Gate MIR and target YAML JSON modes

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -310,6 +310,10 @@ and do not assume Phase 4 is ready without evidence.
   serialization coverage into
   `tests/integration/cli_build/frontend_json/module_graph.rs`, leaving
   typed-program and diagnostics JSON checks in the parent module.
+- `emit-json mir` and `emit-json target-yaml` now reject with explicit gated
+  diagnostics tied to the v1 JSON/YAML backlog. Coverage:
+  `emit_json_mir_command_is_explicitly_gated` and
+  `emit_json_target_yaml_command_is_explicitly_gated`.
 - Build-graph JSON host-effect tests now split declared file-read fallback
   accept/reject coverage into
   `tests/integration/cli_build/build_graph_json_host_effects/file_reads.rs`,

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -494,6 +494,10 @@ checked-in docs, tests, and commits only.
 - Frontend JSON integration tests now keep AST and symbol module-graph
   serialization coverage in a focused child module, leaving typed-program and
   diagnostics JSON checks in the parent module.
+- `emit-json mir` and `emit-json target-yaml` now reject with explicit gated
+  diagnostics tied to the v1 JSON/YAML backlog, covered by
+  `emit_json_mir_command_is_explicitly_gated` and
+  `emit_json_target_yaml_command_is_explicitly_gated`.
 - Build-graph JSON host-effect tests now keep declared file-read fallback
   accept/reject cases in a focused child module, leaving env-effect rejection
   ordering coverage in the parent integration module.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -89,6 +89,18 @@ pub fn main() {
                 "typed" => cmd_emit_json_typed(&args[3]),
                 "diagnostics" => cmd_emit_json_diagnostics(&args[3]),
                 "build-graph" => cmd_emit_json_build_graph(&args[3]),
+                "mir" => {
+                    eprintln!(
+                        "error: MIR JSON emission is gated until schema and golden tests exist"
+                    );
+                    process::exit(1);
+                }
+                "target-yaml" => {
+                    eprintln!(
+                        "error: target YAML validation is gated until schemas and negative validation tests exist"
+                    );
+                    process::exit(1);
+                }
                 _ => {
                     eprintln!(
                         "Usage: zen emit-json <ast|symbols|typed|diagnostics|build-graph> <file.zen>"

--- a/tests/docs_truth/phase_audit.rs
+++ b/tests/docs_truth/phase_audit.rs
@@ -33,6 +33,8 @@ fn phase_plan_records_recovered_progress_and_next_slice() {
         "build_program_lowering_rejects_cyclic_target_dependencies",
         "build_graph_rejects_self_target_dependencies",
         "build_program_lowering_rejects_self_target_dependencies",
+        "emit_json_mir_command_is_explicitly_gated",
+        "emit_json_target_yaml_command_is_explicitly_gated",
         "build_graph_rejects_unknown_target_dependencies",
         "build_program_lowering_rejects_unknown_target_dependencies",
         "build_program_lowering_rejects_unsupported_package_targets",

--- a/tests/integration/cli_build/frontend_json.rs
+++ b/tests/integration/cli_build/frontend_json.rs
@@ -103,3 +103,55 @@ main = () i32 {
     assert_eq!(span["line"], 3);
     assert_eq!(span["column"], 5);
 }
+
+#[test]
+fn emit_json_mir_command_is_explicitly_gated() {
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args([
+            "emit-json",
+            "mir",
+            test_dir().join("hello.zen").to_str().unwrap(),
+        ])
+        .output()
+        .expect("run zen emit-json mir");
+
+    assert!(
+        !output.status.success(),
+        "zen emit-json mir should be gated: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("MIR JSON emission is gated until schema and golden tests exist"),
+        "expected MIR gate diagnostic, stderr={stderr}"
+    );
+}
+
+#[test]
+fn emit_json_target_yaml_command_is_explicitly_gated() {
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args([
+            "emit-json",
+            "target-yaml",
+            test_dir().join("hello.zen").to_str().unwrap(),
+        ])
+        .output()
+        .expect("run zen emit-json target-yaml");
+
+    assert!(
+        !output.status.success(),
+        "zen emit-json target-yaml should be gated: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(
+            "target YAML validation is gated until schemas and negative validation tests exist"
+        ),
+        "expected target YAML gate diagnostic, stderr={stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

- Add explicit gated diagnostics for `zen emit-json mir` and `zen emit-json target-yaml`.
- Cover those gated CLI paths with integration tests.
- Record the new JSON/YAML gate evidence in the phase plan and completion audit.

## Validation

- `cargo test --test integration emit_json_mir_command_is_explicitly_gated -- --nocapture`
- `cargo test --test integration emit_json_target_yaml_command_is_explicitly_gated -- --nocapture`
- `cargo test --test integration cli_build::frontend_json -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`