### PR TITLE
Use parser-owned pattern keyword parsing

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -4012,6 +4012,9 @@ and do not assume Phase 4 is ready without evidence.
   `continue`, `loop`, and `cast` through `ParserPrefixKeyword` instead of a raw
   `name.as_str()` match. Covered by
   `parser_prefix_keywords_use_owned_keyword_enum` and parser expression tests.
+- Parser pattern keyword dispatch now parses `true`, `false`, and `_` through
+  `ParserPatternKeyword` instead of raw identifier spelling guards. Covered by
+  `parser_pattern_keywords_use_owned_keyword_enum` and parser pattern tests.
 - Gated `.raise()` and `.await()` method recognition now routes through
   `GatedMethod` enum-owned spellings, covered by
   `typechecker_gated_methods_use_owned_action_enum`,

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3689,6 +3689,9 @@ checked-in docs, tests, and commits only.
   `continue`, `loop`, and `cast` through `ParserPrefixKeyword` instead of a raw
   `name.as_str()` match. Guarded by
   `parser_prefix_keywords_use_owned_keyword_enum` and parser expression tests.
+- Parser pattern keyword dispatch now parses `true`, `false`, and `_` through
+  `ParserPatternKeyword` instead of raw identifier spelling guards. Guarded by
+  `parser_pattern_keywords_use_owned_keyword_enum` and parser pattern tests.
 - Gated `.raise()` and `.await()` method recognition now dispatches through the
   `GatedMethod` enum-owned spellings rather than hand-rolled comparisons,
   preserving the focused Result propagation and Sync/Async effect gates. Guarded

--- a/src/parser/keywords.rs
+++ b/src/parser/keywords.rs
@@ -11,6 +11,13 @@ pub(super) enum ParserPrefixKeyword {
     Cast,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ParserPatternKeyword {
+    True,
+    False,
+    Wildcard,
+}
+
 impl ParserPrefixKeyword {
     const ALL: &[ParserPrefixKeyword] = &[
         ParserPrefixKeyword::True,
@@ -44,6 +51,38 @@ impl ParserPrefixKeyword {
 }
 
 impl FromStr for ParserPrefixKeyword {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|keyword| keyword.as_str() == value)
+            .ok_or(())
+    }
+}
+
+impl ParserPatternKeyword {
+    const ALL: &[ParserPatternKeyword] = &[
+        ParserPatternKeyword::True,
+        ParserPatternKeyword::False,
+        ParserPatternKeyword::Wildcard,
+    ];
+
+    const TRUE: &'static str = "true";
+    const FALSE: &'static str = "false";
+    const WILDCARD: &'static str = "_";
+
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::True => Self::TRUE,
+            Self::False => Self::FALSE,
+            Self::Wildcard => Self::WILDCARD,
+        }
+    }
+}
+
+impl FromStr for ParserPatternKeyword {
     type Err = ();
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {

--- a/src/parser/patterns.rs
+++ b/src/parser/patterns.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::parser::keywords::ParserPatternKeyword;
 
 impl Parser {
     // ── Patterns ──────────────────────────────────────────────
@@ -6,75 +7,71 @@ impl Parser {
     pub(super) fn parse_pattern(&mut self) -> Result<Pattern, CompileError> {
         self.skip_newlines();
         match self.peek().clone() {
-            Token::Identifier(ref name) if name == "true" => {
-                let (_, span) = self.advance();
-                Ok(Pattern::BoolTrue { span })
-            }
-            Token::Identifier(ref name) if name == "false" => {
-                let (_, span) = self.advance();
-                Ok(Pattern::BoolFalse { span })
-            }
-            Token::Identifier(ref name) if name == "_" => {
-                let (_, span) = self.advance();
-                Ok(Pattern::Wildcard { span })
+            Token::Identifier(ref name) => {
+                if let Ok(keyword) = name.parse::<ParserPatternKeyword>() {
+                    let (_, span) = self.advance();
+                    match keyword {
+                        ParserPatternKeyword::True => Ok(Pattern::BoolTrue { span }),
+                        ParserPatternKeyword::False => Ok(Pattern::BoolFalse { span }),
+                        ParserPatternKeyword::Wildcard => Ok(Pattern::Wildcard { span }),
+                    }
+                } else if first_char_is_upper(name) {
+                    // Enum variant pattern: VariantName or VariantName(binding)
+                    let name = name.clone();
+                    let (_, span) = self.advance();
+
+                    if matches!(self.peek(), Token::LParen) {
+                        self.advance();
+                        let inner = self.parse_pattern()?;
+                        self.expect(&Token::RParen)?;
+                        // This is a variant pattern — enum name will be inferred by typechecker
+                        Ok(Pattern::Enum {
+                            enum_name: String::new(), // inferred
+                            variant: name,
+                            payload: Some(Box::new(inner)),
+                            span: span.merge(self.prev_span()),
+                        })
+                    } else if matches!(self.peek(), Token::LBrace) && self.is_struct_pattern() {
+                        // Struct destructuring pattern: Name { field1, field2 }
+                        self.advance();
+                        let mut fields = Vec::new();
+                        loop {
+                            self.skip_newlines();
+                            if matches!(self.peek(), Token::RBrace) {
+                                break;
+                            }
+                            let (field, _) = self.expect_identifier()?;
+                            fields.push((field, None));
+                            self.skip_newlines();
+                            if matches!(self.peek(), Token::Comma) {
+                                self.advance();
+                            }
+                        }
+                        self.expect(&Token::RBrace)?;
+                        Ok(Pattern::Struct {
+                            name,
+                            fields,
+                            span: span.merge(self.prev_span()),
+                        })
+                    } else {
+                        // Simple enum variant (no payload)
+                        Ok(Pattern::Enum {
+                            enum_name: String::new(),
+                            variant: name,
+                            payload: None,
+                            span,
+                        })
+                    }
+                } else {
+                    let (tok, span) = self.advance();
+                    if let Token::Identifier(name) = tok {
+                        Ok(Pattern::Identifier { name, span })
+                    } else {
+                        unreachable!()
+                    }
+                }
             }
             Token::Dot => self.parse_shorthand_enum_pattern(),
-            Token::Identifier(ref name) if first_char_is_upper(name) => {
-                // Enum variant pattern: VariantName or VariantName(binding)
-                let name = name.clone();
-                let (_, span) = self.advance();
-
-                if matches!(self.peek(), Token::LParen) {
-                    self.advance();
-                    let inner = self.parse_pattern()?;
-                    self.expect(&Token::RParen)?;
-                    // This is a variant pattern — enum name will be inferred by typechecker
-                    Ok(Pattern::Enum {
-                        enum_name: String::new(), // inferred
-                        variant: name,
-                        payload: Some(Box::new(inner)),
-                        span: span.merge(self.prev_span()),
-                    })
-                } else if matches!(self.peek(), Token::LBrace) && self.is_struct_pattern() {
-                    // Struct destructuring pattern: Name { field1, field2 }
-                    self.advance();
-                    let mut fields = Vec::new();
-                    loop {
-                        self.skip_newlines();
-                        if matches!(self.peek(), Token::RBrace) {
-                            break;
-                        }
-                        let (field, _) = self.expect_identifier()?;
-                        fields.push((field, None));
-                        self.skip_newlines();
-                        if matches!(self.peek(), Token::Comma) {
-                            self.advance();
-                        }
-                    }
-                    self.expect(&Token::RBrace)?;
-                    Ok(Pattern::Struct {
-                        name,
-                        fields,
-                        span: span.merge(self.prev_span()),
-                    })
-                } else {
-                    // Simple enum variant (no payload)
-                    Ok(Pattern::Enum {
-                        enum_name: String::new(),
-                        variant: name,
-                        payload: None,
-                        span,
-                    })
-                }
-            }
-            Token::Identifier(_) => {
-                let (tok, span) = self.advance();
-                if let Token::Identifier(name) = tok {
-                    Ok(Pattern::Identifier { name, span })
-                } else {
-                    unreachable!()
-                }
-            }
             Token::IntLiteral(_) | Token::FloatLiteral(_) | Token::StringLiteral(_) => {
                 let expr = self.parse_expression()?;
                 let span = expr.span();

--- a/tests/docs_truth/repo_hygiene/parser_enums.rs
+++ b/tests/docs_truth/repo_hygiene/parser_enums.rs
@@ -109,6 +109,32 @@ fn parser_prefix_keywords_use_owned_keyword_enum() {
 }
 
 #[test]
+fn parser_pattern_keywords_use_owned_keyword_enum() {
+    let patterns = read("src/parser/patterns.rs");
+    let keywords = read("src/parser/keywords.rs");
+
+    for forbidden in [r#"name == "true""#, r#"name == "false""#, r#"name == "_""#] {
+        assert!(
+            !patterns.contains(forbidden),
+            "parser pattern keyword dispatch should use ParserPatternKeyword, not raw spelling checks: {forbidden}"
+        );
+    }
+
+    for required in [
+        "enum ParserPatternKeyword",
+        "const ALL: &[ParserPatternKeyword]",
+        "impl FromStr for ParserPatternKeyword",
+        ".find(|keyword| keyword.as_str() == value)",
+        "name.parse::<ParserPatternKeyword>()",
+    ] {
+        assert!(
+            patterns.contains(required) || keywords.contains(required),
+            "parser pattern keyword spelling should live in ParserPatternKeyword: {required}"
+        );
+    }
+}
+
+#[test]
 fn parser_type_names_use_owned_type_name_enums() {
     let parser_types = read("src/parser/types.rs");
     let type_names = read("src/parser/type_names.rs");


### PR DESCRIPTION
## Summary
- Add `ParserPatternKeyword` for pattern-only spellings `true`, `false`, and `_`.
- Route pattern keyword parsing through the enum-owned static table instead of raw identifier guards.
- Add docs-truth coverage and record the evidence in phase/audit docs.

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch parser-pattern-keyword-static-parsing --event push --json databaseId,status,conclusion,name,headSha --limit 20` returned `[]`.