### PR TITLE
[codex] Use StaticString as public static text spelling

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -59,7 +59,7 @@ and do not assume Phase 4 is ready without evidence.
   evidence through `tests/zen/generic_nested_result_enum.zen`,
   `integration::test_generic_nested_result_enum`, and
   `integration::generic_specializations_do_not_emit_unspecialized_c_symbols`,
-  proving `Result<Option<i32>, str>` does not leave undefined generated calls.
+  proving `Result<Option<i32>, StaticString>` does not leave undefined generated calls.
 - Generic method specialization preserves concrete `Self` receiver context in
   call-site typing and specialized method bodies for generic struct and enum
   receivers, with executable and generated-C coverage in
@@ -71,7 +71,7 @@ and do not assume Phase 4 is ready without evidence.
   `integration::test_generic_method_nested_result`, and
   `integration::generic_specializations_do_not_emit_unspecialized_c_symbols`,
   proving `Box<T>.wrap_result` can infer `T` from the concrete receiver and
-  specialize `Result<Option<T>, str>` without unresolved generated C calls.
+  specialize `Result<Option<T>, StaticString>` without unresolved generated C calls.
 - Generic association targets remain gated deliberately. The parser now has
   focused coverage for `Box<T>.implements`, `Box<T>.requires`, and
   `Box<T>.extends` through
@@ -102,14 +102,14 @@ and do not assume Phase 4 is ready without evidence.
   `tests/zen/multi_file_type_method_nested_result_dependency/main.zen`,
   `integration::test_multi_file_type_method_nested_result_dependency_imports`,
   and `integration::generated_c_call_definition_scan_reports_missing_generated_calls`,
-  proving `Result<Option<T>, str>` specialization does not leave undefined
+  proving `Result<Option<T>, StaticString>` specialization does not leave undefined
   generated C calls.
 - Imported generic `Result<T, E>` enum methods now cover multiple concrete
   instantiations in the importing module through
   `tests/zen/multi_file_generic_result_enum_multi_specialization/main.zen`,
   `integration::test_multi_file_generic_result_enum_multi_specialization_imports`,
   and `integration::generic_specializations_do_not_emit_unspecialized_c_symbols`,
-  proving both `Result_unwrap_or_i32_str` and `Result_unwrap_or_bool_str`
+  proving both `Result_unwrap_or_i32_StaticString` and `Result_unwrap_or_bool_StaticString`
   resolve to emitted definitions exactly once without unspecialized `Result_T`
   symbols.
 - Imported generic aggregate constructor arity diagnostics are covered by
@@ -866,7 +866,7 @@ and do not assume Phase 4 is ready without evidence.
 - Resolver type symbols carry behavior impl and `.requires` association
   metadata, and typechecker setup rejects missing or extra association metadata
   before collecting behavior impls/requires from the AST. Specialized behavior
-  references such as `Json<str>` are included in this resolver handoff
+  references such as `Json<StaticString>` are included in this resolver handoff
   validation.
 - Resolver-backed `.requires` conformance checks read validated resolver
   required-behavior refs, so stale AST-only required behavior type arguments
@@ -892,11 +892,11 @@ and do not assume Phase 4 is ready without evidence.
 - Inherited generic behavior dispatch is covered by the executable fixture
   `tests/zen/behavior_inherited_generic_dispatch.zen`.
 - Concrete generic behavior association syntax in `.implements` and `.requires`,
-  such as `Point.implements(Json<str>)`, is parsed, typechecked with substituted
+  such as `Point.implements(Json<StaticString>)`, is parsed, typechecked with substituted
   behavior method signatures, and covered by
   `tests/zen/behavior_json_generic_association.zen`.
 - Generic behavior inheritance in `.extends`, including
-  `PrettyJson.extends(Json<str>)`, is parsed, recorded in resolver metadata,
+  `PrettyJson.extends(Json<StaticString>)`, is parsed, recorded in resolver metadata,
   checked with substituted parent methods, and covered by local and graph-owned
   multi-file fixtures.
 - Unspecialized generic behaviors in `.implements`, `.requires`, and `.extends`
@@ -918,7 +918,7 @@ and do not assume Phase 4 is ready without evidence.
 - Distinct generic behavior specializations implemented by the same concrete
   type dispatch through behavior-specialized impl method symbols, covered by
   `tests/zen/behavior_distinct_generic_specialization_dispatch.zen` and
-  generated-C assertions for `Point_encode__Json_str` and
+  generated-C assertions for `Point_encode__Json_StaticString` and
   `Point_encode__Json_i32`.
 - Imported public types carry source-module behavior impl associations and impl
   methods into graph-owned generic behavior-bound dispatch, covered by
@@ -1029,7 +1029,7 @@ and do not assume Phase 4 is ready without evidence.
   metadata, covered by
   `resolver_phase2::resolver_rejects_duplicate_behavior_parent_edges`.
 - Concrete generic behavior parent inheritance, such as
-  `PrettyJson.extends(Json<str>)`, is parsed, recorded in resolver metadata,
+  `PrettyJson.extends(Json<StaticString>)`, is parsed, recorded in resolver metadata,
   checked with substituted parent method signatures, and covered by
   `tests/zen/behavior_generic_parent_inheritance.zen`.
 - Generic behavior inheritance parent arguments may reference the child
@@ -1042,7 +1042,7 @@ and do not assume Phase 4 is ready without evidence.
   `typechecker::tests::check_program_with_symbols_accepts_resolver_behavior_parent_child_type_param_refs`.
 - Resolver behavior symbols carry parent behavior metadata, and typechecker
   setup rejects missing or extra resolver parent-edge metadata. Specialized
-  parent references such as `Json<str>` are included in this resolver handoff
+  parent references such as `Json<StaticString>` are included in this resolver handoff
   validation.
 - Behavior impl coherence rejects overlapping parent/child behavior impls for
   the same type.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -41,12 +41,12 @@ checked-in docs, tests, and commits only.
   no longer stand in for "emitted once" evidence.
 - Nested generic enum specialization is covered by
   `tests/zen/generic_nested_result_enum.zen`, proving
-  `Result<Option<i32>, str>` runtime behavior and generated-C call/definition
+  `Result<Option<i32>, StaticString>` runtime behavior and generated-C call/definition
   consistency for both the outer result unwrap and inner option unwrap.
 - Generic method specialization with nested generic enum returns is covered by
   `tests/zen/generic_method_nested_result.zen`, proving a specialized
   `Box<T>` method can infer `T` from the receiver and return
-  `Result<Option<T>, str>` without leaving unspecialized C symbols or
+  `Result<Option<T>, StaticString>` without leaving unspecialized C symbols or
   unresolved generated calls.
 - Imported generic methods that return source-module generic enum dependencies
   now also rely on receiver inference in
@@ -55,12 +55,12 @@ checked-in docs, tests, and commits only.
 - Imported generic methods returning nested source-module generic enum
   dependencies are covered by
   `tests/zen/multi_file_type_method_nested_result_dependency/main.zen`,
-  proving `Result<Option<T>, str>` return specialization through an imported
+  proving `Result<Option<T>, StaticString>` return specialization through an imported
   public method without undefined generated C calls.
 - Imported generic `Result<T, E>` enum methods now cover multiple concrete
   instantiations from the importing module through
   `tests/zen/multi_file_generic_result_enum_multi_specialization/main.zen`,
-  preserving `Result_unwrap_or_i32_str` and `Result_unwrap_or_bool_str`
+  preserving `Result_unwrap_or_i32_StaticString` and `Result_unwrap_or_bool_StaticString`
   call/definition pairs without unspecialized `Result_T` symbols.
 - Resolver method symbols carry full value-signature metadata, including
   generic type-parameter names and bounds, and typechecker setup validates
@@ -1104,10 +1104,10 @@ checked-in docs, tests, and commits only.
 - Inherited generic behavior dispatch has executable coverage through
   `tests/zen/behavior_inherited_generic_dispatch.zen`.
 - Concrete generic behavior association syntax in `.implements` and `.requires`,
-  such as `Point.implements(Json<str>)`, has parser, typechecker, and executable
+  such as `Point.implements(Json<StaticString>)`, has parser, typechecker, and executable
   coverage through `tests/zen/behavior_json_generic_association.zen`.
 - Generic behavior inheritance in `.extends`, including
-  `PrettyJson.extends(Json<str>)`, now has parser, resolver metadata,
+  `PrettyJson.extends(Json<StaticString>)`, now has parser, resolver metadata,
   typechecker substitution, local executable coverage, and graph-owned
   multi-file import coverage.
 - Unspecialized generic behaviors in `.implements`, `.requires`, and `.extends`
@@ -1244,7 +1244,7 @@ checked-in docs, tests, and commits only.
 - Resolver type symbols now carry behavior impl and `.requires` association
   metadata, and typechecker setup rejects missing or extra association metadata
   before collecting behavior impls/requires from the AST.
-  Specialized behavior references such as `Json<str>` are included in this
+  Specialized behavior references such as `Json<StaticString>` are included in this
   resolver handoff validation.
   Resolver now rejects duplicate local `.implements` edges before recording
   duplicate metadata, covered by
@@ -1262,7 +1262,7 @@ checked-in docs, tests, and commits only.
   metadata, covered by
   `resolver_phase2::resolver_rejects_duplicate_behavior_parent_edges`.
 - Concrete generic behavior parent inheritance, such as
-  `PrettyJson.extends(Json<str>)`, now has parser, resolver metadata,
+  `PrettyJson.extends(Json<StaticString>)`, now has parser, resolver metadata,
   typechecker substitution, and executable coverage through
   `tests/zen/behavior_generic_parent_inheritance.zen`.
 - Resolver validation for `.extends(...)` parent type arguments now scopes the
@@ -1275,7 +1275,7 @@ checked-in docs, tests, and commits only.
   generic parameters.
 - Resolver behavior symbols now carry parent behavior metadata, and typechecker
   setup rejects missing or extra resolver parent-edge metadata. Specialized
-  parent references such as `Json<str>` are included in this resolver handoff
+  parent references such as `Json<StaticString>` are included in this resolver handoff
   validation.
 - Behavior impl coherence rejects overlapping parent/child behavior impls for
   the same type.
@@ -1419,7 +1419,7 @@ checked-in docs, tests, and commits only.
 - Distinct generic behavior specializations on one concrete type now emit and
   dispatch through behavior-specialized impl method symbols, covered by
   `tests/zen/behavior_distinct_generic_specialization_dispatch.zen` and
-  generated-C assertions for `Point_encode__Json_str` and
+  generated-C assertions for `Point_encode__Json_StaticString` and
   `Point_encode__Json_i32`.
 - Multi-file behavior inheritance fixtures now compile and run through
   graph-owned imports, proving imported child behavior impls carry inherited

--- a/src/ast/typed/types.rs
+++ b/src/ast/typed/types.rs
@@ -84,7 +84,7 @@ impl Type {
             Type::F64 => "f64".into(),
             Type::Bool => "bool".into(),
             Type::Void => "void".into(),
-            Type::Str => "str".into(),
+            Type::Str => "StaticString".into(),
             Type::String => "String".into(),
             Type::Named(n) => n.clone(),
             Type::Struct { name, .. } => name.clone(),
@@ -143,5 +143,15 @@ impl Type {
     /// Returns true if this type is a float.
     pub fn is_float(&self) -> bool {
         matches!(self, Type::F32 | Type::F64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Type;
+
+    #[test]
+    fn static_string_display_uses_public_type_name() {
+        assert_eq!(Type::Str.display_name(), "StaticString");
     }
 }

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -82,7 +82,7 @@ impl AstType {
             AstType::F64 => "f64".into(),
             AstType::Bool => "bool".into(),
             AstType::Void => "void".into(),
-            AstType::Str => "str".into(),
+            AstType::Str => "StaticString".into(),
             AstType::String => "String".into(),
             AstType::Named(n) => n.clone(),
             AstType::Generic { name, type_args } => {
@@ -114,4 +114,14 @@ pub struct Param {
     pub ty: AstType,
     pub mutable: bool,
     pub span: Span,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AstType;
+
+    #[test]
+    fn static_string_display_uses_public_type_name() {
+        assert_eq!(AstType::Str.display_name(), "StaticString");
+    }
 }

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -209,8 +209,8 @@ fn build_intrinsics() -> HashMap<&'static str, Intrinsic> {
     intrinsic!(m, "call_external",  ("func_ptr" => ptr.clone()) -> AstType::I64, "Call external function pointer", "FFI");
 
     // -- String operations ------------------------------------------------
-    intrinsic!(m, "strlen", ("str" => AstType::StaticString) -> AstType::Usize, "Get length of a static string", "String");
-    intrinsic!(m, "static_string_ptr", ("str" => AstType::StaticString) -> ptr.clone(), "Get pointer to static string data", "String");
+    intrinsic!(m, "strlen", ("value" => AstType::StaticString) -> AstType::Usize, "Get length of a static string", "String");
+    intrinsic!(m, "static_string_ptr", ("value" => AstType::StaticString) -> ptr.clone(), "Get pointer to static string data", "String");
 
     // -- IO operations (libc wrappers) ------------------------------------
     intrinsic!(m, "libc_write", ("fd" => AstType::I32, "buf" => ptr.clone(), "len" => AstType::Usize) -> AstType::I64, "Write via libc", "IO");
@@ -236,4 +236,3 @@ fn build_intrinsics() -> HashMap<&'static str, Intrinsic> {
 // ============================================================================
 // Well-Known Types (types with special compiler semantics)
 // ============================================================================
-

--- a/src/parser/tests/behaviors.rs
+++ b/src/parser/tests/behaviors.rs
@@ -98,7 +98,9 @@ fn parse_public_behavior_declaration() {
 
 #[test]
 fn parse_behavior_impl_block() {
-    let prog = parse_ok("Point.implements(Json) {\n    to_json = (value: Point) str { \"{}\" }\n}");
+    let prog = parse_ok(
+        "Point.implements(Json) {\n    to_json = (value: Point) StaticString { \"{}\" }\n}",
+    );
     match &prog.declarations[0] {
         Declaration::ImplBlock {
             type_name,
@@ -231,7 +233,7 @@ fn parse_behavior_extends_with_generic_parent_args() {
 
 #[test]
 fn parse_generic_behavior_function_bound_with_type_args() {
-    let prog = parse_ok("encode<T: Json<T>> = (value: T) str { \"\" }");
+    let prog = parse_ok("encode<T: Json<T>> = (value: T) StaticString { \"\" }");
     match &prog.declarations[0] {
         Declaration::Function { type_params, .. } => {
             assert_eq!(type_params.len(), 1);

--- a/src/parser/tests/examples_types_errors.rs
+++ b/src/parser/tests/examples_types_errors.rs
@@ -56,8 +56,8 @@ fn parse_nested_generics() {
     let prog = parse_ok("bar = (x: Vec<Ptr<i32>>) void { }");
     assert_eq!(prog.declarations.len(), 1);
 
-    // Triple-nested: Map<str, Vec<Ptr<f64>>>
-    let prog = parse_ok("baz = (x: Map<str, Vec<Ptr<f64>>>) void { }");
+    // Triple-nested: Map<StaticString, Vec<Ptr<f64>>>
+    let prog = parse_ok("baz = (x: Map<StaticString, Vec<Ptr<f64>>>) void { }");
     assert_eq!(prog.declarations.len(), 1);
 
     // Deeply nested: A<B<C<D<i32>>>>

--- a/src/parser/tests/expressions.rs
+++ b/src/parser/tests/expressions.rs
@@ -83,7 +83,7 @@ fn parse_enum_variant_payload_expr() {
 #[test]
 fn parse_shorthand_enum_variant_expr_and_pattern() {
     let prog = parse_ok(
-        r#"f = (value: Result<i32, str>) Result<i32, str> {
+        r#"f = (value: Result<i32, StaticString>) Result<i32, StaticString> {
     value ?
         | .Ok(v) { .Ok(v) }
         | .Err(msg) { .Err(msg) }

--- a/src/resolver/metadata_helpers.rs
+++ b/src/resolver/metadata_helpers.rs
@@ -216,7 +216,7 @@ mod tests {
     fn resolver_behavior_impl_method_key_includes_generic_behavior_specialization() {
         assert_eq!(
             resolver_behavior_impl_method_key("Point", "encode", "Json", &[AstType::Str]),
-            "Point.encode__Json_str"
+            "Point.encode__Json_StaticString"
         );
         assert_eq!(
             resolver_behavior_impl_method_key(

--- a/src/typechecker/monomorphize_types.rs
+++ b/src/typechecker/monomorphize_types.rs
@@ -18,7 +18,7 @@ pub(super) fn type_mangle_key(ty: &Type) -> String {
         Type::F64 => "f64".into(),
         Type::Bool => "bool".into(),
         Type::Void => "void".into(),
-        Type::Str => "str".into(),
+        Type::Str => "StaticString".into(),
         Type::String => "String".into(),
         Type::Named(name) | Type::Struct { name, .. } | Type::Enum { name, .. } => {
             symbol_mangle_key(name)
@@ -58,6 +58,16 @@ fn symbol_mangle_key(symbol: &str) -> String {
 
 pub(super) fn concrete_name_matches_generic(concrete_name: &str, generic_name: &str) -> bool {
     concrete_name == generic_name || concrete_name.starts_with(&format!("{generic_name}_"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{type_mangle_key, Type};
+
+    #[test]
+    fn static_string_mangle_uses_public_type_name() {
+        assert_eq!(type_mangle_key(&Type::Str), "StaticString");
+    }
 }
 
 /// Substitute type parameters in an AstType, returning a new AstType.

--- a/src/typechecker/tests/core_semantics/calls_and_returns.rs
+++ b/src/typechecker/tests/core_semantics/calls_and_returns.rs
@@ -202,7 +202,7 @@ fn function_call_argument_type_mismatch_is_error() {
     assert!(
         errors.iter().any(|d| d
             .message
-            .contains("argument 1 for `takes_i32` expects `i32`, found `str`")),
+            .contains("argument 1 for `takes_i32` expects `i32`, found `StaticString`")),
         "expected argument type diagnostic, got {errors:?}"
     );
 }

--- a/src/typechecker/tests/core_semantics/enum_assignment_and_modules.rs
+++ b/src/typechecker/tests/core_semantics/enum_assignment_and_modules.rs
@@ -43,7 +43,7 @@ main = () void {
     assert!(
         errors.iter().any(|d| d
             .message
-            .contains("payload for enum variant `Maybe.Some` expects `i32`, found `str`")),
+            .contains("payload for enum variant `Maybe.Some` expects `i32`, found `StaticString`")),
         "expected payload type diagnostic, got {errors:?}"
     );
 }
@@ -107,7 +107,7 @@ main = () void {
     assert!(
         errors.iter().any(|d| d
             .message
-            .contains("assignment to `x` expects `i32`, found `str`")),
+            .contains("assignment to `x` expects `i32`, found `StaticString`")),
         "expected assignment type diagnostic, got {errors:?}"
     );
 }

--- a/src/typechecker/tests/core_semantics/literals.rs
+++ b/src/typechecker/tests/core_semantics/literals.rs
@@ -31,7 +31,7 @@ Result<T, E>:
     Err(E)
 
 main = () i32 {
-    value = Result<i32, str>.Ok(1)
+    value = Result<i32, StaticString>.Ok(1)
     value.raise()
 }
 "#,

--- a/src/typechecker/tests/core_semantics/struct_literals.rs
+++ b/src/typechecker/tests/core_semantics/struct_literals.rs
@@ -306,7 +306,7 @@ fn struct_literal_field_type_mismatch_is_error() {
     assert!(
         errors.iter().any(|d| d
             .message
-            .contains("field `x` for struct `Point` expects `i32`, found `str`")),
+            .contains("field `x` for struct `Point` expects `i32`, found `StaticString`")),
         "expected field type diagnostic, got {errors:?}"
     );
 }

--- a/src/typechecker/tests/declaration_validation.rs
+++ b/src/typechecker/tests/declaration_validation.rs
@@ -89,7 +89,7 @@ Point: { x: i32 = "bad" }
     assert!(
         err.iter().any(|d| d
             .message
-            .contains("field `x` default expects `i32`, found `str`")),
+            .contains("field `x` default expects `i32`, found `StaticString`")),
         "expected field default type mismatch diagnostic, got {err:?}"
     );
 }

--- a/src/typechecker/tests/declaration_validation/resolver_replay.rs
+++ b/src/typechecker/tests/declaration_validation/resolver_replay.rs
@@ -109,11 +109,11 @@ fn resolver_behavior_impl_replay_task_helper_pushes_metadata_and_type_refs_toget
 Point: { x: i32 }
 
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.implements(Json) {
-    encode = (self: Point) str { "point" }
+    encode = (self: Point) StaticString { "point" }
 }
 "#,
     );
@@ -216,7 +216,7 @@ fn resolver_behavior_impl_block_declaration_tasks_collect_only_behavior_impls() 
 Point: { x: i32 }
 
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.impl = {
@@ -224,7 +224,7 @@ Point.impl = {
 }
 
 Point.implements(Json) {
-    encode = (value: Point) str { "point" }
+    encode = (value: Point) StaticString { "point" }
 }
 "#,
     );

--- a/src/typechecker/tests/declaration_validation/resolver_replay/semantic_bundles.rs
+++ b/src/typechecker/tests/declaration_validation/resolver_replay/semantic_bundles.rs
@@ -7,11 +7,11 @@ fn resolver_declaration_semantic_bundle_replays_validation_passes() {
 Point: { x: i32 = true }
 
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.implements(Json) {
-    encode = (self: Point) str { "point" }
+    encode = (self: Point) StaticString { "point" }
 }
 
 Point.requires(Json)
@@ -76,11 +76,11 @@ fn resolver_declaration_collection_bundle_replays_metadata_semantics_and_refresh
 Point: { x: i32 = true }
 
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.implements(Json) {
-    encode = (self: Point) str { "point" }
+    encode = (self: Point) StaticString { "point" }
 }
 
 Point.requires(Json)
@@ -150,11 +150,11 @@ fn declaration_collection_replay_bundle_collects_ast_and_resolver_tasks_together
 Point: { x: i32 }
 
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.implements(Json) {
-    encode = (self: Point) str { "point" }
+    encode = (self: Point) StaticString { "point" }
 }
 
 Point.requires(Json)
@@ -199,11 +199,11 @@ fn resolver_declaration_semantic_tasks_collect_only_semantic_work() {
 Point: { x: i32 = true }
 
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.implements(Json) {
-    encode = (self: Point) str { "point" }
+    encode = (self: Point) StaticString { "point" }
 }
 
 Point.requires(Json)
@@ -229,11 +229,11 @@ fn resolver_declaration_semantic_bundle_replays_dedicated_semantic_tasks() {
 Point: { x: i32 = true }
 
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.implements(Json) {
-    encode = (self: Point) str { "point" }
+    encode = (self: Point) StaticString { "point" }
 }
 
 Point.requires(Json)

--- a/src/typechecker/tests/declaration_validation/tasks.rs
+++ b/src/typechecker/tests/declaration_validation/tasks.rs
@@ -8,7 +8,7 @@ Point: { x: i32 }
 Option<T>: Some(T), None
 
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Pretty.extends(Json)
@@ -75,7 +75,7 @@ fn ast_precollection_validation_tasks_collect_self_and_extends_work() {
 Point: { x: i32 }
 
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Pretty.extends(Json)
@@ -105,7 +105,7 @@ fn ast_declaration_collection_tasks_include_precollection_validation_work() {
 Point: { x: i32 }
 
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Pretty.extends(Json)
@@ -137,7 +137,7 @@ fn ast_declaration_collection_bundle_replays_collection_passes() {
 Point: { x: i32 }
 
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 make = () Point { Point { x: 1 } }
@@ -247,12 +247,12 @@ Json<T>: behavior {
     encode: (Self) T
 }
 
-Point.implements(Json<str>) {
-    encode = (self: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (self: Point) StaticString { "point" }
 }
 
-Point.requires(Json<str>)
-JsonString.extends(Json<str>)
+Point.requires(Json<StaticString>)
+JsonString.extends(Json<StaticString>)
 
 main = () i32 { 1 }
 "#,
@@ -274,11 +274,11 @@ fn ast_declaration_semantic_bundle_replays_validation_passes() {
 Point: { x: i32 = "bad" }
 
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.implements(Json) {
-    encode = (self: Point) str { "point" }
+    encode = (self: Point) StaticString { "point" }
 }
 
 Point.requires(MissingBehavior)
@@ -311,7 +311,7 @@ main = (value: MissingType) i32 { 1 }
     assert!(
         checker.diagnostics().iter().any(|d| d
             .message
-            .contains("field `x` default expects `i32`, found `str`")),
+            .contains("field `x` default expects `i32`, found `StaticString`")),
         "expected field default diagnostics, got {:?}",
         checker.diagnostics()
     );

--- a/src/typechecker/tests/generic_behaviors/extends.rs
+++ b/src/typechecker/tests/generic_behaviors/extends.rs
@@ -9,17 +9,17 @@ fn behavior_extends_requires_parent_methods() {
 Point: { x: i32 }
 
 Json: behavior {
-    to_json: (Self) str
+    to_json: (Self) StaticString
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
 PrettyJson.extends(Json)
 
 Point.implements(PrettyJson) {
-    pretty = (value: Point) str { "pretty" }
+    pretty = (value: Point) StaticString { "pretty" }
 }
 "#,
     );
@@ -42,18 +42,18 @@ fn behavior_extends_impl_satisfies_parent_requires() {
 Point: { x: i32 }
 
 Json: behavior {
-    to_json: (Self) str
+    to_json: (Self) StaticString
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
 PrettyJson.extends(Json)
 
 Point.implements(PrettyJson) {
-    to_json = (value: Point) str { "point" }
-    pretty = (value: Point) str { "pretty" }
+    to_json = (value: Point) StaticString { "point" }
+    pretty = (value: Point) StaticString { "pretty" }
 }
 
 Point.requires(Json)
@@ -76,13 +76,13 @@ Json<T>: behavior {
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
-PrettyJson.extends(Json<str>)
+PrettyJson.extends(Json<StaticString>)
 
 Point.implements(PrettyJson) {
-    pretty = (value: Point) str { "pretty" }
+    pretty = (value: Point) StaticString { "pretty" }
 }
 "#,
     );
@@ -109,17 +109,17 @@ Json<T>: behavior {
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
-PrettyJson.extends(Json<str>)
+PrettyJson.extends(Json<StaticString>)
 
 Point.implements(PrettyJson) {
-    encode = (value: Point) str { "point" }
-    pretty = (value: Point) str { "pretty" }
+    encode = (value: Point) StaticString { "point" }
+    pretty = (value: Point) StaticString { "pretty" }
 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 "#,
     );
 
@@ -163,15 +163,15 @@ Json<T>: behavior {
     encode: (Self) T
 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
 }
 
 Point.implements(Json<i32>) {
     encode = (value: Point) i32 { value.x }
 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 Point.requires(Json<i32>)
 "#,
     );

--- a/src/typechecker/tests/generic_behaviors/extends/diagnostics.rs
+++ b/src/typechecker/tests/generic_behaviors/extends/diagnostics.rs
@@ -11,18 +11,18 @@ Json<T>: behavior {
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
-PrettyJson.extends(Json<str>)
+PrettyJson.extends(Json<StaticString>)
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
 }
 
 Point.implements(PrettyJson) {
-    encode = (value: Point) str { "point" }
-    pretty = (value: Point) str { "pretty" }
+    encode = (value: Point) StaticString { "point" }
+    pretty = (value: Point) StaticString { "pretty" }
 }
 "#,
     );
@@ -32,7 +32,7 @@ Point.implements(PrettyJson) {
         .expect_err("specialized parent and child behavior impls should overlap");
     assert!(
         errors.iter().any(|d| d.message.contains(
-            "overlapping implementations of behaviors `Json_str` and `PrettyJson` for type `Point`"
+            "overlapping implementations of behaviors `Json_StaticString` and `PrettyJson` for type `Point`"
         )),
         "expected specialized behavior impl overlap diagnostic, got {errors:?}"
     );
@@ -49,24 +49,24 @@ Json<T>: behavior {
 }
 
 CompactJson: behavior {
-    compact: (Self) str
+    compact: (Self) StaticString
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
-CompactJson.extends(Json<str>)
+CompactJson.extends(Json<StaticString>)
 PrettyJson.extends(CompactJson)
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
 }
 
 Point.implements(PrettyJson) {
-    encode = (value: Point) str { "point" }
-    compact = (value: Point) str { "compact" }
-    pretty = (value: Point) str { "pretty" }
+    encode = (value: Point) StaticString { "point" }
+    compact = (value: Point) StaticString { "compact" }
+    pretty = (value: Point) StaticString { "pretty" }
 }
 "#,
     );
@@ -76,7 +76,7 @@ Point.implements(PrettyJson) {
         .expect_err("transitive specialized parent and child behavior impls should overlap");
     assert!(
         errors.iter().any(|d| d.message.contains(
-            "overlapping implementations of behaviors `Json_str` and `PrettyJson` for type `Point`"
+            "overlapping implementations of behaviors `Json_StaticString` and `PrettyJson` for type `Point`"
         )),
         "expected transitive specialized behavior impl overlap diagnostic, got {errors:?}"
     );
@@ -87,11 +87,11 @@ fn behavior_extends_cycle_is_error() {
     let program = parse_program(
         r#"
 Json: behavior {
-    to_json: (Self) str
+    to_json: (Self) StaticString
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
 Json.extends(PrettyJson)
@@ -115,11 +115,11 @@ fn behavior_extends_duplicate_parent_is_error() {
     let program = parse_program(
         r#"
 Json: behavior {
-    to_json: (Self) str
+    to_json: (Self) StaticString
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
 PrettyJson.extends(Json)
@@ -148,11 +148,11 @@ Json<T>: behavior {
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
-PrettyJson.extends(Json<str>)
-PrettyJson.extends(Json<str>)
+PrettyJson.extends(Json<StaticString>)
+PrettyJson.extends(Json<StaticString>)
 "#,
     );
 
@@ -162,7 +162,7 @@ PrettyJson.extends(Json<str>)
     assert!(
         errors.iter().any(|d| {
             d.message
-                .contains("duplicate behavior inheritance `PrettyJson.extends(Json<str>)`")
+                .contains("duplicate behavior inheritance `PrettyJson.extends(Json<StaticString>)`")
         }),
         "expected duplicate generic behavior inheritance diagnostic, got {errors:?}"
     );
@@ -173,11 +173,11 @@ fn behavior_extends_generic_parent_without_type_args_is_error() {
     let program = parse_program(
         r#"
 Json<T>: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
 PrettyJson.extends(Json)
@@ -200,11 +200,11 @@ fn behavior_extends_nongeneric_parent_type_args_are_error() {
     let program = parse_program(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
 PrettyJson.extends(Json<i32>)
@@ -233,7 +233,7 @@ fn behavior_extends_conflicting_method_signature_is_error() {
     let program = parse_program(
         r#"
 Json: behavior {
-    to_json: (Self) str
+    to_json: (Self) StaticString
 }
 
 PrettyJson: behavior {
@@ -263,7 +263,7 @@ fn behavior_impl_signature_mismatch_is_error() {
 Point: { x: i32 }
 
 Json: behavior {
-    to_json: (Self) str
+    to_json: (Self) StaticString
 }
 
 Point.implements(Json) {
@@ -283,9 +283,9 @@ Point.implements(Json) {
         "expected behavior parameter mismatch diagnostic, got {errors:?}"
     );
     assert!(
-        errors
-            .iter()
-            .any(|d| d.message.contains("expects return `str`, found `i32`")),
+        errors.iter().any(|d| d
+            .message
+            .contains("expects return `StaticString`, found `i32`")),
         "expected behavior return mismatch diagnostic, got {errors:?}"
     );
 }

--- a/src/typechecker/tests/generic_behaviors/generic_bounds.rs
+++ b/src/typechecker/tests/generic_behaviors/generic_bounds.rs
@@ -41,8 +41,8 @@ Json<T>: behavior {
     encode: (Self) T
 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
 }
 
 identity<T: Json<T>> = (value: T) T {
@@ -73,11 +73,11 @@ fn behavior_generic_bound_accepts_later_behavior_declaration() {
     let program = parse_program(
         r#"
 Serializable<T: Json>: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Json: behavior {
-    to_json: (Self) str
+    to_json: (Self) StaticString
 }
 
 main = () i32 {
@@ -96,7 +96,7 @@ fn behavior_generic_bound_unknown_behavior_reports_once() {
     let program = parse_program(
         r#"
 Serializable<T: Missing>: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 main = () i32 {
@@ -130,14 +130,14 @@ fn generic_behavior_bound_accepts_type_with_impl() {
 Point: { x: i32 }
 
 Json: behavior {
-    to_json: (Self) str
+    to_json: (Self) StaticString
 }
 
 Point.implements(Json) {
-    to_json = (value: Point) str { "point" }
+    to_json = (value: Point) StaticString { "point" }
 }
 
-encode<T: Json> = (value: T) str {
+encode<T: Json> = (value: T) StaticString {
     "encoded"
 }
 
@@ -161,21 +161,21 @@ fn generic_behavior_bound_accepts_inherited_behavior_impl() {
 Point: { x: i32 }
 
 Json: behavior {
-    to_json: (Self) str
+    to_json: (Self) StaticString
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
 PrettyJson.extends(Json)
 
 Point.implements(PrettyJson) {
-    to_json = (value: Point) str { "point" }
-    pretty = (value: Point) str { "pretty" }
+    to_json = (value: Point) StaticString { "point" }
+    pretty = (value: Point) StaticString { "pretty" }
 }
 
-encode<T: Json> = (value: T) str {
+encode<T: Json> = (value: T) StaticString {
     "encoded"
 }
 
@@ -199,10 +199,10 @@ fn generic_behavior_bound_rejects_type_without_impl() {
 Point: { x: i32 }
 
 Json: behavior {
-    to_json: (Self) str
+    to_json: (Self) StaticString
 }
 
-encode<T: Json> = (value: T) str {
+encode<T: Json> = (value: T) StaticString {
     "encoded"
 }
 

--- a/src/typechecker/tests/generic_behaviors/generic_function_diagnostics.rs
+++ b/src/typechecker/tests/generic_behaviors/generic_function_diagnostics.rs
@@ -9,7 +9,7 @@ identity<T> = (value: T) T {
 }
 
 main = () i32 {
-    identity<i32, str>(1)
+    identity<i32, StaticString>(1)
 }
 "#,
     );
@@ -109,10 +109,10 @@ fn generic_bound_rejects_unspecialized_generic_behavior() {
     let program = parse_program(
         r#"
 Json<T>: behavior {
-    to_json: (Self) str
+    to_json: (Self) StaticString
 }
 
-encode<T: Json> = (value: T) str {
+encode<T: Json> = (value: T) StaticString {
     "encoded"
 }
 
@@ -140,10 +140,10 @@ fn generic_bound_nongeneric_behavior_type_args_are_error() {
     let program = parse_program(
         r#"
 Json: behavior {
-    to_json: (Self) str
+    to_json: (Self) StaticString
 }
 
-encode<T: Json<i32>> = (value: T) str {
+encode<T: Json<i32>> = (value: T) StaticString {
     "encoded"
 }
 

--- a/src/typechecker/tests/generic_behaviors/impls_and_requires.rs
+++ b/src/typechecker/tests/generic_behaviors/impls_and_requires.rs
@@ -7,11 +7,11 @@ fn behavior_impl_with_required_method_passes() {
 Point: { x: i32 }
 
 Json: behavior {
-    to_json: (Self) str
+    to_json: (Self) StaticString
 }
 
 Point.implements(Json) {
-    to_json = (value: Point) str { "point" }
+    to_json = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -28,7 +28,7 @@ fn behavior_impl_missing_required_method_is_error() {
 Point: { x: i32 }
 
 Json: behavior {
-    to_json: (Self) str
+    to_json: (Self) StaticString
 }
 
 Point.implements(Json) {
@@ -55,7 +55,7 @@ fn behavior_impl_can_omit_default_method() {
 Point: { x: i32 }
 
 Json: behavior {
-    to_json: (Self) str { "{}" }
+    to_json: (Self) StaticString { "{}" }
 }
 
 Point.implements(Json) {
@@ -75,15 +75,15 @@ fn behavior_impl_duplicate_is_error() {
 Point: { x: i32 }
 
 Json: behavior {
-    to_json: (Self) str
+    to_json: (Self) StaticString
 }
 
 Point.implements(Json) {
-    to_json = (value: Point) str { "point" }
+    to_json = (value: Point) StaticString { "point" }
 }
 
 Point.implements(Json) {
-    to_json = (value: Point) str { "point" }
+    to_json = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -107,11 +107,11 @@ fn behavior_impl_generic_behavior_without_type_args_is_error() {
 Point: { x: i32 }
 
 Json<T>: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.implements(Json) {
-    encode = (value: Point) str { "point" }
+    encode = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -134,11 +134,11 @@ fn behavior_impl_nongeneric_behavior_type_args_are_error() {
 Point: { x: i32 }
 
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.implements(Json<i32>) {
-    encode = (value: Point) str { "point" }
+    encode = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -170,11 +170,11 @@ Json<T>: behavior {
     encode: (Self) T
 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 "#,
     );
 
@@ -253,7 +253,7 @@ Json<T>: behavior {
     encode: (Self) T
 }
 
-Point.implements(Json<str>) {
+Point.implements(Json<StaticString>) {
     encode = (value: Point) i32 { 1 }
 }
 "#,
@@ -265,7 +265,7 @@ Point.implements(Json<str>) {
     assert!(
         errors.iter().any(|d| d
             .message
-            .contains("method `encode` for behavior `Json_str` expects return `str`, found `i32`")),
+            .contains("method `encode` for behavior `Json_StaticString` expects return `StaticString`, found `i32`")),
         "expected substituted behavior method return diagnostic, got {errors:?}"
     );
 }
@@ -277,22 +277,22 @@ fn behavior_impl_overlapping_inherited_behavior_is_error() {
 Point: { x: i32 }
 
 Json: behavior {
-    to_json: (Self) str
+    to_json: (Self) StaticString
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
 PrettyJson.extends(Json)
 
 Point.implements(Json) {
-    to_json = (value: Point) str { "point" }
+    to_json = (value: Point) StaticString { "point" }
 }
 
 Point.implements(PrettyJson) {
-    to_json = (value: Point) str { "point" }
-    pretty = (value: Point) str { "pretty" }
+    to_json = (value: Point) StaticString { "point" }
+    pretty = (value: Point) StaticString { "pretty" }
 }
 "#,
     );

--- a/src/typechecker/tests/generic_behaviors/requires.rs
+++ b/src/typechecker/tests/generic_behaviors/requires.rs
@@ -10,7 +10,7 @@ Json<T>: behavior {
     encode: (Self) T
 }
 
-Point.requires(Json<i32, str>)
+Point.requires(Json<i32, StaticString>)
 "#,
     );
 
@@ -32,7 +32,7 @@ fn behavior_requires_nongeneric_behavior_type_args_are_error() {
 Point: { x: i32 }
 
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.requires(Json<i32>)
@@ -63,11 +63,11 @@ fn behavior_requires_passes_when_impl_exists() {
 Point: { x: i32 }
 
 Json: behavior {
-    to_json: (Self) str
+    to_json: (Self) StaticString
 }
 
 Point.implements(Json) {
-    to_json = (value: Point) str { "point" }
+    to_json = (value: Point) StaticString { "point" }
 }
 
 Point.requires(Json)
@@ -86,7 +86,7 @@ fn behavior_requires_rejects_missing_impl() {
 Point: { x: i32 }
 
 Json: behavior {
-    to_json: (Self) str
+    to_json: (Self) StaticString
 }
 
 Point.requires(Json)
@@ -111,7 +111,7 @@ fn behavior_requires_generic_behavior_without_type_args_is_error() {
 Point: { x: i32 }
 
 Json<T>: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.requires(Json)

--- a/src/typechecker/tests/resolver_absence/type_parameters.rs
+++ b/src/typechecker/tests/resolver_absence/type_parameters.rs
@@ -5,7 +5,7 @@ fn type_parameter_absence_validation_builds_entries() {
     let program = parse_program(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 identity<T: Json> = (value: T) T { value }

--- a/src/typechecker/tests/resolver_behavior_impls_requires.rs
+++ b/src/typechecker/tests/resolver_behavior_impls_requires.rs
@@ -7,13 +7,13 @@ fn check_program_with_symbols_validates_resolver_behavior_impl_names() {
     let program = parse_program(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point: { x: i32 }
 
 Point.implements(Json) {
-    encode = (value: Point) str { "point" }
+    encode = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -45,8 +45,8 @@ Json<T>: behavior {
 
 Point: { x: i32 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -65,7 +65,7 @@ Point.implements(Json<str>) {
         .expect_err("resolver generic behavior impl metadata mismatch should fail");
 
     let expected =
-            "resolver type symbol 'Point' has behavior impls 'Json<i32>', expected to include 'Json<str>'";
+            "resolver type symbol 'Point' has behavior impls 'Json<i32>', expected to include 'Json<StaticString>'";
     assert!(
         err.iter().any(|d| d.message.contains(expected)),
         "expected resolver generic behavior impl metadata diagnostic, got {err:?}"
@@ -82,8 +82,8 @@ Json<T>: behavior {
 
 Point: { x: i32 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -105,7 +105,7 @@ Point.implements(Json<str>) {
         .expect_err("resolver generic behavior impl ref mismatch should fail");
 
     let expected =
-            "resolver type symbol 'Point' has behavior impl refs 'Json<i32>', expected to include 'Json<str>'";
+            "resolver type symbol 'Point' has behavior impl refs 'Json<i32>', expected to include 'Json<StaticString>'";
     assert!(
         err.iter().any(|d| d.message.contains(expected)),
         "expected resolver generic behavior impl ref diagnostic, got {err:?}"
@@ -117,13 +117,13 @@ fn check_program_with_symbols_validates_resolver_behavior_required_names() {
     let program = parse_program(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point: { x: i32 }
 
 Point.implements(Json) {
-    encode = (value: Point) str { "point" }
+    encode = (value: Point) StaticString { "point" }
 }
 
 Point.requires(Json)
@@ -157,11 +157,11 @@ Json<T>: behavior {
 
 Point: { x: i32 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 "#,
     );
     let mut symbols = crate::resolver::Resolver::new()
@@ -179,7 +179,7 @@ Point.requires(Json<str>)
         .expect_err("resolver generic behavior requires metadata mismatch should fail");
 
     let expected =
-            "resolver type symbol 'Point' has behavior requires 'Json<i32>', expected to include 'Json<str>'";
+            "resolver type symbol 'Point' has behavior requires 'Json<i32>', expected to include 'Json<StaticString>'";
     assert!(
         err.iter().any(|d| d.message.contains(expected)),
         "expected resolver generic behavior requires metadata diagnostic, got {err:?}"
@@ -196,11 +196,11 @@ Json<T>: behavior {
 
 Point: { x: i32 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 "#,
     );
     let mut symbols = crate::resolver::Resolver::new()
@@ -221,7 +221,7 @@ Point.requires(Json<str>)
         .expect_err("resolver generic behavior requires ref mismatch should fail");
 
     let expected =
-            "resolver type symbol 'Point' has behavior requires refs 'Json<i32>', expected to include 'Json<str>'";
+            "resolver type symbol 'Point' has behavior requires refs 'Json<i32>', expected to include 'Json<StaticString>'";
     assert!(
         err.iter().any(|d| d.message.contains(expected)),
         "expected resolver generic behavior requires ref diagnostic, got {err:?}"

--- a/src/typechecker/tests/resolver_behavior_impls_requires/extra_metadata.rs
+++ b/src/typechecker/tests/resolver_behavior_impls_requires/extra_metadata.rs
@@ -5,17 +5,17 @@ fn check_program_with_symbols_rejects_extra_resolver_behavior_impl_names() {
     let program = parse_program(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Debug: behavior {
-    debug: (Self) str
+    debug: (Self) StaticString
 }
 
 Point: { x: i32 }
 
 Point.implements(Json) {
-    encode = (value: Point) str { "point" }
+    encode = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -45,17 +45,17 @@ fn check_program_with_symbols_rejects_extra_resolver_behavior_impl_refs() {
     let program = parse_program(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Debug: behavior {
-    debug: (Self) str
+    debug: (Self) StaticString
 }
 
 Point: { x: i32 }
 
 Point.implements(Json) {
-    encode = (value: Point) str { "point" }
+    encode = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -95,11 +95,11 @@ fn check_program_with_symbols_rejects_extra_resolver_behavior_required_names() {
     let program = parse_program(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Debug: behavior {
-    debug: (Self) str
+    debug: (Self) StaticString
 }
 
 Point: { x: i32 }
@@ -134,11 +134,11 @@ fn check_program_with_symbols_rejects_extra_resolver_behavior_required_refs() {
     let program = parse_program(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Debug: behavior {
-    debug: (Self) str
+    debug: (Self) StaticString
 }
 
 Point: { x: i32 }

--- a/src/typechecker/tests/resolver_behavior_parents.rs
+++ b/src/typechecker/tests/resolver_behavior_parents.rs
@@ -5,11 +5,11 @@ fn check_program_with_symbols_validates_resolver_behavior_parent_names() {
     let program = parse_program(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
 PrettyJson.extends(Json)
@@ -42,10 +42,10 @@ Json<T>: behavior {
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
-PrettyJson.extends(Json<str>)
+PrettyJson.extends(Json<StaticString>)
 "#,
     );
     let mut symbols = crate::resolver::Resolver::new()
@@ -64,7 +64,7 @@ PrettyJson.extends(Json<str>)
 
     assert!(
             err.iter().any(|d| d.message.contains(
-                "resolver behavior symbol 'PrettyJson' has parents 'Json<i32>', expected to include 'Json<str>'"
+                "resolver behavior symbol 'PrettyJson' has parents 'Json<i32>', expected to include 'Json<StaticString>'"
             )),
             "expected resolver generic behavior parent metadata diagnostic, got {err:?}"
         );
@@ -79,10 +79,10 @@ Json<T>: behavior {
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
-PrettyJson.extends(Json<str>)
+PrettyJson.extends(Json<StaticString>)
 "#,
     );
     let mut symbols = crate::resolver::Resolver::new()
@@ -103,7 +103,7 @@ PrettyJson.extends(Json<str>)
         .expect_err("resolver generic behavior parent ref mismatch should fail");
 
     let expected =
-            "resolver behavior symbol 'PrettyJson' has parent refs 'Json<i32>', expected to include 'Json<str>'";
+            "resolver behavior symbol 'PrettyJson' has parent refs 'Json<i32>', expected to include 'Json<StaticString>'";
     assert!(
         err.iter().any(|d| d.message.contains(expected)),
         "expected resolver generic behavior parent ref diagnostic, got {err:?}"
@@ -141,15 +141,15 @@ fn check_program_with_symbols_rejects_extra_resolver_behavior_parent_names() {
     let program = parse_program(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Debug: behavior {
-    debug: (Self) str
+    debug: (Self) StaticString
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
 PrettyJson.extends(Json)
@@ -182,15 +182,15 @@ fn check_program_with_symbols_rejects_extra_resolver_behavior_parent_refs() {
     let program = parse_program(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Debug: behavior {
-    debug: (Self) str
+    debug: (Self) StaticString
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
 PrettyJson.extends(Json)

--- a/src/typechecker/tests/resolver_collection/behavior_impl_methods/default_synthesis.rs
+++ b/src/typechecker/tests/resolver_collection/behavior_impl_methods/default_synthesis.rs
@@ -6,10 +6,10 @@ fn collect_declarations_with_symbols_uses_resolver_impl_behavior_for_defaults() 
         r#"
 Point: { x: i32 }
 Json: behavior {
-    encode: (self: Self) str { "default" }
+    encode: (self: Self) StaticString { "default" }
 }
 Debug: behavior {
-    describe: (Self) str
+    describe: (Self) StaticString
 }
 
 Point.implements(Json) {
@@ -49,7 +49,7 @@ fn collect_declarations_with_symbols_uses_resolver_behavior_impl_target_for_defa
         r#"
 Point: { x: i32 }
 Json: behavior {
-    encode: (self: Self) str { "default" }
+    encode: (self: Self) StaticString { "default" }
 }
 
 Point.implements(Json) {
@@ -81,10 +81,10 @@ fn collect_declarations_with_symbols_uses_resolver_behavior_impl_target_and_name
         r#"
 Point: { x: i32 }
 Json: behavior {
-    encode: (self: Self) str { "default" }
+    encode: (self: Self) StaticString { "default" }
 }
 Debug: behavior {
-    describe: (Self) str
+    describe: (Self) StaticString
 }
 
 Point.implements(Json) {

--- a/src/typechecker/tests/resolver_collection/behavior_impl_methods/mod.rs
+++ b/src/typechecker/tests/resolver_collection/behavior_impl_methods/mod.rs
@@ -80,11 +80,11 @@ fn collect_declarations_with_symbols_uses_resolver_impl_method_name_metadata_for
         r#"
 Point: { x: i32 }
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.implements(Json) {
-    encode = (value: Point) str { "point" }
+    encode = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -113,11 +113,11 @@ fn collect_declarations_with_symbols_does_not_let_stale_ast_name_hide_extra_impl
         r#"
 Point: { x: i32 }
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.implements(Json) {
-    extra = (value: Point) str { "extra" }
+    extra = (value: Point) StaticString { "extra" }
 }
 "#,
     );
@@ -153,11 +153,11 @@ fn collect_declarations_with_symbols_uses_resolver_impl_method_parameter_names_f
         r#"
 Point: { x: i32 }
 Json: behavior {
-    encode: (value: Self) str
+    encode: (value: Self) StaticString
 }
 
 Point.implements(Json) {
-    encode = (value: Point) str { "point" }
+    encode = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -189,11 +189,11 @@ fn collect_declarations_with_symbols_ignores_stale_impl_method_parameter_order_f
         r#"
 Point: { x: i32 }
 Mapper: behavior {
-    map: (value: Self, input: i32) str
+    map: (value: Self, input: i32) StaticString
 }
 
 Point.implements(Mapper) {
-    map = (value: Point, input: i32) str { "point" }
+    map = (value: Point, input: i32) StaticString { "point" }
 }
 "#,
     );
@@ -227,11 +227,11 @@ fn collect_declarations_with_symbols_uses_resolver_behavior_impl_target_name_met
         r#"
 Point: { x: i32 }
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.implements(Json) {
-    encode = (value: Point) str { "point" }
+    encode = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -260,7 +260,7 @@ fn resolver_declaration_metadata_skips_behavior_impl_methods_until_behavior_impl
         r#"
 Point: { x: i32 }
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.impl = {
@@ -268,7 +268,7 @@ Point.impl = {
 }
 
 Point.implements(Json) {
-    encode = (value: Point) str { "point" }
+    encode = (value: Point) StaticString { "point" }
 }
 "#,
     );

--- a/src/typechecker/tests/resolver_collection/behavior_impl_methods/restored_signatures.rs
+++ b/src/typechecker/tests/resolver_collection/behavior_impl_methods/restored_signatures.rs
@@ -7,11 +7,11 @@ fn collect_declarations_with_symbols_does_not_fallback_to_stale_ast_behavior_imp
         r#"
 Point: { x: i32 }
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.implements(Json) {
-    encode = (value: Point) str { "point" }
+    encode = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -47,11 +47,11 @@ fn collect_declarations_with_symbols_clears_stale_behavior_impl_method_signature
         r#"
 Point: { x: i32 }
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.implements(Json) {
-    encode = (value: Point) str { "point" }
+    encode = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -97,11 +97,11 @@ fn collect_declarations_with_symbols_uses_resolver_behavior_impl_method_signatur
         r#"
 Point: { x: i32 }
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.implements(Json) {
-    encode = (value: Point) str { "point" }
+    encode = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -148,11 +148,11 @@ fn collect_declarations_with_symbols_uses_resolver_behavior_impl_generic_method_
         r#"
 Point: { x: i32 }
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.implements(Json) {
-    encode<T> = (value: Point) str { "point" }
+    encode<T> = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -205,11 +205,11 @@ fn collect_declarations_with_symbols_clears_stale_behavior_impl_generic_method_t
         r#"
 Point: { x: i32 }
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.implements(Json) {
-    encode<T> = (value: Point) str { "point" }
+    encode<T> = (value: Point) StaticString { "point" }
 }
 "#,
     );

--- a/src/typechecker/tests/resolver_collection/behavior_impls/impl_diagnostics.rs
+++ b/src/typechecker/tests/resolver_collection/behavior_impls/impl_diagnostics.rs
@@ -10,7 +10,7 @@ Json<T>: behavior {
 
 Point: { x: i32 }
 
-Point.implements(Json<str>) {
+Point.implements(Json<StaticString>) {
 }
 "#,
     );
@@ -39,7 +39,7 @@ Point.implements(Json<str>) {
         .collect();
     assert!(
             messages.iter().any(|message| {
-                *message == "type `Point` implementation of `Json_str` is missing required method `encode`"
+                *message == "type `Point` implementation of `Json_StaticString` is missing required method `encode`"
             }),
             "resolver-restored impl metadata should report the validated missing method, got {:?}",
             messages
@@ -61,18 +61,18 @@ Json<T>: behavior {
     encode: (Self) T
 }
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 Point: { x: i32 }
 
-PrettyJson.extends(Json<str>)
+PrettyJson.extends(Json<StaticString>)
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
 }
 
 Point.implements(PrettyJson) {
-    pretty = (value: Point) str { "point" }
+    pretty = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -112,7 +112,7 @@ Point.implements(PrettyJson) {
     assert!(
             messages.iter().any(|message| {
                 *message
-                    == "overlapping implementations of behaviors `Json_str` and `PrettyJson` for type `Point`"
+                    == "overlapping implementations of behaviors `Json_StaticString` and `PrettyJson` for type `Point`"
             }),
             "resolver-restored impl type args should drive overlap diagnostics, got {:?}",
             messages
@@ -133,7 +133,7 @@ Json<T>: behavior {
 }
 Point: { x: i32 }
 
-Point.implements(Json<str>) {
+Point.implements(Json<StaticString>) {
 }
 
 Point.implements(Json<i32>) {
@@ -183,7 +183,7 @@ Point.implements(Json<i32>) {
     );
     assert!(
         tc.behavior_impls
-            .contains(&("Point".to_string(), "Json_str".to_string()))
+            .contains(&("Point".to_string(), "Json_StaticString".to_string()))
             && tc
                 .behavior_impls
                 .contains(&("Point".to_string(), "Json_i32".to_string())),

--- a/src/typechecker/tests/resolver_collection/behavior_impls/impl_metadata.rs
+++ b/src/typechecker/tests/resolver_collection/behavior_impls/impl_metadata.rs
@@ -10,8 +10,8 @@ Json<T>: behavior {
 
 Point: { x: i32 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -30,8 +30,8 @@ Point.implements(Json<str>) {
 
     assert!(
         tc.behavior_impls
-            .contains(&("Point".to_string(), "Json_str".to_string())),
-        "resolver metadata should restore the validated Json<str> impl"
+            .contains(&("Point".to_string(), "Json_StaticString".to_string())),
+        "resolver metadata should restore the validated Json<StaticString> impl"
     );
     assert!(
         !tc.behavior_impls
@@ -55,8 +55,8 @@ Json<T>: behavior {
 
 Point: { x: i32 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -88,7 +88,7 @@ fn collect_declarations_with_symbols_does_not_synthesize_stale_impl_defaults_aft
         r#"
 Point: { x: i32 }
 Json: behavior {
-    encode: (self: Self) str { "default" }
+    encode: (self: Self) StaticString { "default" }
 }
 
 Point.implements(Json) {
@@ -142,8 +142,8 @@ Json<T>: behavior {
 
 Point: { x: i32 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -174,8 +174,8 @@ Json<T>: behavior {
 
 Point: { x: i32 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -199,8 +199,8 @@ Point.implements(Json<str>) {
 
     assert!(
         tc.behavior_impls
-            .contains(&("Point".to_string(), "Json_str".to_string())),
-        "resolver metadata should restore the validated Point implements Json<str> association"
+            .contains(&("Point".to_string(), "Json_StaticString".to_string())),
+        "resolver metadata should restore the validated Point implements Json<StaticString> association"
     );
     assert!(
             !tc.behavior_impls

--- a/src/typechecker/tests/resolver_collection/behavior_impls/required_diagnostics.rs
+++ b/src/typechecker/tests/resolver_collection/behavior_impls/required_diagnostics.rs
@@ -10,7 +10,7 @@ Json<T>: behavior {
 
 Point: { x: i32 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 "#,
     );
     let symbols = crate::resolver::Resolver::new()
@@ -37,10 +37,8 @@ Point.requires(Json<str>)
         .map(|diagnostic| diagnostic.message.as_str())
         .collect();
     assert!(
-        messages
-            .iter()
-            .any(|message| *message
-                == "type `Point` does not implement required behavior `Json_str`"),
+        messages.iter().any(|message| *message
+            == "type `Point` does not implement required behavior `Json_StaticString`"),
         "resolver-restored requires metadata should report the validated missing impl, got {:?}",
         messages
     );
@@ -61,18 +59,18 @@ Json<T>: behavior {
     encode: (Self) T
 }
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 Point: { x: i32 }
 
-PrettyJson.extends(Json<str>)
+PrettyJson.extends(Json<StaticString>)
 
 Point.implements(PrettyJson) {
-    encode = (value: Point) str { "point" }
-    pretty = (value: Point) str { "point" }
+    encode = (value: Point) StaticString { "point" }
+    pretty = (value: Point) StaticString { "point" }
 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 "#,
     );
     let symbols = crate::resolver::Resolver::new()
@@ -114,13 +112,13 @@ Json<T>: behavior {
 }
 Point: { x: i32 }
 
-Point.implements(Json<str>) {
+Point.implements(Json<StaticString>) {
 }
 
 Point.implements(Json<i32>) {
 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 Point.requires(Json<i32>)
 "#,
     );
@@ -154,7 +152,7 @@ Point.requires(Json<i32>)
     );
     assert!(
         tc.behavior_impls
-            .contains(&("Point".to_string(), "Json_str".to_string()))
+            .contains(&("Point".to_string(), "Json_StaticString".to_string()))
             && tc
                 .behavior_impls
                 .contains(&("Point".to_string(), "Json_i32".to_string())),
@@ -173,11 +171,11 @@ Json<T>: behavior {
 
 Point: { x: i32 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 "#,
     );
     let mut symbols = crate::resolver::Resolver::new()
@@ -211,11 +209,11 @@ Json<T>: behavior {
 
 Point: { x: i32 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 "#,
     );
     let mut symbols = crate::resolver::Resolver::new()
@@ -254,11 +252,11 @@ Json<T>: behavior {
 
 Point: { x: i32 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 "#,
     );
     let symbols = crate::resolver::Resolver::new()

--- a/src/typechecker/tests/resolver_collection/behavior_impls/required_metadata.rs
+++ b/src/typechecker/tests/resolver_collection/behavior_impls/required_metadata.rs
@@ -10,11 +10,11 @@ Json<T>: behavior {
 
 Point: { x: i32 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 "#,
     );
     let symbols = crate::resolver::Resolver::new()
@@ -47,11 +47,11 @@ Json<T>: behavior {
 
 Point: { x: i32 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 "#,
     );
     let symbols = crate::resolver::Resolver::new()
@@ -81,11 +81,11 @@ Json<T>: behavior {
 
 Point: { x: i32 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 "#,
     );
     let symbols = crate::resolver::Resolver::new()

--- a/src/typechecker/tests/resolver_collection/behavior_methods.rs
+++ b/src/typechecker/tests/resolver_collection/behavior_methods.rs
@@ -8,7 +8,7 @@ fn collect_declarations_with_symbols_uses_resolver_behavior_name_metadata() {
     let mut program = parse_program(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 "#,
     );

--- a/src/typechecker/tests/resolver_collection/behavior_methods/default_methods.rs
+++ b/src/typechecker/tests/resolver_collection/behavior_methods/default_methods.rs
@@ -47,7 +47,7 @@ fn collect_declarations_with_symbols_uses_resolver_behavior_default_method_name_
         r#"
 Point: { x: i32 }
 Json: behavior {
-    encode: (self: Self) str { "default" }
+    encode: (self: Self) StaticString { "default" }
 }
 
 Point.implements(Json) {
@@ -87,11 +87,11 @@ fn collect_declarations_with_symbols_skips_default_when_resolver_restores_impl_m
         r#"
 Point: { x: i32 }
 Json: behavior {
-    encode: (self: Self) str { "default" }
+    encode: (self: Self) StaticString { "default" }
 }
 
 Point.implements(Json) {
-    encode = (value: Point) str { "point" }
+    encode = (value: Point) StaticString { "point" }
 }
 "#,
     );

--- a/src/typechecker/tests/resolver_collection/behavior_methods/restored_signatures.rs
+++ b/src/typechecker/tests/resolver_collection/behavior_methods/restored_signatures.rs
@@ -43,11 +43,11 @@ fn collect_declarations_with_symbols_uses_resolver_behavior_method_name_metadata
         r#"
 Point: { x: i32 }
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.implements(Json) {
-    encode = (value: Point) str { "point" }
+    encode = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -76,11 +76,11 @@ fn collect_declarations_with_symbols_uses_resolver_behavior_method_return_presen
         r#"
 Point: { x: i32 }
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.implements(Json) {
-    encode = (value: Point) str { "point" }
+    encode = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -109,11 +109,11 @@ fn collect_declarations_with_symbols_uses_resolver_behavior_method_parameter_cou
         r#"
 Point: { x: i32 }
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.implements(Json) {
-    encode = (value: Point) str { "point" }
+    encode = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -148,11 +148,11 @@ fn collect_declarations_with_symbols_uses_resolver_behavior_method_missing_param
         r#"
 Point: { x: i32 }
 Mapper: behavior {
-    map: (Self, i32) str
+    map: (Self, i32) StaticString
 }
 
 Point.implements(Mapper) {
-    map = (value: Point, input: i32) str { "point" }
+    map = (value: Point, input: i32) StaticString { "point" }
 }
 "#,
     );
@@ -185,11 +185,11 @@ fn collect_declarations_with_symbols_uses_resolver_behavior_method_parameter_nam
         r#"
 Point: { x: i32 }
 Json: behavior {
-    encode: (value: Self) str
+    encode: (value: Self) StaticString
 }
 
 Point.implements(Json) {
-    encode = (value: Point) str { "point" }
+    encode = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -219,11 +219,11 @@ fn collect_declarations_with_symbols_ignores_stale_behavior_method_parameter_ord
         r#"
 Point: { x: i32 }
 Mapper: behavior {
-    map: (value: Self, input: i32) str
+    map: (value: Self, input: i32) StaticString
 }
 
 Point.implements(Mapper) {
-    map = (value: Point, input: i32) str { "point" }
+    map = (value: Point, input: i32) StaticString { "point" }
 }
 "#,
     );
@@ -255,13 +255,13 @@ fn collect_declarations_with_symbols_uses_resolver_behavior_method_count() {
         r#"
 Point: { x: i32 }
 Json: behavior {
-    encode: (Self) str
-    describe: (Self) str
+    encode: (Self) StaticString
+    describe: (Self) StaticString
 }
 
 Point.implements(Json) {
-    encode = (value: Point) str { "point" }
-    describe = (value: Point) str { "desc" }
+    encode = (value: Point) StaticString { "point" }
+    describe = (value: Point) StaticString { "desc" }
 }
 "#,
     );

--- a/src/typechecker/tests/resolver_collection/behavior_parents.rs
+++ b/src/typechecker/tests/resolver_collection/behavior_parents.rs
@@ -11,10 +11,10 @@ Json<T>: behavior {
     encode: (Self) T
 }
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
-PrettyJson.extends(Json<str>)
+PrettyJson.extends(Json<StaticString>)
 "#,
     );
     let symbols = crate::resolver::Resolver::new()
@@ -54,10 +54,10 @@ Json<T>: behavior {
     encode: (Self) T
 }
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
-PrettyJson.extends(Json<str>)
+PrettyJson.extends(Json<StaticString>)
 "#,
     );
     let mut symbols = crate::resolver::Resolver::new()
@@ -87,10 +87,10 @@ fn collect_declarations_with_symbols_avoids_false_duplicate_from_restored_parent
 Marker<T>: behavior {
 }
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
-PrettyJson.extends(Marker<str>)
+PrettyJson.extends(Marker<StaticString>)
 PrettyJson.extends(Marker<i32>)
 "#,
     );
@@ -120,7 +120,7 @@ PrettyJson.extends(Marker<i32>)
         .get("PrettyJson")
         .expect("behavior parents");
     let parent_keys: Vec<_> = parents.iter().map(|parent| parent.key.as_str()).collect();
-    assert_eq!(parent_keys, vec!["Marker_str", "Marker_i32"]);
+    assert_eq!(parent_keys, vec!["Marker_StaticString", "Marker_i32"]);
     assert!(
         tc.diagnostics.iter().all(|diagnostic| !diagnostic
             .message

--- a/src/typechecker/tests/resolver_collection/behavior_parents/default_synthesis.rs
+++ b/src/typechecker/tests/resolver_collection/behavior_parents/default_synthesis.rs
@@ -5,17 +5,17 @@ fn collect_declarations_with_symbols_synthesizes_defaults_from_restored_behavior
     let mut program = parse_program(
         r#"
 Json: behavior {
-    encode: (Self) str { "json" }
+    encode: (Self) StaticString { "json" }
 }
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 Point: { x: i32 }
 
 PrettyJson.extends(Json)
 
 Point.implements(PrettyJson) {
-    pretty = (value: Point) str { "point" }
+    pretty = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -49,14 +49,14 @@ Json<T>: behavior {
     encode: (Self) T { "json" }
 }
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 Point: { x: i32 }
 
-PrettyJson.extends(Json<str>)
+PrettyJson.extends(Json<StaticString>)
 
 Point.implements(PrettyJson) {
-    pretty = (value: Point) str { "point" }
+    pretty = (value: Point) StaticString { "point" }
 }
 "#,
     );

--- a/src/typechecker/tests/resolver_collection/behavior_parents/diagnostics.rs
+++ b/src/typechecker/tests/resolver_collection/behavior_parents/diagnostics.rs
@@ -8,14 +8,14 @@ Json<T>: behavior {
     encode: (Self) T
 }
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 Point: { x: i32 }
 
-PrettyJson.extends(Json<str>)
+PrettyJson.extends(Json<StaticString>)
 
 Point.implements(PrettyJson) {
-    pretty = (value: Point) str { "point" }
+    pretty = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -67,10 +67,10 @@ Debug<T>: behavior {
     encode: (Self) T
 }
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
-PrettyJson.extends(Json<str>)
+PrettyJson.extends(Json<StaticString>)
 PrettyJson.extends(Debug<i32>)
 "#,
     );
@@ -112,7 +112,7 @@ PrettyJson.extends(Debug<i32>)
         .get("PrettyJson")
         .expect("behavior parents");
     let parent_keys: Vec<_> = parents.iter().map(|parent| parent.key.as_str()).collect();
-    assert_eq!(parent_keys, vec!["Json_str", "Debug_i32"]);
+    assert_eq!(parent_keys, vec!["Json_StaticString", "Debug_i32"]);
 }
 
 #[test]
@@ -120,13 +120,13 @@ fn collect_declarations_with_symbols_reports_cycle_from_restored_parent_refs() {
     let mut program = parse_program(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 Debug: behavior {
-    debug: (Self) str
+    debug: (Self) StaticString
 }
 
 Json.extends(PrettyJson)

--- a/src/typechecker/tests/resolver_collection/function_method_templates/generic_functions.rs
+++ b/src/typechecker/tests/resolver_collection/function_method_templates/generic_functions.rs
@@ -8,7 +8,7 @@ Json<T>: behavior {
     encode: (Self) T
 }
 Debug: behavior {
-    debug: (Self) str
+    debug: (Self) StaticString
 }
 apply<T: Json<T>> = (callback: (T) T) (T) T {
     callback

--- a/src/typechecker/tests/resolver_collection/function_method_templates/generic_methods.rs
+++ b/src/typechecker/tests/resolver_collection/function_method_templates/generic_methods.rs
@@ -10,7 +10,7 @@ Json<T>: behavior {
     encode: (Self) T
 }
 Debug: behavior {
-    debug: (Self) str
+    debug: (Self) StaticString
 }
 Box: { value: i32 }
 Box.apply<U: Json<U>> = (self: Box, callback: (U) U) (U) U {

--- a/src/typechecker/tests/resolver_collection/function_method_templates/type_impl_generic_methods/generic_templates.rs
+++ b/src/typechecker/tests/resolver_collection/function_method_templates/type_impl_generic_methods/generic_templates.rs
@@ -52,7 +52,7 @@ Json<T>: behavior {
     encode: (Self) T
 }
 Debug: behavior {
-    debug: (Self) str
+    debug: (Self) StaticString
 }
 Box: { value: i32 }
 

--- a/src/typechecker/tests/resolver_collection/type_metadata.rs
+++ b/src/typechecker/tests/resolver_collection/type_metadata.rs
@@ -10,7 +10,7 @@ Json<T>: behavior {
     encode: (Self) T
 }
 Debug: behavior {
-    debug: (Self) str
+    debug: (Self) StaticString
 }
 Pipeline<T: Json<T>>: { callback: (i32) i32 }
 "#,

--- a/src/typechecker/tests/resolver_collection/type_metadata/enum_metadata.rs
+++ b/src/typechecker/tests/resolver_collection/type_metadata/enum_metadata.rs
@@ -8,7 +8,7 @@ Json<T>: behavior {
     encode: (Self) T
 }
 Debug: behavior {
-    debug: (Self) str
+    debug: (Self) StaticString
 }
 Callback<T: Json<T>>: Wrap((i32) i32), None
 "#,

--- a/src/typechecker/tests/resolver_declarations.rs
+++ b/src/typechecker/tests/resolver_declarations.rs
@@ -120,7 +120,7 @@ fn check_program_with_symbols_requires_resolver_method_receiver_type() {
     let program = parse_program(
         r#"
 Point: { x: i32 }
-Point.label = () str { "point" }
+Point.label = () StaticString { "point" }
 "#,
     );
     let mut symbols = crate::resolver::Resolver::new()

--- a/src/typechecker/tests/resolver_impl_values.rs
+++ b/src/typechecker/tests/resolver_impl_values.rs
@@ -5,13 +5,13 @@ fn check_program_with_symbols_requires_resolver_impl_methods() {
     let program = parse_program(
         r#"
 Json: behavior {
-    stringify: (Self) str
+    stringify: (Self) StaticString
 }
 
 Point: { x: i32 }
 
 Point.implements(Json) {
-    stringify = (value: Point) str { "point" }
+    stringify = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -35,13 +35,13 @@ fn check_program_with_symbols_validates_resolver_impl_method_signature() {
     let program = parse_program(
         r#"
 Json: behavior {
-    stringify: (Self) str
+    stringify: (Self) StaticString
 }
 
 Point: { x: i32 }
 
 Point.implements(Json) {
-    stringify = (value: Point) str { "point" }
+    stringify = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -60,9 +60,11 @@ Point.implements(Json) {
         .expect_err("resolver impl method signature mismatch should fail");
 
     assert!(
-        err.iter().any(|d| d.message.contains(
-            "resolver value symbol 'Point.stringify' has return type 'i32', expected 'str'"
-        )),
+        err.iter().any(|d| {
+            d.message.contains(
+            "resolver value symbol 'Point.stringify' has return type 'i32', expected 'StaticString'"
+        )
+        }),
         "expected resolver impl method signature diagnostic, got {err:?}"
     );
 }
@@ -107,13 +109,13 @@ fn check_program_with_symbols_requires_resolver_impl_method_body_locals() {
     let program = parse_program(
         r#"
 Json: behavior {
-    stringify: (Self) str
+    stringify: (Self) StaticString
 }
 
 Point: { x: i32 }
 
 Point.implements(Json) {
-    stringify = (value: Point) str {
+    stringify = (value: Point) StaticString {
         label = "point"
         label
     }

--- a/src/typechecker/tests/resolver_import_metadata.rs
+++ b/src/typechecker/tests/resolver_import_metadata.rs
@@ -156,7 +156,7 @@ main = () i32 {
         Some(vec![(
             "encode".to_string(),
             vec!["Self".to_string()],
-            "str".to_string(),
+            "StaticString".to_string(),
         )]),
     );
     symbols.set_behavior_method_types_for_test(

--- a/src/typechecker/tests/resolver_import_metadata/module_metadata.rs
+++ b/src/typechecker/tests/resolver_import_metadata/module_metadata.rs
@@ -137,7 +137,7 @@ main = () i32 {
         Some(vec![(
             "encode".to_string(),
             vec!["Self".to_string()],
-            "str".to_string(),
+            "StaticString".to_string(),
         )]),
     );
     symbols.set_behavior_method_types_for_test(

--- a/src/typechecker/tests/resolver_locals/absence.rs
+++ b/src/typechecker/tests/resolver_locals/absence.rs
@@ -84,7 +84,7 @@ add = (a: i32, b: i32) i32 { a + b }
         Some(vec![(
             "encode".to_string(),
             vec!["Self".to_string()],
-            "str".to_string(),
+            "StaticString".to_string(),
         )]),
     );
     symbols.set_behavior_method_types_for_test(

--- a/src/typechecker/tests/resolver_locals/body_locals.rs
+++ b/src/typechecker/tests/resolver_locals/body_locals.rs
@@ -155,7 +155,7 @@ fn check_program_with_symbols_requires_resolver_behavior_default_locals() {
     let program = parse_program(
         r#"
 Json: behavior {
-    to_json: (Self) str {
+    to_json: (Self) StaticString {
         value = "{}"
         value
     }

--- a/src/typechecker/tests/resolver_metadata/impl_and_method_helpers.rs
+++ b/src/typechecker/tests/resolver_metadata/impl_and_method_helpers.rs
@@ -124,11 +124,11 @@ fn resolver_backed_impl_method_key_requires_resolver_collection() {
         r#"
 Point: { x: i32 }
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.implements(Json) {
-    encode = (value: Point) str { "point" }
+    encode = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -168,11 +168,11 @@ fn effective_behavior_impl_methods_carry_named_declaration_and_method_name() {
         r#"
 Point: { x: i32 }
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.implements(Json) {
-    encode = (value: Point) str { "point" }
+    encode = (value: Point) StaticString { "point" }
 }
 "#,
     );

--- a/src/typechecker/tests/resolver_metadata/metadata_requirements.rs
+++ b/src/typechecker/tests/resolver_metadata/metadata_requirements.rs
@@ -174,7 +174,7 @@ fn resolver_behavior_method_metadata_requires_method_types() {
     let program = parse_program(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 "#,
     );

--- a/src/typechecker/tests/resolver_metadata/metadata_restoration.rs
+++ b/src/typechecker/tests/resolver_metadata/metadata_restoration.rs
@@ -59,7 +59,7 @@ fn resolver_enum_variants_from_metadata_uses_owner_scoped_payloads() {
     let program = parse_program(
         r#"
 First: Wrap(i32), None
-Second: Wrap(str)
+Second: Wrap(StaticString)
 "#,
     );
     let symbols = crate::resolver::Resolver::new()
@@ -237,7 +237,7 @@ fn behavior_impl_refs_from_metadata_restores_type_and_behavior_keys() {
     assert_eq!(
         tc.behavior_impl_refs_from_metadata("Point", &metadata),
         vec![
-            ("Point".to_string(), "Json_str".to_string()),
+            ("Point".to_string(), "Json_StaticString".to_string()),
             ("Point".to_string(), "Debug".to_string()),
         ]
     );

--- a/src/typechecker/tests/resolver_metadata/validation_descriptors.rs
+++ b/src/typechecker/tests/resolver_metadata/validation_descriptors.rs
@@ -173,8 +173,8 @@ fn behavior_method_validation_formats_messages() {
 
     assert_eq!(validation.display_code, "METHODS");
     assert_eq!(
-            validation.display_message("Serializable", "(encode(Self) bool)", "(encode(Self) str)"),
-            "resolver behavior symbol 'Serializable' has methods '(encode(Self) bool)', expected '(encode(Self) str)'"
+            validation.display_message("Serializable", "(encode(Self) bool)", "(encode(Self) StaticString)"),
+            "resolver behavior symbol 'Serializable' has methods '(encode(Self) bool)', expected '(encode(Self) StaticString)'"
         );
     assert_eq!(
             validation.typed_message(

--- a/src/typechecker/tests/resolver_module_graph.rs
+++ b/src/typechecker/tests/resolver_module_graph.rs
@@ -133,7 +133,7 @@ pub Result<T, E>:
 
 main = () i32 {
     maybe = Option<i32>.Some(7)
-    result = Result<i32, str>.Ok(9)
+    result = Result<i32, StaticString>.Ok(9)
     0
 }
 "#,
@@ -152,7 +152,10 @@ main = () i32 {
         .expect("graph import bindings should seed generic enum templates");
 
     assert!(typed.types.iter().any(|ty| ty.name == "Option_i32"));
-    assert!(typed.types.iter().any(|ty| ty.name == "Result_i32_str"));
+    assert!(typed
+        .types
+        .iter()
+        .any(|ty| ty.name == "Result_i32_StaticString"));
 }
 
 #[test]

--- a/src/typechecker/tests/resolver_struct_enum_metadata/variant_absence.rs
+++ b/src/typechecker/tests/resolver_struct_enum_metadata/variant_absence.rs
@@ -63,7 +63,7 @@ Option: Some(i32), None
         Some(vec![(
             "encode".to_string(),
             vec!["Self".to_string()],
-            "str".to_string(),
+            "StaticString".to_string(),
         )]),
     );
     symbols.set_behavior_method_types_for_test(

--- a/src/typechecker/tests/resolver_type_behavior_metadata.rs
+++ b/src/typechecker/tests/resolver_type_behavior_metadata.rs
@@ -8,7 +8,7 @@ fn check_program_with_symbols_validates_resolver_type_parameter_counts() {
         r#"
 Box<T>: { value: T }
 Serializable<T>: behavior {
-    encode: (T) str
+    encode: (T) StaticString
 }
 "#,
     );
@@ -43,7 +43,7 @@ fn check_program_with_symbols_validates_resolver_type_parameter_names() {
         r#"
 Box<T>: { value: T }
 Serializable<T>: behavior {
-    encode: (T) str
+    encode: (T) StaticString
 }
 "#,
     );
@@ -106,7 +106,7 @@ fn check_program_with_symbols_validates_resolver_behavior_visibility() {
     let program = parse_program(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 "#,
     );
@@ -133,7 +133,7 @@ fn check_program_with_symbols_validates_resolver_type_parameter_bounds() {
     let program = parse_program(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 Box<T: Json>: { value: T }
 "#,
@@ -200,7 +200,7 @@ fn check_program_with_symbols_validates_resolver_type_like_absent_value_metadata
         r#"
 Box<T>: { value: T }
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 "#,
     );
@@ -255,7 +255,7 @@ fn check_program_with_symbols_validates_resolver_behavior_absent_type_metadata()
     let program = parse_program(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 "#,
     );

--- a/src/typechecker/tests/resolver_type_behavior_metadata/behavior_methods.rs
+++ b/src/typechecker/tests/resolver_type_behavior_metadata/behavior_methods.rs
@@ -5,7 +5,7 @@ fn check_program_with_symbols_validates_resolver_behavior_method_signatures() {
     let program = parse_program(
         r#"
 Serializable: behavior {
-    encode: (Self, i32) str
+    encode: (Self, i32) StaticString
 }
 "#,
     );
@@ -18,7 +18,7 @@ Serializable: behavior {
         Some(vec![(
             "encode".to_string(),
             vec!["Self".to_string(), "bool".to_string()],
-            "str".to_string(),
+            "StaticString".to_string(),
         )]),
     );
     let mut tc = TypeChecker::new();
@@ -29,7 +29,7 @@ Serializable: behavior {
 
     assert!(
             err.iter().any(|d| d.message.contains(
-                "resolver behavior symbol 'Serializable' has methods '(encode(Self, bool) str)', expected '(encode(Self, i32) str)'"
+                "resolver behavior symbol 'Serializable' has methods '(encode(Self, bool) StaticString)', expected '(encode(Self, i32) StaticString)'"
             )),
             "expected resolver behavior method signature diagnostic, got {err:?}"
         );
@@ -127,7 +127,7 @@ Json<T>: behavior {
         Some(vec![(
             "encode".to_string(),
             vec!["Self".to_string()],
-            "str".to_string(),
+            "StaticString".to_string(),
         )]),
     );
     let mut tc = TypeChecker::new();
@@ -138,7 +138,7 @@ Json<T>: behavior {
 
     assert!(
             err.iter().any(|d| d.message.contains(
-                "resolver behavior symbol 'Json' has methods '(encode(Self) str)', expected '(encode(Self) T)'"
+                "resolver behavior symbol 'Json' has methods '(encode(Self) StaticString)', expected '(encode(Self) T)'"
             )),
             "expected resolver generic behavior method signature diagnostic, got {err:?}"
         );

--- a/src/typechecker/tests/resolver_validation/absence.rs
+++ b/src/typechecker/tests/resolver_validation/absence.rs
@@ -7,11 +7,11 @@ fn behavior_association_absence_validation_builds_entries() {
 Point: { x: i32 }
 
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.implements(Json) {
-    encode = (value: Point) str { "point" }
+    encode = (value: Point) StaticString { "point" }
 }
 
 Point.requires(Json)
@@ -107,11 +107,11 @@ fn behavior_declaration_absence_validation_builds_entries() {
     let program = parse_program(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
 PrettyJson.extends(Json)

--- a/src/typechecker/tests/resolver_validation/behavior_refs.rs
+++ b/src/typechecker/tests/resolver_validation/behavior_refs.rs
@@ -76,12 +76,12 @@ fn behavior_ref_validation_maps_role_and_check_diagnostics() {
     let contains =
         BehaviorRefValidation::for_role(BehaviorRefRole::Impl, BehaviorRefCheck::Contains);
     assert_eq!(
-            contains.contains_name_message("Point", "PrettyJson", "Json<str>"),
-            "resolver type symbol 'Point' has behavior impls 'PrettyJson', expected to include 'Json<str>'"
+            contains.contains_name_message("Point", "PrettyJson", "Json<StaticString>"),
+            "resolver type symbol 'Point' has behavior impls 'PrettyJson', expected to include 'Json<StaticString>'"
         );
     assert_eq!(
-            contains.contains_ref_message("Point", "PrettyJson", "Json<str>"),
-            "resolver type symbol 'Point' has behavior impl refs 'PrettyJson', expected to include 'Json<str>'"
+            contains.contains_ref_message("Point", "PrettyJson", "Json<StaticString>"),
+            "resolver type symbol 'Point' has behavior impl refs 'PrettyJson', expected to include 'Json<StaticString>'"
         );
 
     let list = BehaviorRefValidation::for_role(BehaviorRefRole::Parent, BehaviorRefCheck::List);
@@ -129,17 +129,17 @@ Json<T>: behavior {
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
-PrettyJson.extends(Json<str>)
+PrettyJson.extends(Json<StaticString>)
 
 Point.implements(PrettyJson) {
-    encode = (value: Point) str { "point" }
-    pretty = (value: Point) str { "pretty" }
+    encode = (value: Point) StaticString { "point" }
+    pretty = (value: Point) StaticString { "pretty" }
 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 "#,
     );
     let symbols = crate::resolver::Resolver::new()
@@ -153,8 +153,11 @@ Point.requires(Json<str>)
         .expect("type symbol");
 
     let parent = BehaviorRefActual::for_role(behavior, BehaviorRefRole::Parent);
-    assert_eq!(format_behavior_ref_names(parent.names), "Json<str>");
-    assert_eq!(format_behavior_refs(parent.refs), "Json<str>");
+    assert_eq!(
+        format_behavior_ref_names(parent.names),
+        "Json<StaticString>"
+    );
+    assert_eq!(format_behavior_refs(parent.refs), "Json<StaticString>");
 
     let implementation = BehaviorRefActual::for_role(ty, BehaviorRefRole::Impl);
     assert_eq!(
@@ -164,8 +167,11 @@ Point.requires(Json<str>)
     assert_eq!(format_behavior_refs(implementation.refs), "PrettyJson");
 
     let required = BehaviorRefActual::for_role(ty, BehaviorRefRole::Required);
-    assert_eq!(format_behavior_ref_names(required.names), "Json<str>");
-    assert_eq!(format_behavior_refs(required.refs), "Json<str>");
+    assert_eq!(
+        format_behavior_ref_names(required.names),
+        "Json<StaticString>"
+    );
+    assert_eq!(format_behavior_refs(required.refs), "Json<StaticString>");
 }
 
 #[test]
@@ -179,17 +185,17 @@ Json<T>: behavior {
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
-PrettyJson.extends(Json<str>)
+PrettyJson.extends(Json<StaticString>)
 
 Point.implements(PrettyJson) {
-    encode = (value: Point) str { "point" }
-    pretty = (value: Point) str { "pretty" }
+    encode = (value: Point) StaticString { "point" }
+    pretty = (value: Point) StaticString { "pretty" }
 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 "#,
     );
     let symbols = crate::resolver::Resolver::new()
@@ -208,12 +214,18 @@ Point.requires(Json<str>)
     let (required_names, required_refs) =
         BehaviorRefActual::metadata_for_role(ty, BehaviorRefRole::Required);
 
-    assert_eq!(format_behavior_ref_names(parent_names), "Json<str>");
-    assert_eq!(format_behavior_refs(parent_refs), "Json<str>");
+    assert_eq!(
+        format_behavior_ref_names(parent_names),
+        "Json<StaticString>"
+    );
+    assert_eq!(format_behavior_refs(parent_refs), "Json<StaticString>");
     assert_eq!(format_behavior_ref_names(impl_names), "PrettyJson");
     assert_eq!(format_behavior_refs(impl_refs), "PrettyJson");
-    assert_eq!(format_behavior_ref_names(required_names), "Json<str>");
-    assert_eq!(format_behavior_refs(required_refs), "Json<str>");
+    assert_eq!(
+        format_behavior_ref_names(required_names),
+        "Json<StaticString>"
+    );
+    assert_eq!(format_behavior_refs(required_refs), "Json<StaticString>");
 }
 
 #[test]

--- a/src/typechecker/tests/resolver_validation/declaration_metadata.rs
+++ b/src/typechecker/tests/resolver_validation/declaration_metadata.rs
@@ -9,7 +9,7 @@ Point: { x: i32 }
 Option: Some(i32), None
 
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.impl = {
@@ -17,7 +17,7 @@ Point.impl = {
 }
 
 Point.implements(Json) {
-    encode = (value: Point) str { "point" }
+    encode = (value: Point) StaticString { "point" }
 }
 
 Point.requires(Json)
@@ -59,11 +59,11 @@ fn expected_behavior_edges_build_parent_edges_from_extends_together() {
     let program = parse_program(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
 PrettyJson.extends(Json)
@@ -89,11 +89,11 @@ Json<T>: behavior {
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
 Point.implements(PrettyJson) {
-    pretty = (value: Point) str { "pretty" }
+    pretty = (value: Point) StaticString { "pretty" }
 }
 "#,
     );
@@ -114,9 +114,9 @@ Point.implements(PrettyJson) {
     );
 
     assert!(tc.diagnostics.iter().any(|d| d.code == "E0236" && d.message.contains(
-            "resolver type symbol 'Point' has behavior impls 'PrettyJson', expected to include 'Json<str>'"
+            "resolver type symbol 'Point' has behavior impls 'PrettyJson', expected to include 'Json<StaticString>'"
         )));
     assert!(tc.diagnostics.iter().any(|d| d.code == "E0247" && d.message.contains(
-            "resolver type symbol 'Point' has behavior impl refs 'PrettyJson', expected to include 'Json<str>'"
+            "resolver type symbol 'Point' has behavior impl refs 'PrettyJson', expected to include 'Json<StaticString>'"
         )));
 }

--- a/src/typechecker/tests/resolver_validation/expected_symbols.rs
+++ b/src/typechecker/tests/resolver_validation/expected_symbols.rs
@@ -14,7 +14,7 @@ fn expected_parameter_builds_name_display_and_type_together() {
     );
 
     assert_eq!(parameter.name, "mapper");
-    assert_eq!(parameter.display, "(i32) str");
+    assert_eq!(parameter.display, "(i32) StaticString");
     assert_eq!(
         parameter.typed,
         AstType::Function {
@@ -127,8 +127,8 @@ fn expected_behavior_method_builds_signature_and_metadata_together() {
         expected.signature,
         (
             "map".to_string(),
-            vec!["(i32) str".to_string()],
-            "str".to_string(),
+            vec!["(i32) StaticString".to_string()],
+            "StaticString".to_string(),
         )
     );
     assert_eq!(expected.metadata.name, "map");

--- a/src/typechecker/tests/resolver_validation/expected_symbols/leaf_symbols.rs
+++ b/src/typechecker/tests/resolver_validation/expected_symbols/leaf_symbols.rs
@@ -46,11 +46,11 @@ Json<T>: behavior {
     encode: (Self) T
 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 "#,
     );
 
@@ -58,10 +58,10 @@ Point.requires(Json<str>)
     let impl_edge = &expected.impls.edges_for("Point")[0];
     let required_edge = &expected.required.edges_for("Point")[0];
 
-    assert_eq!(impl_edge.display, "Json<str>");
+    assert_eq!(impl_edge.display, "Json<StaticString>");
     assert_eq!(impl_edge.metadata.name, "Json");
     assert_eq!(impl_edge.metadata.type_args, vec![AstType::Str]);
-    assert_eq!(required_edge.display, "Json<str>");
+    assert_eq!(required_edge.display, "Json<StaticString>");
     assert_eq!(required_edge.metadata.name, "Json");
     assert_eq!(required_edge.metadata.type_args, vec![AstType::Str]);
 }

--- a/src/typechecker/tests/resolver_validation/replay_tasks/association_lists.rs
+++ b/src/typechecker/tests/resolver_validation/replay_tasks/association_lists.rs
@@ -13,16 +13,16 @@ Json<T>: behavior {
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
-PrettyJson.extends(Json<str>)
+PrettyJson.extends(Json<StaticString>)
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 "#,
     );
     let symbols = crate::resolver::Resolver::new()
@@ -34,8 +34,8 @@ Point.requires(Json<str>)
     assert_eq!(tasks.type_associations.len(), 1);
     let type_task = &tasks.type_associations[0];
     assert_eq!(type_task.name, "Point");
-    assert_eq!(type_task.impl_edges[0].display, "Json<str>");
-    assert_eq!(type_task.required_edges[0].display, "Json<str>");
+    assert_eq!(type_task.impl_edges[0].display, "Json<StaticString>");
+    assert_eq!(type_task.required_edges[0].display, "Json<StaticString>");
 
     assert_eq!(tasks.behavior_parents.len(), 2);
     let pretty_task = tasks
@@ -43,7 +43,7 @@ Point.requires(Json<str>)
         .iter()
         .find(|task| task.name == "PrettyJson")
         .expect("PrettyJson parent task");
-    assert_eq!(pretty_task.parent_edges[0].display, "Json<str>");
+    assert_eq!(pretty_task.parent_edges[0].display, "Json<StaticString>");
     let json_task = tasks
         .behavior_parents
         .iter()
@@ -100,11 +100,11 @@ Json<T>: behavior {
     encode: (Self) T
 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 "#,
     );
     let symbols = crate::resolver::Resolver::new()
@@ -122,7 +122,7 @@ Point.requires(Json<str>)
     assert_eq!(tasks.type_declarations[0].name, "Point");
     assert_eq!(
         tasks.expected_associations.impls.owned_edges_for("Point")[0].display,
-        "Json<str>"
+        "Json<StaticString>"
     );
     assert_eq!(
         tasks
@@ -130,7 +130,7 @@ Point.requires(Json<str>)
             .required
             .owned_edges_for("Point")[0]
             .display,
-        "Json<str>"
+        "Json<StaticString>"
     );
     assert_eq!(tasks.behavior_declarations.len(), 1);
     assert_eq!(tasks.behavior_declarations[0].name, "Json");
@@ -147,16 +147,16 @@ Json<T>: behavior {
 }
 
 Pretty<T>: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
 Pretty.extends(Json<T>)
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 "#,
     );
     let symbols = crate::resolver::Resolver::new()
@@ -174,11 +174,11 @@ Point.requires(Json<str>)
     assert_eq!(association_tasks.type_associations[0].name, "Point");
     assert_eq!(
         association_tasks.type_associations[0].impl_edges[0].display,
-        "Json<str>"
+        "Json<StaticString>"
     );
     assert_eq!(
         association_tasks.type_associations[0].required_edges[0].display,
-        "Json<str>"
+        "Json<StaticString>"
     );
     assert_eq!(association_tasks.behavior_parents.len(), 2);
     let pretty_task = association_tasks
@@ -225,11 +225,11 @@ Json<T>: behavior {
     encode: (Self) T
 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 
 main = (input: i32) i32 {
     input
@@ -262,8 +262,8 @@ main = (input: i32) i32 {
 
     let type_task = &tasks.behavior_associations.type_associations[0];
     assert_eq!(type_task.name, "Point");
-    assert_eq!(type_task.impl_edges[0].display, "Json<str>");
-    assert_eq!(type_task.required_edges[0].display, "Json<str>");
+    assert_eq!(type_task.impl_edges[0].display, "Json<StaticString>");
+    assert_eq!(type_task.required_edges[0].display, "Json<StaticString>");
     assert_eq!(tasks.behavior_associations.behavior_parents.len(), 1);
 }
 

--- a/src/typechecker/tests/resolver_validation/replay_tasks/association_lists/association_validation.rs
+++ b/src/typechecker/tests/resolver_validation/replay_tasks/association_lists/association_validation.rs
@@ -37,7 +37,7 @@ Json<T>: behavior {
     encode: (Self) T
 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 "#,
     );
     let mut tasks = Vec::new();
@@ -68,11 +68,11 @@ Pretty<T>: behavior {
 
 Pretty.extends(Json<T>)
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 "#,
     );
 
@@ -105,11 +105,11 @@ Json<T>: behavior {
     encode: (Self) T
 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 "#,
     );
     let mut checker = TypeChecker::new();

--- a/src/typechecker/tests/resolver_validation/replay_tasks/declaration_tasks.rs
+++ b/src/typechecker/tests/resolver_validation/replay_tasks/declaration_tasks.rs
@@ -7,7 +7,7 @@ fn impl_block_declaration_tasks_collect_behavior_and_plain_impls() {
 Point: { x: i32 }
 
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point.impl = {
@@ -15,7 +15,7 @@ Point.impl = {
 }
 
 Point.implements(Json) {
-    encode = (value: Point) str { "point" }
+    encode = (value: Point) StaticString { "point" }
 }
 "#,
     );

--- a/src/typechecker/tests/resolver_value_metadata.rs
+++ b/src/typechecker/tests/resolver_value_metadata.rs
@@ -172,9 +172,9 @@ fn check_program_with_symbols_validates_resolver_function_type_parameter_bounds(
     let program = parse_program(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
-encode<T: Json> = (value: T) str { "encoded" }
+encode<T: Json> = (value: T) StaticString { "encoded" }
 "#,
     );
     let mut symbols = crate::resolver::Resolver::new()
@@ -227,7 +227,7 @@ identity<T: Json<T>> = (value: T) T { value }
         .check_program_with_symbols(&program, &symbols)
         .expect_err("resolver function generic bound ref mismatch should fail");
 
-    let expected = "resolver value symbol 'identity' has type parameter bound refs '(T: Json<str>)', expected '(T: Json<T>)'";
+    let expected = "resolver value symbol 'identity' has type parameter bound refs '(T: Json<StaticString>)', expected '(T: Json<T>)'";
     assert!(
         err.iter().any(|d| d.message.contains(expected)),
         "expected resolver function generic bound ref diagnostic, got {err:?}"

--- a/src/typechecker/tests/resolver_value_metadata/absent_declaration_metadata.rs
+++ b/src/typechecker/tests/resolver_value_metadata/absent_declaration_metadata.rs
@@ -35,7 +35,7 @@ main = () i32 { 0 }
         Some(vec![(
             "encode".to_string(),
             vec!["Self".to_string()],
-            "str".to_string(),
+            "StaticString".to_string(),
         )]),
     );
     symbols.set_behavior_method_types_for_test(

--- a/tests/generic_diagnostics/annotations.rs
+++ b/tests/generic_diagnostics/annotations.rs
@@ -11,7 +11,7 @@ Box<T>: {
     value: T
 }
 
-read = (box: Box<i32, str>) i32 {
+read = (box: Box<i32, StaticString>) i32 {
     0
 }
 "#,
@@ -33,7 +33,7 @@ Option<T>:
     None,
     Some(T)
 
-read = (value: Option<i32, str>) i32 {
+read = (value: Option<i32, StaticString>) i32 {
     0
 }
 "#,

--- a/tests/generic_diagnostics/annotations/local.rs
+++ b/tests/generic_diagnostics/annotations/local.rs
@@ -9,7 +9,7 @@ Box<T>: {
 }
 
 main = () i32 {
-    box: Box<i32, str> = Box<i32> { value: 1 }
+    box: Box<i32, StaticString> = Box<i32> { value: 1 }
     box.value
 }
 "#,
@@ -55,7 +55,7 @@ Option<T>:
     Some(T)
 
 main = () i32 {
-    value: Option<i32, str> = Option<i32>.Some(1)
+    value: Option<i32, StaticString> = Option<i32>.Some(1)
     0
 }
 "#,

--- a/tests/generic_diagnostics/behavior_impls.rs
+++ b/tests/generic_diagnostics/behavior_impls.rs
@@ -5,11 +5,11 @@ fn behavior_impl_for_unknown_type_is_error() {
     let errors = frontend_errors(
         r#"
 Json: behavior {
-    to_json: (Self) str
+    to_json: (Self) StaticString
 }
 
 Missing.implements(Json) {
-    to_json = (value: Missing) str {
+    to_json = (value: Missing) StaticString {
         "missing"
     }
 }
@@ -33,11 +33,11 @@ Box<T>: {
 }
 
 Json: behavior {
-    to_json: (Self) str
+    to_json: (Self) StaticString
 }
 
 Box.implements(Json) {
-    to_json = (value: Box) str {
+    to_json = (value: Box) StaticString {
         "box"
     }
 }
@@ -61,7 +61,7 @@ Box<T>: {
 }
 
 Json: behavior {
-    to_json: (Self) str
+    to_json: (Self) StaticString
 }
 
 Box.requires(Json)
@@ -85,15 +85,15 @@ Point: {
 }
 
 Json: behavior {
-    to_json: (Self) str
+    to_json: (Self) StaticString
 }
 
 Point.implements(Json) {
-    to_json = (value: Point) str {
+    to_json = (value: Point) StaticString {
         "point"
     }
 
-    extra = (value: Point) str {
+    extra = (value: Point) StaticString {
         "extra"
     }
 }
@@ -118,15 +118,15 @@ Point: {
 }
 
 Json: behavior {
-    to_json: (Self) str
+    to_json: (Self) StaticString
 }
 
 Point.implements(Json) {
-    to_json = (value: Point) str {
+    to_json = (value: Point) StaticString {
         "point"
     }
 
-    to_json = (value: Point) str {
+    to_json = (value: Point) StaticString {
         "point again"
     }
 }

--- a/tests/generic_diagnostics/bounds.rs
+++ b/tests/generic_diagnostics/bounds.rs
@@ -5,7 +5,7 @@ fn generic_struct_behavior_bound_failure_is_error() {
     let errors = typecheck_errors(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point: {
@@ -37,7 +37,7 @@ fn generic_enum_behavior_bound_failure_is_error() {
     let errors = typecheck_errors(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point: {
@@ -69,7 +69,7 @@ fn generic_struct_annotation_bound_failure_is_error() {
     let errors = typecheck_errors(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point: {
@@ -99,7 +99,7 @@ fn generic_enum_annotation_bound_failure_is_error() {
     let errors = typecheck_errors(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point: {
@@ -129,7 +129,7 @@ fn generic_struct_local_annotation_bound_failure_is_error() {
     let errors = typecheck_errors(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point: {
@@ -161,7 +161,7 @@ fn generic_enum_local_annotation_bound_failure_is_error() {
     let errors = typecheck_errors(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point: {

--- a/tests/generic_diagnostics/call_site_annotations.rs
+++ b/tests/generic_diagnostics/call_site_annotations.rs
@@ -14,7 +14,7 @@ identity<T> = (value: T) T {
 
 main = () i32 {
     box = Box<i32> { value: 1 }
-    bad = identity<Box<i32, str>>(box)
+    bad = identity<Box<i32, StaticString>>(box)
     bad.value
 }
 "#,
@@ -51,7 +51,7 @@ Holder.wrap<T> = (self: Holder, value: T) T {
 main = () i32 {
     holder = Holder { value: 1 }
     box = Box<i32> { value: 1 }
-    bad = holder.wrap<Box<i32, str>>(box)
+    bad = holder.wrap<Box<i32, StaticString>>(box)
     bad.value
 }
 "#,
@@ -111,7 +111,7 @@ Box<T>: {
 }
 
 main = () i32 {
-    f = (box: Box<i32, str>) i32 {
+    f = (box: Box<i32, StaticString>) i32 {
         0
     }
     0
@@ -162,7 +162,7 @@ Box<T>: {
 
 main = () i32 {
     box = Box<i32> { value: 1 }
-    bad = cast(box, Box<i32, str>)
+    bad = cast(box, Box<i32, StaticString>)
     bad.value
 }
 "#,

--- a/tests/generic_diagnostics/call_site_bounds.rs
+++ b/tests/generic_diagnostics/call_site_bounds.rs
@@ -8,14 +8,14 @@ fn generic_function_behavior_bound_failure_is_error() {
     let errors = typecheck_errors(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point: {
     x: i32
 }
 
-encode<T: Json> = (value: T) str {
+encode<T: Json> = (value: T) StaticString {
     value.encode()
 }
 

--- a/tests/generic_diagnostics/call_site_bounds/methods.rs
+++ b/tests/generic_diagnostics/call_site_bounds/methods.rs
@@ -5,7 +5,7 @@ fn generic_method_behavior_bound_failure_is_error() {
     let errors = typecheck_errors(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point: {
@@ -48,7 +48,7 @@ fn generic_receiver_method_behavior_bound_failure_is_error() {
     let errors = typecheck_errors(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point: {
@@ -85,7 +85,7 @@ fn generic_result_enum_method_behavior_bound_failure_is_error() {
     let errors = typecheck_errors(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point: {
@@ -102,7 +102,7 @@ Result.map<T, E, U: Json> = (self: Self, fallback: U) U {
 }
 
 main = () i32 {
-    value = Result<i32, str>.Ok(1)
+    value = Result<i32, StaticString>.Ok(1)
     point = Point { x: 1 }
     bad = value.map(point)
     0
@@ -129,14 +129,14 @@ fn generic_ufc_function_behavior_bound_failure_is_error() {
     let errors = typecheck_errors(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 
 Point: {
     x: i32
 }
 
-as_json<T: Json> = (value: T) str {
+as_json<T: Json> = (value: T) StaticString {
     value.encode()
 }
 

--- a/tests/generic_diagnostics/composite_annotations.rs
+++ b/tests/generic_diagnostics/composite_annotations.rs
@@ -12,7 +12,7 @@ Option<T>:
     None,
     Some(T)
 
-read = (box: Box<Option<i32, str>>) i32 {
+read = (box: Box<Option<i32, StaticString>>) i32 {
     0
 }
 "#,
@@ -39,7 +39,7 @@ Option<T>:
     Some(T)
 
 main = () i32 {
-    value = Box<Option<i32, str>> { value: Option<i32>.Some(1) }
+    value = Box<Option<i32, StaticString>> { value: Option<i32>.Some(1) }
     0
 }
 "#,
@@ -61,7 +61,7 @@ Box<T>: {
     value: T
 }
 
-call = (f: (Box<i32, str>) i32) i32 {
+call = (f: (Box<i32, StaticString>) i32) i32 {
     0
 }
 "#,
@@ -105,7 +105,7 @@ Box<T>: {
     value: T
 }
 
-read = (ptr: Ptr<Box<i32, str>>) i32 {
+read = (ptr: Ptr<Box<i32, StaticString>>) i32 {
     0
 }
 "#,
@@ -149,7 +149,7 @@ Box<T>: {
     value: T
 }
 
-read = (items: [Box<i32, str>; 1]) i32 {
+read = (items: [Box<i32, StaticString>; 1]) i32 {
     0
 }
 "#,

--- a/tests/generic_diagnostics/constructors.rs
+++ b/tests/generic_diagnostics/constructors.rs
@@ -9,7 +9,7 @@ Box<T>: {
 }
 
 main = () i32 {
-    box = Box<i32, str> { value: 1 }
+    box = Box<i32, StaticString> { value: 1 }
     box.value
 }
 "#,
@@ -96,7 +96,7 @@ Option<T>:
     Some(T)
 
 main = () i32 {
-    value = Option<i32, str>.Some(1)
+    value = Option<i32, StaticString>.Some(1)
     0
 }
 "#,

--- a/tests/generic_diagnostics/inference_conflicts/functions/basic.rs
+++ b/tests/generic_diagnostics/inference_conflicts/functions/basic.rs
@@ -17,7 +17,7 @@ main = () i32 {
 
     assert!(
         errors.iter().any(|d| d.message.contains(
-            "conflicting inferred type argument `T` for generic function `choose`: inferred `i32` and `str`"
+            "conflicting inferred type argument `T` for generic function `choose`: inferred `i32` and `StaticString`"
         )),
         "expected generic function inference conflict diagnostic, got {errors:?}"
     );

--- a/tests/generic_diagnostics/inference_conflicts/functions/compound_params.rs
+++ b/tests/generic_diagnostics/inference_conflicts/functions/compound_params.rs
@@ -9,7 +9,7 @@ choose_with<T> = (left: T, mapper: (T) T) T {
 }
 
 main = () i32 {
-    mapper = (value: str) str {
+    mapper = (value: StaticString) StaticString {
         value
     }
     choose_with(1, mapper)
@@ -19,7 +19,7 @@ main = () i32 {
 
     assert!(
         errors.iter().any(|d| d.message.contains(
-            "conflicting inferred type argument `T` for generic function `choose_with`: inferred `i32` and `str`"
+            "conflicting inferred type argument `T` for generic function `choose_with`: inferred `i32` and `StaticString`"
         )),
         "expected generic function function-type inference conflict diagnostic, got {errors:?}"
     );
@@ -42,7 +42,7 @@ main = () i32 {
 
     assert!(
         errors.iter().any(|d| d.message.contains(
-            "conflicting inferred type argument `T` for generic function `choose_array`: inferred `i32` and `str`"
+            "conflicting inferred type argument `T` for generic function `choose_array`: inferred `i32` and `StaticString`"
         )),
         "expected generic function array-type inference conflict diagnostic, got {errors:?}"
     );
@@ -57,7 +57,7 @@ choose_raw<T> = (left: T, ptr: RawPtr<T>) T {
 }
 
 main = () i32 {
-    ptr = cast("bad", RawPtr<str>)
+    ptr = cast("bad", RawPtr<StaticString>)
     choose_raw(1, ptr)
 }
 "#,
@@ -65,7 +65,7 @@ main = () i32 {
 
     assert!(
         errors.iter().any(|d| d.message.contains(
-            "conflicting inferred type argument `T` for generic function `choose_raw`: inferred `i32` and `str`"
+            "conflicting inferred type argument `T` for generic function `choose_raw`: inferred `i32` and `StaticString`"
         )),
         "expected generic function raw-pointer inference conflict diagnostic, got {errors:?}"
     );
@@ -80,7 +80,7 @@ choose_ptr<T> = (left: T, ptr: Ptr<T>) T {
 }
 
 main = () i32 {
-    ptr = cast("bad", Ptr<str>)
+    ptr = cast("bad", Ptr<StaticString>)
     choose_ptr(1, ptr)
 }
 "#,
@@ -88,7 +88,7 @@ main = () i32 {
 
     assert!(
         errors.iter().any(|d| d.message.contains(
-            "conflicting inferred type argument `T` for generic function `choose_ptr`: inferred `i32` and `str`"
+            "conflicting inferred type argument `T` for generic function `choose_ptr`: inferred `i32` and `StaticString`"
         )),
         "expected generic function pointer inference conflict diagnostic, got {errors:?}"
     );
@@ -103,7 +103,7 @@ choose_mut_ptr<T> = (left: T, ptr: MutPtr<T>) T {
 }
 
 main = () i32 {
-    ptr = cast("bad", MutPtr<str>)
+    ptr = cast("bad", MutPtr<StaticString>)
     choose_mut_ptr(1, ptr)
 }
 "#,
@@ -111,7 +111,7 @@ main = () i32 {
 
     assert!(
         errors.iter().any(|d| d.message.contains(
-            "conflicting inferred type argument `T` for generic function `choose_mut_ptr`: inferred `i32` and `str`"
+            "conflicting inferred type argument `T` for generic function `choose_mut_ptr`: inferred `i32` and `StaticString`"
         )),
         "expected generic function mutable pointer inference conflict diagnostic, got {errors:?}"
     );
@@ -126,7 +126,7 @@ choose_slice<T> = (left: T, items: Slice<T>) T {
 }
 
 main = () i32 {
-    items = cast("bad", Slice<str>)
+    items = cast("bad", Slice<StaticString>)
     choose_slice(1, items)
 }
 "#,
@@ -134,7 +134,7 @@ main = () i32 {
 
     assert!(
         errors.iter().any(|d| d.message.contains(
-            "conflicting inferred type argument `T` for generic function `choose_slice`: inferred `i32` and `str`"
+            "conflicting inferred type argument `T` for generic function `choose_slice`: inferred `i32` and `StaticString`"
         )),
         "expected generic function slice inference conflict diagnostic, got {errors:?}"
     );

--- a/tests/generic_diagnostics/inference_conflicts/functions/generic_params.rs
+++ b/tests/generic_diagnostics/inference_conflicts/functions/generic_params.rs
@@ -13,7 +13,7 @@ choose_box<T> = (left: T, box: Box<T>) T {
 }
 
 main = () i32 {
-    box = Box<str> { value: "bad" }
+    box = Box<StaticString> { value: "bad" }
     choose_box(1, box)
 }
 "#,
@@ -21,7 +21,7 @@ main = () i32 {
 
     assert!(
         errors.iter().any(|d| d.message.contains(
-            "conflicting inferred type argument `T` for generic function `choose_box`: inferred `i32` and `str`"
+            "conflicting inferred type argument `T` for generic function `choose_box`: inferred `i32` and `StaticString`"
         )),
         "expected generic function struct inference conflict diagnostic, got {errors:?}"
     );
@@ -40,7 +40,7 @@ choose_option<T> = (left: T, value: Option<T>) T {
 }
 
 main = () i32 {
-    value = Option<str>.Some("bad")
+    value = Option<StaticString>.Some("bad")
     choose_option(1, value)
 }
 "#,
@@ -48,7 +48,7 @@ main = () i32 {
 
     assert!(
         errors.iter().any(|d| d.message.contains(
-            "conflicting inferred type argument `T` for generic function `choose_option`: inferred `i32` and `str`"
+            "conflicting inferred type argument `T` for generic function `choose_option`: inferred `i32` and `StaticString`"
         )),
         "expected generic function enum inference conflict diagnostic, got {errors:?}"
     );

--- a/tests/generic_diagnostics/inference_conflicts/methods/compound_params.rs
+++ b/tests/generic_diagnostics/inference_conflicts/methods/compound_params.rs
@@ -14,7 +14,7 @@ Box.choose_with<T> = (self: Box<T>, mapper: (T) T) T {
 
 main = () i32 {
     box = Box<i32> { value: 1 }
-    mapper = (value: str) str {
+    mapper = (value: StaticString) StaticString {
         value
     }
     box.choose_with(mapper)
@@ -24,7 +24,7 @@ main = () i32 {
 
     assert!(
         errors.iter().any(|d| d.message.contains(
-            "conflicting inferred type argument `T` for generic method `Box.choose_with`: inferred `i32` and `str`"
+            "conflicting inferred type argument `T` for generic method `Box.choose_with`: inferred `i32` and `StaticString`"
         )),
         "expected generic method function-type inference conflict diagnostic, got {errors:?}"
     );
@@ -52,7 +52,7 @@ main = () i32 {
 
     assert!(
         errors.iter().any(|d| d.message.contains(
-            "conflicting inferred type argument `T` for generic method `Box.choose_array`: inferred `i32` and `str`"
+            "conflicting inferred type argument `T` for generic method `Box.choose_array`: inferred `i32` and `StaticString`"
         )),
         "expected generic method array-type inference conflict diagnostic, got {errors:?}"
     );
@@ -72,7 +72,7 @@ Box.choose_raw<T> = (self: Box<T>, ptr: RawPtr<T>) T {
 
 main = () i32 {
     box = Box<i32> { value: 1 }
-    ptr = cast("bad", RawPtr<str>)
+    ptr = cast("bad", RawPtr<StaticString>)
     box.choose_raw(ptr)
 }
 "#,
@@ -80,7 +80,7 @@ main = () i32 {
 
     assert!(
         errors.iter().any(|d| d.message.contains(
-            "conflicting inferred type argument `T` for generic method `Box.choose_raw`: inferred `i32` and `str`"
+            "conflicting inferred type argument `T` for generic method `Box.choose_raw`: inferred `i32` and `StaticString`"
         )),
         "expected generic method raw-pointer inference conflict diagnostic, got {errors:?}"
     );
@@ -100,7 +100,7 @@ Box.choose_ptr<T> = (self: Box<T>, ptr: Ptr<T>) T {
 
 main = () i32 {
     box = Box<i32> { value: 1 }
-    ptr = cast("bad", Ptr<str>)
+    ptr = cast("bad", Ptr<StaticString>)
     box.choose_ptr(ptr)
 }
 "#,
@@ -108,7 +108,7 @@ main = () i32 {
 
     assert!(
         errors.iter().any(|d| d.message.contains(
-            "conflicting inferred type argument `T` for generic method `Box.choose_ptr`: inferred `i32` and `str`"
+            "conflicting inferred type argument `T` for generic method `Box.choose_ptr`: inferred `i32` and `StaticString`"
         )),
         "expected generic method pointer inference conflict diagnostic, got {errors:?}"
     );
@@ -128,7 +128,7 @@ Box.choose_mut_ptr<T> = (self: Box<T>, ptr: MutPtr<T>) T {
 
 main = () i32 {
     box = Box<i32> { value: 1 }
-    ptr = cast("bad", MutPtr<str>)
+    ptr = cast("bad", MutPtr<StaticString>)
     box.choose_mut_ptr(ptr)
 }
 "#,
@@ -136,7 +136,7 @@ main = () i32 {
 
     assert!(
         errors.iter().any(|d| d.message.contains(
-            "conflicting inferred type argument `T` for generic method `Box.choose_mut_ptr`: inferred `i32` and `str`"
+            "conflicting inferred type argument `T` for generic method `Box.choose_mut_ptr`: inferred `i32` and `StaticString`"
         )),
         "expected generic method mutable pointer inference conflict diagnostic, got {errors:?}"
     );
@@ -156,7 +156,7 @@ Box.choose_slice<T> = (self: Box<T>, items: Slice<T>) T {
 
 main = () i32 {
     box = Box<i32> { value: 1 }
-    items = cast("bad", Slice<str>)
+    items = cast("bad", Slice<StaticString>)
     box.choose_slice(items)
 }
 "#,
@@ -164,7 +164,7 @@ main = () i32 {
 
     assert!(
         errors.iter().any(|d| d.message.contains(
-            "conflicting inferred type argument `T` for generic method `Box.choose_slice`: inferred `i32` and `str`"
+            "conflicting inferred type argument `T` for generic method `Box.choose_slice`: inferred `i32` and `StaticString`"
         )),
         "expected generic method slice inference conflict diagnostic, got {errors:?}"
     );

--- a/tests/generic_diagnostics/inference_conflicts/methods/generic_params.rs
+++ b/tests/generic_diagnostics/inference_conflicts/methods/generic_params.rs
@@ -18,7 +18,7 @@ Holder.choose_box<T> = (self: Holder, left: T, box: Box<T>) T {
 
 main = () i32 {
     holder = Holder { value: 0 }
-    box = Box<str> { value: "bad" }
+    box = Box<StaticString> { value: "bad" }
     holder.choose_box(1, box)
 }
 "#,
@@ -26,7 +26,7 @@ main = () i32 {
 
     assert!(
         errors.iter().any(|d| d.message.contains(
-            "conflicting inferred type argument `T` for generic method `Holder.choose_box`: inferred `i32` and `str`"
+            "conflicting inferred type argument `T` for generic method `Holder.choose_box`: inferred `i32` and `StaticString`"
         )),
         "expected generic method struct inference conflict diagnostic, got {errors:?}"
     );
@@ -50,7 +50,7 @@ Holder.choose_option<T> = (self: Holder, left: T, value: Option<T>) T {
 
 main = () i32 {
     holder = Holder { value: 0 }
-    value = Option<str>.Some("bad")
+    value = Option<StaticString>.Some("bad")
     holder.choose_option(1, value)
 }
 "#,
@@ -58,7 +58,7 @@ main = () i32 {
 
     assert!(
         errors.iter().any(|d| d.message.contains(
-            "conflicting inferred type argument `T` for generic method `Holder.choose_option`: inferred `i32` and `str`"
+            "conflicting inferred type argument `T` for generic method `Holder.choose_option`: inferred `i32` and `StaticString`"
         )),
         "expected generic method enum inference conflict diagnostic, got {errors:?}"
     );

--- a/tests/generic_diagnostics/inference_conflicts/methods/receiver.rs
+++ b/tests/generic_diagnostics/inference_conflicts/methods/receiver.rs
@@ -21,7 +21,7 @@ main = () i32 {
 
     assert!(
         errors.iter().any(|d| d.message.contains(
-            "conflicting inferred type argument `T` for generic method `Box.choose`: inferred `i32` and `str`"
+            "conflicting inferred type argument `T` for generic method `Box.choose`: inferred `i32` and `StaticString`"
         )),
         "expected generic method inference conflict diagnostic, got {errors:?}"
     );
@@ -58,7 +58,7 @@ main = () i32 {
 
     assert!(
         errors.iter().any(|d| d.message.contains(
-            "conflicting inferred type argument `T` for generic method `Box.replace`: inferred `i32` and `str`"
+            "conflicting inferred type argument `T` for generic method `Box.replace`: inferred `i32` and `StaticString`"
         )),
         "expected generic method receiver inference conflict diagnostic, got {errors:?}"
     );
@@ -79,7 +79,7 @@ Result.unwrap_or<T, E> = (self: Self, fallback: T) T {
 }
 
 main = () i32 {
-    value = Result<i32, str>.Ok(1)
+    value = Result<i32, StaticString>.Ok(1)
     value.unwrap_or("bad")
 }
 "#,
@@ -87,7 +87,7 @@ main = () i32 {
 
     assert!(
         errors.iter().any(|d| d.message.contains(
-            "conflicting inferred type argument `T` for generic method `Result.unwrap_or`: inferred `i32` and `str`"
+            "conflicting inferred type argument `T` for generic method `Result.unwrap_or`: inferred `i32` and `StaticString`"
         )),
         "expected generic Result enum method receiver inference conflict diagnostic, got {errors:?}"
     );

--- a/tests/generic_diagnostics/method_type_args.rs
+++ b/tests/generic_diagnostics/method_type_args.rs
@@ -86,7 +86,7 @@ Box.get<T> = (self: Box<T>) T {
 
 main = () i32 {
     box = Box<i32> { value: 1 }
-    box.get<i32, str>()
+    box.get<i32, StaticString>()
 }
 "#,
     );

--- a/tests/generic_diagnostics/method_type_args/enum_methods.rs
+++ b/tests/generic_diagnostics/method_type_args/enum_methods.rs
@@ -16,7 +16,7 @@ Option.unwrap_or<T> = (self: Self, fallback: T) T {
 
 main = () i32 {
     value = Option<i32>.Some(1)
-    value.unwrap_or<i32, str>(0)
+    value.unwrap_or<i32, StaticString>(0)
 }
 "#,
     );
@@ -48,7 +48,7 @@ Result.unwrap_or<T, E> = (self: Self, fallback: T) T {
 }
 
 main = () i32 {
-    value = Result<i32, str>.Ok(1)
+    value = Result<i32, StaticString>.Ok(1)
     value.unwrap_or<i32>(0)
 }
 "#,

--- a/tests/integration/cli_build/diagnostics/dedup.rs
+++ b/tests/integration/cli_build/diagnostics/dedup.rs
@@ -24,7 +24,7 @@ pub Point: {
         r#"
 { Json, Point } = traits
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 
 main = () i32 {
     0
@@ -46,7 +46,7 @@ main = () i32 {
     );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let diagnostic = "type `Point` does not implement required behavior `Json_str`";
+    let diagnostic = "type `Point` does not implement required behavior `Json_StaticString`";
     assert!(
         stderr.contains(diagnostic),
         "expected missing behavior diagnostic, stderr={stderr}"

--- a/tests/integration/frontend_diagnostics.rs
+++ b/tests/integration/frontend_diagnostics.rs
@@ -106,7 +106,7 @@ pub Result.unwrap_or<T, E> = (self: Self, fallback: T) T {
 { Result } = result
 
 main = () i32 {
-    value = Result<i32, str>.Ok(1)
+    value = Result<i32, StaticString>.Ok(1)
     value.unwrap_or<i32>(0)
 }
 "#,
@@ -209,8 +209,8 @@ pub Option<T>:
 { Box, Option } = types
 
 main = () i32 {
-    boxed = Box<i32, str> { value: 1 }
-    value = Option<i32, str>.Some(1)
+    boxed = Box<i32, StaticString> { value: 1 }
+    value = Option<i32, StaticString>.Some(1)
     boxed.value
 }
 "#,

--- a/tests/integration/frontend_diagnostics/behavior_extends/inherited_requirements.rs
+++ b/tests/integration/frontend_diagnostics/behavior_extends/inherited_requirements.rs
@@ -12,10 +12,10 @@ pub Json<T>: behavior {
 }
 
 pub PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
-PrettyJson.extends(Json<str>)
+PrettyJson.extends(Json<StaticString>)
 "#,
     )
     .expect("write traits module");
@@ -31,7 +31,7 @@ Point: {
 }
 
 Point.implements(PrettyJson) {
-    pretty = (value: Point) str {
+    pretty = (value: Point) StaticString {
         "point"
     }
 }
@@ -78,10 +78,10 @@ pub Json<T>: behavior {
 { Json } = base
 
 pub PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
-PrettyJson.extends(Json<str>)
+PrettyJson.extends(Json<StaticString>)
 "#,
     )
     .expect("write traits module");
@@ -97,7 +97,7 @@ Point: {
 }
 
 Point.implements(PrettyJson) {
-    pretty = (value: Point) str {
+    pretty = (value: Point) StaticString {
         "point"
     }
 }
@@ -135,14 +135,14 @@ pub Json<T>: behavior {
 }
 
 pub PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
 pub FancyJson: behavior {
-    fancy: (Self) str
+    fancy: (Self) StaticString
 }
 
-PrettyJson.extends(Json<str>)
+PrettyJson.extends(Json<StaticString>)
 FancyJson.extends(PrettyJson)
 "#,
     )
@@ -159,11 +159,11 @@ Point: {
 }
 
 Point.implements(FancyJson) {
-    pretty = (value: Point) str {
+    pretty = (value: Point) StaticString {
         "pretty"
     }
 
-    fancy = (value: Point) str {
+    fancy = (value: Point) StaticString {
         "fancy"
     }
 }

--- a/tests/integration/frontend_diagnostics/behavior_extends/overlaps.rs
+++ b/tests/integration/frontend_diagnostics/behavior_extends/overlaps.rs
@@ -12,10 +12,10 @@ pub Json<T>: behavior {
 }
 
 pub PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
-PrettyJson.extends(Json<str>)
+PrettyJson.extends(Json<StaticString>)
 "#,
     )
     .expect("write traits module");
@@ -30,18 +30,18 @@ Point: {
     x: i32
 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str {
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString {
         "point"
     }
 }
 
 Point.implements(PrettyJson) {
-    encode = (value: Point) str {
+    encode = (value: Point) StaticString {
         "point"
     }
 
-    pretty = (value: Point) str {
+    pretty = (value: Point) StaticString {
         "pretty"
     }
 }
@@ -63,7 +63,7 @@ main = () i32 {
 
     assert!(
         message.contains(
-            "overlapping implementations of behaviors `Json_str` and `PrettyJson` for type `Point`"
+            "overlapping implementations of behaviors `Json_StaticString` and `PrettyJson` for type `Point`"
         ),
         "expected imported behavior impl overlap diagnostic, panic={message}"
     );
@@ -81,14 +81,14 @@ pub Json<T>: behavior {
 }
 
 pub CompactJson: behavior {
-    compact: (Self) str
+    compact: (Self) StaticString
 }
 
 pub PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
-CompactJson.extends(Json<str>)
+CompactJson.extends(Json<StaticString>)
 PrettyJson.extends(CompactJson)
 "#,
     )
@@ -104,22 +104,22 @@ Point: {
     x: i32
 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str {
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString {
         "point"
     }
 }
 
 Point.implements(PrettyJson) {
-    encode = (value: Point) str {
+    encode = (value: Point) StaticString {
         "point"
     }
 
-    compact = (value: Point) str {
+    compact = (value: Point) StaticString {
         "compact"
     }
 
-    pretty = (value: Point) str {
+    pretty = (value: Point) StaticString {
         "pretty"
     }
 }
@@ -141,7 +141,7 @@ main = () i32 {
 
     assert!(
         message.contains(
-            "overlapping implementations of behaviors `Json_str` and `PrettyJson` for type `Point`"
+            "overlapping implementations of behaviors `Json_StaticString` and `PrettyJson` for type `Point`"
         ),
         "expected imported transitive behavior impl overlap diagnostic, panic={message}"
     );
@@ -171,14 +171,14 @@ Point: {
     x: i32
 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str {
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString {
         "point"
     }
 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str {
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString {
         "point-again"
     }
 }
@@ -199,7 +199,7 @@ main = () i32 {
         .unwrap_or("<non-string panic>");
 
     assert!(
-        message.contains("duplicate behavior implementation `Json<str>` for `Point`"),
+        message.contains("duplicate behavior implementation `Json<StaticString>` for `Point`"),
         "expected imported duplicate behavior impl diagnostic, panic={message}"
     );
 }

--- a/tests/integration/frontend_diagnostics/generic_behavior_imports.rs
+++ b/tests/integration/frontend_diagnostics/generic_behavior_imports.rs
@@ -24,7 +24,7 @@ Point: {
     x: i32
 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 
 main = () i32 {
     0
@@ -42,7 +42,7 @@ main = () i32 {
         .unwrap_or("<non-string panic>");
 
     assert!(
-        message.contains("type `Point` does not implement required behavior `Json_str`"),
+        message.contains("type `Point` does not implement required behavior `Json_StaticString`"),
         "expected imported generic behavior requires diagnostic, panic={message}"
     );
 }
@@ -72,7 +72,7 @@ Point: {
 }
 
 Point.implements(Json) {
-    encode = (value: Point) str {
+    encode = (value: Point) StaticString {
         "point"
     }
 }
@@ -119,7 +119,7 @@ pub Json<T>: behavior {
 { Json } = traits
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
 PrettyJson.extends(Json)
@@ -169,7 +169,7 @@ Point: {
     x: i32
 }
 
-Point.requires(Json<i32, str>)
+Point.requires(Json<i32, StaticString>)
 
 main = () i32 {
     0
@@ -212,7 +212,7 @@ pub Json<T>: behavior {
         r#"
 { Json } = traits
 
-encode<T: Json> = (value: T) str {
+encode<T: Json> = (value: T) StaticString {
     "encoded"
 }
 
@@ -261,14 +261,14 @@ Point: {
     x: i32
 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str {
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString {
         "point"
     }
 }
 
-Point.requires(Json<str>)
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
+Point.requires(Json<StaticString>)
 
 main = () i32 {
     0
@@ -286,7 +286,7 @@ main = () i32 {
         .unwrap_or("<non-string panic>");
 
     assert!(
-        message.contains("duplicate required behavior `Json<str>` for `Point`"),
+        message.contains("duplicate required behavior `Json<StaticString>` for `Point`"),
         "expected imported duplicate behavior requires diagnostic, panic={message}"
     );
 }

--- a/tests/integration/generic_specializations/behavior_bounds/imported_behavior_impls.rs
+++ b/tests/integration/generic_specializations/behavior_bounds/imported_behavior_impls.rs
@@ -5,10 +5,10 @@ fn imported_behavior_impl_specializations_do_not_emit_unspecialized_c_symbols() 
     let c_source = compile_to_c_with_generated_call_check(
         &test_dir().join("multi_file_imported_behavior_impl/main.zen"),
     );
-    assert!(c_source.contains("zen_str Point_encode__Json_str(Point value)"));
+    assert!(c_source.contains("zen_str Point_encode__Json_StaticString(Point value)"));
     assert!(c_source.contains("zen_str encode_Point(Point value)"));
-    assert!(c_source.contains("Point_encode__Json_str(value)"));
-    assert_c_call_resolves_to_definition(&c_source, "Point_encode__Json_str");
+    assert!(c_source.contains("Point_encode__Json_StaticString(value)"));
+    assert_c_call_resolves_to_definition(&c_source, "Point_encode__Json_StaticString");
     assert_c_call_resolves_to_definition(&c_source, "encode_Point");
     assert!(!c_source.contains("T_encode"));
 
@@ -62,10 +62,10 @@ fn imported_behavior_requires_do_not_emit_unspecialized_c_symbols() {
     let c_source = compile_to_c_with_generated_call_check(
         &test_dir().join("multi_file_imported_behavior_requires/main.zen"),
     );
-    assert!(c_source.contains("zen_str Point_encode__Json_str(Point value)"));
+    assert!(c_source.contains("zen_str Point_encode__Json_StaticString(Point value)"));
     assert!(c_source.contains("zen_str encode_Point(Point value)"));
-    assert!(c_source.contains("Point_encode__Json_str(value)"));
-    assert_c_call_resolves_to_definition(&c_source, "Point_encode__Json_str");
+    assert!(c_source.contains("Point_encode__Json_StaticString(value)"));
+    assert_c_call_resolves_to_definition(&c_source, "Point_encode__Json_StaticString");
     assert_c_call_resolves_to_definition(&c_source, "encode_Point");
     assert!(!c_source.contains("T_encode"));
 

--- a/tests/integration/generic_specializations/behavior_bounds/local_and_defaults.rs
+++ b/tests/integration/generic_specializations/behavior_bounds/local_and_defaults.rs
@@ -21,17 +21,17 @@ fn local_behavior_bound_specializations_do_not_emit_unspecialized_c_symbols() {
     let c_source = compile_to_c_with_generated_call_check(
         &test_dir().join("behavior_distinct_generic_specialization_dispatch.zen"),
     );
-    assert!(c_source.contains("zen_str Point_encode__Json_str(Point value)"));
+    assert!(c_source.contains("zen_str Point_encode__Json_StaticString(Point value)"));
     assert!(c_source.contains("int32_t Point_encode__Json_i32(Point value)"));
     assert!(c_source.contains("zen_str encode_str_Point(Point value)"));
     assert!(c_source.contains("int32_t encode_i32_Point(Point value)"));
-    assert!(c_source.contains("Point_encode__Json_str(value)"));
+    assert!(c_source.contains("Point_encode__Json_StaticString(value)"));
     assert!(c_source.contains("Point_encode__Json_i32(value)"));
-    assert_c_call_resolves_to_definition(&c_source, "Point_encode__Json_str");
+    assert_c_call_resolves_to_definition(&c_source, "Point_encode__Json_StaticString");
     assert_c_call_resolves_to_definition(&c_source, "Point_encode__Json_i32");
     assert_c_call_resolves_to_definition(&c_source, "encode_str_Point");
     assert_c_call_resolves_to_definition(&c_source, "encode_i32_Point");
-    assert_c_function_definition_count(&c_source, "Point_encode__Json_str", 1);
+    assert_c_function_definition_count(&c_source, "Point_encode__Json_StaticString", 1);
     assert_c_function_definition_count(&c_source, "Point_encode__Json_i32", 1);
     assert!(!c_source.contains("Json_T"));
     assert!(!c_source.contains("T_encode"));

--- a/tests/integration/generic_specializations/enum_generated_c.rs
+++ b/tests/integration/generic_specializations/enum_generated_c.rs
@@ -53,23 +53,26 @@ fn enum_specializations_do_not_emit_unspecialized_c_symbols() {
 
     let c_source =
         compile_to_c_with_generated_call_check(&test_dir().join("generic_result_enum.zen"));
-    assert!(c_source.contains("typedef struct Result_i32_str Result_i32_str;"));
-    assert!(c_source.contains("int32_t unwrap_or_i32_str(Result_i32_str value, int32_t fallback)"));
-    assert!(c_source.contains("Result_i32_str_Err"));
-    assert!(c_source.contains("unwrap_or_i32_str(err, 9LL)"));
-    assert_c_call_resolves_to_definition(&c_source, "unwrap_or_i32_str");
+    assert!(c_source.contains("typedef struct Result_i32_StaticString Result_i32_StaticString;"));
+    assert!(c_source.contains(
+        "int32_t unwrap_or_i32_StaticString(Result_i32_StaticString value, int32_t fallback)"
+    ));
+    assert!(c_source.contains("Result_i32_StaticString_Err"));
+    assert!(c_source.contains("unwrap_or_i32_StaticString(err, 9LL)"));
+    assert_c_call_resolves_to_definition(&c_source, "unwrap_or_i32_StaticString");
     assert!(!c_source.contains("Result_T"));
     assert!(!c_source.contains("T unwrap_or"));
     assert!(!c_source.contains("unwrap_or(err"));
 
     let c_source =
         compile_to_c_with_generated_call_check(&test_dir().join("generic_result_enum_method.zen"));
-    assert!(c_source.contains("typedef struct Result_i32_str Result_i32_str;"));
-    assert!(c_source
-        .contains("int32_t Result_unwrap_or_i32_str(Result_i32_str self, int32_t fallback)"));
-    assert!(c_source.contains("Result_unwrap_or_i32_str(ok, 0LL)"));
-    assert!(c_source.contains("Result_unwrap_or_i32_str(err, 34LL)"));
-    assert_c_call_resolves_to_definition(&c_source, "Result_unwrap_or_i32_str");
+    assert!(c_source.contains("typedef struct Result_i32_StaticString Result_i32_StaticString;"));
+    assert!(c_source.contains(
+        "int32_t Result_unwrap_or_i32_StaticString(Result_i32_StaticString self, int32_t fallback)"
+    ));
+    assert!(c_source.contains("Result_unwrap_or_i32_StaticString(ok, 0LL)"));
+    assert!(c_source.contains("Result_unwrap_or_i32_StaticString(err, 34LL)"));
+    assert_c_call_resolves_to_definition(&c_source, "Result_unwrap_or_i32_StaticString");
     assert!(!c_source.contains("Result_T"));
     assert!(!c_source.contains("T Result_unwrap_or"));
     assert!(!c_source.contains("Result_unwrap_or(err"));
@@ -77,21 +80,22 @@ fn enum_specializations_do_not_emit_unspecialized_c_symbols() {
     let c_source = compile_to_c_with_generated_call_check(
         &test_dir().join("generic_result_enum_multi_specialization.zen"),
     );
-    assert!(c_source.contains("typedef struct Result_i32_str Result_i32_str;"));
-    assert!(c_source.contains("typedef struct Result_bool_str Result_bool_str;"));
-    assert!(c_source
-        .contains("int32_t Result_unwrap_or_i32_str(Result_i32_str self, int32_t fallback)"));
-    assert!(
-        c_source.contains("bool Result_unwrap_or_bool_str(Result_bool_str self, bool fallback)")
-    );
-    assert!(c_source.contains("Result_unwrap_or_i32_str(ok_int, 0LL)"));
-    assert!(c_source.contains("Result_unwrap_or_i32_str(err_int, 34LL)"));
-    assert!(c_source.contains("Result_unwrap_or_bool_str(ok_bool, true)"));
-    assert!(c_source.contains("Result_unwrap_or_bool_str(err_bool, true)"));
-    assert_c_call_resolves_to_definition(&c_source, "Result_unwrap_or_i32_str");
-    assert_c_call_resolves_to_definition(&c_source, "Result_unwrap_or_bool_str");
-    assert_c_function_definition_count(&c_source, "Result_unwrap_or_i32_str", 1);
-    assert_c_function_definition_count(&c_source, "Result_unwrap_or_bool_str", 1);
+    assert!(c_source.contains("typedef struct Result_i32_StaticString Result_i32_StaticString;"));
+    assert!(c_source.contains("typedef struct Result_bool_StaticString Result_bool_StaticString;"));
+    assert!(c_source.contains(
+        "int32_t Result_unwrap_or_i32_StaticString(Result_i32_StaticString self, int32_t fallback)"
+    ));
+    assert!(c_source.contains(
+        "bool Result_unwrap_or_bool_StaticString(Result_bool_StaticString self, bool fallback)"
+    ));
+    assert!(c_source.contains("Result_unwrap_or_i32_StaticString(ok_int, 0LL)"));
+    assert!(c_source.contains("Result_unwrap_or_i32_StaticString(err_int, 34LL)"));
+    assert!(c_source.contains("Result_unwrap_or_bool_StaticString(ok_bool, true)"));
+    assert!(c_source.contains("Result_unwrap_or_bool_StaticString(err_bool, true)"));
+    assert_c_call_resolves_to_definition(&c_source, "Result_unwrap_or_i32_StaticString");
+    assert_c_call_resolves_to_definition(&c_source, "Result_unwrap_or_bool_StaticString");
+    assert_c_function_definition_count(&c_source, "Result_unwrap_or_i32_StaticString", 1);
+    assert_c_function_definition_count(&c_source, "Result_unwrap_or_bool_StaticString", 1);
     assert!(!c_source.contains("Result_T"));
     assert!(!c_source.contains("T Result_unwrap_or"));
     assert!(!c_source.contains("Result_unwrap_or(err"));
@@ -99,13 +103,14 @@ fn enum_specializations_do_not_emit_unspecialized_c_symbols() {
     let c_source =
         compile_to_c_with_generated_call_check(&test_dir().join("generic_nested_result_enum.zen"));
     assert!(c_source.contains("typedef struct Option_i32 Option_i32;"));
-    assert!(c_source.contains("typedef struct Result_Option_i32_str Result_Option_i32_str;"));
+    assert!(c_source
+        .contains("typedef struct Result_Option_i32_StaticString Result_Option_i32_StaticString;"));
     assert!(c_source.contains(
-        "Option_i32 unwrap_result_Option_i32_str(Result_Option_i32_str value, Option_i32 fallback)"
+        "Option_i32 unwrap_result_Option_i32_StaticString(Result_Option_i32_StaticString value, Option_i32 fallback)"
     ));
-    assert!(c_source.contains("unwrap_result_Option_i32_str(ok,"));
+    assert!(c_source.contains("unwrap_result_Option_i32_StaticString(ok,"));
     assert!(c_source.contains("unwrap_option_i32(some, 0LL)"));
-    assert_c_call_resolves_to_definition(&c_source, "unwrap_result_Option_i32_str");
+    assert_c_call_resolves_to_definition(&c_source, "unwrap_result_Option_i32_StaticString");
     assert_c_call_resolves_to_definition(&c_source, "unwrap_option_i32");
     assert!(!c_source.contains("Result_T"));
     assert!(!c_source.contains("Option_T"));

--- a/tests/integration/generic_specializations/method_worklist_generated_c.rs
+++ b/tests/integration/generic_specializations/method_worklist_generated_c.rs
@@ -45,13 +45,14 @@ fn method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols() {
     let c_source = compile_to_c_with_generated_call_check(
         &test_dir().join("generic_method_nested_result.zen"),
     );
-    assert!(c_source.contains("typedef struct Result_Option_i32_str Result_Option_i32_str;"));
-    assert!(c_source.contains("Result_Option_i32_str Box_wrap_result_i32(Box_i32 self)"));
+    assert!(c_source
+        .contains("typedef struct Result_Option_i32_StaticString Result_Option_i32_StaticString;"));
+    assert!(c_source.contains("Result_Option_i32_StaticString Box_wrap_result_i32(Box_i32 self)"));
     assert!(c_source.contains("Box_wrap_result_i32(box)"));
-    assert!(c_source.contains("unwrap_result_Option_i32_str(wrapped,"));
+    assert!(c_source.contains("unwrap_result_Option_i32_StaticString(wrapped,"));
     assert!(c_source.contains("unwrap_option_i32(some, 0LL)"));
     assert_c_call_resolves_to_definition(&c_source, "Box_wrap_result_i32");
-    assert_c_call_resolves_to_definition(&c_source, "unwrap_result_Option_i32_str");
+    assert_c_call_resolves_to_definition(&c_source, "unwrap_result_Option_i32_StaticString");
     assert_c_call_resolves_to_definition(&c_source, "unwrap_option_i32");
     assert!(!c_source.contains("Result_T"));
     assert!(!c_source.contains("Option_T"));
@@ -82,11 +83,11 @@ fn method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols() {
 
     let c_source = compile_to_c_with_generated_call_check(&test_dir().join("generic_vec.zen"));
     assert!(c_source.contains("int32_t Vec_len_i32(Vec_i32 self)"));
-    assert!(c_source.contains("int32_t Vec_len_str(Vec_str self)"));
+    assert!(c_source.contains("int32_t Vec_len_StaticString(Vec_StaticString self)"));
     assert!(c_source.contains("Vec_len_i32(ints)"));
-    assert!(c_source.contains("Vec_len_str(words)"));
+    assert!(c_source.contains("Vec_len_StaticString(words)"));
     assert_c_call_resolves_to_definition(&c_source, "Vec_len_i32");
-    assert_c_call_resolves_to_definition(&c_source, "Vec_len_str");
+    assert_c_call_resolves_to_definition(&c_source, "Vec_len_StaticString");
     assert!(!c_source.contains("Vec_T"));
     assert!(!c_source.contains("T Vec_len"));
 

--- a/tests/integration/generic_specializations/multifile_generated_c/enum_dependencies.rs
+++ b/tests/integration/generic_specializations/multifile_generated_c/enum_dependencies.rs
@@ -5,15 +5,15 @@ fn multi_file_generic_enum_specializations_do_not_emit_unspecialized_c_symbols()
     let c_source =
         compile_to_c_with_generated_call_check(&test_dir().join("multi_file_generic/main.zen"));
     assert!(c_source.contains("typedef struct Option_i32 Option_i32;"));
-    assert!(c_source.contains("typedef struct Result_i32_str Result_i32_str;"));
+    assert!(c_source.contains("typedef struct Result_i32_StaticString Result_i32_StaticString;"));
     assert!(c_source.contains("int32_t unwrap_option_i32(Option_i32 value, int32_t fallback)"));
-    assert!(
-        c_source.contains("int32_t unwrap_result_i32_str(Result_i32_str value, int32_t fallback)")
-    );
+    assert!(c_source.contains(
+        "int32_t unwrap_result_i32_StaticString(Result_i32_StaticString value, int32_t fallback)"
+    ));
     assert!(c_source.contains("unwrap_option_i32(some, 0LL)"));
-    assert!(c_source.contains("unwrap_result_i32_str(err, 9LL)"));
+    assert!(c_source.contains("unwrap_result_i32_StaticString(err, 9LL)"));
     assert_c_call_resolves_to_definition(&c_source, "unwrap_option_i32");
-    assert_c_call_resolves_to_definition(&c_source, "unwrap_result_i32_str");
+    assert_c_call_resolves_to_definition(&c_source, "unwrap_result_i32_StaticString");
     assert!(!c_source.contains("Option_T"));
     assert!(!c_source.contains("Result_T"));
     assert!(!c_source.contains("T unwrap_option"));
@@ -36,12 +36,13 @@ fn multi_file_generic_enum_specializations_do_not_emit_unspecialized_c_symbols()
     let c_source = compile_to_c_with_generated_call_check(
         &test_dir().join("multi_file_generic_result_enum_method/main.zen"),
     );
-    assert!(c_source.contains("typedef struct Result_i32_str Result_i32_str;"));
-    assert!(c_source
-        .contains("int32_t Result_unwrap_or_i32_str(Result_i32_str self, int32_t fallback)"));
-    assert!(c_source.contains("Result_unwrap_or_i32_str(ok, 0LL)"));
-    assert!(c_source.contains("Result_unwrap_or_i32_str(err, 144LL)"));
-    assert_c_call_resolves_to_definition(&c_source, "Result_unwrap_or_i32_str");
+    assert!(c_source.contains("typedef struct Result_i32_StaticString Result_i32_StaticString;"));
+    assert!(c_source.contains(
+        "int32_t Result_unwrap_or_i32_StaticString(Result_i32_StaticString self, int32_t fallback)"
+    ));
+    assert!(c_source.contains("Result_unwrap_or_i32_StaticString(ok, 0LL)"));
+    assert!(c_source.contains("Result_unwrap_or_i32_StaticString(err, 144LL)"));
+    assert_c_call_resolves_to_definition(&c_source, "Result_unwrap_or_i32_StaticString");
     assert!(!c_source.contains("Result_T"));
     assert!(!c_source.contains("T Result_unwrap_or"));
     assert!(!c_source.contains("Result_unwrap_or(err"));
@@ -49,21 +50,22 @@ fn multi_file_generic_enum_specializations_do_not_emit_unspecialized_c_symbols()
     let c_source = compile_to_c_with_generated_call_check(
         &test_dir().join("multi_file_generic_result_enum_multi_specialization/main.zen"),
     );
-    assert!(c_source.contains("typedef struct Result_i32_str Result_i32_str;"));
-    assert!(c_source.contains("typedef struct Result_bool_str Result_bool_str;"));
-    assert!(c_source
-        .contains("int32_t Result_unwrap_or_i32_str(Result_i32_str self, int32_t fallback)"));
-    assert!(
-        c_source.contains("bool Result_unwrap_or_bool_str(Result_bool_str self, bool fallback)")
-    );
-    assert!(c_source.contains("Result_unwrap_or_i32_str(ok_int, 0LL)"));
-    assert!(c_source.contains("Result_unwrap_or_i32_str(err_int, 144LL)"));
-    assert!(c_source.contains("Result_unwrap_or_bool_str(ok_bool, true)"));
-    assert!(c_source.contains("Result_unwrap_or_bool_str(err_bool, true)"));
-    assert_c_call_resolves_to_definition(&c_source, "Result_unwrap_or_i32_str");
-    assert_c_call_resolves_to_definition(&c_source, "Result_unwrap_or_bool_str");
-    assert_c_function_definition_count(&c_source, "Result_unwrap_or_i32_str", 1);
-    assert_c_function_definition_count(&c_source, "Result_unwrap_or_bool_str", 1);
+    assert!(c_source.contains("typedef struct Result_i32_StaticString Result_i32_StaticString;"));
+    assert!(c_source.contains("typedef struct Result_bool_StaticString Result_bool_StaticString;"));
+    assert!(c_source.contains(
+        "int32_t Result_unwrap_or_i32_StaticString(Result_i32_StaticString self, int32_t fallback)"
+    ));
+    assert!(c_source.contains(
+        "bool Result_unwrap_or_bool_StaticString(Result_bool_StaticString self, bool fallback)"
+    ));
+    assert!(c_source.contains("Result_unwrap_or_i32_StaticString(ok_int, 0LL)"));
+    assert!(c_source.contains("Result_unwrap_or_i32_StaticString(err_int, 144LL)"));
+    assert!(c_source.contains("Result_unwrap_or_bool_StaticString(ok_bool, true)"));
+    assert!(c_source.contains("Result_unwrap_or_bool_StaticString(err_bool, true)"));
+    assert_c_call_resolves_to_definition(&c_source, "Result_unwrap_or_i32_StaticString");
+    assert_c_call_resolves_to_definition(&c_source, "Result_unwrap_or_bool_StaticString");
+    assert_c_function_definition_count(&c_source, "Result_unwrap_or_i32_StaticString", 1);
+    assert_c_function_definition_count(&c_source, "Result_unwrap_or_bool_StaticString", 1);
     assert!(!c_source.contains("Result_T"));
     assert!(!c_source.contains("T Result_unwrap_or"));
     assert!(!c_source.contains("Result_unwrap_or(err"));

--- a/tests/integration/generic_specializations/multifile_generated_c/method_worklist_dependencies.rs
+++ b/tests/integration/generic_specializations/multifile_generated_c/method_worklist_dependencies.rs
@@ -140,8 +140,9 @@ fn multi_file_generic_method_and_worklist_specializations_do_not_emit_unspeciali
         &test_dir().join("multi_file_type_method_nested_result_dependency/main.zen"),
     );
     assert!(c_source.contains("typedef struct Option_i32 Option_i32;"));
-    assert!(c_source.contains("typedef struct Result_Option_i32_str Result_Option_i32_str;"));
-    assert!(c_source.contains("Result_Option_i32_str Box_wrap_result_i32(Box_i32 self)"));
+    assert!(c_source
+        .contains("typedef struct Result_Option_i32_StaticString Result_Option_i32_StaticString;"));
+    assert!(c_source.contains("Result_Option_i32_StaticString Box_wrap_result_i32(Box_i32 self)"));
     assert!(c_source.contains("Box_wrap_result_i32(box)"));
     assert_c_call_resolves_to_definition(&c_source, "Box_wrap_result_i32");
     assert!(!c_source.contains("Option_T"));

--- a/tests/integration/import_visibility_private_methods.rs
+++ b/tests/integration/import_visibility_private_methods.rs
@@ -56,7 +56,7 @@ fn imported_private_behavior_impl_methods_are_not_directly_visible() {
         &model_path,
         r#"
 Hidden: behavior {
-    reveal: (Self) str
+    reveal: (Self) StaticString
 }
 
 pub Point: {
@@ -64,7 +64,7 @@ pub Point: {
 }
 
 Point.implements(Hidden) {
-    reveal = (value: Point) str {
+    reveal = (value: Point) StaticString {
         "hidden"
     }
 }

--- a/tests/resolver_phase2/behavior_relations.rs
+++ b/tests/resolver_phase2/behavior_relations.rs
@@ -5,7 +5,7 @@ fn resolver_accepts_behavior_requires_known_type_and_behavior() {
     let program = parse_program(
         r#"
 Json: behavior {
-    stringify: (Self) str
+    stringify: (Self) StaticString
 }
 
 Point: { x: i32 }
@@ -24,7 +24,7 @@ fn resolver_rejects_duplicate_behavior_required_edges() {
     let program = parse_program(
         r#"
 Json: behavior {
-    stringify: (Self) str
+    stringify: (Self) StaticString
 }
 
 Point: { x: i32 }
@@ -69,11 +69,11 @@ fn resolver_accepts_behavior_extends_known_behaviors() {
     let program = parse_program(
         r#"
 Json: behavior {
-    stringify: (Self) str
+    stringify: (Self) StaticString
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
 PrettyJson.extends(Json)
@@ -90,11 +90,11 @@ fn resolver_rejects_duplicate_behavior_parent_edges() {
     let program = parse_program(
         r#"
 Json: behavior {
-    stringify: (Self) str
+    stringify: (Self) StaticString
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
 PrettyJson.extends(Json)

--- a/tests/resolver_phase2/core_symbols.rs
+++ b/tests/resolver_phase2/core_symbols.rs
@@ -128,7 +128,7 @@ distance = (point: Point) UnknownReturn { 0 }
 fn resolver_rejects_method_on_unknown_type() {
     let program = parse_program(
         r#"
-Missing.label = () str { "missing" }
+Missing.label = () StaticString { "missing" }
 "#,
     );
 

--- a/tests/resolver_phase2/generic_behavior_associations.rs
+++ b/tests/resolver_phase2/generic_behavior_associations.rs
@@ -5,10 +5,10 @@ fn resolver_records_behavior_parent_names() {
     let program = parse_program(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
 PrettyJson.extends(Json)
@@ -37,11 +37,11 @@ Json<T>: behavior {
 
 Point: { x: i32 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str { "point" }
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 "#,
     );
 
@@ -50,7 +50,7 @@ Point.requires(Json<str>)
 
     assert_eq!(
         point.behavior_impl_names.as_deref(),
-        Some(&["Json<str>".to_string()][..])
+        Some(&["Json<StaticString>".to_string()][..])
     );
     assert_eq!(
         point.behavior_impl_refs.as_deref(),
@@ -63,7 +63,7 @@ Point.requires(Json<str>)
     );
     assert_eq!(
         point.behavior_required_names.as_deref(),
-        Some(&["Json<str>".to_string()][..])
+        Some(&["Json<StaticString>".to_string()][..])
     );
     assert_eq!(
         point.behavior_required_refs.as_deref(),
@@ -84,10 +84,10 @@ Json<T>: behavior {
     encode: (Self) T
 }
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
-PrettyJson.extends(Json<str>)
+PrettyJson.extends(Json<StaticString>)
 "#,
     );
 
@@ -99,7 +99,7 @@ PrettyJson.extends(Json<str>)
             .expect("behavior symbol")
             .behavior_parent_names
             .as_deref(),
-        Some(&["Json<str>".to_string()][..])
+        Some(&["Json<StaticString>".to_string()][..])
     );
     assert_eq!(
         table

--- a/tests/resolver_phase2/generic_behavior_metadata.rs
+++ b/tests/resolver_phase2/generic_behavior_metadata.rs
@@ -10,7 +10,7 @@ fn resolver_records_type_and_behavior_generic_parameter_counts() {
 Box<T>: { value: T }
 Option<T>: Some(T), None
 Serializable<T>: behavior {
-    encode: (T) str
+    encode: (T) StaticString
 }
 "#,
     );
@@ -71,7 +71,7 @@ fn resolver_rejects_duplicate_type_parameter_names() {
 Box<T, T>: { value: T }
 Option<T, T>: Some(T), None
 Serializable<T, T>: behavior {
-    encode: (T) str
+    encode: (T) StaticString
 }
 identity<T, T> = (value: T) T { value }
 "#,
@@ -96,12 +96,12 @@ fn resolver_records_type_and_behavior_generic_bounds() {
     let program = parse_program(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
 Box<T: Json>: { value: T }
 Option<T: Json>: Some(T), None
 Serializable<T: Json>: behavior {
-    encode: (T) str
+    encode: (T) StaticString
 }
 "#,
     );

--- a/tests/resolver_phase2/generic_behavior_metadata/method_signatures.rs
+++ b/tests/resolver_phase2/generic_behavior_metadata/method_signatures.rs
@@ -5,7 +5,7 @@ fn resolver_records_behavior_method_signatures() {
     let program = parse_program(
         r#"
 Serializable: behavior {
-    encode: (Self, i32) str
+    encode: (Self, i32) StaticString
     reset: () void
 }
 "#,
@@ -24,7 +24,7 @@ Serializable: behavior {
                 (
                     "encode".to_string(),
                     vec!["Self".to_string(), "i32".to_string()],
-                    "str".to_string()
+                    "StaticString".to_string()
                 ),
                 ("reset".to_string(), vec![], "void".to_string())
             ][..]
@@ -37,8 +37,8 @@ fn resolver_rejects_duplicate_behavior_method_names() {
     let program = parse_program(
         r#"
 Serializable: behavior {
-    encode: (Self) str
-    encode: (Self, i32) str
+    encode: (Self) StaticString
+    encode: (Self, i32) StaticString
 }
 "#,
     );
@@ -61,7 +61,7 @@ fn resolver_rejects_duplicate_signature_parameter_names() {
     let program = parse_program(
         r#"
 Json: behavior {
-    encode: (value: Self, value: Self) str
+    encode: (value: Self, value: Self) StaticString
 }
 "#,
     );
@@ -190,7 +190,7 @@ fn resolver_records_behavior_default_method_body_locals() {
     let program = parse_program(
         r#"
 Json: behavior {
-    stringify: (Self) str {
+    stringify: (Self) StaticString {
         label = "json"
         label
     }

--- a/tests/resolver_phase2/impls.rs
+++ b/tests/resolver_phase2/impls.rs
@@ -5,13 +5,13 @@ fn resolver_records_behavior_impl_methods_as_value_symbols() {
     let program = parse_program(
         r#"
 Json: behavior {
-    stringify: (Self) str
+    stringify: (Self) StaticString
 }
 
 Point: { x: i32 }
 
 Point.implements(Json) {
-    stringify = (value: Point) str { "point" }
+    stringify = (value: Point) StaticString { "point" }
 }
 "#,
     );
@@ -31,7 +31,7 @@ Point.implements(Json) {
         method.parameter_type_names.as_deref(),
         Some(&["Point".to_string()][..])
     );
-    assert_eq!(method.return_type_name.as_deref(), Some("str"));
+    assert_eq!(method.return_type_name.as_deref(), Some("StaticString"));
     assert_eq!(method.type_parameter_count, Some(0));
     assert_eq!(method.type_parameter_names.as_deref(), Some(&[][..]));
     assert_eq!(method.type_parameter_bounds.as_deref(), Some(&[][..]));
@@ -182,13 +182,13 @@ fn resolver_records_behavior_impl_method_body_locals() {
     let program = parse_program(
         r#"
 Json: behavior {
-    stringify: (Self) str
+    stringify: (Self) StaticString
 }
 
 Point: { x: i32 }
 
 Point.implements(Json) {
-    stringify = (value: Point) str {
+    stringify = (value: Point) StaticString {
         label = "point"
         label
     }

--- a/tests/resolver_phase2/value_metadata.rs
+++ b/tests/resolver_phase2/value_metadata.rs
@@ -186,9 +186,9 @@ fn resolver_records_value_symbol_generic_bounds() {
     let program = parse_program(
         r#"
 Json: behavior {
-    encode: (Self) str
+    encode: (Self) StaticString
 }
-encode<T: Json> = (value: T) str { "encoded" }
+encode<T: Json> = (value: T) StaticString { "encoded" }
 "#,
     );
 

--- a/tests/zen/behavior_default_method_dispatch.zen
+++ b/tests/zen/behavior_default_method_dispatch.zen
@@ -1,7 +1,7 @@
 { io } = std
 
 Json: behavior {
-    to_json: (Self) str {
+    to_json: (Self) StaticString {
         "default"
     }
 }

--- a/tests/zen/behavior_distinct_generic_specialization_dispatch.zen
+++ b/tests/zen/behavior_distinct_generic_specialization_dispatch.zen
@@ -8,8 +8,8 @@ Json<T>: behavior {
     encode: (Self) T
 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str {
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString {
         "point"
     }
 }
@@ -20,7 +20,7 @@ Point.implements(Json<i32>) {
     }
 }
 
-encode_str<T: Json<str>> = (value: T) str {
+encode_str<T: Json<StaticString>> = (value: T) StaticString {
     value.encode()
 }
 

--- a/tests/zen/behavior_generic_default_method.zen
+++ b/tests/zen/behavior_generic_default_method.zen
@@ -10,7 +10,7 @@ Point: {
     x: i32
 }
 
-Point.implements(Json<str>) {
+Point.implements(Json<StaticString>) {
 }
 
 main = () i32 {

--- a/tests/zen/behavior_generic_parent_inheritance.zen
+++ b/tests/zen/behavior_generic_parent_inheritance.zen
@@ -9,22 +9,22 @@ Json<T>: behavior {
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
-PrettyJson.extends(Json<str>)
+PrettyJson.extends(Json<StaticString>)
 
 Point.implements(PrettyJson) {
-    encode = (value: Point) str {
+    encode = (value: Point) StaticString {
         "point"
     }
 
-    pretty = (value: Point) str {
+    pretty = (value: Point) StaticString {
         "pretty"
     }
 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 
 main = () i32 {
     point = Point { x: 1 }

--- a/tests/zen/behavior_inherited_default_method.zen
+++ b/tests/zen/behavior_inherited_default_method.zen
@@ -1,13 +1,13 @@
 { io } = std
 
 Json: behavior {
-    to_json: (Self) str {
+    to_json: (Self) StaticString {
         "default-json"
     }
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
 PrettyJson.extends(Json)
@@ -17,7 +17,7 @@ Point: {
 }
 
 Point.implements(PrettyJson) {
-    pretty = (value: Point) str {
+    pretty = (value: Point) StaticString {
         "pretty-point"
     }
 }

--- a/tests/zen/behavior_inherited_generic_dispatch.zen
+++ b/tests/zen/behavior_inherited_generic_dispatch.zen
@@ -1,11 +1,11 @@
 { io } = std
 
 Json: behavior {
-    to_json: (Self) str
+    to_json: (Self) StaticString
 }
 
 PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
 PrettyJson.extends(Json)
@@ -15,16 +15,16 @@ Point: {
 }
 
 Point.implements(PrettyJson) {
-    to_json = (value: Point) str {
+    to_json = (value: Point) StaticString {
         "point-json"
     }
 
-    pretty = (value: Point) str {
+    pretty = (value: Point) StaticString {
         "pretty-point"
     }
 }
 
-encode<T: Json> = (value: T) str {
+encode<T: Json> = (value: T) StaticString {
     value.to_json()
 }
 

--- a/tests/zen/behavior_json_explicit_impl.zen
+++ b/tests/zen/behavior_json_explicit_impl.zen
@@ -5,11 +5,11 @@ Point: {
 }
 
 Json: behavior {
-    to_json: (Self) str
+    to_json: (Self) StaticString
 }
 
 Point.implements(Json) {
-    to_json = (value: Point) str {
+    to_json = (value: Point) StaticString {
         "{\"x\":1}"
     }
 }

--- a/tests/zen/behavior_json_generic_association.zen
+++ b/tests/zen/behavior_json_generic_association.zen
@@ -8,13 +8,13 @@ Point: {
     x: i32
 }
 
-Point.implements(Json<str>) {
-    encode = (self: Point) str {
+Point.implements(Json<StaticString>) {
+    encode = (self: Point) StaticString {
         "point"
     }
 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 
 main = () i32 {
     point = Point { x: 1 }

--- a/tests/zen/behavior_json_generic_dispatch.zen
+++ b/tests/zen/behavior_json_generic_dispatch.zen
@@ -1,7 +1,7 @@
 { io } = std
 
 Json: behavior {
-    to_json: (Self) str
+    to_json: (Self) StaticString
 }
 
 Point: {
@@ -9,12 +9,12 @@ Point: {
 }
 
 Point.implements(Json) {
-    to_json = (self: Point) str {
+    to_json = (self: Point) StaticString {
         "point"
     }
 }
 
-encode<T: Json> = (value: T) str {
+encode<T: Json> = (value: T) StaticString {
     value.to_json()
 }
 

--- a/tests/zen/generic_identity.zen
+++ b/tests/zen/generic_identity.zen
@@ -9,6 +9,6 @@ main = () i32 {
     y = identity(7)
     io.println("${x}")
     io.println("${y}")
-    io.println(identity<str>("ok"))
+    io.println(identity<StaticString>("ok"))
     0
 }

--- a/tests/zen/generic_method_nested_result.zen
+++ b/tests/zen/generic_method_nested_result.zen
@@ -12,8 +12,8 @@ Result<T, E>:
     Ok(T),
     Err(E)
 
-Box.wrap_result<T> = (self: Box<T>) Result<Option<T>, str> {
-    Result<Option<T>, str>.Ok(Option<T>.Some(self.value))
+Box.wrap_result<T> = (self: Box<T>) Result<Option<T>, StaticString> {
+    Result<Option<T>, StaticString>.Ok(Option<T>.Some(self.value))
 }
 
 unwrap_option<T> = (value: Option<T>, fallback: T) T {
@@ -31,7 +31,7 @@ unwrap_result<T, E> = (value: Result<T, E>, fallback: T) T {
 main = () i32 {
     box = Box<i32> { value: 42 }
     wrapped = box.wrap_result()
-    fallback = Result<Option<i32>, str>.Err("bad")
+    fallback = Result<Option<i32>, StaticString>.Err("bad")
     some = unwrap_result(wrapped, Option<i32>.None)
     other = unwrap_result(fallback, Option<i32>.Some(7))
     io.println("${unwrap_option(some, 0)}")

--- a/tests/zen/generic_nested_result_enum.zen
+++ b/tests/zen/generic_nested_result_enum.zen
@@ -21,8 +21,8 @@ unwrap_result<T, E> = (value: Result<T, E>, fallback: T) T {
 }
 
 main = () i32 {
-    ok = Result<Option<i32>, str>.Ok(Option<i32>.Some(42))
-    err = Result<Option<i32>, str>.Err("bad")
+    ok = Result<Option<i32>, StaticString>.Ok(Option<i32>.Some(42))
+    err = Result<Option<i32>, StaticString>.Err("bad")
     some = unwrap_result(ok, Option<i32>.None)
     fallback = unwrap_result(err, Option<i32>.Some(7))
     io.println("${unwrap_option(some, 0)}")

--- a/tests/zen/generic_result_enum.zen
+++ b/tests/zen/generic_result_enum.zen
@@ -11,8 +11,8 @@ unwrap_or<T, E> = (value: Result<T, E>, fallback: T) T {
 }
 
 main = () i32 {
-    ok = Result<i32, str>.Ok(5)
-    err = Result<i32, str>.Err("bad")
+    ok = Result<i32, StaticString>.Ok(5)
+    err = Result<i32, StaticString>.Err("bad")
     io.println("${unwrap_or(ok, 0)}")
     io.println("${unwrap_or(err, 9)}")
     0

--- a/tests/zen/generic_result_enum_method.zen
+++ b/tests/zen/generic_result_enum_method.zen
@@ -11,8 +11,8 @@ Result.unwrap_or<T, E> = (self: Self, fallback: T) T {
 }
 
 main = () i32 {
-    ok = Result<i32, str>.Ok(21)
-    err = Result<i32, str>.Err("bad")
+    ok = Result<i32, StaticString>.Ok(21)
+    err = Result<i32, StaticString>.Err("bad")
     io.println("${ok.unwrap_or(0)}")
     io.println("${err.unwrap_or(34)}")
     0

--- a/tests/zen/generic_result_enum_multi_specialization.zen
+++ b/tests/zen/generic_result_enum_multi_specialization.zen
@@ -11,10 +11,10 @@ Result.unwrap_or<T, E> = (self: Self, fallback: T) T {
 }
 
 main = () i32 {
-    ok_int = Result<i32, str>.Ok(21)
-    err_int = Result<i32, str>.Err("bad")
-    ok_bool = Result<bool, str>.Ok(false)
-    err_bool = Result<bool, str>.Err("nope")
+    ok_int = Result<i32, StaticString>.Ok(21)
+    err_int = Result<i32, StaticString>.Err("bad")
+    ok_bool = Result<bool, StaticString>.Ok(false)
+    err_bool = Result<bool, StaticString>.Err("nope")
 
     io.println("${ok_int.unwrap_or(0)}")
     io.println("${err_int.unwrap_or(34)}")

--- a/tests/zen/generic_vec.zen
+++ b/tests/zen/generic_vec.zen
@@ -11,7 +11,7 @@ Vec<T>.len = (self: Vec<T>) i32 {
 
 main = () i32 {
     ints = Vec<i32> { first: 4, len: 1 }
-    words = Vec<str> { first: "zen", len: 1 }
+    words = Vec<StaticString> { first: "zen", len: 1 }
     io.println("${ints.len()}")
     io.println("${words.len()}")
     0

--- a/tests/zen/multi_file_behavior_inheritance/main.zen
+++ b/tests/zen/multi_file_behavior_inheritance/main.zen
@@ -6,20 +6,20 @@ Point: {
 }
 
 Point.implements(FancyJson) {
-    encode = (value: Point) str {
+    encode = (value: Point) StaticString {
         "encoded"
     }
 
-    pretty = (value: Point) str {
+    pretty = (value: Point) StaticString {
         "pretty"
     }
 
-    fancy = (value: Point) str {
+    fancy = (value: Point) StaticString {
         "fancy"
     }
 }
 
-encode<T: Json<str>> = (value: T) str {
+encode<T: Json<StaticString>> = (value: T) StaticString {
     value.encode()
 }
 

--- a/tests/zen/multi_file_behavior_inheritance/traits.zen
+++ b/tests/zen/multi_file_behavior_inheritance/traits.zen
@@ -3,12 +3,12 @@ pub Json<T>: behavior {
 }
 
 pub PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
 pub FancyJson: behavior {
-    fancy: (Self) str
+    fancy: (Self) StaticString
 }
 
-PrettyJson.extends(Json<str>)
+PrettyJson.extends(Json<StaticString>)
 FancyJson.extends(PrettyJson)

--- a/tests/zen/multi_file_generic/main.zen
+++ b/tests/zen/multi_file_generic/main.zen
@@ -4,8 +4,8 @@
 main = () i32 {
     some = Option<i32>.Some(42)
     none = Option<i32>.None
-    ok = Result<i32, str>.Ok(5)
-    err = Result<i32, str>.Err("bad")
+    ok = Result<i32, StaticString>.Ok(5)
+    err = Result<i32, StaticString>.Err("bad")
     io.println("${unwrap_option(some, 0)}")
     io.println("${unwrap_option(none, 7)}")
     io.println("${unwrap_result(ok, 0)}")

--- a/tests/zen/multi_file_generic_result_enum_method/main.zen
+++ b/tests/zen/multi_file_generic_result_enum_method/main.zen
@@ -2,8 +2,8 @@
 { Result } = result
 
 main = () i32 {
-    ok = Result<i32, str>.Ok(55)
-    err = Result<i32, str>.Err("bad")
+    ok = Result<i32, StaticString>.Ok(55)
+    err = Result<i32, StaticString>.Err("bad")
     io.println("${ok.unwrap_or(0)}")
     io.println("${err.unwrap_or(144)}")
     0

--- a/tests/zen/multi_file_generic_result_enum_multi_specialization/main.zen
+++ b/tests/zen/multi_file_generic_result_enum_multi_specialization/main.zen
@@ -2,10 +2,10 @@
 { Result } = result
 
 main = () i32 {
-    ok_int = Result<i32, str>.Ok(55)
-    err_int = Result<i32, str>.Err("bad")
-    ok_bool = Result<bool, str>.Ok(false)
-    err_bool = Result<bool, str>.Err("nope")
+    ok_int = Result<i32, StaticString>.Ok(55)
+    err_int = Result<i32, StaticString>.Err("bad")
+    ok_bool = Result<bool, StaticString>.Ok(false)
+    err_bool = Result<bool, StaticString>.Err("nope")
 
     io.println("${ok_int.unwrap_or(0)}")
     io.println("${err_int.unwrap_or(144)}")

--- a/tests/zen/multi_file_imported_behavior_default/main.zen
+++ b/tests/zen/multi_file_imported_behavior_default/main.zen
@@ -1,7 +1,7 @@
 { io } = std
 { Json, Point } = traits
 
-render<T: Json> = (value: T) str {
+render<T: Json> = (value: T) StaticString {
     value.to_json()
 }
 

--- a/tests/zen/multi_file_imported_behavior_default/traits.zen
+++ b/tests/zen/multi_file_imported_behavior_default/traits.zen
@@ -1,5 +1,5 @@
 pub Json: behavior {
-    to_json: (Self) str {
+    to_json: (Self) StaticString {
         "default-json"
     }
 }

--- a/tests/zen/multi_file_imported_behavior_impl/main.zen
+++ b/tests/zen/multi_file_imported_behavior_impl/main.zen
@@ -1,7 +1,7 @@
 { io } = std
 { Json, Point } = traits
 
-encode<T: Json<str>> = (value: T) str {
+encode<T: Json<StaticString>> = (value: T) StaticString {
     value.encode()
 }
 

--- a/tests/zen/multi_file_imported_behavior_impl/traits.zen
+++ b/tests/zen/multi_file_imported_behavior_impl/traits.zen
@@ -6,8 +6,8 @@ pub Point: {
     x: i32
 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str {
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString {
         "encoded"
     }
 }

--- a/tests/zen/multi_file_imported_behavior_requires/main.zen
+++ b/tests/zen/multi_file_imported_behavior_requires/main.zen
@@ -1,9 +1,9 @@
 { io } = std
 { Json, Point } = traits
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 
-encode<T: Json<str>> = (value: T) str {
+encode<T: Json<StaticString>> = (value: T) StaticString {
     value.encode()
 }
 

--- a/tests/zen/multi_file_imported_behavior_requires/traits.zen
+++ b/tests/zen/multi_file_imported_behavior_requires/traits.zen
@@ -6,8 +6,8 @@ pub Point: {
     x: i32
 }
 
-Point.implements(Json<str>) {
-    encode = (value: Point) str {
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString {
         "required"
     }
 }

--- a/tests/zen/multi_file_imported_behavior_requires_inherited/main.zen
+++ b/tests/zen/multi_file_imported_behavior_requires_inherited/main.zen
@@ -7,18 +7,18 @@ Point: {
 }
 
 Point.implements(PrettyJson) {
-    encode = (value: Point) str {
+    encode = (value: Point) StaticString {
         "inherited-required"
     }
 
-    pretty = (value: Point) str {
+    pretty = (value: Point) StaticString {
         "pretty"
     }
 }
 
-Point.requires(Json<str>)
+Point.requires(Json<StaticString>)
 
-encode<T: Json<str>> = (value: T) str {
+encode<T: Json<StaticString>> = (value: T) StaticString {
     value.encode()
 }
 

--- a/tests/zen/multi_file_imported_behavior_requires_inherited/traits.zen
+++ b/tests/zen/multi_file_imported_behavior_requires_inherited/traits.zen
@@ -1,7 +1,7 @@
 { Json } = base
 
 pub PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
-PrettyJson.extends(Json<str>)
+PrettyJson.extends(Json<StaticString>)

--- a/tests/zen/multi_file_imported_child_parent_dispatch/main.zen
+++ b/tests/zen/multi_file_imported_child_parent_dispatch/main.zen
@@ -6,16 +6,16 @@ Point: {
 }
 
 Point.implements(PrettyJson) {
-    encode = (value: Point) str {
+    encode = (value: Point) StaticString {
         "encoded"
     }
 
-    pretty = (value: Point) str {
+    pretty = (value: Point) StaticString {
         "pretty"
     }
 }
 
-render<T: PrettyJson> = (value: T) str {
+render<T: PrettyJson> = (value: T) StaticString {
     value.encode()
 }
 

--- a/tests/zen/multi_file_imported_child_parent_dispatch/traits.zen
+++ b/tests/zen/multi_file_imported_child_parent_dispatch/traits.zen
@@ -1,7 +1,7 @@
 { Json } = base
 
 pub PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
-PrettyJson.extends(Json<str>)
+PrettyJson.extends(Json<StaticString>)

--- a/tests/zen/multi_file_imported_generic_behavior_default/main.zen
+++ b/tests/zen/multi_file_imported_generic_behavior_default/main.zen
@@ -1,7 +1,7 @@
 { io } = std
 { Json, Point } = traits
 
-render<T: Json<str>> = (value: T) str {
+render<T: Json<StaticString>> = (value: T) StaticString {
     value.encode()
 }
 

--- a/tests/zen/multi_file_imported_generic_behavior_default/traits.zen
+++ b/tests/zen/multi_file_imported_generic_behavior_default/traits.zen
@@ -8,5 +8,5 @@ pub Point: {
     x: i32
 }
 
-Point.implements(Json<str>) {
+Point.implements(Json<StaticString>) {
 }

--- a/tests/zen/multi_file_imported_impl_imported_behavior/main.zen
+++ b/tests/zen/multi_file_imported_impl_imported_behavior/main.zen
@@ -2,7 +2,7 @@
 { Json } = traits
 { Point } = model
 
-encode<T: Json<str>> = (value: T) str {
+encode<T: Json<StaticString>> = (value: T) StaticString {
     value.encode()
 }
 

--- a/tests/zen/multi_file_imported_impl_imported_behavior/model.zen
+++ b/tests/zen/multi_file_imported_impl_imported_behavior/model.zen
@@ -5,11 +5,11 @@ pub Point: {
 }
 
 Point.implements(PrettyJson) {
-    encode = (value: Point) str {
+    encode = (value: Point) StaticString {
         "encoded"
     }
 
-    pretty = (value: Point) str {
+    pretty = (value: Point) StaticString {
         "pretty"
     }
 }

--- a/tests/zen/multi_file_imported_impl_imported_behavior/traits.zen
+++ b/tests/zen/multi_file_imported_impl_imported_behavior/traits.zen
@@ -3,7 +3,7 @@ pub Json<T>: behavior {
 }
 
 pub PrettyJson: behavior {
-    pretty: (Self) str
+    pretty: (Self) StaticString
 }
 
-PrettyJson.extends(Json<str>)
+PrettyJson.extends(Json<StaticString>)

--- a/tests/zen/multi_file_type_method_nested_result_dependency/main.zen
+++ b/tests/zen/multi_file_type_method_nested_result_dependency/main.zen
@@ -5,7 +5,7 @@
 main = () i32 {
     box = Box<i32> { value: 109 }
     wrapped = box.wrap_result()
-    fallback = Result<Option<i32>, str>.Err("bad")
+    fallback = Result<Option<i32>, StaticString>.Err("bad")
     some = unwrap_result(wrapped, Option<i32>.None)
     other = unwrap_result(fallback, Option<i32>.Some(7))
     io.println("${unwrap_option(some, 0)}")

--- a/tests/zen/multi_file_type_method_nested_result_dependency/model.zen
+++ b/tests/zen/multi_file_type_method_nested_result_dependency/model.zen
@@ -4,8 +4,8 @@ pub Box<T>: {
     value: T
 }
 
-pub Box.wrap_result<T> = (self: Box<T>) Result<Option<T>, str> {
-    Result<Option<T>, str>.Ok(Option<T>.Some(self.value))
+pub Box.wrap_result<T> = (self: Box<T>) Result<Option<T>, StaticString> {
+    Result<Option<T>, StaticString>.Ok(Option<T>.Some(self.value))
 }
 
 pub unwrap_option<T> = (value: Option<T>, fallback: T) T {


### PR DESCRIPTION
## Summary

- Display static string types as `StaticString` in AST and typed diagnostics.
- Use `StaticString` in generic specialization mangling so generated symbol assertions no longer teach `str`.
- Update parser, resolver, generic diagnostics, integration fixtures, public Zen fixtures, and phase/audit docs to use the public static-text spelling.
- Rename static string intrinsic parameter labels from `str` to `value`.

## Why

`str` reads like a dynamic or borrowed string spelling from host languages. The language-level type here is a baked-in static string literal with stable storage semantics, while allocator-backed dynamic text should remain `String`.

## Validation

- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
