### PR TITLE
[codex] Show gated emit-json modes in root usage

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3861,6 +3861,10 @@ and do not assume Phase 4 is ready without evidence.
   `build-graph`, `hir`, `mir`, and `target-yaml`. This is covered by
   `emit_json_usage_lists_supported_and_gated_modes`, preserving the IR-boundary
   gate in user-facing CLI errors.
+- The root `zen` usage banner now lists the same gated `emit-json hir`,
+  `emit-json mir`, and `emit-json target-yaml` commands, covered by
+  `root_usage_lists_supported_and_gated_emit_json_modes`, so top-level help
+  does not hide the explicitly gated IR/YAML surface.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3536,6 +3536,10 @@ checked-in docs, tests, and commits only.
   deterministic `build-graph`, and gated `hir`/`mir`/`target-yaml` modes.
   Covered by `emit_json_usage_lists_supported_and_gated_modes`, so the CLI
   help text cannot hide gated IR/YAML modes from users.
+- The root `zen` usage banner now mirrors that IR/YAML boundary by listing the
+  gated `emit-json hir`, `emit-json mir`, and `emit-json target-yaml` commands
+  as gated instead of omitting them. Covered by
+  `root_usage_lists_supported_and_gated_emit_json_modes`.
 
 ## Current Phase
 

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -14,5 +14,8 @@ pub(super) fn print_usage() {
     eprintln!("  emit-json typed <file>   Emit checked typed program JSON");
     eprintln!("  emit-json diagnostics <file>   Emit diagnostics JSON");
     eprintln!("  emit-json build-graph <build.zen>   Emit deterministic build graph JSON");
+    eprintln!("  emit-json hir <file>   Gated HIR JSON");
+    eprintln!("  emit-json mir <file>   Gated MIR JSON");
+    eprintln!("  emit-json target-yaml <file>   Gated target YAML validation");
     eprintln!("  <file>         Run a .zen file");
 }

--- a/tests/integration/cli_build/diagnostics.rs
+++ b/tests/integration/cli_build/diagnostics.rs
@@ -4,6 +4,8 @@ mod check_command;
 mod dedup;
 #[path = "diagnostics/emit_command.rs"]
 mod emit_command;
+#[path = "diagnostics/usage.rs"]
+mod usage;
 
 fn write_imported_module_type_error_fixture(tmp: &tempfile::TempDir) -> std::path::PathBuf {
     let math_path = tmp.path().join("math.zen");

--- a/tests/integration/cli_build/diagnostics/usage.rs
+++ b/tests/integration/cli_build/diagnostics/usage.rs
@@ -1,0 +1,32 @@
+use std::process::Command;
+
+#[test]
+fn root_usage_lists_supported_and_gated_emit_json_modes() {
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .output()
+        .expect("run zen without args");
+
+    assert!(
+        !output.status.success(),
+        "zen without args should fail: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    for expected in [
+        "emit-json ast <file>",
+        "emit-json symbols <file>",
+        "emit-json typed <file>",
+        "emit-json diagnostics <file>",
+        "emit-json build-graph <build.zen>",
+        "emit-json hir <file>   Gated HIR JSON",
+        "emit-json mir <file>   Gated MIR JSON",
+        "emit-json target-yaml <file>   Gated target YAML validation",
+    ] {
+        assert!(
+            stderr.contains(expected),
+            "root usage should list `{expected}`, stderr={stderr}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- List gated `emit-json hir`, `emit-json mir`, and `emit-json target-yaml` in the root `zen` usage banner.
- Add integration coverage for running `zen` without args so top-level help stays aligned with the checked, deterministic, and gated JSON/YAML surface.
- Record the CLI boundary hardening in the phase plan and completion audit.

## Validation

- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
