### PR TITLE
[codex] Clarify Channel stdlib boundary

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3907,6 +3907,10 @@ and do not assume Phase 4 is ready without evidence.
   gated diagnostics rather than ordinary unknown-type errors. Covered by
   `actor_framework_types_are_rejected_as_gated_not_unknown` and
   `semantic_builtin_type_checks_use_shared_spelling_helper`.
+- `Channel` remains documented as an experimental stdlib channel sketch rather
+  than a global actor builtin type spelling, preserving the importable stdlib
+  channel boundary until promotion has compiler-path evidence. Covered by
+  `v1_spec_records_phase_one_feature_gates_and_test_backlog`.
 - Gated builtin type lookup now uses `GatedBuiltinType::ALL` as the enum-owned
   static table rather than a separate name-to-variant match, covered by
   `semantic_builtin_type_checks_use_shared_spelling_helper`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3583,6 +3583,10 @@ checked-in docs, tests, and commits only.
   actor-specific gated diagnostics instead of unknown-type errors. Covered by
   `actor_framework_types_are_rejected_as_gated_not_unknown` and
   `semantic_builtin_type_checks_use_shared_spelling_helper`.
+- `Channel` remains documented as an experimental stdlib channel sketch rather
+  than a global actor builtin type spelling, preserving the importable stdlib
+  channel boundary until promotion has compiler-path evidence. Guarded by
+  `v1_spec_records_phase_one_feature_gates_and_test_backlog`.
 - Gated builtin type lookup now uses `GatedBuiltinType::ALL` as the enum-owned
   static table, so adding future gated type spellings does not require a
   separate name-to-variant match. Guarded by

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -97,11 +97,12 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   Neither replaces compiler resolver, typechecker, effect checker, or MIR passes.
   `zen emit-json ast <file>` emits `semantic_status: "unchecked"` to make that
   boundary explicit.
-- `Actors in std`: gated. Actors are a stdlib framework first, with `Actor`,
-  `ActorRef`, `Mailbox`, `Channel`, and `Supervisor` built on effect-aware queues
-  and typed allocators. No actor syntax is v1-stable yet, and promoted actor
-  framework type spellings report gated diagnostics until std actor semantics
-  exist.
+- `Actors in std`: gated. Actors are a stdlib framework first, with promoted
+  framework spellings `Actor`, `ActorRef`, `Mailbox`, and `Supervisor` built on
+  effect-aware queues and typed allocators. No actor syntax is v1-stable yet,
+  and promoted actor framework type spellings report gated diagnostics until
+  std actor semantics exist. `Channel` remains an experimental stdlib channel
+  sketch until promoted, so it is not a global actor builtin type spelling.
 - `JSON/YAML IR boundaries`: gated. JSON is the machine-readable exchange format
   for compiler-owned AST, typed HIR, MIR, symbol tables, type layouts, and
   diagnostics. YAML is the human-authored format for target descriptions, ABI

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -48,6 +48,7 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "Type matching",
         "Behavior association",
         "AST traversal",
+        "`Channel` remains an experimental stdlib channel",
         "semantic_status: \"unchecked\"",
         "typed JSON is explicitly marked checked",
         "diagnostics JSON is explicitly",
@@ -255,5 +256,9 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
     assert!(
         !spec.contains("| Strict resolver, symbol IDs, privacy | gated |"),
         "docs/V1_SPEC.md should not describe implemented resolver/module privacy evidence as gated"
+    );
+    assert!(
+        !spec.contains("`ActorRef`, `Mailbox`, `Channel`, and `Supervisor`"),
+        "docs/V1_SPEC.md should not imply Channel is a globally gated actor builtin"
     );
 }


### PR DESCRIPTION
## Summary
- document `Channel` as an experimental stdlib channel sketch, not a promoted global actor builtin spelling
- keep promoted actor builtin gates scoped to `Actor`, `ActorRef`, `Mailbox`, and `Supervisor`
- add docs-truth coverage and update phase/audit notes

## Validation
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`