### PR TITLE
[codex] Split static string runtime layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ main = () i32 {
   fluent without requiring class-based design.
 - Behaviors describe required capabilities directly, so generic code can state
   the operations it needs.
-- `StaticString` names text baked into the program, while allocator-backed String
-  is the owned, dynamic text type.
+- `StaticString` names text baked into the program with compile-time length,
+  while allocator-backed String is the owned, dynamic text type.
 - The language is designed for predictable native programs: explicit types,
   explicit imports, and no hidden object model.
 

--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3882,6 +3882,11 @@ and do not assume Phase 4 is ready without evidence.
   allocation must remain explicit. Covered by
   `static_string_literal_does_not_implicitly_allocate_string` and
   `types_compatible_basics`.
+- C runtime layout now keeps the same split: static string literals emit as
+  direct `zen_str` compound literals with `sizeof`-derived compile-time length,
+  while dynamic `zen_string` carries an allocator pointer. Covered by
+  `runtime_separates_static_and_allocator_backed_strings` and
+  `emit_string_literal`.
 - Builtin public type spellings now use shared AST helpers rather than
   duplicated semantic string comparisons, covered by
   `semantic_builtin_type_checks_use_shared_spelling_helper`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3559,6 +3559,11 @@ checked-in docs, tests, and commits only.
   allocate dynamic `String` values. Covered by
   `static_string_literal_does_not_implicitly_allocate_string` and
   `types_compatible_basics`.
+- C runtime layout now mirrors that public model: static string literals emit
+  as direct `zen_str` compound literals whose length is derived with `sizeof`,
+  while dynamic `zen_string` carries an allocator pointer. Covered by
+  `runtime_separates_static_and_allocator_backed_strings` and
+  `emit_string_literal`.
 - Builtin public type spellings now route through shared AST type helpers
   instead of ad hoc semantic string checks, keeping `String` recognition and
   `StaticString` display spelling tied to one source. Guarded by

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -71,11 +71,12 @@ Generic behavior inheritance with child type-parameter parent args is covered by
 ## Type, Module, ABI, Error, Effect, And Comptime Decisions
 
 - `StaticString` is baked into the program. It denotes literal/static text with
-  stable storage and length. The allocator-backed `String` type is owned,
-  dynamic text and depends on the typed allocator model before it can be
-  promoted as a stable construction target. Static string literals do not
-  implicitly allocate or coerce into `String`; dynamic `String` construction
-  must go through an explicit allocator-aware path once that path is promoted.
+  stable storage and compile-time length in the generated runtime layout. The
+  allocator-backed `String` type is owned, dynamic text and carries allocator
+  identity before it can be promoted as a stable construction target. Static
+  string literals do not implicitly allocate or coerce into `String`; dynamic
+  `String` construction must go through an explicit allocator-aware path once
+  that path is promoted.
 - `Sync/Async effects`: gated. `Sync` and `Async` are real effects in v1, not
   marker-only types. Sync code must not call async operations except through an
   explicit runtime blocking boundary. Async operations lower through checked task,

--- a/src/ast/typed/types.rs
+++ b/src/ast/typed/types.rs
@@ -26,8 +26,8 @@ pub enum Type {
     Void,
 
     // Strings
-    Str,    // static string: { ptr, len }
-    String, // heap string: { ptr, len, cap, alloc }
+    Str,    // static string view over baked program storage: { ptr, len }
+    String, // allocator-backed dynamic string: { ptr, len, cap, allocator }
 
     // Named type — struct/enum by mangled name
     Named(std::string::String),

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -35,8 +35,8 @@ pub enum AstType {
     Void,
 
     // Strings
-    Str,    // static string: { ptr, len }
-    String, // heap string: { ptr, len, cap, alloc }
+    Str,    // static string view over baked program storage: { ptr, len }
+    String, // allocator-backed dynamic string: { ptr, len, cap, allocator }
 
     // User-defined / unresolved named type
     Named(std::string::String),

--- a/src/codegen/c/emit.rs
+++ b/src/codegen/c/emit.rs
@@ -92,7 +92,7 @@ impl CEmitter {
             TypedExprKind::FloatLiteral(v) => format_float(*v).to_string(),
             TypedExprKind::StringLiteral(s) => {
                 let escaped = c_escape_string(s);
-                format!("zen_str_from_literal(\"{}\")", escaped)
+                c_static_str_literal(&escaped)
             }
             TypedExprKind::BoolLiteral(b) => {
                 if *b {

--- a/src/codegen/c/mod.rs
+++ b/src/codegen/c/mod.rs
@@ -158,6 +158,11 @@ fn c_escape_string(s: &str) -> String {
     out
 }
 
+/// Build a static string view from a C string literal expression.
+fn c_static_str_literal(escaped_literal: &str) -> String {
+    format!("(zen_str){{ .ptr = \"{escaped_literal}\", .len = sizeof(\"{escaped_literal}\") - 1 }}")
+}
+
 /// Format a float for C source code.
 fn format_float(v: f64) -> String {
     let s = format!("{}", v);

--- a/src/codegen/c/strings.rs
+++ b/src/codegen/c/strings.rs
@@ -10,7 +10,7 @@ impl CEmitter {
             match &parts[0] {
                 TypedStringPart::Literal(s) => {
                     let escaped = c_escape_string(s);
-                    return format!("zen_str_from_literal(\"{}\")", escaped);
+                    return c_static_str_literal(&escaped);
                 }
                 TypedStringPart::Expr(e) => {
                     return self.emit_to_str(e);
@@ -46,7 +46,7 @@ impl CEmitter {
                 arg_exprs.join(", ")
             ));
         }
-        format!("zen_str_from_literal({})", buf)
+        format!("zen_str_from_cstr({})", buf)
     }
 
     pub(super) fn emit_printf_arg(&mut self, expr: &TypedExpression) -> (String, String) {
@@ -87,9 +87,11 @@ impl CEmitter {
                 )
             }
             Type::Bool => {
-                format!("zen_str_from_literal(({}) ? \"true\" : \"false\")", val)
+                let true_str = c_static_str_literal("true");
+                let false_str = c_static_str_literal("false");
+                format!("(({}) ? {} : {})", val, true_str, false_str)
             }
-            _ => format!("zen_str_from_literal(\"<{}>\")", expr.ty.display_name()),
+            _ => c_static_str_literal(&format!("<{}>", expr.ty.display_name())),
         }
     }
 }

--- a/src/codegen/c/tests/expression_emission.rs
+++ b/src/codegen/c/tests/expression_emission.rs
@@ -32,7 +32,10 @@ fn emit_bool_literal() {
 fn emit_string_literal() {
     let mut e = CEmitter::new();
     let expr = texpr(TypedExprKind::StringLiteral("hi".into()), Type::Str);
-    assert_eq!(e.emit_expr_inline(&expr), "zen_str_from_literal(\"hi\")");
+    assert_eq!(
+        e.emit_expr_inline(&expr),
+        "(zen_str){ .ptr = \"hi\", .len = sizeof(\"hi\") - 1 }"
+    );
 }
 
 #[test]

--- a/src/codegen/c/tests/program_generation.rs
+++ b/src/codegen/c/tests/program_generation.rs
@@ -59,6 +59,21 @@ fn generates_function() {
 }
 
 #[test]
+fn runtime_separates_static_and_allocator_backed_strings() {
+    let backend = CBackend;
+    let output = backend.generate(&make_simple_program()).unwrap();
+
+    assert!(output.contains("typedef struct { const char* ptr; size_t len; } zen_str;"));
+    assert!(output.contains("typedef struct zen_allocator zen_allocator;"));
+    assert!(output.contains(
+        "typedef struct { char* ptr; size_t len; size_t cap; zen_allocator* allocator; } zen_string;"
+    ));
+    assert!(output.contains("static zen_str zen_str_from_cstr(const char* s)"));
+    assert!(!output.contains("zen_str_from_literal"));
+    assert!(!output.contains("#define ZEN_STATIC_STR"));
+}
+
+#[test]
 fn generates_struct() {
     let backend = CBackend;
     let program = TypedProgram {

--- a/src/codegen/c/types/runtime_helpers.rs
+++ b/src/codegen/c/types/runtime_helpers.rs
@@ -4,10 +4,11 @@ impl CEmitter {
     pub(super) fn emit_runtime_types(&mut self) {
         self.line("/* Runtime types */");
         self.line("typedef struct { const char* ptr; size_t len; } zen_str;");
-        self.line("typedef struct { char* ptr; size_t len; size_t cap; } zen_string;");
+        self.line("typedef struct zen_allocator zen_allocator;");
+        self.line("typedef struct { char* ptr; size_t len; size_t cap; zen_allocator* allocator; } zen_string;");
         self.blank();
 
-        self.emit_string_literal_helper();
+        self.emit_c_string_view_helper();
         self.emit_string_print_helper();
         self.emit_int_string_helper();
         self.emit_float_string_helper();
@@ -32,8 +33,8 @@ impl CEmitter {
         self.blank();
     }
 
-    fn emit_string_literal_helper(&mut self) {
-        self.line("static zen_str zen_str_from_literal(const char* s) {");
+    fn emit_c_string_view_helper(&mut self) {
+        self.line("static zen_str zen_str_from_cstr(const char* s) {");
         self.indent();
         self.line("return (zen_str){ .ptr = s, .len = strlen(s) };");
         self.dedent();


### PR DESCRIPTION
## Summary
- emit `StaticString` literals as direct `zen_str` compound literals with `sizeof`-derived lengths
- make dynamic `zen_string` carry allocator identity in the generated C runtime layout
- update docs and tests for the static-vs-allocator-backed string model

## Validation
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`