### PR TITLE
Use static type declaration keyword parsing

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -4004,6 +4004,10 @@ and do not assume Phase 4 is ready without evidence.
   builtin generic wrapper spellings through focused parser type-name enums
   instead of matching raw strings in `resolve_type_name`. Covered by
   `parser_type_names_use_owned_type_name_enums` and parser type examples.
+- Parser type-declaration suffix keywords now parse through
+  `TypeDeclarationKeyword::ALL`, keeping `impl`, `implements`, `requires`, and
+  `extends` on one enum-owned static spelling table. Covered by
+  `parser_type_declaration_suffixes_use_owned_keyword_enum`.
 - Gated `.raise()` and `.await()` method recognition now routes through
   `GatedMethod` enum-owned spellings, covered by
   `typechecker_gated_methods_use_owned_action_enum`,

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3681,6 +3681,10 @@ checked-in docs, tests, and commits only.
   builtin generic wrapper spellings through focused parser type-name enums
   instead of matching raw strings in `resolve_type_name`. Guarded by
   `parser_type_names_use_owned_type_name_enums` and parser type examples.
+- Parser type-declaration suffix keywords now parse through
+  `TypeDeclarationKeyword::ALL`, so `impl`, `implements`, `requires`, and
+  `extends` stay in one enum-owned static spelling table. Guarded by
+  `parser_type_declaration_suffixes_use_owned_keyword_enum`.
 - Gated `.raise()` and `.await()` method recognition now dispatches through the
   `GatedMethod` enum-owned spellings rather than hand-rolled comparisons,
   preserving the focused Result propagation and Sync/Async effect gates. Guarded

--- a/src/ast/declarations.rs
+++ b/src/ast/declarations.rs
@@ -14,6 +14,12 @@ pub enum TypeDeclarationKeyword {
 }
 
 impl TypeDeclarationKeyword {
+    pub const ALL: &[TypeDeclarationKeyword] = &[
+        TypeDeclarationKeyword::Impl,
+        TypeDeclarationKeyword::Implements,
+        TypeDeclarationKeyword::Requires,
+        TypeDeclarationKeyword::Extends,
+    ];
     pub const IMPL: &'static str = "impl";
     pub const IMPLEMENTS: &'static str = "implements";
     pub const REQUIRES: &'static str = "requires";
@@ -39,17 +45,11 @@ impl FromStr for TypeDeclarationKeyword {
     type Err = ();
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        if value == Self::Impl.as_str() {
-            Ok(Self::Impl)
-        } else if value == Self::Implements.as_str() {
-            Ok(Self::Implements)
-        } else if value == Self::Requires.as_str() {
-            Ok(Self::Requires)
-        } else if value == Self::Extends.as_str() {
-            Ok(Self::Extends)
-        } else {
-            Err(())
-        }
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|keyword| keyword.as_str() == value)
+            .ok_or(())
     }
 }
 

--- a/tests/docs_truth/repo_hygiene/parser_enums.rs
+++ b/tests/docs_truth/repo_hygiene/parser_enums.rs
@@ -3,6 +3,7 @@ use super::*;
 #[test]
 fn parser_type_declaration_suffixes_use_owned_keyword_enum() {
     let source = read("src/parser/declarations.rs");
+    let ast_declarations = read("src/ast/declarations.rs");
 
     for forbidden in [
         r#"method_name == "impl""#,
@@ -20,6 +21,28 @@ fn parser_type_declaration_suffixes_use_owned_keyword_enum() {
         source.contains("TypeDeclarationKeyword"),
         "parser type declaration suffix dispatch should use TypeDeclarationKeyword"
     );
+
+    for forbidden in [
+        "value == Self::Impl.as_str()",
+        "value == Self::Implements.as_str()",
+        "value == Self::Requires.as_str()",
+        "value == Self::Extends.as_str()",
+    ] {
+        assert!(
+            !ast_declarations.contains(forbidden),
+            "TypeDeclarationKeyword parsing should use the enum-owned static table, not raw if-chain spelling checks: {forbidden}"
+        );
+    }
+
+    for required in [
+        "pub const ALL: &[TypeDeclarationKeyword]",
+        ".find(|keyword| keyword.as_str() == value)",
+    ] {
+        assert!(
+            ast_declarations.contains(required),
+            "TypeDeclarationKeyword spelling should parse through its static table: {required}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Parse `TypeDeclarationKeyword` values through an enum-owned static `ALL` table.
- Strengthen docs-truth coverage so `impl`/`implements`/`requires`/`extends` parsing does not drift back to a raw if-chain.
- Record the evidence in the phase plan and completion audit.

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch type-declaration-keyword-static-parsing --event push --json databaseId,status,conclusion,name,headSha --limit 20` returned `[]`.