### PR TITLE
Add Sync Async allocator gate evidence

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3928,6 +3928,9 @@ and do not assume Phase 4 is ready without evidence.
   `typed_allocator_type_is_rejected_as_gated_not_unknown`,
   `sync_async_effect_modes_are_rejected_as_gated_not_unknown`, and
   `semantic_builtin_type_checks_use_shared_spelling_helper`.
+- Sync and Async typed allocator annotations now both reject through the
+  allocator gate rather than falling through to unknown-type diagnostics.
+  Covered by `sync_and_async_typed_allocator_modes_are_rejected_as_gated_not_unknown`.
 - Actor framework type spellings `Actor`, `ActorRef`, `Mailbox`, and
   `Supervisor` now use AST gated builtin type metadata and produce actor-specific
   gated diagnostics rather than ordinary unknown-type errors. Covered by

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3603,6 +3603,9 @@ checked-in docs, tests, and commits only.
   errors. Covered by `typed_allocator_type_is_rejected_as_gated_not_unknown`,
   `sync_async_effect_modes_are_rejected_as_gated_not_unknown`, and
   `semantic_builtin_type_checks_use_shared_spelling_helper`.
+- Sync and Async typed allocator annotations now both reject through the
+  allocator gate instead of falling through to unknown-type diagnostics. Guarded
+  by `sync_and_async_typed_allocator_modes_are_rejected_as_gated_not_unknown`.
 - Actor framework type spellings `Actor`, `ActorRef`, `Mailbox`, and
   `Supervisor` now share the same AST-owned gated builtin type path and report
   actor-specific gated diagnostics instead of unknown-type errors. Covered by

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -183,7 +183,7 @@ Generic behavior inheritance with child type-parameter parent args is covered by
 | Target/build YAML validation | gated | Schema and negative validation tests |
 | Behaviors and type association | gated | Positive/negative behavior solver tests |
 | `Sync/Async effects` | gated | `async_scheduler_intrinsics_are_rejected_as_gated_not_unknown`, `effect_await_is_rejected_until_async_lowering_exists`, `atomic_intrinsics_are_rejected_as_effect_gates`; effect checker positive/negative tests still required |
-| `Typed allocators` | gated | `dynamic_string_type_is_rejected_as_allocator_backed_gate`, `typed_allocator_type_is_rejected_as_gated_not_unknown`, `raw_memory_intrinsics_are_rejected_as_allocator_gates`, `byte_memory_intrinsics_are_rejected_as_allocator_gates`; sync and async allocator tests still required |
+| `Typed allocators` | gated | `dynamic_string_type_is_rejected_as_allocator_backed_gate`, `typed_allocator_type_is_rejected_as_gated_not_unknown`, `sync_and_async_typed_allocator_modes_are_rejected_as_gated_not_unknown`, `raw_memory_intrinsics_are_rejected_as_allocator_gates`, `byte_memory_intrinsics_are_rejected_as_allocator_gates`; positive allocator semantics tests still required |
 | Comptime type matching | gated | `comptime_type_match_intrinsic_is_rejected_as_gated_not_unknown`; type metadata and derive tests still required |
 | Ownership and raw pointer operations | gated | `raw_pointer_intrinsics_are_rejected_as_ownership_gates`; ownership/resource tests still required |
 | Host syscalls | gated | `syscall_intrinsics_are_rejected_as_host_effect_gates`; host-effect declaration and ABI tests still required |

--- a/src/typechecker/tests/core_semantics/feature_gates.rs
+++ b/src/typechecker/tests/core_semantics/feature_gates.rs
@@ -112,6 +112,35 @@ main = (allocator: Allocator<i32, Sync>) void { }
 }
 
 #[test]
+fn sync_and_async_typed_allocator_modes_are_rejected_as_gated_not_unknown() {
+    let program = parse_program(
+        r#"
+use_sync_allocator = (allocator: Allocator<i32, Sync>) void { }
+use_async_allocator = (allocator: Allocator<i32, Async>) void { }
+"#,
+    );
+    let mut tc = TypeChecker::new();
+
+    let err = tc.check_program(&program).expect_err(
+        "typed allocator Sync/Async modes should stay gated until allocator semantics exist",
+    );
+
+    let allocator_gate_count = err
+        .iter()
+        .filter(|diagnostic| diagnostic.message.contains("typed allocators are gated"))
+        .count();
+    assert_eq!(
+        allocator_gate_count, 2,
+        "expected Sync and Async allocator annotations to both report allocator gates, got {err:?}"
+    );
+    assert!(
+        err.iter()
+            .all(|d| !d.message.contains("unknown type symbol")),
+        "allocator/effect mode gates should not be reported as ordinary unknown types, got {err:?}"
+    );
+}
+
+#[test]
 fn dynamic_string_type_is_rejected_as_allocator_backed_gate() {
     let program = parse_program(
         r#"

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -58,6 +58,7 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "Typed allocators",
         "raw_memory_intrinsics_are_rejected_as_allocator_gates",
         "byte_memory_intrinsics_are_rejected_as_allocator_gates",
+        "sync_and_async_typed_allocator_modes_are_rejected_as_gated_not_unknown",
         "@builtin.raw_allocate",
         "@builtin.raw_deallocate",
         "@builtin.raw_reallocate",
@@ -319,5 +320,9 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
     assert!(
         !spec.contains("`ActorRef`, `Mailbox`, `Channel`, and `Supervisor`"),
         "docs/V1_SPEC.md should not imply Channel is a globally gated actor builtin"
+    );
+    assert!(
+        !spec.contains("sync and async allocator tests still required"),
+        "docs/V1_SPEC.md should not keep stale allocator-test backlog wording after Sync/Async allocator gate coverage exists"
     );
 }


### PR DESCRIPTION
## Summary
- Add a focused semantic test proving both `Allocator<i32, Sync>` and `Allocator<i32, Async>` reject through allocator gates instead of unknown-type diagnostics.
- Update the V1 spec evidence list to reference the new gate test while keeping positive allocator semantics gated.
- Record the new evidence in phase and completion audit docs.

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch allocator-sync-async-gate-evidence --event push --json databaseId,status,conclusion,name,headSha --limit 20` returned `[]`.