### PR TITLE
[codex] Use enum spellings for emit-json modes

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3890,6 +3890,11 @@ and do not assume Phase 4 is ready without evidence.
   `typechecker_gated_methods_use_owned_action_enum`,
   `result_raise_is_rejected_until_propagation_lowering_exists`, and
   `effect_await_is_rejected_until_async_lowering_exists`.
+- `zen emit-json` mode routing now uses `EmitJsonMode` enum-owned spellings and
+  derives its usage mode list from that same ordered source, covered by
+  `cli_emit_json_modes_use_owned_mode_enum`,
+  `emit_json_usage_lists_supported_and_gated_modes`, and
+  `emit_json_layout_command_is_explicitly_gated`.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3569,6 +3569,12 @@ checked-in docs, tests, and commits only.
   by `typechecker_gated_methods_use_owned_action_enum`,
   `result_raise_is_rejected_until_propagation_lowering_exists`, and
   `effect_await_is_rejected_until_async_lowering_exists`.
+- `zen emit-json` mode routing now uses `EmitJsonMode` enum-owned spellings and
+  generates its usage mode list from the same ordered source, keeping checked,
+  deterministic, and gated IR boundary modes aligned. Guarded by
+  `cli_emit_json_modes_use_owned_mode_enum`,
+  `emit_json_usage_lists_supported_and_gated_modes`, and
+  `emit_json_layout_command_is_explicitly_gated`.
 
 ## Current Phase
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 use std::process;
+use std::str::FromStr;
 
 mod build_graph_execution;
 mod build_graph_loading;
@@ -34,8 +35,90 @@ use json_emit::{
 };
 use usage::print_usage;
 
-const EMIT_JSON_USAGE: &str =
-    "Usage: zen emit-json <ast|symbols|typed|diagnostics|build-graph|hir|mir|layout|target-yaml> <file.zen>";
+#[derive(Clone, Copy)]
+enum EmitJsonMode {
+    Ast,
+    Symbols,
+    Typed,
+    Diagnostics,
+    BuildGraph,
+    Hir,
+    Mir,
+    Layout,
+    TargetYaml,
+}
+
+impl EmitJsonMode {
+    const AST: &'static str = "ast";
+    const SYMBOLS: &'static str = "symbols";
+    const TYPED: &'static str = "typed";
+    const DIAGNOSTICS: &'static str = "diagnostics";
+    const BUILD_GRAPH: &'static str = "build-graph";
+    const HIR: &'static str = "hir";
+    const MIR: &'static str = "mir";
+    const LAYOUT: &'static str = "layout";
+    const TARGET_YAML: &'static str = "target-yaml";
+
+    const ORDERED: [Self; 9] = [
+        Self::Ast,
+        Self::Symbols,
+        Self::Typed,
+        Self::Diagnostics,
+        Self::BuildGraph,
+        Self::Hir,
+        Self::Mir,
+        Self::Layout,
+        Self::TargetYaml,
+    ];
+
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Ast => Self::AST,
+            Self::Symbols => Self::SYMBOLS,
+            Self::Typed => Self::TYPED,
+            Self::Diagnostics => Self::DIAGNOSTICS,
+            Self::BuildGraph => Self::BUILD_GRAPH,
+            Self::Hir => Self::HIR,
+            Self::Mir => Self::MIR,
+            Self::Layout => Self::LAYOUT,
+            Self::TargetYaml => Self::TARGET_YAML,
+        }
+    }
+
+    fn usage() -> String {
+        Self::ORDERED
+            .iter()
+            .map(|mode| mode.as_str())
+            .collect::<Vec<_>>()
+            .join("|")
+    }
+}
+
+impl FromStr for EmitJsonMode {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            Self::AST => Ok(Self::Ast),
+            Self::SYMBOLS => Ok(Self::Symbols),
+            Self::TYPED => Ok(Self::Typed),
+            Self::DIAGNOSTICS => Ok(Self::Diagnostics),
+            Self::BUILD_GRAPH => Ok(Self::BuildGraph),
+            Self::HIR => Ok(Self::Hir),
+            Self::MIR => Ok(Self::Mir),
+            Self::LAYOUT => Ok(Self::Layout),
+            Self::TARGET_YAML => Ok(Self::TargetYaml),
+            _ => Err(()),
+        }
+    }
+}
+
+fn emit_json_usage() -> String {
+    format!(
+        "Usage: zen emit-json <{}> <file.zen>",
+        EmitJsonMode::usage()
+    )
+}
 
 pub fn main() {
     let args: Vec<String> = std::env::args().collect();
@@ -83,41 +166,42 @@ pub fn main() {
         }
         "emit-json" => {
             if args.len() < 4 {
-                eprintln!("{EMIT_JSON_USAGE}");
+                eprintln!("{}", emit_json_usage());
                 process::exit(1);
             }
-            match args[2].as_str() {
-                "ast" => cmd_emit_json_ast(&args[3]),
-                "symbols" => cmd_emit_json_symbols(&args[3]),
-                "typed" => cmd_emit_json_typed(&args[3]),
-                "diagnostics" => cmd_emit_json_diagnostics(&args[3]),
-                "build-graph" => cmd_emit_json_build_graph(&args[3]),
-                "hir" => {
+            let mode = args[2].as_str();
+            match mode.parse::<EmitJsonMode>() {
+                Ok(EmitJsonMode::Ast) => cmd_emit_json_ast(&args[3]),
+                Ok(EmitJsonMode::Symbols) => cmd_emit_json_symbols(&args[3]),
+                Ok(EmitJsonMode::Typed) => cmd_emit_json_typed(&args[3]),
+                Ok(EmitJsonMode::Diagnostics) => cmd_emit_json_diagnostics(&args[3]),
+                Ok(EmitJsonMode::BuildGraph) => cmd_emit_json_build_graph(&args[3]),
+                Ok(EmitJsonMode::Hir) => {
                     eprintln!(
                         "error: HIR JSON emission is gated until schema and golden tests exist"
                     );
                     process::exit(1);
                 }
-                "mir" => {
+                Ok(EmitJsonMode::Mir) => {
                     eprintln!(
                         "error: MIR JSON emission is gated until schema and golden tests exist"
                     );
                     process::exit(1);
                 }
-                "layout" => {
+                Ok(EmitJsonMode::Layout) => {
                     eprintln!(
                         "error: type layout JSON emission is gated until ABI layout tests exist"
                     );
                     process::exit(1);
                 }
-                "target-yaml" => {
+                Ok(EmitJsonMode::TargetYaml) => {
                     eprintln!(
                         "error: target YAML validation is gated until schemas and negative validation tests exist"
                     );
                     process::exit(1);
                 }
-                _ => {
-                    eprintln!("{EMIT_JSON_USAGE}");
+                Err(()) => {
+                    eprintln!("{}", emit_json_usage());
                     process::exit(1);
                 }
             }

--- a/tests/docs_truth/repo_hygiene/parser_enums.rs
+++ b/tests/docs_truth/repo_hygiene/parser_enums.rs
@@ -71,3 +71,25 @@ fn typechecker_gated_methods_use_owned_action_enum() {
         "typechecker gated method dispatch should parse through GatedMethod"
     );
 }
+
+#[test]
+fn cli_emit_json_modes_use_owned_mode_enum() {
+    let source = read("src/cli.rs");
+
+    assert!(
+        source.contains("enum EmitJsonMode"),
+        "emit-json command routing should use an owned EmitJsonMode enum"
+    );
+    assert!(
+        source.contains("mode.parse::<EmitJsonMode>()"),
+        "emit-json command routing should parse modes through EmitJsonMode"
+    );
+    assert!(
+        source.contains("EmitJsonMode::usage()"),
+        "emit-json usage should be generated from EmitJsonMode"
+    );
+    assert!(
+        !source.contains("<ast|symbols|typed|diagnostics|build-graph|hir|mir|layout|target-yaml>"),
+        "emit-json usage should not duplicate the mode list as a raw string"
+    );
+}


### PR DESCRIPTION
## Summary

- route `zen emit-json` mode parsing through `EmitJsonMode`
- derive the usage mode list from the same ordered enum source
- add docs-truth hygiene coverage so checked, deterministic, and gated JSON/YAML modes do not drift

## Validation

- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`