### PR TITLE
Parse build DSL method identifiers

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3996,6 +3996,10 @@ and do not assume Phase 4 is ready without evidence.
   lowering body. Covered by
   `codegen_c_intrinsics_use_owned_name_enum`, `production_rust_files_stay_below_cleanup_threshold`,
   and `codegen::c` tests.
+- Build graph host-effect method recognition now parses build DSL method names
+  through `BuildTargetDslIdent` instead of matching raw method strings.
+  Covered by `build_target_dsl_ident_owns_source_spelling` and
+  `build_graph_host_effect_methods_parse_dsl_ident_enum`.
 - Gated `.raise()` and `.await()` method recognition now routes through
   `GatedMethod` enum-owned spellings, covered by
   `typechecker_gated_methods_use_owned_action_enum`,

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3673,6 +3673,10 @@ checked-in docs, tests, and commits only.
   lowering body. Guarded by
   `codegen_c_intrinsics_use_owned_name_enum`, `production_rust_files_stay_below_cleanup_threshold`,
   and `codegen::c` tests.
+- Build graph host-effect method recognition now parses build DSL method names
+  through `BuildTargetDslIdent` instead of matching raw method strings.
+  Guarded by `build_target_dsl_ident_owns_source_spelling` and
+  `build_graph_host_effect_methods_parse_dsl_ident_enum`.
 - Gated `.raise()` and `.await()` method recognition now dispatches through the
   `GatedMethod` enum-owned spellings rather than hand-rolled comparisons,
   preserving the focused Result propagation and Sync/Async effect gates. Guarded

--- a/src/build_graph/lowering.rs
+++ b/src/build_graph/lowering.rs
@@ -265,13 +265,9 @@ fn host_effect(expr: &Expression) -> Option<HostEffect> {
     let [Expression::StringLiteral { value: argument, .. }] = args.as_slice() else {
         return None;
     };
-    match method.as_str() {
-        method if method == BuildTargetDslIdent::Env.as_str() => {
-            Some(HostEffect::ReadEnv(argument.clone()))
-        }
-        method if method == BuildTargetDslIdent::ReadFile.as_str() => {
-            Some(HostEffect::ReadFile(argument.clone()))
-        }
+    match method.parse::<BuildTargetDslIdent>() {
+        Ok(BuildTargetDslIdent::Env) => Some(HostEffect::ReadEnv(argument.clone())),
+        Ok(BuildTargetDslIdent::ReadFile) => Some(HostEffect::ReadFile(argument.clone())),
         _ => None,
     }
 }

--- a/src/build_graph/lowering/dsl.rs
+++ b/src/build_graph/lowering/dsl.rs
@@ -180,6 +180,22 @@ impl fmt::Display for BuildTargetDslIdent {
     }
 }
 
+impl FromStr for BuildTargetDslIdent {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            Self::BUILDER => Ok(Self::Builder),
+            Self::ADD => Ok(Self::Add),
+            Self::BUILD => Ok(Self::Build),
+            Self::ENV => Ok(Self::Env),
+            Self::OS => Ok(Self::Os),
+            Self::READ_FILE => Ok(Self::ReadFile),
+            _ => Err(()),
+        }
+    }
+}
+
 impl fmt::Display for BuildTargetDslKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())

--- a/src/build_graph/lowering_tests.rs
+++ b/src/build_graph/lowering_tests.rs
@@ -55,6 +55,13 @@ fn build_target_dsl_ident_owns_source_spelling() {
     assert_eq!(BuildTargetDslIdent::Env.as_str(), "env");
     assert_eq!(BuildTargetDslIdent::Os.as_str(), "os");
     assert_eq!(BuildTargetDslIdent::ReadFile.as_str(), "read_file");
+    assert_eq!("b".parse(), Ok(BuildTargetDslIdent::Builder));
+    assert_eq!("add".parse(), Ok(BuildTargetDslIdent::Add));
+    assert_eq!("build".parse(), Ok(BuildTargetDslIdent::Build));
+    assert_eq!("env".parse(), Ok(BuildTargetDslIdent::Env));
+    assert_eq!("os".parse(), Ok(BuildTargetDslIdent::Os));
+    assert_eq!("read_file".parse(), Ok(BuildTargetDslIdent::ReadFile));
+    assert!("read_env".parse::<BuildTargetDslIdent>().is_err());
     assert_eq!(BuildTargetDslIdent::Builder.to_string(), "b");
 }
 

--- a/tests/docs_truth/repo_hygiene/parser_enums.rs
+++ b/tests/docs_truth/repo_hygiene/parser_enums.rs
@@ -262,6 +262,31 @@ fn codegen_c_intrinsics_use_owned_name_enum() {
 }
 
 #[test]
+fn build_graph_host_effect_methods_parse_dsl_ident_enum() {
+    let lowering = read("src/build_graph/lowering.rs");
+    let dsl = read("src/build_graph/lowering/dsl.rs");
+
+    for forbidden in [
+        "match method.as_str()",
+        "method == BuildTargetDslIdent::Env.as_str()",
+        "method == BuildTargetDslIdent::ReadFile.as_str()",
+    ] {
+        assert!(
+            !lowering.contains(forbidden),
+            "build graph host-effect method dispatch should parse through BuildTargetDslIdent: {forbidden}"
+        );
+    }
+    assert!(
+        lowering.contains("method.parse::<BuildTargetDslIdent>()"),
+        "build graph host-effect method dispatch should parse method names through BuildTargetDslIdent"
+    );
+    assert!(
+        dsl.contains("impl FromStr for BuildTargetDslIdent"),
+        "BuildTargetDslIdent should own parsing for build DSL method names"
+    );
+}
+
+#[test]
 fn cli_emit_json_modes_use_owned_mode_enum() {
     let source = read("src/cli.rs");
 


### PR DESCRIPTION
## Summary

- Add `FromStr` for `BuildTargetDslIdent` so build DSL method names parse through the enum that owns their static spellings.
- Route host-effect method recognition through `method.parse::<BuildTargetDslIdent>()` instead of matching method strings directly.
- Add docs-truth coverage for the host-effect dispatch path and update phase/audit docs.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Push-triggered Actions check for this branch returned `[]`.