### PR TITLE
[codex] Use enum spellings for gated methods

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3885,6 +3885,11 @@ and do not assume Phase 4 is ready without evidence.
 - Builtin public type spellings now use shared AST helpers rather than
   duplicated semantic string comparisons, covered by
   `semantic_builtin_type_checks_use_shared_spelling_helper`.
+- Gated `.raise()` and `.await()` method recognition now routes through
+  `GatedMethod` enum-owned spellings, covered by
+  `typechecker_gated_methods_use_owned_action_enum`,
+  `result_raise_is_rejected_until_propagation_lowering_exists`, and
+  `effect_await_is_rejected_until_async_lowering_exists`.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3563,6 +3563,12 @@ checked-in docs, tests, and commits only.
   instead of ad hoc semantic string checks, keeping `String` recognition and
   `StaticString` display spelling tied to one source. Guarded by
   `semantic_builtin_type_checks_use_shared_spelling_helper`.
+- Gated `.raise()` and `.await()` method recognition now dispatches through the
+  `GatedMethod` enum-owned spellings rather than hand-rolled comparisons,
+  preserving the focused Result propagation and Sync/Async effect gates. Guarded
+  by `typechecker_gated_methods_use_owned_action_enum`,
+  `result_raise_is_rejected_until_propagation_lowering_exists`, and
+  `effect_await_is_rejected_until_async_lowering_exists`.
 
 ## Current Phase
 

--- a/src/typechecker/expressions/method_call_support.rs
+++ b/src/typechecker/expressions/method_call_support.rs
@@ -48,12 +48,10 @@ impl FromStr for GatedMethod {
     type Err = ();
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        if value == Self::ResultRaise.as_str() {
-            Ok(Self::ResultRaise)
-        } else if value == Self::EffectAwait.as_str() {
-            Ok(Self::EffectAwait)
-        } else {
-            Err(())
+        match value {
+            Self::RAISE => Ok(Self::ResultRaise),
+            Self::AWAIT => Ok(Self::EffectAwait),
+            _ => Err(()),
         }
     }
 }

--- a/tests/docs_truth/repo_hygiene/parser_enums.rs
+++ b/tests/docs_truth/repo_hygiene/parser_enums.rs
@@ -57,6 +57,8 @@ fn typechecker_gated_methods_use_owned_action_enum() {
     for forbidden in [
         r#""raise" => Some(Self::ResultRaise)"#,
         r#""await" => Some(Self::EffectAwait)"#,
+        "value == Self::ResultRaise.as_str()",
+        "value == Self::EffectAwait.as_str()",
         "from_method_name",
     ] {
         assert!(


### PR DESCRIPTION
## Summary

- route `.raise()` and `.await()` gated-method parsing through `GatedMethod` enum-owned spellings
- tighten docs-truth hygiene so raw gated-method spelling comparisons do not return
- record the Result propagation and Sync/Async gate hardening in phase/audit docs

## Validation

- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`