### PR TITLE
Use parser-owned type name enums

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -4000,6 +4000,10 @@ and do not assume Phase 4 is ready without evidence.
   through `BuildTargetDslIdent` instead of matching raw method strings.
   Covered by `build_target_dsl_ident_owns_source_spelling` and
   `build_graph_host_effect_methods_parse_dsl_ident_enum`.
+- Parser type-name resolution now routes primitive, `StaticString`, `Self`, and
+  builtin generic wrapper spellings through focused parser type-name enums
+  instead of matching raw strings in `resolve_type_name`. Covered by
+  `parser_type_names_use_owned_type_name_enums` and parser type examples.
 - Gated `.raise()` and `.await()` method recognition now routes through
   `GatedMethod` enum-owned spellings, covered by
   `typechecker_gated_methods_use_owned_action_enum`,

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3677,6 +3677,10 @@ checked-in docs, tests, and commits only.
   through `BuildTargetDslIdent` instead of matching raw method strings.
   Guarded by `build_target_dsl_ident_owns_source_spelling` and
   `build_graph_host_effect_methods_parse_dsl_ident_enum`.
+- Parser type-name resolution now routes primitive, `StaticString`, `Self`, and
+  builtin generic wrapper spellings through focused parser type-name enums
+  instead of matching raw strings in `resolve_type_name`. Guarded by
+  `parser_type_names_use_owned_type_name_enums` and parser type examples.
 - Gated `.raise()` and `.await()` method recognition now dispatches through the
   `GatedMethod` enum-owned spellings rather than hand-rolled comparisons,
   preserving the focused Result propagation and Sync/Async effect gates. Guarded

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -22,6 +22,7 @@ mod import_declarations;
 mod patterns;
 mod precedence;
 mod statements;
+mod type_names;
 mod types;
 
 #[cfg(test)]

--- a/src/parser/type_names.rs
+++ b/src/parser/type_names.rs
@@ -1,0 +1,128 @@
+use crate::ast::types::{AstType, STATIC_STRING_TYPE_NAME};
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ParserBuiltinTypeName {
+    I8,
+    I16,
+    I32,
+    I64,
+    U8,
+    U16,
+    U32,
+    U64,
+    Usize,
+    F32,
+    F64,
+    Bool,
+    Void,
+    Str,
+    StaticString,
+    SelfType,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ParserBuiltinGenericTypeName {
+    Ptr,
+    MutPtr,
+    RawPtr,
+    Slice,
+}
+
+impl ParserBuiltinTypeName {
+    const I8_NAME: &'static str = "i8";
+    const I16_NAME: &'static str = "i16";
+    const I32_NAME: &'static str = "i32";
+    const I64_NAME: &'static str = "i64";
+    const U8_NAME: &'static str = "u8";
+    const U16_NAME: &'static str = "u16";
+    const U32_NAME: &'static str = "u32";
+    const U64_NAME: &'static str = "u64";
+    const USIZE_NAME: &'static str = "usize";
+    const F32_NAME: &'static str = "f32";
+    const F64_NAME: &'static str = "f64";
+    const BOOL_NAME: &'static str = "bool";
+    const VOID_NAME: &'static str = "void";
+    const STR_NAME: &'static str = "str";
+    const SELF_NAME: &'static str = "Self";
+
+    pub(super) fn ast_type(self) -> AstType {
+        match self {
+            Self::I8 => AstType::I8,
+            Self::I16 => AstType::I16,
+            Self::I32 => AstType::I32,
+            Self::I64 => AstType::I64,
+            Self::U8 => AstType::U8,
+            Self::U16 => AstType::U16,
+            Self::U32 => AstType::U32,
+            Self::U64 => AstType::U64,
+            Self::Usize => AstType::Usize,
+            Self::F32 => AstType::F32,
+            Self::F64 => AstType::F64,
+            Self::Bool => AstType::Bool,
+            Self::Void => AstType::Void,
+            Self::Str | Self::StaticString => AstType::Str,
+            Self::SelfType => AstType::SelfType,
+        }
+    }
+}
+
+impl FromStr for ParserBuiltinTypeName {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            Self::I8_NAME => Ok(Self::I8),
+            Self::I16_NAME => Ok(Self::I16),
+            Self::I32_NAME => Ok(Self::I32),
+            Self::I64_NAME => Ok(Self::I64),
+            Self::U8_NAME => Ok(Self::U8),
+            Self::U16_NAME => Ok(Self::U16),
+            Self::U32_NAME => Ok(Self::U32),
+            Self::U64_NAME => Ok(Self::U64),
+            Self::USIZE_NAME => Ok(Self::Usize),
+            Self::F32_NAME => Ok(Self::F32),
+            Self::F64_NAME => Ok(Self::F64),
+            Self::BOOL_NAME => Ok(Self::Bool),
+            Self::VOID_NAME => Ok(Self::Void),
+            Self::STR_NAME => Ok(Self::Str),
+            STATIC_STRING_TYPE_NAME => Ok(Self::StaticString),
+            Self::SELF_NAME => Ok(Self::SelfType),
+            _ => Err(()),
+        }
+    }
+}
+
+impl ParserBuiltinGenericTypeName {
+    const PTR: &'static str = "Ptr";
+    const MUT_PTR: &'static str = "MutPtr";
+    const RAW_PTR: &'static str = "RawPtr";
+    const SLICE: &'static str = "Slice";
+
+    pub(super) fn ast_type(self, mut type_args: Vec<AstType>) -> Result<AstType, Vec<AstType>> {
+        if type_args.len() != 1 {
+            return Err(type_args);
+        }
+        let ty = Box::new(type_args.remove(0));
+        Ok(match self {
+            Self::Ptr => AstType::Ptr(ty),
+            Self::MutPtr => AstType::MutPtr(ty),
+            Self::RawPtr => AstType::RawPtr(ty),
+            Self::Slice => AstType::Slice(ty),
+        })
+    }
+}
+
+impl FromStr for ParserBuiltinGenericTypeName {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            Self::PTR => Ok(Self::Ptr),
+            Self::MUT_PTR => Ok(Self::MutPtr),
+            Self::RAW_PTR => Ok(Self::RawPtr),
+            Self::SLICE => Ok(Self::Slice),
+            _ => Err(()),
+        }
+    }
+}

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::parser::type_names::{ParserBuiltinGenericTypeName, ParserBuiltinTypeName};
 
 impl Parser {
     // ── Types ─────────────────────────────────────────────────
@@ -7,7 +8,7 @@ impl Parser {
         self.skip_newlines();
         let (tok, span) = self.advance();
         match tok {
-            Token::Identifier(name) => self.resolve_type_name(&name, span),
+            Token::Identifier(name) => self.resolve_type_name(&name),
             Token::LParen => {
                 // Function type: `(i32, i32) i32`
                 let mut params = Vec::new();
@@ -55,26 +56,12 @@ impl Parser {
         }
     }
 
-    fn resolve_type_name(&mut self, name: &str, _span: Span) -> Result<AstType, CompileError> {
-        let base = match name {
-            "i8" => return Ok(AstType::I8),
-            "i16" => return Ok(AstType::I16),
-            "i32" => return Ok(AstType::I32),
-            "i64" => return Ok(AstType::I64),
-            "u8" => return Ok(AstType::U8),
-            "u16" => return Ok(AstType::U16),
-            "u32" => return Ok(AstType::U32),
-            "u64" => return Ok(AstType::U64),
-            "usize" => return Ok(AstType::Usize),
-            "f32" => return Ok(AstType::F32),
-            "f64" => return Ok(AstType::F64),
-            "bool" => return Ok(AstType::Bool),
-            "void" => return Ok(AstType::Void),
-            "str" => return Ok(AstType::Str),
-            "StaticString" => return Ok(AstType::Str),
-            "Self" => return Ok(AstType::SelfType),
-            _ => name.to_string(),
-        };
+    fn resolve_type_name(&mut self, name: &str) -> Result<AstType, CompileError> {
+        if let Ok(builtin) = name.parse::<ParserBuiltinTypeName>() {
+            return Ok(builtin.ast_type());
+        }
+
+        let base = name.to_string();
 
         // Check for generic args: Name<T, U>
         if matches!(self.peek(), Token::Lt) {
@@ -94,22 +81,18 @@ impl Parser {
             self.expect_gt()?;
 
             // Handle well-known generic types
-            match base.as_str() {
-                "Ptr" if type_args.len() == 1 => Ok(AstType::Ptr(Box::new(type_args.remove(0)))),
-                "MutPtr" if type_args.len() == 1 => {
-                    Ok(AstType::MutPtr(Box::new(type_args.remove(0))))
-                }
-                "RawPtr" if type_args.len() == 1 => {
-                    Ok(AstType::RawPtr(Box::new(type_args.remove(0))))
-                }
-                "Slice" if type_args.len() == 1 => {
-                    Ok(AstType::Slice(Box::new(type_args.remove(0))))
-                }
-                _ => Ok(AstType::Generic {
-                    name: base,
-                    type_args,
-                }),
+            if let Ok(builtin) = base.parse::<ParserBuiltinGenericTypeName>() {
+                return Ok(builtin.ast_type(type_args).unwrap_or_else(|type_args| {
+                    AstType::Generic {
+                        name: base,
+                        type_args,
+                    }
+                }));
             }
+            Ok(AstType::Generic {
+                name: base,
+                type_args,
+            })
         } else {
             Ok(AstType::Named(base))
         }

--- a/tests/docs_truth/repo_hygiene/parser_enums.rs
+++ b/tests/docs_truth/repo_hygiene/parser_enums.rs
@@ -51,6 +51,55 @@ fn parser_loop_control_calls_use_owned_action_enum() {
 }
 
 #[test]
+fn parser_type_names_use_owned_type_name_enums() {
+    let parser_types = read("src/parser/types.rs");
+    let type_names = read("src/parser/type_names.rs");
+
+    for forbidden in [
+        r#""i8" =>"#,
+        r#""i16" =>"#,
+        r#""i32" =>"#,
+        r#""i64" =>"#,
+        r#""u8" =>"#,
+        r#""u16" =>"#,
+        r#""u32" =>"#,
+        r#""u64" =>"#,
+        r#""usize" =>"#,
+        r#""f32" =>"#,
+        r#""f64" =>"#,
+        r#""bool" =>"#,
+        r#""void" =>"#,
+        r#""str" =>"#,
+        r#""StaticString" =>"#,
+        r#""Self" =>"#,
+        r#""Ptr" if"#,
+        r#""MutPtr" if"#,
+        r#""RawPtr" if"#,
+        r#""Slice" if"#,
+        "match base.as_str()",
+    ] {
+        assert!(
+            !parser_types.contains(forbidden),
+            "parser type-name resolution should parse through owned parser type-name enums: {forbidden}"
+        );
+    }
+
+    for required in [
+        "enum ParserBuiltinTypeName",
+        "enum ParserBuiltinGenericTypeName",
+        "impl FromStr for ParserBuiltinTypeName",
+        "impl FromStr for ParserBuiltinGenericTypeName",
+        "name.parse::<ParserBuiltinTypeName>()",
+        "base.parse::<ParserBuiltinGenericTypeName>()",
+    ] {
+        assert!(
+            type_names.contains(required) || parser_types.contains(required),
+            "parser type-name spelling should live in parser type-name enums: {required}"
+        );
+    }
+}
+
+#[test]
 fn typechecker_gated_methods_use_owned_action_enum() {
     let source = read("src/typechecker/expressions/method_call_support.rs");
 


### PR DESCRIPTION
## Summary

- Move parser builtin type spellings and builtin generic wrapper spellings into `src/parser/type_names.rs`.
- Route `resolve_type_name` through `ParserBuiltinTypeName` and `ParserBuiltinGenericTypeName` instead of raw string matches.
- Remove the unused span parameter and avoid cloning generic type arguments when falling back to ordinary generic types.
- Add docs-truth coverage and update phase/audit docs.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Push-triggered Actions check for this branch returned `[]`.