### PR TITLE
[codex] Mark build graph JSON as deterministic

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3869,6 +3869,9 @@ and do not assume Phase 4 is ready without evidence.
   `emit_json_symbols_command_outputs_module_symbol_tables`, so resolver-owned
   symbol metadata is explicitly separated from unchecked AST JSON and checked
   typed JSON.
+- Build graph JSON now carries `format: "zen.build_graph.v0"` and
+  `semantic_status: "deterministic"` while preserving the existing graph
+  payload keys, covered by `emit_json_build_graph_outputs_project_build_graph`.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3544,6 +3544,10 @@ checked-in docs, tests, and commits only.
   `format: "zen.symbols.v0"`, making resolver-owned metadata distinct from
   unchecked AST JSON and checked typed JSON. Covered by
   `emit_json_symbols_command_outputs_module_symbol_tables`.
+- Build graph JSON now carries `format: "zen.build_graph.v0"` and
+  `semantic_status: "deterministic"` at the top level while preserving the
+  existing target, dependency, feature, and host-effect payload keys. Covered by
+  `emit_json_build_graph_outputs_project_build_graph`.
 
 ## Current Phase
 

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -112,6 +112,8 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   target C for one graph target, `zen build build.zen` compiles executable
   targets through that graph, and direct `zen build.zen` aliases that same graph
   build path. `zen test build.zen` compiles and runs test graph targets.
+  `zen emit-json build-graph <build.zen>` emits `format: "zen.build_graph.v0"`
+  and `semantic_status: "deterministic"` with the constrained graph payload.
   Executable target dependencies compile before their dependents. Test targets
   are lowered, emitted in build graph JSON, compiled, and run through the
   constrained test command. Library targets are lowered and emitted in build

--- a/src/build_graph.rs
+++ b/src/build_graph.rs
@@ -64,6 +64,15 @@ pub struct BuildGraph {
     used_host_effects: Vec<HostEffect>,
 }
 
+#[derive(Serialize)]
+struct BuildGraphJson<'a> {
+    format: &'static str,
+    semantic_status: &'static str,
+    targets: &'a [BuildTarget],
+    declared_host_effects: &'a [HostEffect],
+    used_host_effects: &'a [HostEffect],
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct BuildTarget {
     name: String,
@@ -170,7 +179,13 @@ impl BuildGraph {
     }
 
     pub fn canonical_json(&self) -> Result<String, serde_json::Error> {
-        serde_json::to_string(self)
+        serde_json::to_string(&BuildGraphJson {
+            format: "zen.build_graph.v0",
+            semantic_status: "deterministic",
+            targets: &self.targets,
+            declared_host_effects: &self.declared_host_effects,
+            used_host_effects: &self.used_host_effects,
+        })
     }
 }
 

--- a/tests/integration/cli_build/build_graph_json.rs
+++ b/tests/integration/cli_build/build_graph_json.rs
@@ -18,6 +18,8 @@ fn emit_json_build_graph_outputs_project_build_graph() {
     );
 
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("build graph json");
+    assert_eq!(json["format"], "zen.build_graph.v0");
+    assert_eq!(json["semantic_status"], "deterministic");
     assert_eq!(json["targets"][0]["name"], "myapp");
     assert_eq!(json["targets"][0]["kind"]["root_source_file"], "main.zen");
     assert_eq!(json["targets"][0]["kind"]["out_dir"], "build/");


### PR DESCRIPTION
## Summary

- Add `format: "zen.build_graph.v0"` and `semantic_status: "deterministic"` to canonical build graph JSON.
- Preserve existing top-level graph payload keys for targets, declared host effects, and used host effects.
- Assert the metadata in `emit-json build-graph` integration coverage and record the boundary in v1/audit docs.

## Validation

- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
