### PR TITLE
[codex] Move AST traversal out of backlog

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -314,6 +314,10 @@ and do not assume Phase 4 is ready without evidence.
   fixture proves a semantically invalid program can emit AST JSON while
   `emit-json typed` rejects it. Coverage:
   `emit_json_ast_marks_semantically_unchecked_sources_that_typed_json_rejects`.
+- AST traversal is no longer listed in the Required Test Backlog because the
+  AST JSON tooling view has positive output evidence and negative semantic
+  bypass evidence. Covered by
+  `v1_spec_records_phase_one_feature_gates_and_test_backlog`.
 - Typed JSON now carries `semantic_status: "checked"`, covered by
   `emit_json_typed_command_outputs_checked_program`, keeping the checked output
   boundary explicit alongside the unchecked AST marker.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -498,6 +498,10 @@ checked-in docs, tests, and commits only.
   fixture proves a semantically invalid program can emit AST JSON while
   `emit-json typed` rejects it. Covered by
   `emit_json_ast_marks_semantically_unchecked_sources_that_typed_json_rejects`.
+- AST traversal is no longer listed in the Required Test Backlog because the
+  AST JSON tooling view has positive output evidence and negative semantic
+  bypass evidence. Guarded by
+  `v1_spec_records_phase_one_feature_gates_and_test_backlog`.
 - Typed JSON now carries `semantic_status: "checked"`, covered by
   `emit_json_typed_command_outputs_checked_program`, keeping the checked output
   boundary explicit alongside the unchecked AST marker.

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -164,8 +164,10 @@ Generic behavior inheritance with child type-parameter parent args is covered by
 
 Constrained `build.zen` execution already has positive and negative evidence:
 Deterministic build graph compiles executable and test targets, while build
-scripts using undeclared host side effects are rejected. The remaining backlog
-below is for v1 areas without that minimum positive/negative proof.
+scripts using undeclared host side effects are rejected. AST traversal also has
+minimum boundary evidence: AST JSON emits a parsed tooling view and
+semantically invalid programs still fail through typed JSON. The remaining
+backlog below is for v1 areas without that minimum positive/negative proof.
 
 ## Required Test Backlog
 
@@ -178,7 +180,6 @@ planned positive test and one planned negative test before implementation.
 | `Typed allocators` | `Allocator<i32, Sync>` returns a checked pointer result and propagates into a container | `Allocator<i32, Sync>` cannot satisfy an `Allocator<i32, Async>` parameter |
 | Type matching | `to_json<T>` derive branches on struct and enum metadata | Ambiguous or unreachable type-match arm is diagnosed |
 | Behavior association | Explicit `Json<T>` impl takes precedence over generated derive fallback | Missing or ambiguous associated behavior impl is rejected |
-| AST traversal | Tooling can read AST JSON for a parsed source fixture | AST traversal cannot bypass semantic checks for a core language feature |
 | Actors in std | Actor mailbox send/receive works with scheduler and allocator integration | Actor using async mailbox from sync-only context is rejected |
 | JSON/YAML IR boundaries | Checked MIR JSON and target YAML validate against schemas | Hand-authored JSON IR cannot override compiler-owned types or layouts |
 

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -254,6 +254,10 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "docs/V1_SPEC.md should not list constrained build.zen execution as only planned backlog"
     );
     assert!(
+        !backlog.contains("| AST traversal |"),
+        "docs/V1_SPEC.md should not list AST traversal in the no-minimum-proof backlog after AST JSON boundary tests exist"
+    );
+    assert!(
         !spec.contains("| Strict resolver, symbol IDs, privacy | gated |"),
         "docs/V1_SPEC.md should not describe implemented resolver/module privacy evidence as gated"
     );


### PR DESCRIPTION
## Summary
- record existing AST JSON positive and semantic-bypass negative evidence in `docs/V1_SPEC.md`
- remove AST traversal from the no-minimum-proof Required Test Backlog
- add docs-truth coverage and update phase/audit notes

## Validation
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`