### PR TITLE
[codex] Use a gated builtin type table

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3898,6 +3898,9 @@ and do not assume Phase 4 is ready without evidence.
   gated diagnostics rather than ordinary unknown-type errors. Covered by
   `actor_framework_types_are_rejected_as_gated_not_unknown` and
   `semantic_builtin_type_checks_use_shared_spelling_helper`.
+- Gated builtin type lookup now uses `GatedBuiltinType::ALL` as the enum-owned
+  static table rather than a separate name-to-variant match, covered by
+  `semantic_builtin_type_checks_use_shared_spelling_helper`.
 - Builtin public type spellings now use shared AST helpers rather than
   duplicated semantic string comparisons, covered by
   `semantic_builtin_type_checks_use_shared_spelling_helper`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3574,6 +3574,10 @@ checked-in docs, tests, and commits only.
   actor-specific gated diagnostics instead of unknown-type errors. Covered by
   `actor_framework_types_are_rejected_as_gated_not_unknown` and
   `semantic_builtin_type_checks_use_shared_spelling_helper`.
+- Gated builtin type lookup now uses `GatedBuiltinType::ALL` as the enum-owned
+  static table, so adding future gated type spellings does not require a
+  separate name-to-variant match. Guarded by
+  `semantic_builtin_type_checks_use_shared_spelling_helper`.
 - Builtin public type spellings now route through shared AST type helpers
   instead of ad hoc semantic string checks, keeping `String` recognition and
   `StaticString` display spelling tied to one source. Guarded by

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -27,17 +27,21 @@ pub enum GatedBuiltinType {
 }
 
 impl GatedBuiltinType {
+    pub const ALL: &[GatedBuiltinType] = &[
+        Self::Allocator,
+        Self::SyncEffect,
+        Self::AsyncEffect,
+        Self::Actor,
+        Self::ActorRef,
+        Self::Mailbox,
+        Self::Supervisor,
+    ];
+
     pub fn from_name(name: &str) -> Option<Self> {
-        match name {
-            ALLOCATOR_TYPE_NAME => Some(Self::Allocator),
-            SYNC_EFFECT_TYPE_NAME => Some(Self::SyncEffect),
-            ASYNC_EFFECT_TYPE_NAME => Some(Self::AsyncEffect),
-            ACTOR_TYPE_NAME => Some(Self::Actor),
-            ACTOR_REF_TYPE_NAME => Some(Self::ActorRef),
-            MAILBOX_TYPE_NAME => Some(Self::Mailbox),
-            SUPERVISOR_TYPE_NAME => Some(Self::Supervisor),
-            _ => None,
-        }
+        GatedBuiltinType::ALL
+            .iter()
+            .copied()
+            .find(|ty| ty.as_str() == name)
     }
 
     pub fn as_str(self) -> &'static str {

--- a/tests/docs_truth/repo_hygiene/builtin_type_spelling.rs
+++ b/tests/docs_truth/repo_hygiene/builtin_type_spelling.rs
@@ -16,6 +16,7 @@ fn semantic_builtin_type_checks_use_shared_spelling_helper() {
         "pub const MAILBOX_TYPE_NAME: &str = \"Mailbox\"",
         "pub const SUPERVISOR_TYPE_NAME: &str = \"Supervisor\"",
         "pub enum GatedBuiltinType",
+        "pub const ALL: &[GatedBuiltinType]",
         "pub fn gated_builtin_type_name",
     ] {
         assert!(
@@ -23,6 +24,13 @@ fn semantic_builtin_type_checks_use_shared_spelling_helper() {
             "gated builtin type spelling should live in the AST type helper module: {required}"
         );
     }
+    assert!(
+        helper.contains("GatedBuiltinType::ALL")
+            && helper.contains(".iter()")
+            && helper.contains(".copied()")
+            && helper.contains(".find(|ty| ty.as_str() == name)"),
+        "gated builtin type lookup should use the enum-owned static table"
+    );
     assert!(
         helper.contains("pub fn is_builtin_type_name"),
         "builtin type-name recognition should be centralized"


### PR DESCRIPTION
## Summary
- route gated builtin type lookup through `GatedBuiltinType::ALL`
- remove the separate name-to-variant match for gated builtin types
- strengthen docs-truth coverage so future gated type spellings stay tied to the enum-owned table

## Validation
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`