### PR TITLE
[codex] List gated emit-json modes in usage

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3856,6 +3856,11 @@ and do not assume Phase 4 is ready without evidence.
   inherited behavior dispatch, imported behavior association fixtures, and hard
   diagnostics. The broader generated/fallback association solver remains gated
   in the Feature Matrix.
+- `zen emit-json` usage diagnostics now list the full checked, deterministic,
+  and gated JSON/YAML mode surface: `ast`, `symbols`, `typed`, `diagnostics`,
+  `build-graph`, `hir`, `mir`, and `target-yaml`. This is covered by
+  `emit_json_usage_lists_supported_and_gated_modes`, preserving the IR-boundary
+  gate in user-facing CLI errors.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3531,6 +3531,11 @@ checked-in docs, tests, and commits only.
   inherited behavior dispatch, imported behavior associations, and hard
   diagnostics are covered while broader generated/fallback association semantics
   remain in the gated Feature Matrix row.
+- `zen emit-json` usage diagnostics now advertise the complete current JSON
+  boundary surface, including checked `ast`/`symbols`/`typed`/`diagnostics`,
+  deterministic `build-graph`, and gated `hir`/`mir`/`target-yaml` modes.
+  Covered by `emit_json_usage_lists_supported_and_gated_modes`, so the CLI
+  help text cannot hide gated IR/YAML modes from users.
 
 ## Current Phase
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,6 +34,9 @@ use json_emit::{
 };
 use usage::print_usage;
 
+const EMIT_JSON_USAGE: &str =
+    "Usage: zen emit-json <ast|symbols|typed|diagnostics|build-graph|hir|mir|target-yaml> <file.zen>";
+
 pub fn main() {
     let args: Vec<String> = std::env::args().collect();
 
@@ -80,7 +83,7 @@ pub fn main() {
         }
         "emit-json" => {
             if args.len() < 4 {
-                eprintln!("Usage: zen emit-json <ast|symbols|typed|diagnostics> <file.zen>");
+                eprintln!("{EMIT_JSON_USAGE}");
                 process::exit(1);
             }
             match args[2].as_str() {
@@ -108,9 +111,7 @@ pub fn main() {
                     process::exit(1);
                 }
                 _ => {
-                    eprintln!(
-                        "Usage: zen emit-json <ast|symbols|typed|diagnostics|build-graph> <file.zen>"
-                    );
+                    eprintln!("{EMIT_JSON_USAGE}");
                     process::exit(1);
                 }
             }

--- a/tests/integration/cli_build/frontend_json.rs
+++ b/tests/integration/cli_build/frontend_json.rs
@@ -5,6 +5,45 @@ use std::process::Command;
 mod module_graph;
 
 #[test]
+fn emit_json_usage_lists_supported_and_gated_modes() {
+    let missing_mode_output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .arg("emit-json")
+        .output()
+        .expect("run zen emit-json without mode");
+    assert!(
+        !missing_mode_output.status.success(),
+        "zen emit-json without mode should fail: stdout={}, stderr={}",
+        String::from_utf8_lossy(&missing_mode_output.stdout),
+        String::from_utf8_lossy(&missing_mode_output.stderr)
+    );
+
+    let unknown_mode_output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args([
+            "emit-json",
+            "unknown",
+            test_dir().join("hello.zen").to_str().unwrap(),
+        ])
+        .output()
+        .expect("run zen emit-json unknown mode");
+    assert!(
+        !unknown_mode_output.status.success(),
+        "zen emit-json unknown mode should fail: stdout={}, stderr={}",
+        String::from_utf8_lossy(&unknown_mode_output.stdout),
+        String::from_utf8_lossy(&unknown_mode_output.stderr)
+    );
+
+    let expected_usage =
+        "Usage: zen emit-json <ast|symbols|typed|diagnostics|build-graph|hir|mir|target-yaml> <file.zen>";
+    for output in [&missing_mode_output, &unknown_mode_output] {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains(expected_usage),
+            "emit-json usage should list supported and gated modes, stderr={stderr}"
+        );
+    }
+}
+
+#[test]
 fn emit_json_typed_command_outputs_checked_program() {
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
         .args([


### PR DESCRIPTION
## Summary

- Add integration coverage for `zen emit-json` missing/unknown mode usage.
- Keep usage text aligned with the current checked, deterministic, and gated JSON/YAML surface: `ast`, `symbols`, `typed`, `diagnostics`, `build-graph`, `hir`, `mir`, and `target-yaml`.
- Record the IR-boundary usage hardening in the phase plan and completion audit.

## Validation

- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
