### PR TITLE
Use parser-owned mutability keyword parsing

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -4021,6 +4021,9 @@ and do not assume Phase 4 is ready without evidence.
 - Parser module roots now construct `@builtin` and `@std` spellings through
   `ParserModuleRoot` instead of parser-local raw strings. Covered by
   `parser_module_roots_use_owned_root_enum` and parser import tests.
+- Parser mutability markers now parse `mut` through `ParserMutabilityKeyword`
+  and a shared parser helper for fields and parameters. Covered by
+  `parser_mutability_keywords_use_owned_keyword_enum`.
 - Gated `.raise()` and `.await()` method recognition now routes through
   `GatedMethod` enum-owned spellings, covered by
   `typechecker_gated_methods_use_owned_action_enum`,

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3698,6 +3698,9 @@ checked-in docs, tests, and commits only.
 - Parser module roots now construct `@builtin` and `@std` spellings through
   `ParserModuleRoot` instead of parser-local raw strings. Guarded by
   `parser_module_roots_use_owned_root_enum` and parser import tests.
+- Parser mutability markers now parse `mut` through `ParserMutabilityKeyword`
+  and a shared parser helper for fields and parameters. Guarded by
+  `parser_mutability_keywords_use_owned_keyword_enum`.
 - Gated `.raise()` and `.await()` method recognition now dispatches through the
   `GatedMethod` enum-owned spellings rather than hand-rolled comparisons,
   preserving the focused Result propagation and Sync/Async effect gates. Guarded

--- a/src/parser/declaration_types.rs
+++ b/src/parser/declaration_types.rs
@@ -33,12 +33,7 @@ impl Parser {
             let field_start = self.peek_span();
 
             // optional `mut` prefix
-            let mutable = if matches!(self.peek(), Token::Identifier(ref s) if s == "mut") {
-                self.advance();
-                true
-            } else {
-                false
-            };
+            let mutable = self.consume_mutability_keyword();
 
             let (field_name, _) = self.expect_identifier()?;
             self.expect(&Token::Colon)?;

--- a/src/parser/declarations.rs
+++ b/src/parser/declarations.rs
@@ -1,6 +1,18 @@
 use super::*;
 
 impl Parser {
+    pub(super) fn consume_mutability_keyword(&mut self) -> bool {
+        use crate::parser::keywords::ParserMutabilityKeyword;
+
+        if let Token::Identifier(ref name) = self.peek() {
+            if name.parse::<ParserMutabilityKeyword>().is_ok() {
+                self.advance();
+                return true;
+            }
+        }
+        false
+    }
+
     // ── Declarations ──────────────────────────────────────────
 
     pub(super) fn parse_declaration(&mut self) -> Result<Declaration, CompileError> {
@@ -259,12 +271,7 @@ impl Parser {
             let param_start = self.peek_span();
 
             // Optional `mut` qualifier
-            let mutable = if matches!(self.peek(), Token::Identifier(ref s) if s == "mut") {
-                self.advance();
-                true
-            } else {
-                false
-            };
+            let mutable = self.consume_mutability_keyword();
 
             let (name, _) = self.expect_identifier()?;
             self.expect(&Token::Colon)?;

--- a/src/parser/keywords.rs
+++ b/src/parser/keywords.rs
@@ -29,6 +29,11 @@ pub(super) enum ParserModuleRoot {
     AtStd,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ParserMutabilityKeyword {
+    Mut,
+}
+
 impl ParserPrefixKeyword {
     const ALL: &[ParserPrefixKeyword] = &[
         ParserPrefixKeyword::True,
@@ -159,6 +164,30 @@ impl FromStr for ParserModuleRoot {
             .iter()
             .copied()
             .find(|root| root.as_str() == value)
+            .ok_or(())
+    }
+}
+
+impl ParserMutabilityKeyword {
+    const ALL: &[ParserMutabilityKeyword] = &[ParserMutabilityKeyword::Mut];
+
+    const MUT: &'static str = "mut";
+
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Mut => Self::MUT,
+        }
+    }
+}
+
+impl FromStr for ParserMutabilityKeyword {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|keyword| keyword.as_str() == value)
             .ok_or(())
     }
 }

--- a/tests/docs_truth/repo_hygiene/parser_keywords.rs
+++ b/tests/docs_truth/repo_hygiene/parser_keywords.rs
@@ -120,3 +120,35 @@ fn parser_module_roots_use_owned_root_enum() {
         );
     }
 }
+
+#[test]
+fn parser_mutability_keywords_use_owned_keyword_enum() {
+    for path in [
+        "src/parser/declaration_types.rs",
+        "src/parser/declarations.rs",
+    ] {
+        let source = read(path);
+        for forbidden in [r#"s == "mut""#] {
+            assert!(
+                !source.contains(forbidden),
+                "{path} should parse mutability through ParserMutabilityKeyword, not raw spelling checks: {forbidden}"
+            );
+        }
+    }
+
+    let keywords = read("src/parser/keywords.rs");
+    for required in [
+        "enum ParserMutabilityKeyword",
+        "const ALL: &[ParserMutabilityKeyword]",
+        "impl FromStr for ParserMutabilityKeyword",
+        ".find(|keyword| keyword.as_str() == value)",
+        "self.consume_mutability_keyword()",
+    ] {
+        assert!(
+            keywords.contains(required)
+                || read("src/parser/declaration_types.rs").contains(required)
+                || read("src/parser/declarations.rs").contains(required),
+            "parser mutability spelling should live in ParserMutabilityKeyword: {required}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ParserMutabilityKeyword` for parser-owned `mut` spelling.
- Route struct field and parameter mutability parsing through a shared helper instead of raw `s == "mut"` checks.
- Add docs-truth coverage and record the evidence in phase/audit docs.

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch parser-mut-keyword-static-parsing --event push --json databaseId,status,conclusion,name,headSha --limit 20` returned `[]`.