### PR TITLE
Use parser-owned prefix keyword parsing

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -4008,6 +4008,10 @@ and do not assume Phase 4 is ready without evidence.
   `TypeDeclarationKeyword::ALL`, keeping `impl`, `implements`, `requires`, and
   `extends` on one enum-owned static spelling table. Covered by
   `parser_type_declaration_suffixes_use_owned_keyword_enum`.
+- Parser prefix keyword dispatch now parses `true`, `false`, `return`, `break`,
+  `continue`, `loop`, and `cast` through `ParserPrefixKeyword` instead of a raw
+  `name.as_str()` match. Covered by
+  `parser_prefix_keywords_use_owned_keyword_enum` and parser expression tests.
 - Gated `.raise()` and `.await()` method recognition now routes through
   `GatedMethod` enum-owned spellings, covered by
   `typechecker_gated_methods_use_owned_action_enum`,

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3685,6 +3685,10 @@ checked-in docs, tests, and commits only.
   `TypeDeclarationKeyword::ALL`, so `impl`, `implements`, `requires`, and
   `extends` stay in one enum-owned static spelling table. Guarded by
   `parser_type_declaration_suffixes_use_owned_keyword_enum`.
+- Parser prefix keyword dispatch now parses `true`, `false`, `return`, `break`,
+  `continue`, `loop`, and `cast` through `ParserPrefixKeyword` instead of a raw
+  `name.as_str()` match. Guarded by
+  `parser_prefix_keywords_use_owned_keyword_enum` and parser expression tests.
 - Gated `.raise()` and `.await()` method recognition now dispatches through the
   `GatedMethod` enum-owned spellings rather than hand-rolled comparisons,
   preserving the focused Result propagation and Sync/Async effect gates. Guarded

--- a/src/parser/atoms.rs
+++ b/src/parser/atoms.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::parser::keywords::ParserPrefixKeyword;
 
 mod forms;
 
@@ -68,46 +69,35 @@ impl Parser {
             // String interpolation
             Token::StringChunk(_) | Token::InterpolationStart => self.parse_string_interpolation(),
 
-            // Identifier (or keyword-like: true, false, break, continue, loop, cast)
-            Token::Identifier(ref name) => match name.as_str() {
-                "true" => {
+            // Identifier or parser-owned prefix keyword.
+            Token::Identifier(ref name) => {
+                if let Ok(keyword) = name.parse::<ParserPrefixKeyword>() {
                     let (_, span) = self.advance();
-                    Ok(Expression::BoolLiteral { value: true, span })
-                }
-                "false" => {
-                    let (_, span) = self.advance();
-                    Ok(Expression::BoolLiteral { value: false, span })
-                }
-                "return" => {
-                    let (_, span) = self.advance();
-                    Err(CompileError::Syntax(
-                        "return keyword has been removed; use the final expression in the block"
-                            .into(),
-                        Some(span),
-                    ))
-                }
-                "break" => {
-                    let (_, span) = self.advance();
-                    Ok(Expression::Break { span })
-                }
-                "continue" => {
-                    let (_, span) = self.advance();
-                    Ok(Expression::Continue { span })
-                }
-                "loop" => {
-                    let (_, span) = self.advance();
-                    self.parse_loop(span)
-                }
-                "cast" => {
-                    let (_, span) = self.advance();
-                    self.parse_cast(span)
-                }
-                _ => {
+                    match keyword {
+                        ParserPrefixKeyword::True => Ok(Expression::BoolLiteral {
+                            value: true,
+                            span,
+                        }),
+                        ParserPrefixKeyword::False => Ok(Expression::BoolLiteral {
+                            value: false,
+                            span,
+                        }),
+                        ParserPrefixKeyword::Return => Err(CompileError::Syntax(
+                            "return keyword has been removed; use the final expression in the block"
+                                .into(),
+                            Some(span),
+                        )),
+                        ParserPrefixKeyword::Break => Ok(Expression::Break { span }),
+                        ParserPrefixKeyword::Continue => Ok(Expression::Continue { span }),
+                        ParserPrefixKeyword::Loop => self.parse_loop(span),
+                        ParserPrefixKeyword::Cast => self.parse_cast(span),
+                    }
+                } else {
                     let name = name.clone();
                     let (_, span) = self.advance();
                     Ok(Expression::Identifier { name, span })
                 }
-            },
+            }
 
             // @this.defer(expr) or other @ tokens
             Token::AtThis => {

--- a/src/parser/keywords.rs
+++ b/src/parser/keywords.rs
@@ -1,0 +1,56 @@
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ParserPrefixKeyword {
+    True,
+    False,
+    Return,
+    Break,
+    Continue,
+    Loop,
+    Cast,
+}
+
+impl ParserPrefixKeyword {
+    const ALL: &[ParserPrefixKeyword] = &[
+        ParserPrefixKeyword::True,
+        ParserPrefixKeyword::False,
+        ParserPrefixKeyword::Return,
+        ParserPrefixKeyword::Break,
+        ParserPrefixKeyword::Continue,
+        ParserPrefixKeyword::Loop,
+        ParserPrefixKeyword::Cast,
+    ];
+
+    const TRUE: &'static str = "true";
+    const FALSE: &'static str = "false";
+    const RETURN: &'static str = "return";
+    const BREAK: &'static str = "break";
+    const CONTINUE: &'static str = "continue";
+    const LOOP: &'static str = "loop";
+    const CAST: &'static str = "cast";
+
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::True => Self::TRUE,
+            Self::False => Self::FALSE,
+            Self::Return => Self::RETURN,
+            Self::Break => Self::BREAK,
+            Self::Continue => Self::CONTINUE,
+            Self::Loop => Self::LOOP,
+            Self::Cast => Self::CAST,
+        }
+    }
+}
+
+impl FromStr for ParserPrefixKeyword {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|keyword| keyword.as_str() == value)
+            .ok_or(())
+    }
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -19,6 +19,7 @@ mod declaration_types;
 mod declarations;
 mod expressions;
 mod import_declarations;
+mod keywords;
 mod patterns;
 mod precedence;
 mod statements;

--- a/tests/docs_truth/repo_hygiene/parser_enums.rs
+++ b/tests/docs_truth/repo_hygiene/parser_enums.rs
@@ -74,6 +74,41 @@ fn parser_loop_control_calls_use_owned_action_enum() {
 }
 
 #[test]
+fn parser_prefix_keywords_use_owned_keyword_enum() {
+    let atoms = read("src/parser/atoms.rs");
+    let keywords = read("src/parser/keywords.rs");
+
+    for forbidden in [
+        "match name.as_str()",
+        r#""true" =>"#,
+        r#""false" =>"#,
+        r#""return" =>"#,
+        r#""break" =>"#,
+        r#""continue" =>"#,
+        r#""loop" =>"#,
+        r#""cast" =>"#,
+    ] {
+        assert!(
+            !atoms.contains(forbidden),
+            "parser prefix keyword dispatch should use ParserPrefixKeyword, not raw spelling checks: {forbidden}"
+        );
+    }
+
+    for required in [
+        "enum ParserPrefixKeyword",
+        "const ALL: &[ParserPrefixKeyword]",
+        "impl FromStr for ParserPrefixKeyword",
+        ".find(|keyword| keyword.as_str() == value)",
+        "name.parse::<ParserPrefixKeyword>()",
+    ] {
+        assert!(
+            atoms.contains(required) || keywords.contains(required),
+            "parser prefix keyword spelling should live in ParserPrefixKeyword: {required}"
+        );
+    }
+}
+
+#[test]
 fn parser_type_names_use_owned_type_name_enums() {
     let parser_types = read("src/parser/types.rs");
     let type_names = read("src/parser/type_names.rs");


### PR DESCRIPTION
## Summary
- Add `ParserPrefixKeyword` with enum-owned static spellings for prefix-only parser keywords.
- Route `true`/`false`/`return`/`break`/`continue`/`loop`/`cast` parsing through the enum instead of a raw `name.as_str()` match.
- Add docs-truth coverage and record the evidence in the phase plan/audit.

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch parser-prefix-keyword-static-parsing --event push --json databaseId,status,conclusion,name,headSha --limit 20` returned `[]`.