### PR TITLE
[codex] Use static gated builtin diagnostics

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3901,6 +3901,13 @@ and do not assume Phase 4 is ready without evidence.
 - Gated builtin type lookup now uses `GatedBuiltinType::ALL` as the enum-owned
   static table rather than a separate name-to-variant match, covered by
   `semantic_builtin_type_checks_use_shared_spelling_helper`.
+- Gated builtin type diagnostics now return enum-owned `&'static str` messages
+  rather than allocating formatted `String` values, preserving static compiler
+  diagnostic text for allocator, effect, and actor gates. Covered by
+  `semantic_builtin_type_checks_use_shared_spelling_helper`,
+  `typed_allocator_type_is_rejected_as_gated_not_unknown`,
+  `sync_async_effect_modes_are_rejected_as_gated_not_unknown`, and
+  `actor_framework_types_are_rejected_as_gated_not_unknown`.
 - Builtin public type spellings now use shared AST helpers rather than
   duplicated semantic string comparisons, covered by
   `semantic_builtin_type_checks_use_shared_spelling_helper`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3578,6 +3578,13 @@ checked-in docs, tests, and commits only.
   static table, so adding future gated type spellings does not require a
   separate name-to-variant match. Guarded by
   `semantic_builtin_type_checks_use_shared_spelling_helper`.
+- Gated builtin type diagnostics now return enum-owned `&'static str` messages
+  rather than allocating formatted `String` values, preserving static compiler
+  diagnostic text for allocator, effect, and actor gates. Covered by
+  `semantic_builtin_type_checks_use_shared_spelling_helper`,
+  `typed_allocator_type_is_rejected_as_gated_not_unknown`,
+  `sync_async_effect_modes_are_rejected_as_gated_not_unknown`, and
+  `actor_framework_types_are_rejected_as_gated_not_unknown`.
 - Builtin public type spellings now route through shared AST type helpers
   instead of ad hoc semantic string checks, keeping `String` recognition and
   `StaticString` display spelling tied to one source. Guarded by

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -56,22 +56,28 @@ impl GatedBuiltinType {
         }
     }
 
-    pub fn gate_message(self) -> std::string::String {
+    pub fn gate_message(self) -> &'static str {
         match self {
             Self::Allocator => {
-                "typed allocators are gated until allocator ownership and effect semantics are implemented".into()
+                "typed allocators are gated until allocator ownership and effect semantics are implemented"
             }
-            Self::SyncEffect | Self::AsyncEffect => {
-                format!(
-                    "`{}` effect mode is gated until Sync/Async effect checking is implemented",
-                    self.as_str()
-                )
+            Self::SyncEffect => {
+                "`Sync` effect mode is gated until Sync/Async effect checking is implemented"
             }
-            Self::Actor | Self::ActorRef | Self::Mailbox | Self::Supervisor => {
-                format!(
-                    "`{}` framework type is gated until std actor scheduling and mailbox semantics are implemented",
-                    self.as_str()
-                )
+            Self::AsyncEffect => {
+                "`Async` effect mode is gated until Sync/Async effect checking is implemented"
+            }
+            Self::Actor => {
+                "`Actor` framework type is gated until std actor scheduling and mailbox semantics are implemented"
+            }
+            Self::ActorRef => {
+                "`ActorRef` framework type is gated until std actor scheduling and mailbox semantics are implemented"
+            }
+            Self::Mailbox => {
+                "`Mailbox` framework type is gated until std actor scheduling and mailbox semantics are implemented"
+            }
+            Self::Supervisor => {
+                "`Supervisor` framework type is gated until std actor scheduling and mailbox semantics are implemented"
             }
         }
     }

--- a/tests/docs_truth/repo_hygiene/builtin_type_spelling.rs
+++ b/tests/docs_truth/repo_hygiene/builtin_type_spelling.rs
@@ -17,6 +17,7 @@ fn semantic_builtin_type_checks_use_shared_spelling_helper() {
         "pub const SUPERVISOR_TYPE_NAME: &str = \"Supervisor\"",
         "pub enum GatedBuiltinType",
         "pub const ALL: &[GatedBuiltinType]",
+        "pub fn gate_message(self) -> &'static str",
         "pub fn gated_builtin_type_name",
     ] {
         assert!(
@@ -30,6 +31,10 @@ fn semantic_builtin_type_checks_use_shared_spelling_helper() {
             && helper.contains(".copied()")
             && helper.contains(".find(|ty| ty.as_str() == name)"),
         "gated builtin type lookup should use the enum-owned static table"
+    );
+    assert!(
+        !helper.contains("format!(\n                    \"`{}`"),
+        "gated builtin type diagnostics should be enum-owned static strings, not allocated formatting"
     );
     assert!(
         helper.contains("pub fn is_builtin_type_name"),


### PR DESCRIPTION
## Summary
- return `&'static str` from `GatedBuiltinType::gate_message`
- replace allocated formatted gated builtin diagnostics with enum-owned static messages
- add docs-truth coverage and update phase/audit notes

## Validation
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`