### PR TITLE
Use static enum parsing for language names

### DIFF
--- a/src/build_graph/lowering/dsl.rs
+++ b/src/build_graph/lowering/dsl.rs
@@ -38,7 +38,11 @@ pub(super) enum HostEffectResultVariant {
 }
 
 impl BuildTargetDslKind {
-    const ALL: [Self; 3] = [Self::Executable, Self::Test, Self::Library];
+    const ALL: &[BuildTargetDslKind] = &[
+        BuildTargetDslKind::Executable,
+        BuildTargetDslKind::Test,
+        BuildTargetDslKind::Library,
+    ];
     const EXECUTABLE: &'static str = "Executable";
     const TEST: &'static str = "Test";
     const LIBRARY: &'static str = "Library";
@@ -67,6 +71,18 @@ impl BuildTargetDslKind {
 }
 
 impl BuildTargetField {
+    const ALL: &[BuildTargetField] = &[
+        BuildTargetField::Name,
+        BuildTargetField::Main,
+        BuildTargetField::Root,
+        BuildTargetField::RootSourceFile,
+        BuildTargetField::OutDir,
+        BuildTargetField::Dependencies,
+        BuildTargetField::Features,
+        BuildTargetField::Exports,
+        BuildTargetField::Packages,
+        BuildTargetField::Link,
+    ];
     const NAME: &'static str = "name";
     const MAIN: &'static str = "main";
     const ROOT: &'static str = "root";
@@ -102,23 +118,17 @@ impl FromStr for BuildTargetField {
     type Err = ();
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            Self::NAME => Ok(Self::Name),
-            Self::MAIN => Ok(Self::Main),
-            Self::ROOT => Ok(Self::Root),
-            Self::ROOT_SOURCE_FILE => Ok(Self::RootSourceFile),
-            Self::OUT_DIR => Ok(Self::OutDir),
-            Self::DEPENDENCIES => Ok(Self::Dependencies),
-            Self::FEATURES => Ok(Self::Features),
-            Self::EXPORTS => Ok(Self::Exports),
-            Self::PACKAGES => Ok(Self::Packages),
-            Self::LINK => Ok(Self::Link),
-            _ => Err(()),
-        }
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|field| field.as_str() == value)
+            .ok_or(())
     }
 }
 
 impl HostEffectResultVariant {
+    const ALL: &[HostEffectResultVariant] =
+        &[HostEffectResultVariant::Ok, HostEffectResultVariant::Err];
     const OK: &'static str = "Ok";
     const ERR: &'static str = "Err";
 
@@ -140,11 +150,11 @@ impl FromStr for HostEffectResultVariant {
     type Err = ();
 
     fn from_str(value: &str) -> Result<Self, <Self as FromStr>::Err> {
-        match value {
-            Self::OK => Ok(Self::Ok),
-            Self::ERR => Ok(Self::Err),
-            _ => Err(()),
-        }
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|variant| variant.as_str() == value)
+            .ok_or(())
     }
 }
 
@@ -155,6 +165,14 @@ impl fmt::Display for BuildTargetField {
 }
 
 impl BuildTargetDslIdent {
+    const ALL: &[BuildTargetDslIdent] = &[
+        BuildTargetDslIdent::Builder,
+        BuildTargetDslIdent::Add,
+        BuildTargetDslIdent::Build,
+        BuildTargetDslIdent::Env,
+        BuildTargetDslIdent::Os,
+        BuildTargetDslIdent::ReadFile,
+    ];
     const BUILDER: &'static str = "b";
     const ADD: &'static str = "add";
     const BUILD: &'static str = "build";
@@ -184,15 +202,11 @@ impl FromStr for BuildTargetDslIdent {
     type Err = ();
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            Self::BUILDER => Ok(Self::Builder),
-            Self::ADD => Ok(Self::Add),
-            Self::BUILD => Ok(Self::Build),
-            Self::ENV => Ok(Self::Env),
-            Self::OS => Ok(Self::Os),
-            Self::READ_FILE => Ok(Self::ReadFile),
-            _ => Err(()),
-        }
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|ident| ident.as_str() == value)
+            .ok_or(())
     }
 }
 
@@ -206,11 +220,10 @@ impl FromStr for BuildTargetDslKind {
     type Err = ();
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            Self::EXECUTABLE => Ok(Self::Executable),
-            Self::TEST => Ok(Self::Test),
-            Self::LIBRARY => Ok(Self::Library),
-            _ => Err(()),
-        }
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|kind| kind.as_str() == value)
+            .ok_or(())
     }
 }

--- a/src/parser/type_names.rs
+++ b/src/parser/type_names.rs
@@ -30,6 +30,24 @@ pub(super) enum ParserBuiltinGenericTypeName {
 }
 
 impl ParserBuiltinTypeName {
+    const ALL: &[ParserBuiltinTypeName] = &[
+        ParserBuiltinTypeName::I8,
+        ParserBuiltinTypeName::I16,
+        ParserBuiltinTypeName::I32,
+        ParserBuiltinTypeName::I64,
+        ParserBuiltinTypeName::U8,
+        ParserBuiltinTypeName::U16,
+        ParserBuiltinTypeName::U32,
+        ParserBuiltinTypeName::U64,
+        ParserBuiltinTypeName::Usize,
+        ParserBuiltinTypeName::F32,
+        ParserBuiltinTypeName::F64,
+        ParserBuiltinTypeName::Bool,
+        ParserBuiltinTypeName::Void,
+        ParserBuiltinTypeName::Str,
+        ParserBuiltinTypeName::StaticString,
+        ParserBuiltinTypeName::SelfType,
+    ];
     const I8_NAME: &'static str = "i8";
     const I16_NAME: &'static str = "i16";
     const I32_NAME: &'static str = "i32";
@@ -45,6 +63,27 @@ impl ParserBuiltinTypeName {
     const VOID_NAME: &'static str = "void";
     const STR_NAME: &'static str = "str";
     const SELF_NAME: &'static str = "Self";
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::I8 => Self::I8_NAME,
+            Self::I16 => Self::I16_NAME,
+            Self::I32 => Self::I32_NAME,
+            Self::I64 => Self::I64_NAME,
+            Self::U8 => Self::U8_NAME,
+            Self::U16 => Self::U16_NAME,
+            Self::U32 => Self::U32_NAME,
+            Self::U64 => Self::U64_NAME,
+            Self::Usize => Self::USIZE_NAME,
+            Self::F32 => Self::F32_NAME,
+            Self::F64 => Self::F64_NAME,
+            Self::Bool => Self::BOOL_NAME,
+            Self::Void => Self::VOID_NAME,
+            Self::Str => Self::STR_NAME,
+            Self::StaticString => STATIC_STRING_TYPE_NAME,
+            Self::SelfType => Self::SELF_NAME,
+        }
+    }
 
     pub(super) fn ast_type(self) -> AstType {
         match self {
@@ -71,33 +110,34 @@ impl FromStr for ParserBuiltinTypeName {
     type Err = ();
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            Self::I8_NAME => Ok(Self::I8),
-            Self::I16_NAME => Ok(Self::I16),
-            Self::I32_NAME => Ok(Self::I32),
-            Self::I64_NAME => Ok(Self::I64),
-            Self::U8_NAME => Ok(Self::U8),
-            Self::U16_NAME => Ok(Self::U16),
-            Self::U32_NAME => Ok(Self::U32),
-            Self::U64_NAME => Ok(Self::U64),
-            Self::USIZE_NAME => Ok(Self::Usize),
-            Self::F32_NAME => Ok(Self::F32),
-            Self::F64_NAME => Ok(Self::F64),
-            Self::BOOL_NAME => Ok(Self::Bool),
-            Self::VOID_NAME => Ok(Self::Void),
-            Self::STR_NAME => Ok(Self::Str),
-            STATIC_STRING_TYPE_NAME => Ok(Self::StaticString),
-            Self::SELF_NAME => Ok(Self::SelfType),
-            _ => Err(()),
-        }
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|name| name.as_str() == value)
+            .ok_or(())
     }
 }
 
 impl ParserBuiltinGenericTypeName {
+    const ALL: &[ParserBuiltinGenericTypeName] = &[
+        ParserBuiltinGenericTypeName::Ptr,
+        ParserBuiltinGenericTypeName::MutPtr,
+        ParserBuiltinGenericTypeName::RawPtr,
+        ParserBuiltinGenericTypeName::Slice,
+    ];
     const PTR: &'static str = "Ptr";
     const MUT_PTR: &'static str = "MutPtr";
     const RAW_PTR: &'static str = "RawPtr";
     const SLICE: &'static str = "Slice";
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Ptr => Self::PTR,
+            Self::MutPtr => Self::MUT_PTR,
+            Self::RawPtr => Self::RAW_PTR,
+            Self::Slice => Self::SLICE,
+        }
+    }
 
     pub(super) fn ast_type(self, mut type_args: Vec<AstType>) -> Result<AstType, Vec<AstType>> {
         if type_args.len() != 1 {
@@ -117,12 +157,10 @@ impl FromStr for ParserBuiltinGenericTypeName {
     type Err = ();
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            Self::PTR => Ok(Self::Ptr),
-            Self::MUT_PTR => Ok(Self::MutPtr),
-            Self::RAW_PTR => Ok(Self::RawPtr),
-            Self::SLICE => Ok(Self::Slice),
-            _ => Err(()),
-        }
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|name| name.as_str() == value)
+            .ok_or(())
     }
 }

--- a/tests/docs_truth/repo_hygiene/build_graph_dsl.rs
+++ b/tests/docs_truth/repo_hygiene/build_graph_dsl.rs
@@ -1,0 +1,35 @@
+use super::*;
+
+#[test]
+fn build_graph_dsl_parsing_uses_enum_static_tables() {
+    let dsl = read("src/build_graph/lowering/dsl.rs");
+
+    for forbidden in [
+        r#"match value {
+            Self::NAME => Ok(Self::Name),"#,
+        r#"Self::BUILDER => Ok(Self::Builder)"#,
+        r#"Self::EXECUTABLE => Ok(Self::Executable)"#,
+        r#"Self::OK => Ok(Self::Ok)"#,
+    ] {
+        assert!(
+            !dsl.contains(forbidden),
+            "build graph DSL parsing should use enum-owned static tables, not raw FromStr match arms: {forbidden}"
+        );
+    }
+
+    for required in [
+        "const ALL: &[BuildTargetField]",
+        "const ALL: &[BuildTargetDslIdent]",
+        "const ALL: &[BuildTargetDslKind]",
+        "const ALL: &[HostEffectResultVariant]",
+        ".find(|field| field.as_str() == value)",
+        ".find(|ident| ident.as_str() == value)",
+        ".find(|kind| kind.as_str() == value)",
+        ".find(|variant| variant.as_str() == value)",
+    ] {
+        assert!(
+            dsl.contains(required),
+            "build graph DSL spelling should parse through enum static tables: {required}"
+        );
+    }
+}

--- a/tests/docs_truth/repo_hygiene/mod.rs
+++ b/tests/docs_truth/repo_hygiene/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+mod build_graph_dsl;
 mod builtin_type_spelling;
 mod ci_configs;
 mod file_size;

--- a/tests/docs_truth/repo_hygiene/parser_enums.rs
+++ b/tests/docs_truth/repo_hygiene/parser_enums.rs
@@ -84,11 +84,42 @@ fn parser_type_names_use_owned_type_name_enums() {
         );
     }
 
+    for forbidden in [
+        "Self::I8_NAME => Ok(Self::I8)",
+        "Self::I16_NAME => Ok(Self::I16)",
+        "Self::I32_NAME => Ok(Self::I32)",
+        "Self::I64_NAME => Ok(Self::I64)",
+        "Self::U8_NAME => Ok(Self::U8)",
+        "Self::U16_NAME => Ok(Self::U16)",
+        "Self::U32_NAME => Ok(Self::U32)",
+        "Self::U64_NAME => Ok(Self::U64)",
+        "Self::USIZE_NAME => Ok(Self::Usize)",
+        "Self::F32_NAME => Ok(Self::F32)",
+        "Self::F64_NAME => Ok(Self::F64)",
+        "Self::BOOL_NAME => Ok(Self::Bool)",
+        "Self::VOID_NAME => Ok(Self::Void)",
+        "Self::STR_NAME => Ok(Self::Str)",
+        "STATIC_STRING_TYPE_NAME => Ok(Self::StaticString)",
+        "Self::SELF_NAME => Ok(Self::SelfType)",
+        "Self::PTR => Ok(Self::Ptr)",
+        "Self::MUT_PTR => Ok(Self::MutPtr)",
+        "Self::RAW_PTR => Ok(Self::RawPtr)",
+        "Self::SLICE => Ok(Self::Slice)",
+    ] {
+        assert!(
+            !type_names.contains(forbidden),
+            "parser type-name FromStr should use enum-owned static tables, not raw match arms: {forbidden}"
+        );
+    }
+
     for required in [
         "enum ParserBuiltinTypeName",
         "enum ParserBuiltinGenericTypeName",
+        "const ALL: &[ParserBuiltinTypeName]",
+        "const ALL: &[ParserBuiltinGenericTypeName]",
         "impl FromStr for ParserBuiltinTypeName",
         "impl FromStr for ParserBuiltinGenericTypeName",
+        ".find(|name| name.as_str() == value)",
         "name.parse::<ParserBuiltinTypeName>()",
         "base.parse::<ParserBuiltinGenericTypeName>()",
     ] {


### PR DESCRIPTION
## Summary
- Parse build graph DSL fields, identifiers, target kinds, and host-effect variants through enum-owned static `ALL` tables.
- Parse parser built-in type names and built-in generic type names through enum-owned static `ALL` tables.
- Add docs-truth guards so these language spellings do not drift back into raw `FromStr` match arms.

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch build-graph-dsl-static-parsing --event push --json databaseId,status,conclusion,name,headSha --limit 20` returned `[]`.