### PR TITLE
[codex] Centralize builtin type spellings

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3882,6 +3882,9 @@ and do not assume Phase 4 is ready without evidence.
   allocation must remain explicit. Covered by
   `static_string_literal_does_not_implicitly_allocate_string` and
   `types_compatible_basics`.
+- Builtin public type spellings now use shared AST helpers rather than
+  duplicated semantic string comparisons, covered by
+  `semantic_builtin_type_checks_use_shared_spelling_helper`.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3559,6 +3559,10 @@ checked-in docs, tests, and commits only.
   allocate dynamic `String` values. Covered by
   `static_string_literal_does_not_implicitly_allocate_string` and
   `types_compatible_basics`.
+- Builtin public type spellings now route through shared AST type helpers
+  instead of ad hoc semantic string checks, keeping `String` recognition and
+  `StaticString` display spelling tied to one source. Guarded by
+  `semantic_builtin_type_checks_use_shared_spelling_helper`.
 
 ## Current Phase
 

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -10,7 +10,7 @@ pub use declarations::{BehaviorMethod, Declaration, EnumVariant, StructField, Ty
 pub use expressions::{BinaryOp, Expression, MatchArm, StringPart, UnaryOp};
 pub use patterns::Pattern;
 pub use statements::Statement;
-pub use types::{AstType, Param};
+pub use types::{is_builtin_type_name, AstType, Param};
 
 use crate::error::FileId;
 use serde::Serialize;

--- a/src/ast/typed/types.rs
+++ b/src/ast/typed/types.rs
@@ -1,3 +1,4 @@
+use crate::ast::types::{DYNAMIC_STRING_TYPE_NAME, STATIC_STRING_TYPE_NAME};
 use serde::Serialize;
 
 // Fully resolved types — no generics, no inference variables.
@@ -84,8 +85,8 @@ impl Type {
             Type::F64 => "f64".into(),
             Type::Bool => "bool".into(),
             Type::Void => "void".into(),
-            Type::Str => "StaticString".into(),
-            Type::String => "String".into(),
+            Type::Str => STATIC_STRING_TYPE_NAME.into(),
+            Type::String => DYNAMIC_STRING_TYPE_NAME.into(),
             Type::Named(n) => n.clone(),
             Type::Struct { name, .. } => name.clone(),
             Type::Enum { name, .. } => name.clone(),

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -1,6 +1,13 @@
 use crate::error::Span;
 use serde::Serialize;
 
+pub const STATIC_STRING_TYPE_NAME: &str = "StaticString";
+pub const DYNAMIC_STRING_TYPE_NAME: &str = "String";
+
+pub fn is_builtin_type_name(name: &str) -> bool {
+    name == DYNAMIC_STRING_TYPE_NAME
+}
+
 /// Parser-level type representation.
 ///
 /// These types may be unresolved — `Named("Point")` hasn't been looked up yet,
@@ -82,8 +89,8 @@ impl AstType {
             AstType::F64 => "f64".into(),
             AstType::Bool => "bool".into(),
             AstType::Void => "void".into(),
-            AstType::Str => "StaticString".into(),
-            AstType::String => "String".into(),
+            AstType::Str => STATIC_STRING_TYPE_NAME.into(),
+            AstType::String => DYNAMIC_STRING_TYPE_NAME.into(),
             AstType::Named(n) => n.clone(),
             AstType::Generic { name, type_args } => {
                 let args: Vec<_> = type_args.iter().map(|a| a.display_name()).collect();

--- a/src/resolver/type_validation.rs
+++ b/src/resolver/type_validation.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use crate::ast::{AstType, Param, TypeParam};
+use crate::ast::{is_builtin_type_name, AstType, Param, TypeParam};
 use crate::error::{Diagnostic, Span};
 
 use super::{Namespace, Resolver, SymbolTable};
@@ -171,7 +171,7 @@ impl Resolver {
         type_params: &[TypeParam],
         name: &str,
     ) -> bool {
-        if name == "String" {
+        if is_builtin_type_name(name) {
             return true;
         }
         table.lookup(Namespace::Type, name).is_some()

--- a/src/typechecker/generic_type_reference_walker.rs
+++ b/src/typechecker/generic_type_reference_walker.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::ast::is_builtin_type_name;
 
 mod expressions;
 
@@ -222,7 +223,7 @@ impl TypeChecker {
     }
 
     fn is_known_named_type(&self, name: &str) -> bool {
-        if name == "String" {
+        if is_builtin_type_name(name) {
             return true;
         }
         self.structs.contains_key(name)

--- a/src/typechecker/resolve.rs
+++ b/src/typechecker/resolve.rs
@@ -3,7 +3,7 @@
 
 use crate::ast::expressions::BinaryOp;
 use crate::ast::typed::Type;
-use crate::ast::AstType;
+use crate::ast::{is_builtin_type_name, AstType};
 use crate::error::{Diagnostic, Span};
 
 use super::TypeChecker;
@@ -36,7 +36,7 @@ impl TypeChecker {
                 {
                     return concrete.clone();
                 }
-                if name == "String" {
+                if is_builtin_type_name(name) {
                     return Type::String;
                 }
                 if let Some(info) = self.structs.get(name) {

--- a/tests/docs_truth/repo_hygiene/builtin_type_spelling.rs
+++ b/tests/docs_truth/repo_hygiene/builtin_type_spelling.rs
@@ -1,0 +1,26 @@
+use super::*;
+
+#[test]
+fn semantic_builtin_type_checks_use_shared_spelling_helper() {
+    let helper = read("src/ast/types.rs");
+    assert!(
+        helper.contains("pub const DYNAMIC_STRING_TYPE_NAME: &str = \"String\""),
+        "dynamic String spelling should live in the AST type helper module"
+    );
+    assert!(
+        helper.contains("pub fn is_builtin_type_name"),
+        "builtin type-name recognition should be centralized"
+    );
+
+    for path in [
+        "src/resolver/type_validation.rs",
+        "src/typechecker/generic_type_reference_walker.rs",
+        "src/typechecker/resolve.rs",
+    ] {
+        let source = read(path);
+        assert!(
+            !source.contains("name == \"String\""),
+            "{path} should not hard-code dynamic String spelling in semantic logic"
+        );
+    }
+}

--- a/tests/docs_truth/repo_hygiene/mod.rs
+++ b/tests/docs_truth/repo_hygiene/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+mod builtin_type_spelling;
 mod ci_configs;
 mod file_size;
 mod parser_enums;


### PR DESCRIPTION
## Summary

- move public static/dynamic string type spellings into shared AST type helpers
- route resolver/typechecker builtin `String` recognition through the shared helper
- add a docs-truth hygiene guard preventing raw semantic `String` comparisons from returning

## Validation

- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`