### PR TITLE
[codex] Label AST JSON as unchecked in usage

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3870,6 +3870,10 @@ and do not assume Phase 4 is ready without evidence.
   `emit-json mir`, and `emit-json target-yaml` commands, covered by
   `root_usage_lists_supported_and_gated_emit_json_modes`, so top-level help
   does not hide the explicitly gated IR/YAML surface.
+- The root `zen` usage banner now labels `emit-json ast` as unchecked AST JSON,
+  matching its `semantic_status: "unchecked"` payload instead of implying
+  semantic acceptance. Covered by
+  `root_usage_lists_supported_and_gated_emit_json_modes`.
 - Symbols JSON now carries `semantic_status: "resolved"`, covered by
   `emit_json_symbols_command_outputs_module_symbol_tables`, so resolver-owned
   symbol metadata is explicitly separated from unchecked AST JSON and checked

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3545,6 +3545,10 @@ checked-in docs, tests, and commits only.
   gated `emit-json hir`, `emit-json mir`, and `emit-json target-yaml` commands
   as gated instead of omitting them. Covered by
   `root_usage_lists_supported_and_gated_emit_json_modes`.
+- The root `zen` usage banner now labels `emit-json ast` as unchecked AST JSON,
+  matching its `semantic_status: "unchecked"` payload instead of implying
+  semantic acceptance. Covered by
+  `root_usage_lists_supported_and_gated_emit_json_modes`.
 - Symbols JSON now carries `semantic_status: "resolved"` alongside
   `format: "zen.symbols.v0"`, making resolver-owned metadata distinct from
   unchecked AST JSON and checked typed JSON. Covered by

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -9,7 +9,7 @@ pub(super) fn print_usage() {
         "  build-graph <build.zen>   Compile executable targets from deterministic build graph"
     );
     eprintln!("  emit  <file>   Emit C source (no compilation)");
-    eprintln!("  emit-json ast <file>   Emit resolved AST JSON");
+    eprintln!("  emit-json ast <file>   Emit unchecked AST JSON");
     eprintln!("  emit-json symbols <file>   Emit resolver symbol tables JSON");
     eprintln!("  emit-json typed <file>   Emit checked typed program JSON");
     eprintln!("  emit-json diagnostics <file>   Emit diagnostics JSON");

--- a/tests/integration/cli_build/diagnostics/usage.rs
+++ b/tests/integration/cli_build/diagnostics/usage.rs
@@ -15,7 +15,7 @@ fn root_usage_lists_supported_and_gated_emit_json_modes() {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     for expected in [
-        "emit-json ast <file>",
+        "emit-json ast <file>   Emit unchecked AST JSON",
         "emit-json symbols <file>",
         "emit-json typed <file>",
         "emit-json diagnostics <file>",


### PR DESCRIPTION
## Summary
- update root usage text for `emit-json ast` to say unchecked AST JSON
- align CLI help wording with the emitted `semantic_status: "unchecked"` boundary
- update integration coverage and phase/audit notes

## Validation
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`