### PR TITLE
[codex] Gate allocator and effect type spellings

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3887,6 +3887,12 @@ and do not assume Phase 4 is ready without evidence.
   while dynamic `zen_string` carries an allocator pointer. Covered by
   `runtime_separates_static_and_allocator_backed_strings` and
   `emit_string_literal`.
+- `Allocator`, `Sync`, and `Async` type spellings are now owned by AST gated
+  builtin type metadata and produce gated diagnostics rather than ordinary
+  unknown-type errors. Covered by
+  `typed_allocator_type_is_rejected_as_gated_not_unknown`,
+  `sync_async_effect_modes_are_rejected_as_gated_not_unknown`, and
+  `semantic_builtin_type_checks_use_shared_spelling_helper`.
 - Builtin public type spellings now use shared AST helpers rather than
   duplicated semantic string comparisons, covered by
   `semantic_builtin_type_checks_use_shared_spelling_helper`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3564,6 +3564,11 @@ checked-in docs, tests, and commits only.
   while dynamic `zen_string` carries an allocator pointer. Covered by
   `runtime_separates_static_and_allocator_backed_strings` and
   `emit_string_literal`.
+- `Allocator`, `Sync`, and `Async` type spellings now live in AST-owned gated
+  builtin type metadata and produce gated diagnostics instead of unknown-type
+  errors. Covered by `typed_allocator_type_is_rejected_as_gated_not_unknown`,
+  `sync_async_effect_modes_are_rejected_as_gated_not_unknown`, and
+  `semantic_builtin_type_checks_use_shared_spelling_helper`.
 - Builtin public type spellings now route through shared AST type helpers
   instead of ad hoc semantic string checks, keeping `String` recognition and
   `StaticString` display spelling tied to one source. Guarded by

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -84,6 +84,8 @@ Generic behavior inheritance with child type-parameter parent args is covered by
 - `Typed allocators`: gated. v1 allocators are typed by allocated value and effect
   mode, such as `Allocator<T, Sync>` and `Allocator<T, Async>`. Sync allocation
   returns a direct checked result; async allocation returns a task/effect result.
+  Until allocator lowering exists, these spellings produce gated diagnostics
+  rather than unknown-type errors.
 - `Type matching`: gated. Comptime type matching operates on typed metadata for
   primitives, structs, enums, fields, variants, behaviors, allocator modes, and
   effect modes. It is separate from runtime value matching.

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -10,7 +10,7 @@ pub use declarations::{BehaviorMethod, Declaration, EnumVariant, StructField, Ty
 pub use expressions::{BinaryOp, Expression, MatchArm, StringPart, UnaryOp};
 pub use patterns::Pattern;
 pub use statements::Statement;
-pub use types::{is_builtin_type_name, AstType, Param};
+pub use types::{gated_builtin_type_name, is_builtin_type_name, AstType, Param};
 
 use crate::error::FileId;
 use serde::Serialize;

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -3,9 +3,56 @@ use serde::Serialize;
 
 pub const STATIC_STRING_TYPE_NAME: &str = "StaticString";
 pub const DYNAMIC_STRING_TYPE_NAME: &str = "String";
+pub const ALLOCATOR_TYPE_NAME: &str = "Allocator";
+pub const SYNC_EFFECT_TYPE_NAME: &str = "Sync";
+pub const ASYNC_EFFECT_TYPE_NAME: &str = "Async";
 
 pub fn is_builtin_type_name(name: &str) -> bool {
     name == DYNAMIC_STRING_TYPE_NAME
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GatedBuiltinType {
+    Allocator,
+    SyncEffect,
+    AsyncEffect,
+}
+
+impl GatedBuiltinType {
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            ALLOCATOR_TYPE_NAME => Some(Self::Allocator),
+            SYNC_EFFECT_TYPE_NAME => Some(Self::SyncEffect),
+            ASYNC_EFFECT_TYPE_NAME => Some(Self::AsyncEffect),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Allocator => ALLOCATOR_TYPE_NAME,
+            Self::SyncEffect => SYNC_EFFECT_TYPE_NAME,
+            Self::AsyncEffect => ASYNC_EFFECT_TYPE_NAME,
+        }
+    }
+
+    pub fn gate_message(self) -> std::string::String {
+        match self {
+            Self::Allocator => {
+                "typed allocators are gated until allocator ownership and effect semantics are implemented".into()
+            }
+            Self::SyncEffect | Self::AsyncEffect => {
+                format!(
+                    "`{}` effect mode is gated until Sync/Async effect checking is implemented",
+                    self.as_str()
+                )
+            }
+        }
+    }
+}
+
+pub fn gated_builtin_type_name(name: &str) -> Option<GatedBuiltinType> {
+    GatedBuiltinType::from_name(name)
 }
 
 /// Parser-level type representation.

--- a/src/typechecker/generic_type_reference_walker.rs
+++ b/src/typechecker/generic_type_reference_walker.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::ast::is_builtin_type_name;
+use crate::ast::{gated_builtin_type_name, is_builtin_type_name};
 
 mod expressions;
 
@@ -76,6 +76,12 @@ impl TypeChecker {
                     return;
                 }
 
+                if let Some(gated) = gated_builtin_type_name(name) {
+                    self.diagnostics
+                        .push(Diagnostic::error("E0202", gated.gate_message(), span));
+                    return;
+                }
+
                 if !self.is_known_named_type(name) {
                     if reject_unknown {
                         self.diagnostics.push(Diagnostic::error(
@@ -110,6 +116,12 @@ impl TypeChecker {
                 }
             }
             AstType::Generic { name, type_args } => {
+                if let Some(gated) = gated_builtin_type_name(name) {
+                    self.diagnostics
+                        .push(Diagnostic::error("E0202", gated.gate_message(), span));
+                    return;
+                }
+
                 self.validate_generic_type_arg_refs_with_unknowns(
                     type_args,
                     scoped_type_params,

--- a/src/typechecker/tests/core_semantics/literals.rs
+++ b/src/typechecker/tests/core_semantics/literals.rs
@@ -85,3 +85,59 @@ main = () i32 {
         "await gate should not be reported as an ordinary missing method, got {err:?}"
     );
 }
+
+#[test]
+fn typed_allocator_type_is_rejected_as_gated_not_unknown() {
+    let program = parse_program(
+        r#"
+main = (allocator: Allocator<i32, Sync>) void { }
+"#,
+    );
+    let mut tc = TypeChecker::new();
+
+    let err = tc
+        .check_program(&program)
+        .expect_err("typed allocator types should stay gated until allocator semantics exist");
+
+    assert!(
+        err.iter()
+            .any(|d| d.message.contains("typed allocators are gated")),
+        "expected typed allocator gate diagnostic, got {err:?}"
+    );
+    assert!(
+        err.iter()
+            .all(|d| !d.message.contains("unknown type symbol")),
+        "allocator/effect gate should not be reported as ordinary unknown types, got {err:?}"
+    );
+}
+
+#[test]
+fn sync_async_effect_modes_are_rejected_as_gated_not_unknown() {
+    let program = parse_program(
+        r#"
+use_sync = (mode: Sync) void { }
+use_async = (mode: Async) void { }
+"#,
+    );
+    let mut tc = TypeChecker::new();
+
+    let err = tc
+        .check_program(&program)
+        .expect_err("effect mode types should stay gated until effect semantics exist");
+
+    for expected in [
+        "`Sync` effect mode is gated",
+        "`Async` effect mode is gated",
+    ] {
+        assert!(
+            err.iter()
+                .any(|diagnostic| diagnostic.message.contains(expected)),
+            "expected diagnostic `{expected}`, got {err:?}"
+        );
+    }
+    assert!(
+        err.iter()
+            .all(|d| !d.message.contains("unknown type symbol")),
+        "effect mode gate should not be reported as ordinary unknown types, got {err:?}"
+    );
+}

--- a/tests/docs_truth/repo_hygiene/builtin_type_spelling.rs
+++ b/tests/docs_truth/repo_hygiene/builtin_type_spelling.rs
@@ -7,6 +7,18 @@ fn semantic_builtin_type_checks_use_shared_spelling_helper() {
         helper.contains("pub const DYNAMIC_STRING_TYPE_NAME: &str = \"String\""),
         "dynamic String spelling should live in the AST type helper module"
     );
+    for required in [
+        "pub const ALLOCATOR_TYPE_NAME: &str = \"Allocator\"",
+        "pub const SYNC_EFFECT_TYPE_NAME: &str = \"Sync\"",
+        "pub const ASYNC_EFFECT_TYPE_NAME: &str = \"Async\"",
+        "pub enum GatedBuiltinType",
+        "pub fn gated_builtin_type_name",
+    ] {
+        assert!(
+            helper.contains(required),
+            "gated builtin type spelling should live in the AST type helper module: {required}"
+        );
+    }
     assert!(
         helper.contains("pub fn is_builtin_type_name"),
         "builtin type-name recognition should be centralized"


### PR DESCRIPTION
## Summary
- centralize `Allocator`, `Sync`, and `Async` as AST-owned gated builtin type spellings
- report typed allocator/effect mode references as gated diagnostics instead of unknown type symbols
- add focused typechecker and docs-truth coverage for the gated spelling path

## Validation
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`