### PR TITLE
Add target YAML gate input boundary evidence

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -4054,6 +4054,10 @@ and do not assume Phase 4 is ready without evidence.
   `emit_json_mir_command_is_explicitly_gated`,
   `emit_json_layout_command_is_explicitly_gated`, and
   `emit_json_target_yaml_command_is_explicitly_gated`.
+- Hand-authored target YAML remains outside the compiler-owned IR path:
+  `emit-json target-yaml` rejects a real `.yaml` file at the schema-validation
+  gate before emitting any JSON. Covered by
+  `emit_json_target_yaml_rejects_hand_authored_yaml_before_validation`.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3733,6 +3733,10 @@ checked-in docs, tests, and commits only.
   `emit_json_mir_command_is_explicitly_gated`,
   `emit_json_layout_command_is_explicitly_gated`, and
   `emit_json_target_yaml_command_is_explicitly_gated`.
+- Hand-authored target YAML remains outside the compiler-owned IR path:
+  `emit-json target-yaml` now has explicit coverage that a real `.yaml` file is
+  rejected at the schema-validation gate before emitting any JSON. Guarded by
+  `emit_json_target_yaml_rejects_hand_authored_yaml_before_validation`.
 
 ## Current Phase
 

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -144,7 +144,9 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   explicitly marked unchecked; symbols JSON is explicitly marked resolved;
   typed JSON is explicitly marked checked; diagnostics JSON is explicitly
   marked diagnostic. semantic acceptance must use typed JSON, diagnostics,
-  check, build, or test paths.
+  check, build, or test paths. Hand-authored target YAML remains gated before
+  validation or JSON emission, covered by
+  `emit_json_target_yaml_rejects_hand_authored_yaml_before_validation`.
 - `build.zen`: constrained. `zen check build.zen` validates the deterministic
   graph and verifies declared target sources exist, `zen emit build.zen` emits
   target C for one graph target, `zen build build.zen` compiles executable

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -97,6 +97,7 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "zen emit-json typed <file>",
         "zen emit-json diagnostics <file>",
         "semantic acceptance must use typed",
+        "emit_json_target_yaml_rejects_hand_authored_yaml_before_validation",
         "build.zen",
         "zen test build.zen",
         "test target execution",

--- a/tests/integration/cli_build/frontend_json.rs
+++ b/tests/integration/cli_build/frontend_json.rs
@@ -223,6 +223,52 @@ fn emit_json_target_yaml_command_is_explicitly_gated() {
 }
 
 #[test]
+fn emit_json_target_yaml_rejects_hand_authored_yaml_before_validation() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let yaml_path = tmp.path().join("target.yaml");
+    std::fs::write(
+        &yaml_path,
+        r#"
+triple: x86_64-unknown-linux-gnu
+layout:
+  pointer_width: 64
+overrides:
+  i32: i64
+"#,
+    )
+    .expect("write target yaml");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "target-yaml", yaml_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json target-yaml on YAML input");
+
+    assert!(
+        !output.status.success(),
+        "zen emit-json target-yaml should be gated before YAML validation: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.trim().is_empty(),
+        "gated target-yaml should not emit schema or target JSON, stdout={stdout}"
+    );
+    assert!(
+        stderr.contains(
+            "target YAML validation is gated until schemas and negative validation tests exist"
+        ),
+        "expected target YAML gate diagnostic, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("unknown command") && !stderr.contains("No such file"),
+        "target-yaml should reject through the IR-boundary gate, not command/path handling, stderr={stderr}"
+    );
+}
+
+#[test]
 fn emit_json_layout_command_is_explicitly_gated() {
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
         .args([


### PR DESCRIPTION
## Summary
- Add an integration test proving `emit-json target-yaml` rejects a real `.yaml` input at the schema-validation gate before emitting JSON.
- Record the hand-authored YAML boundary in the V1 spec and audit docs.
- Keep target YAML validation gated until schema and negative validation tests exist.

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch target-yaml-gate-input-boundary --event push --json databaseId,status,conclusion,name,headSha --limit 20` returned `[]`.