### PR TITLE
Use enum-owned module root prefixes

### DIFF
--- a/src/module_system/graph_loading.rs
+++ b/src/module_system/graph_loading.rs
@@ -5,6 +5,7 @@ use crate::ast::{Declaration, Program};
 use crate::error::{CompileError, FileTable, Span};
 use crate::resolver::{Namespace, Resolver, SymbolTable};
 
+use super::root_prefix::parse_module_root_prefix;
 use super::{ImportBinding, ModuleId, ModuleSystem, ResolvedModule, ResolvedModuleGraph};
 
 impl ModuleSystem {
@@ -124,13 +125,14 @@ impl ModuleSystem {
             self.reject_duplicate_requested_imports(&names, &module_path, span)?;
 
             let first = &module_path[0];
+            let root_prefix = parse_module_root_prefix(first);
             if first == "@builtin"
-                || ((first == "std" || first == "@std") && module_path.len() == 1)
+                || (root_prefix.is_some_and(|prefix| prefix.is_std()) && module_path.len() == 1)
             {
                 continue;
             }
 
-            let file_path = if first == "std" || first == "@std" {
+            let file_path = if root_prefix.is_some_and(|prefix| prefix.is_std()) {
                 self.resolve_stdlib_file_path(&module_path[1..])?
                     .ok_or_else(|| {
                         vec![CompileError::Resolution(

--- a/src/module_system/import_resolution.rs
+++ b/src/module_system/import_resolution.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use crate::ast::{Declaration, Program};
 use crate::error::{CompileError, FileTable, Span};
 
+use super::root_prefix::parse_module_root_prefix;
 use super::ModuleSystem;
 
 impl ModuleSystem {
@@ -45,7 +46,7 @@ impl ModuleSystem {
 
             let first = &module_path[0];
 
-            if first == "std" || first == "@std" {
+            if parse_module_root_prefix(first).is_some_and(|prefix| prefix.is_std()) {
                 if module_path.len() == 1 {
                     continue;
                 }
@@ -205,7 +206,7 @@ impl ModuleSystem {
 
         let first = &module_path[0];
 
-        if first == "@std" || first == "std" {
+        if parse_module_root_prefix(first).is_some_and(|prefix| prefix.is_std()) {
             return self.resolve_stdlib_import(&module_path[1..], files);
         }
 

--- a/src/module_system/mod.rs
+++ b/src/module_system/mod.rs
@@ -9,6 +9,7 @@ use crate::resolver::SymbolTable;
 
 mod graph_loading;
 mod import_resolution;
+mod root_prefix;
 
 use import_resolution::find_stdlib_root;
 

--- a/src/module_system/root_prefix.rs
+++ b/src/module_system/root_prefix.rs
@@ -1,0 +1,47 @@
+use std::fmt;
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ModuleRootPrefix {
+    Std,
+    AtStd,
+}
+
+impl ModuleRootPrefix {
+    const STD: &'static str = "std";
+    const AT_STD: &'static str = "@std";
+    const ALL: &[ModuleRootPrefix] = &[ModuleRootPrefix::Std, ModuleRootPrefix::AtStd];
+
+    pub(super) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Std => Self::STD,
+            Self::AtStd => Self::AT_STD,
+        }
+    }
+
+    pub(super) const fn is_std(self) -> bool {
+        matches!(self, Self::Std | Self::AtStd)
+    }
+}
+
+impl fmt::Display for ModuleRootPrefix {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for ModuleRootPrefix {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|prefix| prefix.as_str() == value)
+            .ok_or(())
+    }
+}
+
+pub(super) fn parse_module_root_prefix(value: &str) -> Option<ModuleRootPrefix> {
+    value.parse().ok()
+}

--- a/tests/docs_truth/repo_hygiene/mod.rs
+++ b/tests/docs_truth/repo_hygiene/mod.rs
@@ -3,6 +3,7 @@ use super::*;
 mod builtin_type_spelling;
 mod ci_configs;
 mod file_size;
+mod module_system;
 mod parser_enums;
 mod removed_syntax;
 mod source_truth;

--- a/tests/docs_truth/repo_hygiene/module_system.rs
+++ b/tests/docs_truth/repo_hygiene/module_system.rs
@@ -1,0 +1,41 @@
+use super::*;
+
+#[test]
+fn module_system_roots_use_owned_prefix_enum() {
+    let import_resolution = read("src/module_system/import_resolution.rs");
+    let graph_loading = read("src/module_system/graph_loading.rs");
+    let root_prefix = read("src/module_system/root_prefix.rs");
+
+    for (path, source) in [
+        ("src/module_system/import_resolution.rs", import_resolution),
+        ("src/module_system/graph_loading.rs", graph_loading),
+    ] {
+        for forbidden in [
+            r#"first == "std""#,
+            r#"first == "@std""#,
+            r#"match first.as_str()"#,
+            r#""std" =>"#,
+            r#""@std" =>"#,
+        ] {
+            assert!(
+                !source.contains(forbidden),
+                "{path} should parse module roots through ModuleRootPrefix, not raw spelling checks: {forbidden}"
+            );
+        }
+    }
+
+    for required in [
+        "enum ModuleRootPrefix",
+        "const STD: &'static str = \"std\"",
+        "const AT_STD: &'static str = \"@std\"",
+        "impl FromStr for ModuleRootPrefix",
+        "impl fmt::Display for ModuleRootPrefix",
+        ".find(|prefix| prefix.as_str() == value)",
+        "pub(super) fn parse_module_root_prefix",
+    ] {
+        assert!(
+            root_prefix.contains(required),
+            "module root spelling should live in ModuleRootPrefix: {required}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ModuleRootPrefix` as the owned source of truth for `std` / `@std` module roots.
- Route legacy import resolution and module graph loading through the typed prefix parser.
- Add a docs-truth guard so raw module root spelling checks do not come back.

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch module-system-root-prefix-enum --event push --json databaseId,status,conclusion,name,headSha --limit 20` returned `[]`.