### PR TITLE
Use parser-owned module root parsing

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -4018,6 +4018,9 @@ and do not assume Phase 4 is ready without evidence.
 - Parser `@this.defer(...)` dispatch now parses `defer` through
   `ParserThisMethod` instead of a raw method spelling check. Covered by
   `parser_this_methods_use_owned_method_enum` and defer tests.
+- Parser module roots now construct `@builtin` and `@std` spellings through
+  `ParserModuleRoot` instead of parser-local raw strings. Covered by
+  `parser_module_roots_use_owned_root_enum` and parser import tests.
 - Gated `.raise()` and `.await()` method recognition now routes through
   `GatedMethod` enum-owned spellings, covered by
   `typechecker_gated_methods_use_owned_action_enum`,

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3695,6 +3695,9 @@ checked-in docs, tests, and commits only.
 - Parser `@this.defer(...)` dispatch now parses `defer` through
   `ParserThisMethod` instead of a raw method spelling check. Guarded by
   `parser_this_methods_use_owned_method_enum` and defer tests.
+- Parser module roots now construct `@builtin` and `@std` spellings through
+  `ParserModuleRoot` instead of parser-local raw strings. Guarded by
+  `parser_module_roots_use_owned_root_enum` and parser import tests.
 - Gated `.raise()` and `.await()` method recognition now dispatches through the
   `GatedMethod` enum-owned spellings rather than hand-rolled comparisons,
   preserving the focused Result propagation and Sync/Async effect gates. Guarded

--- a/src/parser/atoms.rs
+++ b/src/parser/atoms.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::parser::keywords::{ParserPrefixKeyword, ParserThisMethod};
+use crate::parser::keywords::{ParserModuleRoot, ParserPrefixKeyword, ParserThisMethod};
 
 mod forms;
 
@@ -152,7 +152,7 @@ impl Parser {
 
                 Ok(Expression::FunctionCall {
                     name: func_name,
-                    module: Some("@builtin".to_string()),
+                    module: Some(ParserModuleRoot::AtBuiltin.as_str().to_string()),
                     type_args,
                     args,
                     span: span.merge(end),
@@ -181,11 +181,7 @@ impl Parser {
 
                 // Last part is the function name
                 let func_name = module_parts.pop().unwrap();
-                let module = if module_parts.is_empty() {
-                    "@std".to_string()
-                } else {
-                    format!("@std.{}", module_parts.join("."))
-                };
+                let module = ParserModuleRoot::AtStd.join_module_parts(&module_parts);
 
                 if matches!(self.peek(), Token::LParen) {
                     self.advance();

--- a/src/parser/import_declarations.rs
+++ b/src/parser/import_declarations.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::parser::keywords::ParserModuleRoot;
 
 impl Parser {
     pub(super) fn parse_import(&mut self) -> Result<Declaration, CompileError> {
@@ -41,11 +42,11 @@ impl Parser {
         match self.peek().clone() {
             Token::AtStd => {
                 self.advance();
-                path.push("@std".to_string());
+                path.push(ParserModuleRoot::AtStd.as_str().to_string());
             }
             Token::AtBuiltin => {
                 self.advance();
-                path.push("@builtin".to_string());
+                path.push(ParserModuleRoot::AtBuiltin.as_str().to_string());
             }
             Token::Identifier(name) => {
                 self.advance();

--- a/src/parser/keywords.rs
+++ b/src/parser/keywords.rs
@@ -23,6 +23,12 @@ pub(super) enum ParserThisMethod {
     Defer,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ParserModuleRoot {
+    AtBuiltin,
+    AtStd,
+}
+
 impl ParserPrefixKeyword {
     const ALL: &[ParserPrefixKeyword] = &[
         ParserPrefixKeyword::True,
@@ -119,6 +125,40 @@ impl FromStr for ParserThisMethod {
             .iter()
             .copied()
             .find(|method| method.as_str() == value)
+            .ok_or(())
+    }
+}
+
+impl ParserModuleRoot {
+    const ALL: &[ParserModuleRoot] = &[ParserModuleRoot::AtBuiltin, ParserModuleRoot::AtStd];
+
+    const AT_BUILTIN: &'static str = "@builtin";
+    const AT_STD: &'static str = "@std";
+
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::AtBuiltin => Self::AT_BUILTIN,
+            Self::AtStd => Self::AT_STD,
+        }
+    }
+
+    pub(super) fn join_module_parts(self, parts: &[String]) -> String {
+        if parts.is_empty() {
+            self.as_str().to_string()
+        } else {
+            format!("{}.{}", self.as_str(), parts.join("."))
+        }
+    }
+}
+
+impl FromStr for ParserModuleRoot {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|root| root.as_str() == value)
             .ok_or(())
     }
 }

--- a/tests/docs_truth/repo_hygiene/parser_keywords.rs
+++ b/tests/docs_truth/repo_hygiene/parser_keywords.rs
@@ -86,3 +86,37 @@ fn parser_this_methods_use_owned_method_enum() {
         );
     }
 }
+
+#[test]
+fn parser_module_roots_use_owned_root_enum() {
+    for path in ["src/parser/atoms.rs", "src/parser/import_declarations.rs"] {
+        let source = read(path);
+        for forbidden in [
+            r#""@builtin".to_string()"#,
+            r#""@std".to_string()"#,
+            r#"format!("@std.{}""#,
+        ] {
+            assert!(
+                !source.contains(forbidden),
+                "{path} should construct parser module roots through ParserModuleRoot, not raw root spelling: {forbidden}"
+            );
+        }
+    }
+
+    let keywords = read("src/parser/keywords.rs");
+    for required in [
+        "enum ParserModuleRoot",
+        "const ALL: &[ParserModuleRoot]",
+        "impl FromStr for ParserModuleRoot",
+        ".find(|root| root.as_str() == value)",
+        "ParserModuleRoot::AtBuiltin.as_str().to_string()",
+        "ParserModuleRoot::AtStd.join_module_parts(&module_parts)",
+    ] {
+        assert!(
+            keywords.contains(required)
+                || read("src/parser/atoms.rs").contains(required)
+                || read("src/parser/import_declarations.rs").contains(required),
+            "parser module root spelling should live in ParserModuleRoot: {required}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ParserModuleRoot` for parser-owned `@builtin` and `@std` spellings.
- Route parser import roots and module-qualified call module strings through the enum-owned root helpers.
- Add docs-truth coverage and record the evidence in phase/audit docs.

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch parser-module-root-static-parsing --event push --json databaseId,status,conclusion,name,headSha --limit 20` returned `[]`.