### PR TITLE
Use enum-owned C intrinsic names

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3991,6 +3991,11 @@ and do not assume Phase 4 is ready without evidence.
   threshold while preserving every gate test name. Covered by
   `production_rust_files_stay_below_cleanup_threshold` and
   `typechecker::tests::core_semantics`.
+- C backend intrinsic lowering now parses through a `CIntrinsic` enum with
+  enum-owned static spellings instead of matching raw builtin strings in the
+  lowering body. Covered by
+  `codegen_c_intrinsics_use_owned_name_enum`, `production_rust_files_stay_below_cleanup_threshold`,
+  and `codegen::c` tests.
 - Gated `.raise()` and `.await()` method recognition now routes through
   `GatedMethod` enum-owned spellings, covered by
   `typechecker_gated_methods_use_owned_action_enum`,

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3668,6 +3668,11 @@ checked-in docs, tests, and commits only.
   threshold while preserving every gate test name. Guarded by
   `production_rust_files_stay_below_cleanup_threshold` and
   `typechecker::tests::core_semantics`.
+- C backend intrinsic lowering now parses through a `CIntrinsic` enum with
+  enum-owned static spellings instead of matching raw builtin strings in the
+  lowering body. Guarded by
+  `codegen_c_intrinsics_use_owned_name_enum`, `production_rust_files_stay_below_cleanup_threshold`,
+  and `codegen::c` tests.
 - Gated `.raise()` and `.await()` method recognition now dispatches through the
   `GatedMethod` enum-owned spellings rather than hand-rolled comparisons,
   preserving the focused Result propagation and Sync/Async effect gates. Guarded

--- a/src/codegen/c/intrinsics.rs
+++ b/src/codegen/c/intrinsics.rs
@@ -1,4 +1,7 @@
 use super::*;
+use names::CIntrinsic;
+
+mod names;
 
 impl CEmitter {
     // ── Intrinsics ────────────────────────────────────────────
@@ -9,42 +12,47 @@ impl CEmitter {
         args: &[TypedExpression],
         result_ty: &Type,
     ) -> String {
-        match name {
+        let Ok(intrinsic) = name.parse::<CIntrinsic>() else {
+            self.line(&format!("#error \"Unknown intrinsic: {}\"", name));
+            return "(void)0".into();
+        };
+
+        match intrinsic {
             // -- Memory allocation ----------------------------------------
-            "raw_allocate" => {
+            CIntrinsic::RawAllocate => {
                 let size = self.emit_expr_inline(&args[0]);
                 format!("malloc({})", size)
             }
-            "raw_deallocate" => {
+            CIntrinsic::RawDeallocate => {
                 let ptr = self.emit_expr_inline(&args[0]);
                 format!("free({})", ptr)
             }
-            "raw_reallocate" => {
+            CIntrinsic::RawReallocate => {
                 let ptr = self.emit_expr_inline(&args[0]);
                 let new_size = self.emit_expr_inline(&args[2]);
                 format!("realloc({}, {})", ptr, new_size)
             }
 
             // -- Memory operations ----------------------------------------
-            "memcpy" => {
+            CIntrinsic::Memcpy => {
                 let dest = self.emit_expr_inline(&args[0]);
                 let src = self.emit_expr_inline(&args[1]);
                 let n = self.emit_expr_inline(&args[2]);
                 format!("memcpy({}, {}, {})", dest, src, n)
             }
-            "memmove" => {
+            CIntrinsic::Memmove => {
                 let dest = self.emit_expr_inline(&args[0]);
                 let src = self.emit_expr_inline(&args[1]);
                 let n = self.emit_expr_inline(&args[2]);
                 format!("memmove({}, {}, {})", dest, src, n)
             }
-            "memset" => {
+            CIntrinsic::Memset => {
                 let dest = self.emit_expr_inline(&args[0]);
                 let val = self.emit_expr_inline(&args[1]);
                 let n = self.emit_expr_inline(&args[2]);
                 format!("memset({}, {}, {})", dest, val, n)
             }
-            "memcmp" => {
+            CIntrinsic::Memcmp => {
                 let a = self.emit_expr_inline(&args[0]);
                 let b = self.emit_expr_inline(&args[1]);
                 let n = self.emit_expr_inline(&args[2]);
@@ -52,12 +60,12 @@ impl CEmitter {
             }
 
             // -- Load / Store ---------------------------------------------
-            "load" => {
+            CIntrinsic::Load => {
                 let ptr = self.emit_expr_inline(&args[0]);
                 let ty = self.c_type(result_ty);
                 format!("(*(({}*)({})))", ty, ptr)
             }
-            "store" => {
+            CIntrinsic::Store => {
                 let ptr = self.emit_expr_inline(&args[0]);
                 let val = self.emit_expr_inline(&args[1]);
                 let ty = self.c_type(&args[1].ty);
@@ -65,7 +73,7 @@ impl CEmitter {
             }
 
             // -- Type introspection ---------------------------------------
-            "sizeof" => {
+            CIntrinsic::Sizeof => {
                 if !args.is_empty() {
                     let ty = self.c_type(&args[0].ty);
                     format!("sizeof({})", ty)
@@ -76,7 +84,7 @@ impl CEmitter {
                     "0".into()
                 }
             }
-            "alignof" => {
+            CIntrinsic::Alignof => {
                 if !args.is_empty() {
                     let ty = self.c_type(&args[0].ty);
                     format!("_Alignof({})", ty)
@@ -87,20 +95,20 @@ impl CEmitter {
             }
 
             // -- Pointer operations ---------------------------------------
-            "int_to_ptr" => {
+            CIntrinsic::IntToPtr => {
                 let val = self.emit_expr_inline(&args[0]);
                 format!("((void*)(uintptr_t)({}))", val)
             }
-            "ptr_to_int" => {
+            CIntrinsic::PtrToInt => {
                 let ptr = self.emit_expr_inline(&args[0]);
                 format!("((uintptr_t)({}))", ptr)
             }
-            "gep" => {
+            CIntrinsic::Gep => {
                 let base = self.emit_expr_inline(&args[0]);
                 let offset = self.emit_expr_inline(&args[1]);
                 format!("((uint8_t*)({}) + ({}))", base, offset)
             }
-            "gep_struct" => {
+            CIntrinsic::GepStruct => {
                 // Struct GEP: byte-offset into a struct by field index.
                 // In C we just cast to uint8_t* and offset, since the
                 // actual field layout matches.
@@ -108,43 +116,43 @@ impl CEmitter {
                 let idx = self.emit_expr_inline(&args[1]);
                 format!("((uint8_t*)({}) + ({}))", ptr, idx)
             }
-            "raw_ptr_offset" => {
+            CIntrinsic::RawPtrOffset => {
                 let ptr = self.emit_expr_inline(&args[0]);
                 let offset = self.emit_expr_inline(&args[1]);
                 format!("((uint8_t*)({}) + ({}))", ptr, offset)
             }
-            "raw_ptr_cast" => {
+            CIntrinsic::RawPtrCast => {
                 let ptr = self.emit_expr_inline(&args[0]);
                 let ty = self.c_type(result_ty);
                 format!("(({})({})", ty, ptr)
             }
-            "null_ptr" | "nullptr" => "(NULL)".into(),
-            "is_null" => {
+            CIntrinsic::NullPtr | CIntrinsic::Nullptr => "(NULL)".into(),
+            CIntrinsic::IsNull => {
                 let ptr = self.emit_expr_inline(&args[0]);
                 format!("(({}) == NULL)", ptr)
             }
 
             // -- Atomic operations ----------------------------------------
-            "atomic_load" => {
+            CIntrinsic::AtomicLoad => {
                 let ptr = self.emit_expr_inline(&args[0]);
                 format!("__atomic_load_n({}, __ATOMIC_SEQ_CST)", ptr)
             }
-            "atomic_store" => {
+            CIntrinsic::AtomicStore => {
                 let ptr = self.emit_expr_inline(&args[0]);
                 let val = self.emit_expr_inline(&args[1]);
                 format!("__atomic_store_n({}, {}, __ATOMIC_SEQ_CST)", ptr, val)
             }
-            "atomic_add" => {
+            CIntrinsic::AtomicAdd => {
                 let ptr = self.emit_expr_inline(&args[0]);
                 let val = self.emit_expr_inline(&args[1]);
                 format!("__atomic_fetch_add({}, {}, __ATOMIC_SEQ_CST)", ptr, val)
             }
-            "atomic_sub" => {
+            CIntrinsic::AtomicSub => {
                 let ptr = self.emit_expr_inline(&args[0]);
                 let val = self.emit_expr_inline(&args[1]);
                 format!("__atomic_fetch_sub({}, {}, __ATOMIC_SEQ_CST)", ptr, val)
             }
-            "atomic_cas" => {
+            CIntrinsic::AtomicCas => {
                 let ptr = self.emit_expr_inline(&args[0]);
                 let expected = self.emit_expr_inline(&args[1]);
                 let desired = self.emit_expr_inline(&args[2]);
@@ -155,37 +163,37 @@ impl CEmitter {
                     ptr, tmp, desired
                 )
             }
-            "atomic_xchg" => {
+            CIntrinsic::AtomicXchg => {
                 let ptr = self.emit_expr_inline(&args[0]);
                 let val = self.emit_expr_inline(&args[1]);
                 format!("__atomic_exchange_n({}, {}, __ATOMIC_SEQ_CST)", ptr, val)
             }
-            "fence" => "(__atomic_thread_fence(__ATOMIC_SEQ_CST), (void)0)".into(),
+            CIntrinsic::Fence => "(__atomic_thread_fence(__ATOMIC_SEQ_CST), (void)0)".into(),
 
             // -- Syscalls -------------------------------------------------
-            "syscall0" => {
+            CIntrinsic::Syscall0 => {
                 let num = self.emit_expr_inline(&args[0]);
                 format!("syscall({})", num)
             }
-            "syscall1" => {
+            CIntrinsic::Syscall1 => {
                 let num = self.emit_expr_inline(&args[0]);
                 let a0 = self.emit_expr_inline(&args[1]);
                 format!("syscall({}, {})", num, a0)
             }
-            "syscall2" => {
+            CIntrinsic::Syscall2 => {
                 let num = self.emit_expr_inline(&args[0]);
                 let a0 = self.emit_expr_inline(&args[1]);
                 let a1 = self.emit_expr_inline(&args[2]);
                 format!("syscall({}, {}, {})", num, a0, a1)
             }
-            "syscall3" => {
+            CIntrinsic::Syscall3 => {
                 let num = self.emit_expr_inline(&args[0]);
                 let a0 = self.emit_expr_inline(&args[1]);
                 let a1 = self.emit_expr_inline(&args[2]);
                 let a2 = self.emit_expr_inline(&args[3]);
                 format!("syscall({}, {}, {}, {})", num, a0, a1, a2)
             }
-            "syscall4" => {
+            CIntrinsic::Syscall4 => {
                 let num = self.emit_expr_inline(&args[0]);
                 let a0 = self.emit_expr_inline(&args[1]);
                 let a1 = self.emit_expr_inline(&args[2]);
@@ -193,7 +201,7 @@ impl CEmitter {
                 let a3 = self.emit_expr_inline(&args[4]);
                 format!("syscall({}, {}, {}, {}, {})", num, a0, a1, a2, a3)
             }
-            "syscall5" => {
+            CIntrinsic::Syscall5 => {
                 let num = self.emit_expr_inline(&args[0]);
                 let a0 = self.emit_expr_inline(&args[1]);
                 let a1 = self.emit_expr_inline(&args[2]);
@@ -202,7 +210,7 @@ impl CEmitter {
                 let a4 = self.emit_expr_inline(&args[5]);
                 format!("syscall({}, {}, {}, {}, {}, {})", num, a0, a1, a2, a3, a4)
             }
-            "syscall6" => {
+            CIntrinsic::Syscall6 => {
                 let num = self.emit_expr_inline(&args[0]);
                 let a0 = self.emit_expr_inline(&args[1]);
                 let a1 = self.emit_expr_inline(&args[2]);
@@ -217,10 +225,10 @@ impl CEmitter {
             }
 
             // -- Debug / trap / panic -------------------------------------
-            "trap" => "(__builtin_trap(), (void)0)".into(),
-            "debugtrap" => "(__builtin_debugtrap(), (void)0)".into(),
-            "unreachable" => "(__builtin_unreachable(), (void)0)".into(),
-            "panic" => {
+            CIntrinsic::Trap => "(__builtin_trap(), (void)0)".into(),
+            CIntrinsic::Debugtrap => "(__builtin_debugtrap(), (void)0)".into(),
+            CIntrinsic::Unreachable => "(__builtin_unreachable(), (void)0)".into(),
+            CIntrinsic::Panic => {
                 let msg = self.emit_expr_inline(&args[0]);
                 format!(
                     "(fprintf(stderr, \"panic: %.*s\\n\", (int)({msg}).len, ({msg}).ptr), abort(), (void)0)"
@@ -228,62 +236,62 @@ impl CEmitter {
             }
 
             // -- Bitwise operations ---------------------------------------
-            "bswap16" => {
+            CIntrinsic::Bswap16 => {
                 let val = self.emit_expr_inline(&args[0]);
                 format!("__builtin_bswap16({})", val)
             }
-            "bswap32" => {
+            CIntrinsic::Bswap32 => {
                 let val = self.emit_expr_inline(&args[0]);
                 format!("__builtin_bswap32({})", val)
             }
-            "bswap64" => {
+            CIntrinsic::Bswap64 => {
                 let val = self.emit_expr_inline(&args[0]);
                 format!("__builtin_bswap64({})", val)
             }
-            "ctlz" => {
+            CIntrinsic::Ctlz => {
                 let val = self.emit_expr_inline(&args[0]);
                 format!("((uint64_t)__builtin_clzll({}))", val)
             }
-            "cttz" => {
+            CIntrinsic::Cttz => {
                 let val = self.emit_expr_inline(&args[0]);
                 format!("((uint64_t)__builtin_ctzll({}))", val)
             }
-            "ctpop" => {
+            CIntrinsic::Ctpop => {
                 let val = self.emit_expr_inline(&args[0]);
                 format!("((uint64_t)__builtin_popcountll({}))", val)
             }
 
             // -- Overflow-checked arithmetic ------------------------------
-            "add_overflow" => self.emit_overflow_op("add", args),
-            "sub_overflow" => self.emit_overflow_op("sub", args),
-            "mul_overflow" => self.emit_overflow_op("mul", args),
+            CIntrinsic::AddOverflow => self.emit_overflow_op("add", args),
+            CIntrinsic::SubOverflow => self.emit_overflow_op("sub", args),
+            CIntrinsic::MulOverflow => self.emit_overflow_op("mul", args),
 
             // -- Type conversions -----------------------------------------
-            "trunc_f64_i64" => {
+            CIntrinsic::TruncF64I64 => {
                 let val = self.emit_expr_inline(&args[0]);
                 format!("((int64_t)({}))", val)
             }
-            "trunc_f32_i32" => {
+            CIntrinsic::TruncF32I32 => {
                 let val = self.emit_expr_inline(&args[0]);
                 format!("((int32_t)({}))", val)
             }
-            "sitofp_i64_f64" => {
+            CIntrinsic::SitofpI64F64 => {
                 let val = self.emit_expr_inline(&args[0]);
                 format!("((double)({}))", val)
             }
-            "uitofp_u64_f64" => {
+            CIntrinsic::UitofpU64F64 => {
                 let val = self.emit_expr_inline(&args[0]);
                 format!("((double)({}))", val)
             }
 
             // -- IO (libc wrappers) ---------------------------------------
-            "libc_write" => {
+            CIntrinsic::LibcWrite => {
                 let fd = self.emit_expr_inline(&args[0]);
                 let buf = self.emit_expr_inline(&args[1]);
                 let len = self.emit_expr_inline(&args[2]);
                 format!("((int64_t)write({}, {}, {}))", fd, buf, len)
             }
-            "libc_read" => {
+            CIntrinsic::LibcRead => {
                 let fd = self.emit_expr_inline(&args[0]);
                 let buf = self.emit_expr_inline(&args[1]);
                 let len = self.emit_expr_inline(&args[2]);
@@ -291,37 +299,37 @@ impl CEmitter {
             }
 
             // -- String operations ----------------------------------------
-            "strlen" => {
+            CIntrinsic::Strlen => {
                 let s = self.emit_expr_inline(&args[0]);
                 format!("strlen({})", s)
             }
-            "static_string_ptr" => {
+            CIntrinsic::StaticStringPtr => {
                 let s = self.emit_expr_inline(&args[0]);
                 format!("((uint8_t*)({}))", s)
             }
 
             // -- FFI / dynamic loading ------------------------------------
-            "load_library" => {
+            CIntrinsic::LoadLibrary => {
                 let path = self.emit_expr_inline(&args[0]);
                 format!("dlopen({}, RTLD_LAZY)", path)
             }
-            "get_symbol" => {
+            CIntrinsic::GetSymbol => {
                 let handle = self.emit_expr_inline(&args[0]);
                 let sym = self.emit_expr_inline(&args[1]);
                 format!("dlsym({}, {})", handle, sym)
             }
-            "unload_library" => {
+            CIntrinsic::UnloadLibrary => {
                 let handle = self.emit_expr_inline(&args[0]);
                 format!("dlclose({})", handle)
             }
-            "dlerror" => "((uint8_t*)dlerror())".into(),
-            "call_external" => {
+            CIntrinsic::Dlerror => "((uint8_t*)dlerror())".into(),
+            CIntrinsic::CallExternal => {
                 let fptr = self.emit_expr_inline(&args[0]);
                 format!("((int64_t(*)(void))({}))()", fptr)
             }
 
             // -- Inline C -------------------------------------------------
-            "inline_c" => {
+            CIntrinsic::InlineC => {
                 // The arg should be a string literal containing raw C code.
                 if let TypedExprKind::StringLiteral(code) = &args[0].kind {
                     self.line(code);
@@ -333,21 +341,21 @@ impl CEmitter {
             }
 
             // -- Enum intrinsics ------------------------------------------
-            "discriminant" => {
+            CIntrinsic::Discriminant => {
                 let val = self.emit_expr_inline(&args[0]);
                 format!("((int32_t)(((int32_t*)({}))[0]))", val)
             }
-            "set_discriminant" => {
+            CIntrinsic::SetDiscriminant => {
                 let ptr = self.emit_expr_inline(&args[0]);
                 let disc = self.emit_expr_inline(&args[1]);
                 format!("(((int32_t*)({})) [0] = ({}))", ptr, disc)
             }
-            "get_payload" => {
+            CIntrinsic::GetPayload => {
                 let val = self.emit_expr_inline(&args[0]);
                 // Payload sits after the discriminant (4 bytes, aligned)
                 format!("((uint8_t*)({}) + sizeof(int32_t))", val)
             }
-            "set_payload" => {
+            CIntrinsic::SetPayload => {
                 let ptr = self.emit_expr_inline(&args[0]);
                 let payload = self.emit_expr_inline(&args[1]);
                 // This is a raw byte copy; caller must know the size.
@@ -357,12 +365,6 @@ impl CEmitter {
                     "(memcpy((uint8_t*)({}) + sizeof(int32_t), {}, 0), (void)0)",
                     ptr, payload
                 )
-            }
-
-            // -- Unknown --------------------------------------------------
-            _ => {
-                self.line(&format!("#error \"Unknown intrinsic: {}\"", name));
-                "(void)0".into()
             }
         }
     }

--- a/src/codegen/c/intrinsics/names.rs
+++ b/src/codegen/c/intrinsics/names.rs
@@ -1,0 +1,295 @@
+use std::fmt;
+use std::str::FromStr;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum CIntrinsic {
+    AddOverflow,
+    Alignof,
+    AtomicAdd,
+    AtomicCas,
+    AtomicLoad,
+    AtomicStore,
+    AtomicSub,
+    AtomicXchg,
+    Bswap16,
+    Bswap32,
+    Bswap64,
+    CallExternal,
+    Ctpop,
+    Ctlz,
+    Cttz,
+    Debugtrap,
+    Discriminant,
+    Dlerror,
+    Fence,
+    Gep,
+    GepStruct,
+    GetPayload,
+    GetSymbol,
+    InlineC,
+    IntToPtr,
+    IsNull,
+    LibcRead,
+    LibcWrite,
+    Load,
+    LoadLibrary,
+    Memcmp,
+    Memcpy,
+    Memmove,
+    Memset,
+    MulOverflow,
+    NullPtr,
+    Nullptr,
+    Panic,
+    PtrToInt,
+    RawAllocate,
+    RawDeallocate,
+    RawPtrCast,
+    RawPtrOffset,
+    RawReallocate,
+    SetDiscriminant,
+    SetPayload,
+    Sizeof,
+    SitofpI64F64,
+    StaticStringPtr,
+    Store,
+    Strlen,
+    SubOverflow,
+    Syscall0,
+    Syscall1,
+    Syscall2,
+    Syscall3,
+    Syscall4,
+    Syscall5,
+    Syscall6,
+    Trap,
+    TruncF32I32,
+    TruncF64I64,
+    UitofpU64F64,
+    UnloadLibrary,
+    Unreachable,
+}
+
+impl CIntrinsic {
+    pub(super) const ADD_OVERFLOW: &'static str = "add_overflow";
+    pub(super) const ALIGNOF: &'static str = "alignof";
+    pub(super) const ATOMIC_ADD: &'static str = "atomic_add";
+    pub(super) const ATOMIC_CAS: &'static str = "atomic_cas";
+    pub(super) const ATOMIC_LOAD: &'static str = "atomic_load";
+    pub(super) const ATOMIC_STORE: &'static str = "atomic_store";
+    pub(super) const ATOMIC_SUB: &'static str = "atomic_sub";
+    pub(super) const ATOMIC_XCHG: &'static str = "atomic_xchg";
+    pub(super) const BSWAP16: &'static str = "bswap16";
+    pub(super) const BSWAP32: &'static str = "bswap32";
+    pub(super) const BSWAP64: &'static str = "bswap64";
+    pub(super) const CALL_EXTERNAL: &'static str = "call_external";
+    pub(super) const CTPOP: &'static str = "ctpop";
+    pub(super) const CTLZ: &'static str = "ctlz";
+    pub(super) const CTTZ: &'static str = "cttz";
+    pub(super) const DEBUGTRAP: &'static str = "debugtrap";
+    pub(super) const DISCRIMINANT: &'static str = "discriminant";
+    pub(super) const DLERROR: &'static str = "dlerror";
+    pub(super) const FENCE: &'static str = "fence";
+    pub(super) const GEP: &'static str = "gep";
+    pub(super) const GEP_STRUCT: &'static str = "gep_struct";
+    pub(super) const GET_PAYLOAD: &'static str = "get_payload";
+    pub(super) const GET_SYMBOL: &'static str = "get_symbol";
+    pub(super) const INLINE_C: &'static str = "inline_c";
+    pub(super) const INT_TO_PTR: &'static str = "int_to_ptr";
+    pub(super) const IS_NULL: &'static str = "is_null";
+    pub(super) const LIBC_READ: &'static str = "libc_read";
+    pub(super) const LIBC_WRITE: &'static str = "libc_write";
+    pub(super) const LOAD: &'static str = "load";
+    pub(super) const LOAD_LIBRARY: &'static str = "load_library";
+    pub(super) const MEMCMP: &'static str = "memcmp";
+    pub(super) const MEMCPY: &'static str = "memcpy";
+    pub(super) const MEMMOVE: &'static str = "memmove";
+    pub(super) const MEMSET: &'static str = "memset";
+    pub(super) const MUL_OVERFLOW: &'static str = "mul_overflow";
+    pub(super) const NULL_PTR: &'static str = "null_ptr";
+    pub(super) const NULLPTR: &'static str = "nullptr";
+    pub(super) const PANIC: &'static str = "panic";
+    pub(super) const PTR_TO_INT: &'static str = "ptr_to_int";
+    pub(super) const RAW_ALLOCATE: &'static str = "raw_allocate";
+    pub(super) const RAW_DEALLOCATE: &'static str = "raw_deallocate";
+    pub(super) const RAW_PTR_CAST: &'static str = "raw_ptr_cast";
+    pub(super) const RAW_PTR_OFFSET: &'static str = "raw_ptr_offset";
+    pub(super) const RAW_REALLOCATE: &'static str = "raw_reallocate";
+    pub(super) const SET_DISCRIMINANT: &'static str = "set_discriminant";
+    pub(super) const SET_PAYLOAD: &'static str = "set_payload";
+    pub(super) const SIZEOF: &'static str = "sizeof";
+    pub(super) const SITOFP_I64_F64: &'static str = "sitofp_i64_f64";
+    pub(super) const STATIC_STRING_PTR: &'static str = "static_string_ptr";
+    pub(super) const STORE: &'static str = "store";
+    pub(super) const STRLEN: &'static str = "strlen";
+    pub(super) const SUB_OVERFLOW: &'static str = "sub_overflow";
+    pub(super) const SYSCALL0: &'static str = "syscall0";
+    pub(super) const SYSCALL1: &'static str = "syscall1";
+    pub(super) const SYSCALL2: &'static str = "syscall2";
+    pub(super) const SYSCALL3: &'static str = "syscall3";
+    pub(super) const SYSCALL4: &'static str = "syscall4";
+    pub(super) const SYSCALL5: &'static str = "syscall5";
+    pub(super) const SYSCALL6: &'static str = "syscall6";
+    pub(super) const TRAP: &'static str = "trap";
+    pub(super) const TRUNC_F32_I32: &'static str = "trunc_f32_i32";
+    pub(super) const TRUNC_F64_I64: &'static str = "trunc_f64_i64";
+    pub(super) const UITOFP_U64_F64: &'static str = "uitofp_u64_f64";
+    pub(super) const UNLOAD_LIBRARY: &'static str = "unload_library";
+    pub(super) const UNREACHABLE: &'static str = "unreachable";
+
+    pub(super) const ALL: &[CIntrinsic] = &[
+        Self::AddOverflow,
+        Self::Alignof,
+        Self::AtomicAdd,
+        Self::AtomicCas,
+        Self::AtomicLoad,
+        Self::AtomicStore,
+        Self::AtomicSub,
+        Self::AtomicXchg,
+        Self::Bswap16,
+        Self::Bswap32,
+        Self::Bswap64,
+        Self::CallExternal,
+        Self::Ctpop,
+        Self::Ctlz,
+        Self::Cttz,
+        Self::Debugtrap,
+        Self::Discriminant,
+        Self::Dlerror,
+        Self::Fence,
+        Self::Gep,
+        Self::GepStruct,
+        Self::GetPayload,
+        Self::GetSymbol,
+        Self::InlineC,
+        Self::IntToPtr,
+        Self::IsNull,
+        Self::LibcRead,
+        Self::LibcWrite,
+        Self::Load,
+        Self::LoadLibrary,
+        Self::Memcmp,
+        Self::Memcpy,
+        Self::Memmove,
+        Self::Memset,
+        Self::MulOverflow,
+        Self::NullPtr,
+        Self::Nullptr,
+        Self::Panic,
+        Self::PtrToInt,
+        Self::RawAllocate,
+        Self::RawDeallocate,
+        Self::RawPtrCast,
+        Self::RawPtrOffset,
+        Self::RawReallocate,
+        Self::SetDiscriminant,
+        Self::SetPayload,
+        Self::Sizeof,
+        Self::SitofpI64F64,
+        Self::StaticStringPtr,
+        Self::Store,
+        Self::Strlen,
+        Self::SubOverflow,
+        Self::Syscall0,
+        Self::Syscall1,
+        Self::Syscall2,
+        Self::Syscall3,
+        Self::Syscall4,
+        Self::Syscall5,
+        Self::Syscall6,
+        Self::Trap,
+        Self::TruncF32I32,
+        Self::TruncF64I64,
+        Self::UitofpU64F64,
+        Self::UnloadLibrary,
+        Self::Unreachable,
+    ];
+
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::AddOverflow => Self::ADD_OVERFLOW,
+            Self::Alignof => Self::ALIGNOF,
+            Self::AtomicAdd => Self::ATOMIC_ADD,
+            Self::AtomicCas => Self::ATOMIC_CAS,
+            Self::AtomicLoad => Self::ATOMIC_LOAD,
+            Self::AtomicStore => Self::ATOMIC_STORE,
+            Self::AtomicSub => Self::ATOMIC_SUB,
+            Self::AtomicXchg => Self::ATOMIC_XCHG,
+            Self::Bswap16 => Self::BSWAP16,
+            Self::Bswap32 => Self::BSWAP32,
+            Self::Bswap64 => Self::BSWAP64,
+            Self::CallExternal => Self::CALL_EXTERNAL,
+            Self::Ctpop => Self::CTPOP,
+            Self::Ctlz => Self::CTLZ,
+            Self::Cttz => Self::CTTZ,
+            Self::Debugtrap => Self::DEBUGTRAP,
+            Self::Discriminant => Self::DISCRIMINANT,
+            Self::Dlerror => Self::DLERROR,
+            Self::Fence => Self::FENCE,
+            Self::Gep => Self::GEP,
+            Self::GepStruct => Self::GEP_STRUCT,
+            Self::GetPayload => Self::GET_PAYLOAD,
+            Self::GetSymbol => Self::GET_SYMBOL,
+            Self::InlineC => Self::INLINE_C,
+            Self::IntToPtr => Self::INT_TO_PTR,
+            Self::IsNull => Self::IS_NULL,
+            Self::LibcRead => Self::LIBC_READ,
+            Self::LibcWrite => Self::LIBC_WRITE,
+            Self::Load => Self::LOAD,
+            Self::LoadLibrary => Self::LOAD_LIBRARY,
+            Self::Memcmp => Self::MEMCMP,
+            Self::Memcpy => Self::MEMCPY,
+            Self::Memmove => Self::MEMMOVE,
+            Self::Memset => Self::MEMSET,
+            Self::MulOverflow => Self::MUL_OVERFLOW,
+            Self::NullPtr => Self::NULL_PTR,
+            Self::Nullptr => Self::NULLPTR,
+            Self::Panic => Self::PANIC,
+            Self::PtrToInt => Self::PTR_TO_INT,
+            Self::RawAllocate => Self::RAW_ALLOCATE,
+            Self::RawDeallocate => Self::RAW_DEALLOCATE,
+            Self::RawPtrCast => Self::RAW_PTR_CAST,
+            Self::RawPtrOffset => Self::RAW_PTR_OFFSET,
+            Self::RawReallocate => Self::RAW_REALLOCATE,
+            Self::SetDiscriminant => Self::SET_DISCRIMINANT,
+            Self::SetPayload => Self::SET_PAYLOAD,
+            Self::Sizeof => Self::SIZEOF,
+            Self::SitofpI64F64 => Self::SITOFP_I64_F64,
+            Self::StaticStringPtr => Self::STATIC_STRING_PTR,
+            Self::Store => Self::STORE,
+            Self::Strlen => Self::STRLEN,
+            Self::SubOverflow => Self::SUB_OVERFLOW,
+            Self::Syscall0 => Self::SYSCALL0,
+            Self::Syscall1 => Self::SYSCALL1,
+            Self::Syscall2 => Self::SYSCALL2,
+            Self::Syscall3 => Self::SYSCALL3,
+            Self::Syscall4 => Self::SYSCALL4,
+            Self::Syscall5 => Self::SYSCALL5,
+            Self::Syscall6 => Self::SYSCALL6,
+            Self::Trap => Self::TRAP,
+            Self::TruncF32I32 => Self::TRUNC_F32_I32,
+            Self::TruncF64I64 => Self::TRUNC_F64_I64,
+            Self::UitofpU64F64 => Self::UITOFP_U64_F64,
+            Self::UnloadLibrary => Self::UNLOAD_LIBRARY,
+            Self::Unreachable => Self::UNREACHABLE,
+        }
+    }
+}
+
+impl fmt::Display for CIntrinsic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for CIntrinsic {
+    type Err = ();
+
+    fn from_str(name: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|intrinsic| intrinsic.as_str() == name)
+            .ok_or(())
+    }
+}

--- a/tests/docs_truth/repo_hygiene/parser_enums.rs
+++ b/tests/docs_truth/repo_hygiene/parser_enums.rs
@@ -210,6 +210,58 @@ fn typechecker_gated_intrinsics_use_owned_name_enum() {
 }
 
 #[test]
+fn codegen_c_intrinsics_use_owned_name_enum() {
+    let lowering = read("src/codegen/c/intrinsics.rs");
+    let names = read("src/codegen/c/intrinsics/names.rs");
+    let source = format!("{lowering}\n{names}");
+
+    for forbidden in [
+        "match name",
+        r#""raw_allocate" =>"#,
+        r#""raw_deallocate" =>"#,
+        r#""raw_reallocate" =>"#,
+        r#""memcpy" =>"#,
+        r#""memmove" =>"#,
+        r#""memset" =>"#,
+        r#""memcmp" =>"#,
+        r#""atomic_load" =>"#,
+        r#""atomic_store" =>"#,
+        r#""atomic_add" =>"#,
+        r#""atomic_sub" =>"#,
+        r#""atomic_cas" =>"#,
+        r#""atomic_xchg" =>"#,
+        r#""syscall0" =>"#,
+        r#""syscall1" =>"#,
+        r#""syscall2" =>"#,
+        r#""syscall3" =>"#,
+        r#""syscall4" =>"#,
+        r#""syscall5" =>"#,
+        r#""syscall6" =>"#,
+    ] {
+        assert!(
+            !lowering.contains(forbidden),
+            "C intrinsic lowering should parse through CIntrinsic, not raw spelling dispatch: {forbidden}"
+        );
+    }
+
+    for required in [
+        "enum CIntrinsic",
+        "const ALL: &[CIntrinsic]",
+        "impl fmt::Display for CIntrinsic",
+        "impl FromStr for CIntrinsic",
+        "name.parse::<CIntrinsic>()",
+        "Self::RAW_ALLOCATE",
+        "Self::ATOMIC_LOAD",
+        "Self::SYSCALL6",
+    ] {
+        assert!(
+            source.contains(required),
+            "C intrinsic spelling should live in CIntrinsic: {required}"
+        );
+    }
+}
+
+#[test]
 fn cli_emit_json_modes_use_owned_mode_enum() {
     let source = read("src/cli.rs");
 


### PR DESCRIPTION
## Summary

- Route C backend intrinsic lowering through a `CIntrinsic` enum parsed from static `&'static str` spellings.
- Move backend intrinsic spellings into `src/codegen/c/intrinsics/names.rs` so the lowering body no longer matches raw builtin string literals.
- Add docs-truth coverage to guard against raw C intrinsic name dispatch and update phase/audit docs.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Push-triggered Actions check for this branch returned `[]`.