### PR TITLE
Use static typechecker import roots

### DIFF
--- a/src/typechecker/import_roots.rs
+++ b/src/typechecker/import_roots.rs
@@ -1,0 +1,37 @@
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RootImportPath {
+    Std,
+    AtStd,
+}
+
+impl RootImportPath {
+    const STD: &'static str = "std";
+    const AT_STD: &'static str = "@std";
+    const ALL: &[RootImportPath] = &[RootImportPath::Std, RootImportPath::AtStd];
+
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Std => Self::STD,
+            Self::AtStd => Self::AT_STD,
+        }
+    }
+
+    fn matches_path(self, path: &[String]) -> bool {
+        path.len() == 1 && path.first().is_some_and(|segment| segment == self.as_str())
+    }
+}
+
+impl fmt::Display for RootImportPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+pub(super) fn parse_root_import_path(path: &[String]) -> Option<RootImportPath> {
+    RootImportPath::ALL
+        .iter()
+        .copied()
+        .find(|root| root.matches_path(path))
+}

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -25,6 +25,7 @@ mod gated_intrinsics;
 mod generic_bound_validation;
 mod generic_type_reference_walker;
 mod generic_type_validation;
+mod import_roots;
 mod monomorphize;
 mod monomorphize_dependencies;
 mod monomorphize_inference;

--- a/src/typechecker/scope_management.rs
+++ b/src/typechecker/scope_management.rs
@@ -37,8 +37,8 @@ impl TypeChecker {
     }
 
     pub(crate) fn is_root_std_import(&self, name: &str) -> bool {
-        self.imports
-            .get(name)
-            .is_some_and(|path| path == &["std".to_string()] || path == &["@std".to_string()])
+        self.imports.get(name).is_some_and(|path| {
+            crate::typechecker::import_roots::parse_root_import_path(path).is_some()
+        })
     }
 }

--- a/tests/docs_truth/repo_hygiene/mod.rs
+++ b/tests/docs_truth/repo_hygiene/mod.rs
@@ -7,4 +7,5 @@ mod module_system;
 mod parser_enums;
 mod removed_syntax;
 mod source_truth;
+mod typechecker_imports;
 mod typechecker_runtime;

--- a/tests/docs_truth/repo_hygiene/typechecker_imports.rs
+++ b/tests/docs_truth/repo_hygiene/typechecker_imports.rs
@@ -1,0 +1,35 @@
+use super::*;
+
+#[test]
+fn typechecker_root_imports_use_static_root_enum() {
+    let scope_management = read("src/typechecker/scope_management.rs");
+    let import_roots = read("src/typechecker/import_roots.rs");
+
+    for forbidden in [
+        r#"["std".to_string()]"#,
+        r#"["@std".to_string()]"#,
+        r#"path == &["std".to_string()]"#,
+        r#"path == &["@std".to_string()]"#,
+        r#"path == &["#,
+    ] {
+        assert!(
+            !scope_management.contains(forbidden),
+            "typechecker import root checks should not allocate strings for static import roots: {forbidden}"
+        );
+    }
+
+    for required in [
+        "enum RootImportPath",
+        "const STD: &'static str = \"std\"",
+        "const AT_STD: &'static str = \"@std\"",
+        "const ALL: &[RootImportPath]",
+        "impl fmt::Display for RootImportPath",
+        ".find(|root| root.matches_path(path))",
+        "pub(super) fn parse_root_import_path",
+    ] {
+        assert!(
+            import_roots.contains(required),
+            "typechecker root import spelling should live in RootImportPath: {required}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add `RootImportPath` as the static owner for root std import paths in typechecker semantics.
- Replace allocation-based `vec!["std".to_string()]` style import checks with static path matching.
- Add a docs-truth guard so typechecker root import checks do not regress to owned string allocation.

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch typechecker-root-std-import-enum --event push --json databaseId,status,conclusion,name,headSha --limit 20` returned `[]`.