### PR TITLE
[codex] Mark resolver feature implemented in v1 spec

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3816,6 +3816,10 @@ and do not assume Phase 4 is ready without evidence.
   coverage, so `build.zen` is no longer listed as only planned backlog. This is
   guarded by
   `docs_truth::v1_spec_records_phase_one_feature_gates_and_test_backlog`.
+- `docs/V1_SPEC.md` now marks strict resolver, symbol IDs, and privacy as
+  implemented rather than gated, backed by resolver/module/privacy evidence and
+  guarded by
+  `docs_truth::v1_spec_records_phase_one_feature_gates_and_test_backlog`.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3263,6 +3263,9 @@ checked-in docs, tests, and commits only.
   `src/lexer/tests/syntax_examples.rs`, keeping Zen function/import,
   declaration, UFC, pattern-match, and method-call tokenization examples
   separate from core token/operator coverage.
+- `docs/V1_SPEC.md` now records strict resolver, symbol IDs, and privacy as
+  implemented with resolver/module/privacy tests as the evidence gate, guarded
+  by `docs_truth::v1_spec_records_phase_one_feature_gates_and_test_backlog`.
 - C codegen type mapping tests now live in
   `src/codegen/c/tests/type_mapping.rs`, keeping primitive, string, pointer,
   named, and function-pointer type mapping coverage separate from program

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -127,7 +127,7 @@ Generic behavior inheritance with child type-parameter parent args is covered by
 | Local module loading | implemented | Existing integration tests |
 | Typechecked C backend for tested fixtures | implemented | `cargo test --tests` |
 | README and contributor truth assertions | implemented | `tests/docs_truth.rs` |
-| Strict resolver, symbol IDs, privacy | gated | Phase 2 tests |
+| Strict resolver, symbol IDs, privacy | implemented | Resolver/module/privacy tests |
 | HIR/MIR JSON emission | gated | Schema and golden tests |
 | Target/build YAML validation | gated | Schema and negative validation tests |
 | Behaviors and type association | gated | Positive/negative behavior solver tests |

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -230,4 +230,8 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         !backlog.contains("| `build.zen` |"),
         "docs/V1_SPEC.md should not list constrained build.zen execution as only planned backlog"
     );
+    assert!(
+        !spec.contains("| Strict resolver, symbol IDs, privacy | gated |"),
+        "docs/V1_SPEC.md should not describe implemented resolver/module privacy evidence as gated"
+    );
 }


### PR DESCRIPTION
## Summary

- Mark the `Strict resolver, symbol IDs, privacy` V1 feature-matrix row as implemented instead of gated.
- Add a docs-truth regression assertion so the row cannot drift back to gated wording while resolver/module/privacy evidence exists.
- Record the spec alignment in the phase plan and completion audit.

## Validation

- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`