### PR TITLE
Add HIR MIR JSON gate input boundary evidence

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -4057,6 +4057,10 @@ and do not assume Phase 4 is ready without evidence.
   `emit_json_mir_command_is_explicitly_gated`,
   `emit_json_layout_command_is_explicitly_gated`, and
   `emit_json_target_yaml_command_is_explicitly_gated`.
+- Real program inputs to `emit-json hir` and `emit-json mir` now reject at the
+  schema/golden-test gate before emitting HIR or MIR JSON. Covered by
+  `emit_json_hir_rejects_program_before_hir_json` and
+  `emit_json_mir_rejects_program_before_mir_json`.
 - Hand-authored target YAML remains outside the compiler-owned IR path:
   `emit-json target-yaml` rejects a real `.yaml` file at the schema-validation
   gate before emitting any JSON. Covered by

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3736,6 +3736,10 @@ checked-in docs, tests, and commits only.
   `emit_json_mir_command_is_explicitly_gated`,
   `emit_json_layout_command_is_explicitly_gated`, and
   `emit_json_target_yaml_command_is_explicitly_gated`.
+- Real program inputs to `emit-json hir` and `emit-json mir` now reject at the
+  schema/golden-test gate before emitting HIR or MIR JSON. Guarded by
+  `emit_json_hir_rejects_program_before_hir_json` and
+  `emit_json_mir_rejects_program_before_mir_json`.
 - Hand-authored target YAML remains outside the compiler-owned IR path:
   `emit-json target-yaml` now has explicit coverage that a real `.yaml` file is
   rejected at the schema-validation gate before emitting any JSON. Guarded by

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -139,9 +139,13 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   symbol table emission, checked typed program emission, and machine-readable
   diagnostics emission through `zen emit-json ast <file>`,
   `zen emit-json symbols <file>`, `zen emit-json typed <file>`, and
-  `zen emit-json diagnostics <file>`. `zen emit-json layout <file>` is an
-  explicit gated command and rejects until ABI layout tests exist; real program
-  inputs are rejected before layout JSON emission, covered by
+  `zen emit-json diagnostics <file>`. Real program inputs to
+  `zen emit-json hir <file>` and `zen emit-json mir <file>` are rejected before
+  HIR/MIR JSON emission, covered by
+  `emit_json_hir_rejects_program_before_hir_json` and
+  `emit_json_mir_rejects_program_before_mir_json`. `zen emit-json layout <file>`
+  is an explicit gated command and rejects until ABI layout tests exist; real
+  program inputs are rejected before layout JSON emission, covered by
   `emit_json_layout_rejects_program_before_layout_json`. AST JSON is explicitly
   marked unchecked; symbols JSON is explicitly marked resolved;
   typed JSON is explicitly marked checked; diagnostics JSON is explicitly

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -97,6 +97,8 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "zen emit-json typed <file>",
         "zen emit-json diagnostics <file>",
         "semantic acceptance must use typed",
+        "emit_json_hir_rejects_program_before_hir_json",
+        "emit_json_mir_rejects_program_before_mir_json",
         "emit_json_layout_rejects_program_before_layout_json",
         "emit_json_target_yaml_rejects_hand_authored_yaml_before_validation",
         "build.zen",

--- a/tests/integration/cli_build/frontend_json.rs
+++ b/tests/integration/cli_build/frontend_json.rs
@@ -171,6 +171,49 @@ fn emit_json_mir_command_is_explicitly_gated() {
 }
 
 #[test]
+fn emit_json_mir_rejects_program_before_mir_json() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let zen_path = tmp.path().join("mir_subject.zen");
+    std::fs::write(
+        &zen_path,
+        r#"
+main = () i32 {
+    value = 40 + 2
+    value
+}
+"#,
+    )
+    .expect("write MIR subject");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "mir", zen_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json mir on program input");
+
+    assert!(
+        !output.status.success(),
+        "zen emit-json mir should be gated before MIR emission: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.trim().is_empty(),
+        "gated MIR should not emit MIR JSON, stdout={stdout}"
+    );
+    assert!(
+        stderr.contains("MIR JSON emission is gated until schema and golden tests exist"),
+        "expected MIR gate diagnostic, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("unknown command") && !stderr.contains("No such file"),
+        "MIR should reject through the schema/golden-test gate, not command/path handling, stderr={stderr}"
+    );
+}
+
+#[test]
 fn emit_json_hir_command_is_explicitly_gated() {
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
         .args([
@@ -192,6 +235,53 @@ fn emit_json_hir_command_is_explicitly_gated() {
     assert!(
         stderr.contains("HIR JSON emission is gated until schema and golden tests exist"),
         "expected HIR gate diagnostic, stderr={stderr}"
+    );
+}
+
+#[test]
+fn emit_json_hir_rejects_program_before_hir_json() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let zen_path = tmp.path().join("hir_subject.zen");
+    std::fs::write(
+        &zen_path,
+        r#"
+Box<T>: {
+    value: T
+}
+
+main = () i32 {
+    box = Box<i32> { value: 7 }
+    box.value
+}
+"#,
+    )
+    .expect("write HIR subject");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "hir", zen_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json hir on program input");
+
+    assert!(
+        !output.status.success(),
+        "zen emit-json hir should be gated before HIR emission: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.trim().is_empty(),
+        "gated HIR should not emit HIR JSON, stdout={stdout}"
+    );
+    assert!(
+        stderr.contains("HIR JSON emission is gated until schema and golden tests exist"),
+        "expected HIR gate diagnostic, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("unknown command") && !stderr.contains("No such file"),
+        "HIR should reject through the schema/golden-test gate, not command/path handling, stderr={stderr}"
     );
 }
 


### PR DESCRIPTION
## Summary
- Add integration tests proving `emit-json hir` and `emit-json mir` reject real programs at the schema/golden-test gate before emitting JSON.
- Record the HIR/MIR JSON input boundary in the V1 spec and audit docs.
- Keep HIR/MIR schema and golden-test work gated.

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch hir-mir-json-gate-input-boundary --event push --json databaseId,status,conclusion,name,headSha --limit 20` returned `[]`.