### PR TITLE
[codex] Use static table for gated methods

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3916,6 +3916,11 @@ and do not assume Phase 4 is ready without evidence.
   `typechecker_gated_methods_use_owned_action_enum`,
   `result_raise_is_rejected_until_propagation_lowering_exists`, and
   `effect_await_is_rejected_until_async_lowering_exists`.
+- Gated method lookup now uses `GatedMethod::ALL` as the enum-owned static
+  table rather than a separate spelling match, covered by
+  `typechecker_gated_methods_use_owned_action_enum`,
+  `result_raise_is_rejected_until_propagation_lowering_exists`, and
+  `effect_await_is_rejected_until_async_lowering_exists`.
 - `zen emit-json` mode routing now uses `EmitJsonMode` enum-owned spellings and
   derives its usage mode list from that same ordered source, covered by
   `cli_emit_json_modes_use_owned_mode_enum`,

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3595,6 +3595,11 @@ checked-in docs, tests, and commits only.
   by `typechecker_gated_methods_use_owned_action_enum`,
   `result_raise_is_rejected_until_propagation_lowering_exists`, and
   `effect_await_is_rejected_until_async_lowering_exists`.
+- Gated method lookup now uses `GatedMethod::ALL` as the enum-owned static
+  table, so adding future gated methods does not require a separate spelling
+  match. Guarded by `typechecker_gated_methods_use_owned_action_enum`,
+  `result_raise_is_rejected_until_propagation_lowering_exists`, and
+  `effect_await_is_rejected_until_async_lowering_exists`.
 - `zen emit-json` mode routing now uses `EmitJsonMode` enum-owned spellings and
   generates its usage mode list from the same ordered source, keeping checked,
   deterministic, and gated IR boundary modes aligned. Guarded by

--- a/src/typechecker/expressions/method_call_support.rs
+++ b/src/typechecker/expressions/method_call_support.rs
@@ -15,6 +15,8 @@ impl GatedMethod {
     const RAISE: &'static str = "raise";
     const AWAIT: &'static str = "await";
 
+    const ALL: &[GatedMethod] = &[Self::ResultRaise, Self::EffectAwait];
+
     const fn as_str(self) -> &'static str {
         match self {
             Self::ResultRaise => Self::RAISE,
@@ -48,11 +50,11 @@ impl FromStr for GatedMethod {
     type Err = ();
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            Self::RAISE => Ok(Self::ResultRaise),
-            Self::AWAIT => Ok(Self::EffectAwait),
-            _ => Err(()),
-        }
+        GatedMethod::ALL
+            .iter()
+            .copied()
+            .find(|method| method.as_str() == value)
+            .ok_or(())
     }
 }
 

--- a/tests/docs_truth/repo_hygiene/parser_enums.rs
+++ b/tests/docs_truth/repo_hygiene/parser_enums.rs
@@ -70,6 +70,17 @@ fn typechecker_gated_methods_use_owned_action_enum() {
         source.contains("method.parse::<GatedMethod>()"),
         "typechecker gated method dispatch should parse through GatedMethod"
     );
+    assert!(
+        source.contains("const ALL: &[GatedMethod]"),
+        "typechecker gated methods should keep an enum-owned static table"
+    );
+    assert!(
+        source.contains("GatedMethod::ALL")
+            && source.contains(".iter()")
+            && source.contains(".copied()")
+            && source.contains(".find(|method| method.as_str() == value)"),
+        "typechecker gated method parsing should use the enum-owned static table"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- parse `GatedMethod` through an enum-owned static `ALL` table
- keep gated method spelling and diagnostics on the enum source of truth
- add docs-truth coverage and update phase/audit notes

## Validation
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`