### PR TITLE
Use enum-owned std runtime calls

### DIFF
--- a/src/typechecker/expressions/call_validation.rs
+++ b/src/typechecker/expressions/call_validation.rs
@@ -311,7 +311,8 @@ impl TypeChecker {
 
     pub(super) fn is_root_std_runtime_call(&self, module: &str, function: &str) -> bool {
         self.is_root_std_import(module)
-            && matches!((module, function), ("io", "print") | ("io", "println"))
+            && crate::typechecker::std_runtime_calls::parse_std_runtime_call(module, function)
+                .is_some()
     }
 
     pub(super) fn block_satisfies_return(&self, block: &TypedBlock, ret_type: &Type) -> bool {

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -41,6 +41,7 @@ mod scope_management;
 mod self_type_validation;
 mod semantic_validation;
 mod statements;
+mod std_runtime_calls;
 
 use std::collections::{HashMap, HashSet, VecDeque};
 

--- a/src/typechecker/std_runtime_calls.rs
+++ b/src/typechecker/std_runtime_calls.rs
@@ -1,0 +1,40 @@
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum StdRuntimeCall {
+    IoPrint,
+    IoPrintln,
+}
+
+impl StdRuntimeCall {
+    const IO: &'static str = "io";
+    const PRINT: &'static str = "print";
+    const PRINTLN: &'static str = "println";
+    const ALL: &[StdRuntimeCall] = &[StdRuntimeCall::IoPrint, StdRuntimeCall::IoPrintln];
+
+    const fn module(self) -> &'static str {
+        match self {
+            Self::IoPrint | Self::IoPrintln => Self::IO,
+        }
+    }
+
+    const fn function(self) -> &'static str {
+        match self {
+            Self::IoPrint => Self::PRINT,
+            Self::IoPrintln => Self::PRINTLN,
+        }
+    }
+}
+
+impl fmt::Display for StdRuntimeCall {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}", self.module(), self.function())
+    }
+}
+
+pub(super) fn parse_std_runtime_call(module: &str, function: &str) -> Option<StdRuntimeCall> {
+    StdRuntimeCall::ALL
+        .iter()
+        .copied()
+        .find(|call| call.module() == module && call.function() == function)
+}

--- a/tests/docs_truth/repo_hygiene/mod.rs
+++ b/tests/docs_truth/repo_hygiene/mod.rs
@@ -7,3 +7,4 @@ mod module_system;
 mod parser_enums;
 mod removed_syntax;
 mod source_truth;
+mod typechecker_runtime;

--- a/tests/docs_truth/repo_hygiene/typechecker_runtime.rs
+++ b/tests/docs_truth/repo_hygiene/typechecker_runtime.rs
@@ -1,0 +1,37 @@
+use super::*;
+
+#[test]
+fn root_std_runtime_calls_use_owned_intrinsic_enum() {
+    let call_validation = read("src/typechecker/expressions/call_validation.rs");
+    let runtime_calls = read("src/typechecker/std_runtime_calls.rs");
+
+    for forbidden in [
+        r#"("io", "print")"#,
+        r#"("io", "println")"#,
+        r#"matches!((module, function)"#,
+        r#"module == "io""#,
+        r#"function == "print""#,
+        r#"function == "println""#,
+    ] {
+        assert!(
+            !call_validation.contains(forbidden),
+            "root std runtime call checks should parse through StdRuntimeCall, not raw spelling checks: {forbidden}"
+        );
+    }
+
+    for required in [
+        "enum StdRuntimeCall",
+        "const IO: &'static str = \"io\"",
+        "const PRINT: &'static str = \"print\"",
+        "const PRINTLN: &'static str = \"println\"",
+        "const ALL: &[StdRuntimeCall]",
+        "impl fmt::Display for StdRuntimeCall",
+        ".find(|call| call.module() == module && call.function() == function)",
+        "pub(super) fn parse_std_runtime_call",
+    ] {
+        assert!(
+            runtime_calls.contains(required),
+            "root std runtime spelling should live in StdRuntimeCall: {required}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add `StdRuntimeCall` as the owned source of truth for root std runtime stand-ins.
- Route root std runtime method checks through the typed parser instead of tuple string matching.
- Add a docs-truth guard so raw `io.print` / `io.println` dispatch does not return to typechecker semantic logic.

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch typechecker-std-runtime-call-enum --event push --json databaseId,status,conclusion,name,headSha --limit 20` returned `[]`.