### PR TITLE
[codex] Document nested loop controls in learn guide

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3753,6 +3753,11 @@ and do not assume Phase 4 is ready without evidence.
   is guarded by `learn_zen_guide_covers_core_tour_and_gated_previews`,
   `readme_is_language_first_and_links_reference_docs`, and
   `v1_spec_records_phase_one_feature_gates_and_test_backlog`.
+- The Learn Zen guide now includes concrete nested loop-control and UFC
+  loop-control examples, keeping `outer.done()`, `inner.next()`, `done(l)`, and
+  `next(l)` visible in public language docs. Covered by
+  `learn_zen_guide_covers_core_tour_and_gated_previews` and
+  `public_language_docs_and_examples_do_not_teach_return_keyword`.
 - Legacy `zen build-graph build.zen` file-read host-effect validation now
   matches the unselected-target coverage on `zen build build.zen` and direct
   `zen build.zen`: declared fallback arms allow selected executable targets to

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3436,6 +3436,11 @@ checked-in docs, tests, and commits only.
   `learn_zen_guide_covers_core_tour_and_gated_previews`,
   `readme_is_language_first_and_links_reference_docs`, and
   `v1_spec_records_phase_one_feature_gates_and_test_backlog`.
+- The Learn Zen guide now includes concrete nested loop-control and UFC
+  loop-control examples, keeping `outer.done()`, `inner.next()`, `done(l)`, and
+  `next(l)` visible in public language docs. Guarded by
+  `learn_zen_guide_covers_core_tour_and_gated_previews` and
+  `public_language_docs_and_examples_do_not_teach_return_keyword`.
 - Legacy `zen build-graph build.zen` now has the same declared file-read
   unselected-target coverage as the newer graph execution entrypoints: declared
   fallback arms allow selected executable targets to build while unrelated

--- a/docs/learn_zen_in_y_minutes.md
+++ b/docs/learn_zen_in_y_minutes.md
@@ -321,6 +321,48 @@ Loops use prefix `loop((l) { ... })` with explicit loop-control calls:
 operations can be called in UFC form as `done(l)` and `next(l)`. See
 `examples/05_loops.zen` for the tutorial version.
 
+Nested loops can target an outer label directly:
+
+```zen
+nested = (stop: bool) i32 {
+    count ::= 0
+
+    loop((outer) {
+        loop((inner) {
+            stop ?
+                | true { outer.done() }
+                | false {
+                    count = count + 1
+                    inner.next()
+                }
+        })
+
+        outer.next()
+    })
+
+    count
+}
+```
+
+The loop controls are ordinary calls, so UFC form is equivalent:
+
+```zen
+single_step = (ready: bool) i32 {
+    value ::= 0
+
+    loop((l) {
+        ready ?
+            | true { done(l) }
+            | false {
+                value = value + 1
+                next(l)
+            }
+    })
+
+    value
+}
+```
+
 ## Defer
 
 ```zen

--- a/tests/docs_truth/public_docs.rs
+++ b/tests/docs_truth/public_docs.rs
@@ -136,6 +136,8 @@ fn learn_zen_guide_covers_core_tour_and_gated_previews() {
         "l.next()",
         "done(l)",
         "next(l)",
+        "outer.done()",
+        "inner.next()",
         "## Imports And Modules",
         "## Defer",
         "## Gated Preview: Sync, Async, And Allocators",


### PR DESCRIPTION
## Summary
- add concrete nested loop-control example to Learn Zen In Y Minutes
- add concrete UFC loop-control example to the same guide
- strengthen docs-truth coverage and update phase/audit notes

## Validation
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`