### PR TITLE
[codex] Gate layout JSON and split dynamic strings

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3872,6 +3872,16 @@ and do not assume Phase 4 is ready without evidence.
 - Build graph JSON now carries `format: "zen.build_graph.v0"` and
   `semantic_status: "deterministic"` while preserving the existing graph
   payload keys, covered by `emit_json_build_graph_outputs_project_build_graph`.
+- `emit-json layout` now has an explicit gated command and usage entry for type
+  layout JSON, covered by `emit_json_layout_command_is_explicitly_gated`,
+  `emit_json_usage_lists_supported_and_gated_modes`, and
+  `root_usage_lists_supported_and_gated_emit_json_modes`, while ABI layout JSON
+  remains gated until layout tests exist.
+- Static string literals no longer implicitly satisfy allocator-backed
+  `String`; `String` is recognized as a builtin dynamic text type, but
+  allocation must remain explicit. Covered by
+  `static_string_literal_does_not_implicitly_allocate_string` and
+  `types_compatible_basics`.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3548,6 +3548,17 @@ checked-in docs, tests, and commits only.
   `semantic_status: "deterministic"` at the top level while preserving the
   existing target, dependency, feature, and host-effect payload keys. Covered by
   `emit_json_build_graph_outputs_project_build_graph`.
+- `emit-json layout` is now an explicit gated CLI mode for type layout JSON and
+  rejects until ABI layout tests exist. The mode is listed in both root and
+  emit-json usage, and covered by
+  `emit_json_layout_command_is_explicitly_gated`,
+  `emit_json_usage_lists_supported_and_gated_modes`, and
+  `root_usage_lists_supported_and_gated_emit_json_modes`.
+- `StaticString` and allocator-backed `String` are no longer type-compatible:
+  static string literals stay baked into program storage and cannot implicitly
+  allocate dynamic `String` values. Covered by
+  `static_string_literal_does_not_implicitly_allocate_string` and
+  `types_compatible_basics`.
 
 ## Current Phase
 

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -73,7 +73,9 @@ Generic behavior inheritance with child type-parameter parent args is covered by
 - `StaticString` is baked into the program. It denotes literal/static text with
   stable storage and length. The allocator-backed `String` type is owned,
   dynamic text and depends on the typed allocator model before it can be
-  promoted as a stable construction target.
+  promoted as a stable construction target. Static string literals do not
+  implicitly allocate or coerce into `String`; dynamic `String` construction
+  must go through an explicit allocator-aware path once that path is promoted.
 - `Sync/Async effects`: gated. `Sync` and `Async` are real effects in v1, not
   marker-only types. Sync code must not call async operations except through an
   explicit runtime blocking boundary. Async operations lower through checked task,
@@ -103,10 +105,12 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   symbol table emission, checked typed program emission, and machine-readable
   diagnostics emission through `zen emit-json ast <file>`,
   `zen emit-json symbols <file>`, `zen emit-json typed <file>`, and
-  `zen emit-json diagnostics <file>`. AST JSON is explicitly marked unchecked;
-  symbols JSON is explicitly marked resolved; typed JSON is explicitly marked checked;
-  diagnostics JSON is explicitly marked diagnostic. semantic acceptance must use typed JSON,
-  diagnostics, check, build, or test paths.
+  `zen emit-json diagnostics <file>`. `zen emit-json layout <file>` is an
+  explicit gated command and rejects until ABI layout tests exist. AST JSON is
+  explicitly marked unchecked; symbols JSON is explicitly marked resolved;
+  typed JSON is explicitly marked checked; diagnostics JSON is explicitly
+  marked diagnostic. semantic acceptance must use typed JSON, diagnostics,
+  check, build, or test paths.
 - `build.zen`: constrained. `zen check build.zen` validates the deterministic
   graph and verifies declared target sources exist, `zen emit build.zen` emits
   target C for one graph target, `zen build build.zen` compiles executable

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,7 +35,7 @@ use json_emit::{
 use usage::print_usage;
 
 const EMIT_JSON_USAGE: &str =
-    "Usage: zen emit-json <ast|symbols|typed|diagnostics|build-graph|hir|mir|target-yaml> <file.zen>";
+    "Usage: zen emit-json <ast|symbols|typed|diagnostics|build-graph|hir|mir|layout|target-yaml> <file.zen>";
 
 pub fn main() {
     let args: Vec<String> = std::env::args().collect();
@@ -101,6 +101,12 @@ pub fn main() {
                 "mir" => {
                     eprintln!(
                         "error: MIR JSON emission is gated until schema and golden tests exist"
+                    );
+                    process::exit(1);
+                }
+                "layout" => {
+                    eprintln!(
+                        "error: type layout JSON emission is gated until ABI layout tests exist"
                     );
                     process::exit(1);
                 }

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -16,6 +16,7 @@ pub(super) fn print_usage() {
     eprintln!("  emit-json build-graph <build.zen>   Emit deterministic build graph JSON");
     eprintln!("  emit-json hir <file>   Gated HIR JSON");
     eprintln!("  emit-json mir <file>   Gated MIR JSON");
+    eprintln!("  emit-json layout <file>   Gated type layout JSON");
     eprintln!("  emit-json target-yaml <file>   Gated target YAML validation");
     eprintln!("  <file>         Run a .zen file");
 }

--- a/src/resolver/type_validation.rs
+++ b/src/resolver/type_validation.rs
@@ -171,6 +171,9 @@ impl Resolver {
         type_params: &[TypeParam],
         name: &str,
     ) -> bool {
+        if name == "String" {
+            return true;
+        }
         table.lookup(Namespace::Type, name).is_some()
             || table.lookup(Namespace::Import, name).is_some()
             || type_params.iter().any(|type_param| type_param.name == name)

--- a/src/typechecker/generic_type_reference_walker.rs
+++ b/src/typechecker/generic_type_reference_walker.rs
@@ -222,6 +222,9 @@ impl TypeChecker {
     }
 
     fn is_known_named_type(&self, name: &str) -> bool {
+        if name == "String" {
+            return true;
+        }
         self.structs.contains_key(name)
             || self.enums.contains_key(name)
             || self.imports.contains_key(name)

--- a/src/typechecker/resolve.rs
+++ b/src/typechecker/resolve.rs
@@ -184,13 +184,6 @@ impl TypeChecker {
         }
         // Numeric width/sign conversions require explicit casts. Literal
         // coercion is handled before this check at declaration sites.
-        // Str and String are compatible
-        if matches!(
-            (expected, actual),
-            (Type::Str, Type::String) | (Type::String, Type::Str)
-        ) {
-            return true;
-        }
         false
     }
 

--- a/src/typechecker/tests/core_semantics/type_helpers.rs
+++ b/src/typechecker/tests/core_semantics/type_helpers.rs
@@ -17,9 +17,46 @@ fn types_compatible_basics() {
         &Type::Named("OrderId".into())
     ));
     assert!(!tc.types_compatible(&Type::Str, &Type::Named("StaticString".into())));
+    assert!(!tc.types_compatible(&Type::String, &Type::Str));
+    assert!(!tc.types_compatible(&Type::Str, &Type::String));
     // Clear mismatch
     assert!(!tc.types_compatible(&Type::I32, &Type::Str));
     assert!(!tc.types_compatible(&Type::Bool, &Type::I32));
+}
+
+#[test]
+fn static_string_literal_does_not_implicitly_allocate_string() {
+    let program = parse_program(
+        r#"
+takes_string = (value: String) void { }
+
+returns_string = () String {
+    "literal"
+}
+
+main = () void {
+    local: String = "literal"
+    takes_string("literal")
+}
+"#,
+    );
+    let mut tc = TypeChecker::new();
+
+    let err = tc
+        .check_program(&program)
+        .expect_err("static string literals should not implicitly satisfy dynamic String");
+
+    for expected in [
+        "return type mismatch: expected `String`, found `StaticString`",
+        "variable `local` expects `String`, found `StaticString`",
+        "argument 1 for `takes_string` expects `String`, found `StaticString`",
+    ] {
+        assert!(
+            err.iter()
+                .any(|diagnostic| diagnostic.message.contains(expected)),
+            "expected diagnostic `{expected}`, got {err:?}"
+        );
+    }
 }
 
 #[test]

--- a/tests/integration/cli_build/diagnostics/usage.rs
+++ b/tests/integration/cli_build/diagnostics/usage.rs
@@ -22,6 +22,7 @@ fn root_usage_lists_supported_and_gated_emit_json_modes() {
         "emit-json build-graph <build.zen>",
         "emit-json hir <file>   Gated HIR JSON",
         "emit-json mir <file>   Gated MIR JSON",
+        "emit-json layout <file>   Gated type layout JSON",
         "emit-json target-yaml <file>   Gated target YAML validation",
     ] {
         assert!(

--- a/tests/integration/cli_build/frontend_json.rs
+++ b/tests/integration/cli_build/frontend_json.rs
@@ -33,7 +33,7 @@ fn emit_json_usage_lists_supported_and_gated_modes() {
     );
 
     let expected_usage =
-        "Usage: zen emit-json <ast|symbols|typed|diagnostics|build-graph|hir|mir|target-yaml> <file.zen>";
+        "Usage: zen emit-json <ast|symbols|typed|diagnostics|build-graph|hir|mir|layout|target-yaml> <file.zen>";
     for output in [&missing_mode_output, &unknown_mode_output] {
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
@@ -219,5 +219,30 @@ fn emit_json_target_yaml_command_is_explicitly_gated() {
             "target YAML validation is gated until schemas and negative validation tests exist"
         ),
         "expected target YAML gate diagnostic, stderr={stderr}"
+    );
+}
+
+#[test]
+fn emit_json_layout_command_is_explicitly_gated() {
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args([
+            "emit-json",
+            "layout",
+            test_dir().join("hello.zen").to_str().unwrap(),
+        ])
+        .output()
+        .expect("run zen emit-json layout");
+
+    assert!(
+        !output.status.success(),
+        "zen emit-json layout should be gated: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("type layout JSON emission is gated until ABI layout tests exist"),
+        "expected layout gate diagnostic, stderr={stderr}"
     );
 }


### PR DESCRIPTION
## Summary

- add an explicit `zen emit-json layout <file>` gate and keep root/emit-json usage aligned
- make `String` a recognized builtin dynamic text type while removing implicit `StaticString` to `String` compatibility
- update V1/audit docs for the layout gate and static-vs-dynamic string boundary

## Validation

- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`