### PR TITLE
[codex] Gate actor framework type spellings

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3893,6 +3893,11 @@ and do not assume Phase 4 is ready without evidence.
   `typed_allocator_type_is_rejected_as_gated_not_unknown`,
   `sync_async_effect_modes_are_rejected_as_gated_not_unknown`, and
   `semantic_builtin_type_checks_use_shared_spelling_helper`.
+- Actor framework type spellings `Actor`, `ActorRef`, `Mailbox`, and
+  `Supervisor` now use AST gated builtin type metadata and produce actor-specific
+  gated diagnostics rather than ordinary unknown-type errors. Covered by
+  `actor_framework_types_are_rejected_as_gated_not_unknown` and
+  `semantic_builtin_type_checks_use_shared_spelling_helper`.
 - Builtin public type spellings now use shared AST helpers rather than
   duplicated semantic string comparisons, covered by
   `semantic_builtin_type_checks_use_shared_spelling_helper`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3569,6 +3569,11 @@ checked-in docs, tests, and commits only.
   errors. Covered by `typed_allocator_type_is_rejected_as_gated_not_unknown`,
   `sync_async_effect_modes_are_rejected_as_gated_not_unknown`, and
   `semantic_builtin_type_checks_use_shared_spelling_helper`.
+- Actor framework type spellings `Actor`, `ActorRef`, `Mailbox`, and
+  `Supervisor` now share the same AST-owned gated builtin type path and report
+  actor-specific gated diagnostics instead of unknown-type errors. Covered by
+  `actor_framework_types_are_rejected_as_gated_not_unknown` and
+  `semantic_builtin_type_checks_use_shared_spelling_helper`.
 - Builtin public type spellings now route through shared AST type helpers
   instead of ad hoc semantic string checks, keeping `String` recognition and
   `StaticString` display spelling tied to one source. Guarded by

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -99,7 +99,9 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   boundary explicit.
 - `Actors in std`: gated. Actors are a stdlib framework first, with `Actor`,
   `ActorRef`, `Mailbox`, `Channel`, and `Supervisor` built on effect-aware queues
-  and typed allocators. No actor syntax is v1-stable yet.
+  and typed allocators. No actor syntax is v1-stable yet, and promoted actor
+  framework type spellings report gated diagnostics until std actor semantics
+  exist.
 - `JSON/YAML IR boundaries`: gated. JSON is the machine-readable exchange format
   for compiler-owned AST, typed HIR, MIR, symbol tables, type layouts, and
   diagnostics. YAML is the human-authored format for target descriptions, ABI

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -6,6 +6,10 @@ pub const DYNAMIC_STRING_TYPE_NAME: &str = "String";
 pub const ALLOCATOR_TYPE_NAME: &str = "Allocator";
 pub const SYNC_EFFECT_TYPE_NAME: &str = "Sync";
 pub const ASYNC_EFFECT_TYPE_NAME: &str = "Async";
+pub const ACTOR_TYPE_NAME: &str = "Actor";
+pub const ACTOR_REF_TYPE_NAME: &str = "ActorRef";
+pub const MAILBOX_TYPE_NAME: &str = "Mailbox";
+pub const SUPERVISOR_TYPE_NAME: &str = "Supervisor";
 
 pub fn is_builtin_type_name(name: &str) -> bool {
     name == DYNAMIC_STRING_TYPE_NAME
@@ -16,6 +20,10 @@ pub enum GatedBuiltinType {
     Allocator,
     SyncEffect,
     AsyncEffect,
+    Actor,
+    ActorRef,
+    Mailbox,
+    Supervisor,
 }
 
 impl GatedBuiltinType {
@@ -24,6 +32,10 @@ impl GatedBuiltinType {
             ALLOCATOR_TYPE_NAME => Some(Self::Allocator),
             SYNC_EFFECT_TYPE_NAME => Some(Self::SyncEffect),
             ASYNC_EFFECT_TYPE_NAME => Some(Self::AsyncEffect),
+            ACTOR_TYPE_NAME => Some(Self::Actor),
+            ACTOR_REF_TYPE_NAME => Some(Self::ActorRef),
+            MAILBOX_TYPE_NAME => Some(Self::Mailbox),
+            SUPERVISOR_TYPE_NAME => Some(Self::Supervisor),
             _ => None,
         }
     }
@@ -33,6 +45,10 @@ impl GatedBuiltinType {
             Self::Allocator => ALLOCATOR_TYPE_NAME,
             Self::SyncEffect => SYNC_EFFECT_TYPE_NAME,
             Self::AsyncEffect => ASYNC_EFFECT_TYPE_NAME,
+            Self::Actor => ACTOR_TYPE_NAME,
+            Self::ActorRef => ACTOR_REF_TYPE_NAME,
+            Self::Mailbox => MAILBOX_TYPE_NAME,
+            Self::Supervisor => SUPERVISOR_TYPE_NAME,
         }
     }
 
@@ -44,6 +60,12 @@ impl GatedBuiltinType {
             Self::SyncEffect | Self::AsyncEffect => {
                 format!(
                     "`{}` effect mode is gated until Sync/Async effect checking is implemented",
+                    self.as_str()
+                )
+            }
+            Self::Actor | Self::ActorRef | Self::Mailbox | Self::Supervisor => {
+                format!(
+                    "`{}` framework type is gated until std actor scheduling and mailbox semantics are implemented",
                     self.as_str()
                 )
             }

--- a/src/typechecker/tests/core_semantics/literals.rs
+++ b/src/typechecker/tests/core_semantics/literals.rs
@@ -141,3 +141,38 @@ use_async = (mode: Async) void { }
         "effect mode gate should not be reported as ordinary unknown types, got {err:?}"
     );
 }
+
+#[test]
+fn actor_framework_types_are_rejected_as_gated_not_unknown() {
+    let program = parse_program(
+        r#"
+use_actor = (actor: Actor<i32>) void { }
+use_ref = (ref: ActorRef<i32>) void { }
+use_mailbox = (mailbox: Mailbox<i32>) void { }
+use_supervisor = (supervisor: Supervisor) void { }
+"#,
+    );
+    let mut tc = TypeChecker::new();
+
+    let err = tc
+        .check_program(&program)
+        .expect_err("actor framework types should stay gated until std actor semantics exist");
+
+    for expected in [
+        "`Actor` framework type is gated",
+        "`ActorRef` framework type is gated",
+        "`Mailbox` framework type is gated",
+        "`Supervisor` framework type is gated",
+    ] {
+        assert!(
+            err.iter()
+                .any(|diagnostic| diagnostic.message.contains(expected)),
+            "expected diagnostic `{expected}`, got {err:?}"
+        );
+    }
+    assert!(
+        err.iter()
+            .all(|d| !d.message.contains("unknown type symbol")),
+        "actor framework gate should not be reported as ordinary unknown types, got {err:?}"
+    );
+}

--- a/tests/docs_truth/repo_hygiene/builtin_type_spelling.rs
+++ b/tests/docs_truth/repo_hygiene/builtin_type_spelling.rs
@@ -11,6 +11,10 @@ fn semantic_builtin_type_checks_use_shared_spelling_helper() {
         "pub const ALLOCATOR_TYPE_NAME: &str = \"Allocator\"",
         "pub const SYNC_EFFECT_TYPE_NAME: &str = \"Sync\"",
         "pub const ASYNC_EFFECT_TYPE_NAME: &str = \"Async\"",
+        "pub const ACTOR_TYPE_NAME: &str = \"Actor\"",
+        "pub const ACTOR_REF_TYPE_NAME: &str = \"ActorRef\"",
+        "pub const MAILBOX_TYPE_NAME: &str = \"Mailbox\"",
+        "pub const SUPERVISOR_TYPE_NAME: &str = \"Supervisor\"",
         "pub enum GatedBuiltinType",
         "pub fn gated_builtin_type_name",
     ] {


### PR DESCRIPTION
## Summary
- centralize `Actor`, `ActorRef`, `Mailbox`, and `Supervisor` as AST-owned gated builtin type spellings
- report actor framework type references as gated diagnostics instead of unknown type symbols
- update docs and docs-truth coverage for the actor type gate

## Validation
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`