### PR TITLE
[codex] Use enum-owned emit-json gate messages

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3914,6 +3914,14 @@ and do not assume Phase 4 is ready without evidence.
   `cli_emit_json_modes_use_owned_mode_enum`,
   `emit_json_usage_lists_supported_and_gated_modes`, and
   `emit_json_layout_command_is_explicitly_gated`.
+- Gated `emit-json` diagnostics now live on `EmitJsonMode::gate_message`, so
+  HIR, MIR, layout, and target YAML gate text stays attached to the enum that
+  owns mode spelling and usage. Covered by
+  `cli_emit_json_modes_use_owned_mode_enum`,
+  `emit_json_hir_command_is_explicitly_gated`,
+  `emit_json_mir_command_is_explicitly_gated`,
+  `emit_json_layout_command_is_explicitly_gated`, and
+  `emit_json_target_yaml_command_is_explicitly_gated`.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3594,6 +3594,14 @@ checked-in docs, tests, and commits only.
   `cli_emit_json_modes_use_owned_mode_enum`,
   `emit_json_usage_lists_supported_and_gated_modes`, and
   `emit_json_layout_command_is_explicitly_gated`.
+- Gated `emit-json` diagnostics now live on `EmitJsonMode::gate_message`,
+  keeping HIR, MIR, layout, and target YAML gate text attached to the same enum
+  that owns mode spelling and usage. Guarded by
+  `cli_emit_json_modes_use_owned_mode_enum`,
+  `emit_json_hir_command_is_explicitly_gated`,
+  `emit_json_mir_command_is_explicitly_gated`,
+  `emit_json_layout_command_is_explicitly_gated`, and
+  `emit_json_target_yaml_command_is_explicitly_gated`.
 
 ## Current Phase
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -92,6 +92,18 @@ impl EmitJsonMode {
             .collect::<Vec<_>>()
             .join("|")
     }
+
+    fn gate_message(self) -> Option<&'static str> {
+        match self {
+            Self::Hir => Some("HIR JSON emission is gated until schema and golden tests exist"),
+            Self::Mir => Some("MIR JSON emission is gated until schema and golden tests exist"),
+            Self::Layout => Some("type layout JSON emission is gated until ABI layout tests exist"),
+            Self::TargetYaml => Some(
+                "target YAML validation is gated until schemas and negative validation tests exist",
+            ),
+            Self::Ast | Self::Symbols | Self::Typed | Self::Diagnostics | Self::BuildGraph => None,
+        }
+    }
 }
 
 impl FromStr for EmitJsonMode {
@@ -171,34 +183,22 @@ pub fn main() {
             }
             let mode = args[2].as_str();
             match mode.parse::<EmitJsonMode>() {
-                Ok(EmitJsonMode::Ast) => cmd_emit_json_ast(&args[3]),
-                Ok(EmitJsonMode::Symbols) => cmd_emit_json_symbols(&args[3]),
-                Ok(EmitJsonMode::Typed) => cmd_emit_json_typed(&args[3]),
-                Ok(EmitJsonMode::Diagnostics) => cmd_emit_json_diagnostics(&args[3]),
-                Ok(EmitJsonMode::BuildGraph) => cmd_emit_json_build_graph(&args[3]),
-                Ok(EmitJsonMode::Hir) => {
-                    eprintln!(
-                        "error: HIR JSON emission is gated until schema and golden tests exist"
-                    );
-                    process::exit(1);
-                }
-                Ok(EmitJsonMode::Mir) => {
-                    eprintln!(
-                        "error: MIR JSON emission is gated until schema and golden tests exist"
-                    );
-                    process::exit(1);
-                }
-                Ok(EmitJsonMode::Layout) => {
-                    eprintln!(
-                        "error: type layout JSON emission is gated until ABI layout tests exist"
-                    );
-                    process::exit(1);
-                }
-                Ok(EmitJsonMode::TargetYaml) => {
-                    eprintln!(
-                        "error: target YAML validation is gated until schemas and negative validation tests exist"
-                    );
-                    process::exit(1);
+                Ok(mode) => {
+                    if let Some(message) = mode.gate_message() {
+                        eprintln!("error: {message}");
+                        process::exit(1);
+                    }
+                    match mode {
+                        EmitJsonMode::Ast => cmd_emit_json_ast(&args[3]),
+                        EmitJsonMode::Symbols => cmd_emit_json_symbols(&args[3]),
+                        EmitJsonMode::Typed => cmd_emit_json_typed(&args[3]),
+                        EmitJsonMode::Diagnostics => cmd_emit_json_diagnostics(&args[3]),
+                        EmitJsonMode::BuildGraph => cmd_emit_json_build_graph(&args[3]),
+                        EmitJsonMode::Hir
+                        | EmitJsonMode::Mir
+                        | EmitJsonMode::Layout
+                        | EmitJsonMode::TargetYaml => unreachable!("gated emit-json mode exited"),
+                    }
                 }
                 Err(()) => {
                     eprintln!("{}", emit_json_usage());

--- a/tests/docs_truth/repo_hygiene/parser_enums.rs
+++ b/tests/docs_truth/repo_hygiene/parser_enums.rs
@@ -89,6 +89,14 @@ fn cli_emit_json_modes_use_owned_mode_enum() {
         "emit-json usage should be generated from EmitJsonMode"
     );
     assert!(
+        source.contains("fn gate_message(self) -> Option<&'static str>"),
+        "emit-json gated diagnostics should be owned by EmitJsonMode"
+    );
+    assert!(
+        source.contains("mode.gate_message()"),
+        "emit-json command routing should read gated diagnostics from EmitJsonMode"
+    );
+    assert!(
         !source.contains("<ast|symbols|typed|diagnostics|build-graph|hir|mir|layout|target-yaml>"),
         "emit-json usage should not duplicate the mode list as a raw string"
     );


### PR DESCRIPTION
## Summary
- move gated `emit-json` diagnostic text onto `EmitJsonMode::gate_message`
- keep command routing dependent on enum-owned mode behavior instead of duplicated match strings
- strengthen docs-truth coverage and update phase/audit notes

## Validation
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`