### PR TITLE
[codex] Mark symbols JSON as resolved

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3865,6 +3865,10 @@ and do not assume Phase 4 is ready without evidence.
   `emit-json mir`, and `emit-json target-yaml` commands, covered by
   `root_usage_lists_supported_and_gated_emit_json_modes`, so top-level help
   does not hide the explicitly gated IR/YAML surface.
+- Symbols JSON now carries `semantic_status: "resolved"`, covered by
+  `emit_json_symbols_command_outputs_module_symbol_tables`, so resolver-owned
+  symbol metadata is explicitly separated from unchecked AST JSON and checked
+  typed JSON.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3540,6 +3540,10 @@ checked-in docs, tests, and commits only.
   gated `emit-json hir`, `emit-json mir`, and `emit-json target-yaml` commands
   as gated instead of omitting them. Covered by
   `root_usage_lists_supported_and_gated_emit_json_modes`.
+- Symbols JSON now carries `semantic_status: "resolved"` alongside
+  `format: "zen.symbols.v0"`, making resolver-owned metadata distinct from
+  unchecked AST JSON and checked typed JSON. Covered by
+  `emit_json_symbols_command_outputs_module_symbol_tables`.
 
 ## Current Phase
 

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -104,9 +104,9 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   diagnostics emission through `zen emit-json ast <file>`,
   `zen emit-json symbols <file>`, `zen emit-json typed <file>`, and
   `zen emit-json diagnostics <file>`. AST JSON is explicitly marked unchecked;
-  typed JSON is explicitly marked checked; diagnostics JSON is explicitly
-  marked diagnostic; semantic acceptance must use typed JSON, diagnostics,
-  check, build, or test paths.
+  symbols JSON is explicitly marked resolved; typed JSON is explicitly marked checked;
+  diagnostics JSON is explicitly marked diagnostic. semantic acceptance must use typed JSON,
+  diagnostics, check, build, or test paths.
 - `build.zen`: constrained. `zen check build.zen` validates the deterministic
   graph and verifies declared target sources exist, `zen emit build.zen` emits
   target C for one graph target, `zen build build.zen` compiles executable

--- a/src/ir_json.rs
+++ b/src/ir_json.rs
@@ -41,6 +41,7 @@ struct TypedJsonProgram<'a> {
 #[derive(Serialize)]
 struct SymbolsJsonGraph<'a> {
     format: &'static str,
+    semantic_status: &'static str,
     entry_module: u32,
     modules: Vec<SymbolsJsonModule<'a>>,
 }
@@ -110,6 +111,7 @@ pub fn symbols_graph_to_json(graph: &ResolvedModuleGraph) -> serde_json::Result<
 
     let graph = SymbolsJsonGraph {
         format: "zen.symbols.v0",
+        semantic_status: "resolved",
         entry_module: graph.entry.0,
         modules: modules
             .into_iter()

--- a/tests/integration/cli_build/frontend_json/module_graph.rs
+++ b/tests/integration/cli_build/frontend_json/module_graph.rs
@@ -162,6 +162,7 @@ main = () i32 {
     let json: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("emit-json symbols stdout is json");
     assert_eq!(json["format"], "zen.symbols.v0");
+    assert_eq!(json["semantic_status"], "resolved");
     assert_eq!(json["entry_module"], 0);
     assert_eq!(json["modules"].as_array().expect("modules array").len(), 2);
 


### PR DESCRIPTION
## Summary

- Add `semantic_status: "resolved"` to `zen emit-json symbols` output.
- Assert the status marker in the symbols JSON integration coverage.
- Update `docs/V1_SPEC.md`, `docs/PHASE_PLAN.md`, and `docs/COMPLETION_AUDIT.md` so symbols JSON is explicitly separated from unchecked AST JSON and checked typed JSON.

## Validation

- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
