### PR TITLE
Use parser-owned this method parsing

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -4015,6 +4015,9 @@ and do not assume Phase 4 is ready without evidence.
 - Parser pattern keyword dispatch now parses `true`, `false`, and `_` through
   `ParserPatternKeyword` instead of raw identifier spelling guards. Covered by
   `parser_pattern_keywords_use_owned_keyword_enum` and parser pattern tests.
+- Parser `@this.defer(...)` dispatch now parses `defer` through
+  `ParserThisMethod` instead of a raw method spelling check. Covered by
+  `parser_this_methods_use_owned_method_enum` and defer tests.
 - Gated `.raise()` and `.await()` method recognition now routes through
   `GatedMethod` enum-owned spellings, covered by
   `typechecker_gated_methods_use_owned_action_enum`,

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3692,6 +3692,9 @@ checked-in docs, tests, and commits only.
 - Parser pattern keyword dispatch now parses `true`, `false`, and `_` through
   `ParserPatternKeyword` instead of raw identifier spelling guards. Guarded by
   `parser_pattern_keywords_use_owned_keyword_enum` and parser pattern tests.
+- Parser `@this.defer(...)` dispatch now parses `defer` through
+  `ParserThisMethod` instead of a raw method spelling check. Guarded by
+  `parser_this_methods_use_owned_method_enum` and defer tests.
 - Gated `.raise()` and `.await()` method recognition now dispatches through the
   `GatedMethod` enum-owned spellings rather than hand-rolled comparisons,
   preserving the focused Result propagation and Sync/Async effect gates. Guarded

--- a/src/parser/atoms.rs
+++ b/src/parser/atoms.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::parser::keywords::ParserPrefixKeyword;
+use crate::parser::keywords::{ParserPrefixKeyword, ParserThisMethod};
 
 mod forms;
 
@@ -106,14 +106,18 @@ impl Parser {
                 if matches!(self.peek(), Token::Dot) {
                     self.advance(); // consume .
                     let (method, _) = self.expect_identifier()?;
-                    if method == "defer" {
-                        self.expect(&Token::LParen)?;
-                        let expr = self.parse_expression()?;
-                        let end = self.expect(&Token::RParen)?;
-                        return Ok(Expression::Defer {
-                            expr: Box::new(expr),
-                            span: span.merge(end),
-                        });
+                    if let Ok(method) = method.parse::<ParserThisMethod>() {
+                        match method {
+                            ParserThisMethod::Defer => {
+                                self.expect(&Token::LParen)?;
+                                let expr = self.parse_expression()?;
+                                let end = self.expect(&Token::RParen)?;
+                                return Ok(Expression::Defer {
+                                    expr: Box::new(expr),
+                                    span: span.merge(end),
+                                });
+                            }
+                        }
                     }
                     // Other @this.method calls
                     return Err(CompileError::Syntax(

--- a/src/parser/keywords.rs
+++ b/src/parser/keywords.rs
@@ -18,6 +18,11 @@ pub(super) enum ParserPatternKeyword {
     Wildcard,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ParserThisMethod {
+    Defer,
+}
+
 impl ParserPrefixKeyword {
     const ALL: &[ParserPrefixKeyword] = &[
         ParserPrefixKeyword::True,
@@ -90,6 +95,30 @@ impl FromStr for ParserPatternKeyword {
             .iter()
             .copied()
             .find(|keyword| keyword.as_str() == value)
+            .ok_or(())
+    }
+}
+
+impl ParserThisMethod {
+    const ALL: &[ParserThisMethod] = &[ParserThisMethod::Defer];
+
+    const DEFER: &'static str = "defer";
+
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Defer => Self::DEFER,
+        }
+    }
+}
+
+impl FromStr for ParserThisMethod {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|method| method.as_str() == value)
             .ok_or(())
     }
 }

--- a/tests/docs_truth/repo_hygiene/mod.rs
+++ b/tests/docs_truth/repo_hygiene/mod.rs
@@ -6,6 +6,7 @@ mod ci_configs;
 mod file_size;
 mod module_system;
 mod parser_enums;
+mod parser_keywords;
 mod removed_syntax;
 mod source_truth;
 mod typechecker_imports;

--- a/tests/docs_truth/repo_hygiene/parser_enums.rs
+++ b/tests/docs_truth/repo_hygiene/parser_enums.rs
@@ -74,67 +74,6 @@ fn parser_loop_control_calls_use_owned_action_enum() {
 }
 
 #[test]
-fn parser_prefix_keywords_use_owned_keyword_enum() {
-    let atoms = read("src/parser/atoms.rs");
-    let keywords = read("src/parser/keywords.rs");
-
-    for forbidden in [
-        "match name.as_str()",
-        r#""true" =>"#,
-        r#""false" =>"#,
-        r#""return" =>"#,
-        r#""break" =>"#,
-        r#""continue" =>"#,
-        r#""loop" =>"#,
-        r#""cast" =>"#,
-    ] {
-        assert!(
-            !atoms.contains(forbidden),
-            "parser prefix keyword dispatch should use ParserPrefixKeyword, not raw spelling checks: {forbidden}"
-        );
-    }
-
-    for required in [
-        "enum ParserPrefixKeyword",
-        "const ALL: &[ParserPrefixKeyword]",
-        "impl FromStr for ParserPrefixKeyword",
-        ".find(|keyword| keyword.as_str() == value)",
-        "name.parse::<ParserPrefixKeyword>()",
-    ] {
-        assert!(
-            atoms.contains(required) || keywords.contains(required),
-            "parser prefix keyword spelling should live in ParserPrefixKeyword: {required}"
-        );
-    }
-}
-
-#[test]
-fn parser_pattern_keywords_use_owned_keyword_enum() {
-    let patterns = read("src/parser/patterns.rs");
-    let keywords = read("src/parser/keywords.rs");
-
-    for forbidden in [r#"name == "true""#, r#"name == "false""#, r#"name == "_""#] {
-        assert!(
-            !patterns.contains(forbidden),
-            "parser pattern keyword dispatch should use ParserPatternKeyword, not raw spelling checks: {forbidden}"
-        );
-    }
-
-    for required in [
-        "enum ParserPatternKeyword",
-        "const ALL: &[ParserPatternKeyword]",
-        "impl FromStr for ParserPatternKeyword",
-        ".find(|keyword| keyword.as_str() == value)",
-        "name.parse::<ParserPatternKeyword>()",
-    ] {
-        assert!(
-            patterns.contains(required) || keywords.contains(required),
-            "parser pattern keyword spelling should live in ParserPatternKeyword: {required}"
-        );
-    }
-}
-
-#[test]
 fn parser_type_names_use_owned_type_name_enums() {
     let parser_types = read("src/parser/types.rs");
     let type_names = read("src/parser/type_names.rs");

--- a/tests/docs_truth/repo_hygiene/parser_keywords.rs
+++ b/tests/docs_truth/repo_hygiene/parser_keywords.rs
@@ -1,0 +1,88 @@
+use super::*;
+
+#[test]
+fn parser_prefix_keywords_use_owned_keyword_enum() {
+    let atoms = read("src/parser/atoms.rs");
+    let keywords = read("src/parser/keywords.rs");
+
+    for forbidden in [
+        "match name.as_str()",
+        r#""true" =>"#,
+        r#""false" =>"#,
+        r#""return" =>"#,
+        r#""break" =>"#,
+        r#""continue" =>"#,
+        r#""loop" =>"#,
+        r#""cast" =>"#,
+    ] {
+        assert!(
+            !atoms.contains(forbidden),
+            "parser prefix keyword dispatch should use ParserPrefixKeyword, not raw spelling checks: {forbidden}"
+        );
+    }
+
+    for required in [
+        "enum ParserPrefixKeyword",
+        "const ALL: &[ParserPrefixKeyword]",
+        "impl FromStr for ParserPrefixKeyword",
+        ".find(|keyword| keyword.as_str() == value)",
+        "name.parse::<ParserPrefixKeyword>()",
+    ] {
+        assert!(
+            atoms.contains(required) || keywords.contains(required),
+            "parser prefix keyword spelling should live in ParserPrefixKeyword: {required}"
+        );
+    }
+}
+
+#[test]
+fn parser_pattern_keywords_use_owned_keyword_enum() {
+    let patterns = read("src/parser/patterns.rs");
+    let keywords = read("src/parser/keywords.rs");
+
+    for forbidden in [r#"name == "true""#, r#"name == "false""#, r#"name == "_""#] {
+        assert!(
+            !patterns.contains(forbidden),
+            "parser pattern keyword dispatch should use ParserPatternKeyword, not raw spelling checks: {forbidden}"
+        );
+    }
+
+    for required in [
+        "enum ParserPatternKeyword",
+        "const ALL: &[ParserPatternKeyword]",
+        "impl FromStr for ParserPatternKeyword",
+        ".find(|keyword| keyword.as_str() == value)",
+        "name.parse::<ParserPatternKeyword>()",
+    ] {
+        assert!(
+            patterns.contains(required) || keywords.contains(required),
+            "parser pattern keyword spelling should live in ParserPatternKeyword: {required}"
+        );
+    }
+}
+
+#[test]
+fn parser_this_methods_use_owned_method_enum() {
+    let atoms = read("src/parser/atoms.rs");
+    let keywords = read("src/parser/keywords.rs");
+
+    for forbidden in [r#"method == "defer""#] {
+        assert!(
+            !atoms.contains(forbidden),
+            "parser @this method dispatch should use ParserThisMethod, not raw spelling checks: {forbidden}"
+        );
+    }
+
+    for required in [
+        "enum ParserThisMethod",
+        "const ALL: &[ParserThisMethod]",
+        "impl FromStr for ParserThisMethod",
+        ".find(|method| method.as_str() == value)",
+        "method.parse::<ParserThisMethod>()",
+    ] {
+        assert!(
+            atoms.contains(required) || keywords.contains(required),
+            "parser @this method spelling should live in ParserThisMethod: {required}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ParserThisMethod` for the `@this.defer(...)` parser spelling.
- Route `@this` method dispatch through the enum-owned static table instead of a raw `method == "defer"` check.
- Split parser keyword docs-truth guards into a focused module to keep repo hygiene file-size checks green.
- Record the evidence in phase/audit docs.

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch parser-this-method-static-parsing --event push --json databaseId,status,conclusion,name,headSha --limit 20` returned `[]`.