### PR TITLE
Add layout JSON gate input boundary evidence

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3895,6 +3895,9 @@ and do not assume Phase 4 is ready without evidence.
   `emit_json_usage_lists_supported_and_gated_modes`, and
   `root_usage_lists_supported_and_gated_emit_json_modes`, while ABI layout JSON
   remains gated until layout tests exist.
+- Real program inputs to `emit-json layout` now reject at the ABI-layout gate
+  before emitting type layout JSON. Covered by
+  `emit_json_layout_rejects_program_before_layout_json`.
 - Static string literals no longer implicitly satisfy allocator-backed
   `String`; `String` is recognized as a builtin dynamic text type, but
   allocation must remain explicit. Covered by

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3571,6 +3571,9 @@ checked-in docs, tests, and commits only.
   `emit_json_layout_command_is_explicitly_gated`,
   `emit_json_usage_lists_supported_and_gated_modes`, and
   `root_usage_lists_supported_and_gated_emit_json_modes`.
+- Real program inputs to `emit-json layout` now reject at the ABI-layout gate
+  before emitting type layout JSON. Guarded by
+  `emit_json_layout_rejects_program_before_layout_json`.
 - `StaticString` and allocator-backed `String` are no longer type-compatible:
   static string literals stay baked into program storage and cannot implicitly
   allocate dynamic `String` values. Covered by

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -140,8 +140,10 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   diagnostics emission through `zen emit-json ast <file>`,
   `zen emit-json symbols <file>`, `zen emit-json typed <file>`, and
   `zen emit-json diagnostics <file>`. `zen emit-json layout <file>` is an
-  explicit gated command and rejects until ABI layout tests exist. AST JSON is
-  explicitly marked unchecked; symbols JSON is explicitly marked resolved;
+  explicit gated command and rejects until ABI layout tests exist; real program
+  inputs are rejected before layout JSON emission, covered by
+  `emit_json_layout_rejects_program_before_layout_json`. AST JSON is explicitly
+  marked unchecked; symbols JSON is explicitly marked resolved;
   typed JSON is explicitly marked checked; diagnostics JSON is explicitly
   marked diagnostic. semantic acceptance must use typed JSON, diagnostics,
   check, build, or test paths. Hand-authored target YAML remains gated before

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -97,6 +97,7 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "zen emit-json typed <file>",
         "zen emit-json diagnostics <file>",
         "semantic acceptance must use typed",
+        "emit_json_layout_rejects_program_before_layout_json",
         "emit_json_target_yaml_rejects_hand_authored_yaml_before_validation",
         "build.zen",
         "zen test build.zen",

--- a/tests/integration/cli_build/frontend_json.rs
+++ b/tests/integration/cli_build/frontend_json.rs
@@ -292,3 +292,55 @@ fn emit_json_layout_command_is_explicitly_gated() {
         "expected layout gate diagnostic, stderr={stderr}"
     );
 }
+
+#[test]
+fn emit_json_layout_rejects_program_before_layout_json() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let zen_path = tmp.path().join("layout_subject.zen");
+    std::fs::write(
+        &zen_path,
+        r#"
+Point: {
+    x: i32,
+    y: i32
+}
+
+Result<T, E>:
+    Ok(T),
+    Err(E)
+
+main = () i32 {
+    point = Point { x: 1, y: 2 }
+    point.x
+}
+"#,
+    )
+    .expect("write layout subject");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "layout", zen_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json layout on program input");
+
+    assert!(
+        !output.status.success(),
+        "zen emit-json layout should be gated before layout emission: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.trim().is_empty(),
+        "gated layout should not emit type layout JSON, stdout={stdout}"
+    );
+    assert!(
+        stderr.contains("type layout JSON emission is gated until ABI layout tests exist"),
+        "expected layout gate diagnostic, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("unknown command") && !stderr.contains("No such file"),
+        "layout should reject through the ABI-layout gate, not command/path handling, stderr={stderr}"
+    );
+}


### PR DESCRIPTION
## Summary
- Add an integration test proving `emit-json layout` rejects a real program at the ABI-layout gate before emitting JSON.
- Record the layout JSON input boundary in the V1 spec and audit docs.
- Keep ABI layout emission gated until layout tests exist.

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch layout-json-gate-input-boundary --event push --json databaseId,status,conclusion,name,headSha --limit 20` returned `[]`.