### PR TITLE
[codex] Guard quiet CI branch pushes

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -1670,9 +1670,10 @@ and do not assume Phase 4 is ready without evidence.
   `typechecker::tests::collect_declarations_with_symbols_clears_generic_function_template_type_params_when_resolver_bounds_missing`
   and
   `typechecker::tests::collect_declarations_with_symbols_clears_generic_method_template_type_params_when_resolver_bounds_missing`.
-- The docs truth gate now covers the quiet draft-PR CI trigger shape by
-  rejecting `pull_request.synchronize`, requiring manual dispatch, and requiring
-  the draft-PR guard on fmt, clippy, and test jobs.
+- The docs truth gate now covers the quiet CI trigger shape by ensuring normal branch pushes
+  do not run Actions, rejecting `pull_request.synchronize`,
+  requiring manual dispatch, and requiring the draft-PR guard on fmt, clippy,
+  and test jobs.
 - Resolver variant payload expectations now pass paired typed/display payload
   metadata directly to validation instead of wrapping it in a redundant
   intermediate object.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1782,9 +1782,10 @@ checked-in docs, tests, and commits only.
 - Resolver-backed generic template refresh now uses the same complete
   type-parameter metadata as callable info, so incomplete typed bound refs do
   not leave stale function or method template type parameters behind.
-- The docs truth gate now locks the quiet draft-PR CI trigger shape: no
-  `pull_request.synchronize`, manual dispatch retained, and fmt/clippy/test
-  jobs guarded by the draft-PR condition.
+- The docs truth gate now locks the quiet CI trigger shape: normal branch pushes
+  do not run Actions, `pull_request.synchronize` is absent, manual
+  dispatch is retained, and fmt/clippy/test jobs are guarded by the draft-PR
+  condition.
 - Resolver variant payload expectations now pass the paired typed/display
   payload metadata directly to validation instead of wrapping it in a redundant
   intermediate object.

--- a/tests/docs_truth/repo_hygiene/ci_configs.rs
+++ b/tests/docs_truth/repo_hygiene/ci_configs.rs
@@ -21,6 +21,10 @@ fn ci_and_release_only_advertise_existing_targets() {
         "CI pull_request triggers must avoid draft-open and synchronize spam while still running when PRs leave draft"
     );
     assert!(
+        !ci.contains("\n  push:"),
+        "CI workflow should not run on normal branch pushes; use PR ready-for-review checks or manual dispatch"
+    );
+    assert!(
         !ci.contains("types: [opened") && !ci.contains(", opened") && !ci.contains("- opened"),
         "CI workflow should not create skipped runs for draft PR creation"
     );
@@ -38,6 +42,18 @@ fn ci_and_release_only_advertise_existing_targets() {
         ci.contains("workflow_dispatch"),
         "CI must keep a manual dispatch path when draft PR pushes do not run checks"
     );
+
+    let phase_plan = read("docs/PHASE_PLAN.md");
+    let completion_audit = read("docs/COMPLETION_AUDIT.md");
+    for (path, contents) in [
+        ("docs/PHASE_PLAN.md", phase_plan),
+        ("docs/COMPLETION_AUDIT.md", completion_audit),
+    ] {
+        assert!(
+            contents.contains("normal branch pushes"),
+            "{path} should record that CI stays quiet on normal branch pushes"
+        );
+    }
 
     for unsupported in ["LLVM", "zen-lsp", "aarch64-apple-darwin"] {
         assert!(


### PR DESCRIPTION
## Summary

- Add a docs-truth guard that CI does not run on normal branch pushes.
- Keep the existing ready-for-review/manual-dispatch CI trigger shape documented in the phase plan and completion audit.
- Preserve the existing draft/synchronize spam guards for fmt, clippy, and tests.

## Validation

- `cargo test --test docs_truth repo_hygiene::ci_configs::ci_and_release_only_advertise_existing_targets -- --nocapture`
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`