### PR TITLE
Add type match gate surface evidence

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3911,6 +3911,10 @@ and do not assume Phase 4 is ready without evidence.
   type-argument diagnostics. Covered by
   `comptime_type_match_intrinsic_is_rejected_as_gated_not_unknown` and
   `typechecker_gated_intrinsics_use_owned_name_enum`.
+- Primitive and enum `@builtin.type_match<T>()` calls now reject through the
+  same comptime metadata gate, proving the gated surface is not limited to
+  struct names. Covered by
+  `primitive_and_enum_type_match_intrinsics_are_rejected_as_gated_not_unknown`.
 - Planned async scheduler intrinsics now have explicit gated diagnostics:
   `@builtin.async_enqueue(...)` and `@builtin.async_yield()` reject as
   Sync/Async effect gates instead of silently typechecking as unknown void

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3587,6 +3587,10 @@ checked-in docs, tests, and commits only.
   builtin or generic type-argument error. Covered by
   `comptime_type_match_intrinsic_is_rejected_as_gated_not_unknown` and
   `typechecker_gated_intrinsics_use_owned_name_enum`.
+- Primitive and enum `@builtin.type_match<T>()` calls now reject through the
+  same comptime metadata gate, proving the gated surface is not limited to
+  struct names. Guarded by
+  `primitive_and_enum_type_match_intrinsics_are_rejected_as_gated_not_unknown`.
 - Planned async scheduler entry points now have explicit gated intrinsic
   diagnostics: `@builtin.async_enqueue(...)` and `@builtin.async_yield()` report
   Sync/Async effect gates instead of silently typechecking as unknown void

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -184,7 +184,7 @@ Generic behavior inheritance with child type-parameter parent args is covered by
 | Behaviors and type association | gated | Positive/negative behavior solver tests |
 | `Sync/Async effects` | gated | `async_scheduler_intrinsics_are_rejected_as_gated_not_unknown`, `effect_await_is_rejected_until_async_lowering_exists`, `atomic_intrinsics_are_rejected_as_effect_gates`; effect checker positive/negative tests still required |
 | `Typed allocators` | gated | `dynamic_string_type_is_rejected_as_allocator_backed_gate`, `typed_allocator_type_is_rejected_as_gated_not_unknown`, `sync_and_async_typed_allocator_modes_are_rejected_as_gated_not_unknown`, `raw_memory_intrinsics_are_rejected_as_allocator_gates`, `byte_memory_intrinsics_are_rejected_as_allocator_gates`; positive allocator semantics tests still required |
-| Comptime type matching | gated | `comptime_type_match_intrinsic_is_rejected_as_gated_not_unknown`; type metadata and derive tests still required |
+| Comptime type matching | gated | `comptime_type_match_intrinsic_is_rejected_as_gated_not_unknown`, `primitive_and_enum_type_match_intrinsics_are_rejected_as_gated_not_unknown`; type metadata and derive tests still required |
 | Ownership and raw pointer operations | gated | `raw_pointer_intrinsics_are_rejected_as_ownership_gates`; ownership/resource tests still required |
 | Host syscalls | gated | `syscall_intrinsics_are_rejected_as_host_effect_gates`; host-effect declaration and ABI tests still required |
 | Actors in std | gated | Mailbox, scheduling, supervisor tests |

--- a/src/typechecker/tests/core_semantics/intrinsic_gates.rs
+++ b/src/typechecker/tests/core_semantics/intrinsic_gates.rs
@@ -263,3 +263,38 @@ main = () void {
         "type-match gate should not be reported as an ordinary unknown builtin, got {err:?}"
     );
 }
+
+#[test]
+fn primitive_and_enum_type_match_intrinsics_are_rejected_as_gated_not_unknown() {
+    let program = parse_program(
+        r#"
+Choice:
+    First,
+    Second
+
+main = () void {
+    @builtin.type_match<i32>()
+    @builtin.type_match<Choice>()
+}
+"#,
+    );
+    let mut tc = TypeChecker::new();
+
+    let err = tc.check_program(&program).expect_err(
+        "primitive and enum comptime type matching should stay gated until typed metadata lowering exists",
+    );
+
+    let type_match_gate_count = err
+        .iter()
+        .filter(|d| d.message.contains("comptime type matching is gated"))
+        .count();
+    assert_eq!(
+        type_match_gate_count, 2,
+        "expected primitive and enum type-match calls to both report gates, got {err:?}"
+    );
+    assert!(
+        err.iter()
+            .all(|d| !d.message.contains("unknown function `@builtin.type_match`")),
+        "primitive/enum type-match gates should not be reported as ordinary unknown builtins, got {err:?}"
+    );
+}

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -76,6 +76,7 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "Actors in std",
         "JSON/YAML IR boundaries",
         "comptime_type_match_intrinsic_is_rejected_as_gated_not_unknown",
+        "primitive_and_enum_type_match_intrinsics_are_rejected_as_gated_not_unknown",
         "comptime type matching",
         "gated until typed metadata and derive lowering exist",
         "Ownership and raw pointer operations",


### PR DESCRIPTION
## Summary
- Add a semantic gate test proving primitive and enum `@builtin.type_match<T>()` calls reject through the comptime metadata gate.
- Update V1 spec evidence to name the broader type-match gated surface while keeping metadata/derive behavior gated.
- Record the evidence in phase and completion audit docs.

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch type-match-gate-surface-evidence --event push --json databaseId,status,conclusion,name,headSha --limit 20` returned `[]`.