### PR TITLE
[codex] Gate HIR JSON mode explicitly

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -310,9 +310,10 @@ and do not assume Phase 4 is ready without evidence.
   serialization coverage into
   `tests/integration/cli_build/frontend_json/module_graph.rs`, leaving
   typed-program and diagnostics JSON checks in the parent module.
-- `emit-json mir` and `emit-json target-yaml` now reject with explicit gated
-  diagnostics tied to the v1 JSON/YAML backlog. Coverage:
-  `emit_json_mir_command_is_explicitly_gated` and
+- `emit-json hir`, `emit-json mir`, and `emit-json target-yaml` now reject with
+  explicit gated diagnostics tied to the v1 JSON/YAML backlog. Coverage:
+  `emit_json_hir_command_is_explicitly_gated`,
+  `emit_json_mir_command_is_explicitly_gated`, and
   `emit_json_target_yaml_command_is_explicitly_gated`.
 - Build-graph JSON host-effect tests now split declared file-read fallback
   accept/reject coverage into

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -494,9 +494,10 @@ checked-in docs, tests, and commits only.
 - Frontend JSON integration tests now keep AST and symbol module-graph
   serialization coverage in a focused child module, leaving typed-program and
   diagnostics JSON checks in the parent module.
-- `emit-json mir` and `emit-json target-yaml` now reject with explicit gated
-  diagnostics tied to the v1 JSON/YAML backlog, covered by
-  `emit_json_mir_command_is_explicitly_gated` and
+- `emit-json hir`, `emit-json mir`, and `emit-json target-yaml` now reject with
+  explicit gated diagnostics tied to the v1 JSON/YAML backlog, covered by
+  `emit_json_hir_command_is_explicitly_gated`,
+  `emit_json_mir_command_is_explicitly_gated`, and
   `emit_json_target_yaml_command_is_explicitly_gated`.
 - Build-graph JSON host-effect tests now keep declared file-read fallback
   accept/reject cases in a focused child module, leaving env-effect rejection

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -89,6 +89,12 @@ pub fn main() {
                 "typed" => cmd_emit_json_typed(&args[3]),
                 "diagnostics" => cmd_emit_json_diagnostics(&args[3]),
                 "build-graph" => cmd_emit_json_build_graph(&args[3]),
+                "hir" => {
+                    eprintln!(
+                        "error: HIR JSON emission is gated until schema and golden tests exist"
+                    );
+                    process::exit(1);
+                }
                 "mir" => {
                     eprintln!(
                         "error: MIR JSON emission is gated until schema and golden tests exist"

--- a/tests/docs_truth/phase_audit.rs
+++ b/tests/docs_truth/phase_audit.rs
@@ -33,6 +33,7 @@ fn phase_plan_records_recovered_progress_and_next_slice() {
         "build_program_lowering_rejects_cyclic_target_dependencies",
         "build_graph_rejects_self_target_dependencies",
         "build_program_lowering_rejects_self_target_dependencies",
+        "emit_json_hir_command_is_explicitly_gated",
         "emit_json_mir_command_is_explicitly_gated",
         "emit_json_target_yaml_command_is_explicitly_gated",
         "build_graph_rejects_unknown_target_dependencies",

--- a/tests/integration/cli_build/frontend_json.rs
+++ b/tests/integration/cli_build/frontend_json.rs
@@ -130,6 +130,31 @@ fn emit_json_mir_command_is_explicitly_gated() {
 }
 
 #[test]
+fn emit_json_hir_command_is_explicitly_gated() {
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args([
+            "emit-json",
+            "hir",
+            test_dir().join("hello.zen").to_str().unwrap(),
+        ])
+        .output()
+        .expect("run zen emit-json hir");
+
+    assert!(
+        !output.status.success(),
+        "zen emit-json hir should be gated: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("HIR JSON emission is gated until schema and golden tests exist"),
+        "expected HIR gate diagnostic, stderr={stderr}"
+    );
+}
+
+#[test]
 fn emit_json_target_yaml_command_is_explicitly_gated() {
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
         .args([


### PR DESCRIPTION
## Summary

- Add an explicit gated diagnostic for `zen emit-json hir`.
- Cover the HIR CLI gate with an integration test alongside the MIR and target YAML gates.
- Update phase plan and completion audit evidence so the HIR/MIR JSON backlog stays tracked.

## Validation

- `cargo test --test integration emit_json_hir_command_is_explicitly_gated -- --nocapture`
- `cargo test --test integration cli_build::frontend_json -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`