### PR TITLE
Gate std actor framework imports

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3947,6 +3947,11 @@ and do not assume Phase 4 is ready without evidence.
   reject through the same actor gate instead of ordinary unknown-type
   diagnostics. Covered by
   `bare_actor_framework_types_are_rejected_as_gated_not_unknown`.
+- Std actor framework module imports now reject before loading aspirational
+  actor source sketches, so parser diagnostics from mailbox/scheduling/
+  supervisor prototypes do not leak into stable compiler paths. Covered by
+  `stdlib_actor_framework_import_is_gated_before_loading_sketch` and
+  `module_graph_gates_stdlib_actor_framework_import_before_loading_sketch`.
 - `Channel` remains documented as an experimental stdlib channel sketch rather
   than a global actor builtin type spelling, preserving the importable stdlib
   channel boundary until promotion has compiler-path evidence. Covered by

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3622,6 +3622,11 @@ checked-in docs, tests, and commits only.
   reject through the same actor gate instead of ordinary unknown-type
   diagnostics. Guarded by
   `bare_actor_framework_types_are_rejected_as_gated_not_unknown`.
+- Std actor framework module imports now reject before loading aspirational
+  actor source sketches, so parser diagnostics from mailbox/scheduling/
+  supervisor prototypes do not leak into stable compiler paths. Guarded by
+  `stdlib_actor_framework_import_is_gated_before_loading_sketch` and
+  `module_graph_gates_stdlib_actor_framework_import_before_loading_sketch`.
 - `Channel` remains documented as an experimental stdlib channel sketch rather
   than a global actor builtin type spelling, preserving the importable stdlib
   channel boundary until promotion has compiler-path evidence. Guarded by

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -132,6 +132,10 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   std actor semantics exist; this includes generic and bare actor framework
   spellings, covered by `actor_framework_types_are_rejected_as_gated_not_unknown`
   and `bare_actor_framework_types_are_rejected_as_gated_not_unknown`.
+  Imports of std actor framework sketches are also gated before loading
+  aspirational actor source files, covered by
+  `stdlib_actor_framework_import_is_gated_before_loading_sketch` and
+  `module_graph_gates_stdlib_actor_framework_import_before_loading_sketch`.
   `Channel` remains an experimental stdlib channel sketch until promoted, so it
   is not a global actor builtin type spelling.
 - `JSON/YAML IR boundaries`: gated. JSON is the machine-readable exchange format

--- a/src/module_system/graph_loading.rs
+++ b/src/module_system/graph_loading.rs
@@ -133,6 +133,7 @@ impl ModuleSystem {
             }
 
             let file_path = if root_prefix.is_some_and(|prefix| prefix.is_std()) {
+                self.reject_gated_stdlib_module(&module_path[1..], Some(span))?;
                 self.resolve_stdlib_file_path(&module_path[1..])?
                     .ok_or_else(|| {
                         vec![CompileError::Resolution(

--- a/src/module_system/import_resolution.rs
+++ b/src/module_system/import_resolution.rs
@@ -7,6 +7,37 @@ use crate::error::{CompileError, FileTable, Span};
 use super::root_prefix::parse_module_root_prefix;
 use super::ModuleSystem;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GatedStdlibModule {
+    ActorFramework,
+}
+
+impl GatedStdlibModule {
+    const CONCURRENCY_SEGMENT: &'static str = "concurrency";
+    const ACTOR_SEGMENT: &'static str = "actor";
+
+    fn from_sub_path(sub_path: &[String]) -> Option<Self> {
+        if sub_path
+            .first()
+            .is_some_and(|segment| segment == Self::CONCURRENCY_SEGMENT)
+            && sub_path
+                .get(1)
+                .is_some_and(|segment| segment == Self::ACTOR_SEGMENT)
+        {
+            return Some(Self::ActorFramework);
+        }
+        None
+    }
+
+    fn gate_message(self) -> &'static str {
+        match self {
+            Self::ActorFramework => {
+                "std actor framework modules are gated until mailbox, scheduling, supervisor, and allocator semantics are implemented"
+            }
+        }
+    }
+}
+
 impl ModuleSystem {
     /// Walk Import declarations in `program` and load their dependencies.
     ///
@@ -50,6 +81,8 @@ impl ModuleSystem {
                 if module_path.len() == 1 {
                     continue;
                 }
+
+                self.reject_gated_stdlib_module(&module_path[1..], Some(span))?;
 
                 let Some(file_path) = self.resolve_stdlib_file_path(&module_path[1..])? else {
                     return Err(vec![CompileError::Resolution(
@@ -235,6 +268,8 @@ impl ModuleSystem {
             });
         }
 
+        self.reject_gated_stdlib_module(sub_path, None)?;
+
         if let Some(file_path) = self.resolve_stdlib_file_path(sub_path)? {
             return self.load_file(&file_path, files);
         }
@@ -284,6 +319,20 @@ impl ModuleSystem {
         }
 
         Ok(None)
+    }
+
+    pub(super) fn reject_gated_stdlib_module(
+        &self,
+        sub_path: &[String],
+        span: Option<Span>,
+    ) -> Result<(), Vec<CompileError>> {
+        if let Some(gated) = GatedStdlibModule::from_sub_path(sub_path) {
+            return Err(vec![CompileError::Resolution(
+                gated.gate_message().into(),
+                span,
+            )]);
+        }
+        Ok(())
     }
 }
 

--- a/src/module_system/tests.rs
+++ b/src/module_system/tests.rs
@@ -144,6 +144,42 @@ fn stdlib_submodule_import_loads_through_module_system() {
 }
 
 #[test]
+fn stdlib_actor_framework_import_is_gated_before_loading_sketch() {
+    let tmp = setup_temp_dir();
+    let actor_dir = tmp.path().join("stdlib/concurrency/actor");
+    fs::create_dir_all(&actor_dir).unwrap();
+    fs::write(actor_dir.join("actor.zen"), "this is not valid zen\n").unwrap();
+
+    let main_path = tmp.path().join("main.zen");
+    fs::write(
+        &main_path,
+        "{ Actor } = @std.concurrency.actor.actor\n\nmain = () i32 { 0 }\n",
+    )
+    .unwrap();
+
+    let mut files = FileTable::new();
+    let mut ms = ModuleSystem::with_stdlib_root(tmp.path().join("stdlib"));
+
+    let errors = ms
+        .load_with_imports(&main_path, &mut files)
+        .expect_err("actor stdlib imports should be gated before parsing sketches");
+    let messages = errors
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(
+        messages.contains("std actor framework modules are gated"),
+        "expected actor stdlib gate diagnostic, got {messages}"
+    );
+    assert!(
+        !messages.contains("expected") && !messages.contains("unexpected token"),
+        "actor stdlib gate should not leak parser diagnostics from sketches, got {messages}"
+    );
+}
+
+#[test]
 fn cached_module_not_reloaded() {
     let tmp = setup_temp_dir();
 

--- a/src/module_system/tests/graph_loading.rs
+++ b/src/module_system/tests/graph_loading.rs
@@ -151,6 +151,42 @@ fn module_graph_reuses_export_visibility_errors() {
 }
 
 #[test]
+fn module_graph_gates_stdlib_actor_framework_import_before_loading_sketch() {
+    let tmp = setup_temp_dir();
+    let actor_dir = tmp.path().join("stdlib/concurrency/actor");
+    fs::create_dir_all(&actor_dir).unwrap();
+    fs::write(actor_dir.join("actor.zen"), "this is not valid zen\n").unwrap();
+
+    let main_path = tmp.path().join("main.zen");
+    fs::write(
+        &main_path,
+        "{ Actor } = @std.concurrency.actor.actor\n\nmain = () i32 { 0 }\n",
+    )
+    .unwrap();
+
+    let mut files = FileTable::new();
+    let mut ms = ModuleSystem::with_stdlib_root(tmp.path().join("stdlib"));
+
+    let errors = ms
+        .load_module_graph(&main_path, &mut files)
+        .expect_err("actor stdlib imports should be gated before graph loading sketches");
+    let messages = errors
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(
+        messages.contains("std actor framework modules are gated"),
+        "expected actor stdlib gate diagnostic, got {messages}"
+    );
+    assert!(
+        !messages.contains("expected") && !messages.contains("unexpected token"),
+        "actor stdlib gate should not leak parser diagnostics from sketches, got {messages}"
+    );
+}
+
+#[test]
 fn module_graph_detects_circular_imports() {
     let tmp = setup_temp_dir();
 

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -75,6 +75,8 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "diagnostics JSON is explicitly",
         "Actors in std",
         "bare_actor_framework_types_are_rejected_as_gated_not_unknown",
+        "stdlib_actor_framework_import_is_gated_before_loading_sketch",
+        "module_graph_gates_stdlib_actor_framework_import_before_loading_sketch",
         "JSON/YAML IR boundaries",
         "comptime_type_match_intrinsic_is_rejected_as_gated_not_unknown",
         "primitive_and_enum_type_match_intrinsics_are_rejected_as_gated_not_unknown",


### PR DESCRIPTION
## Summary
- Add an enum-owned stdlib module gate for the `concurrency.actor` subtree.
- Reject std actor framework imports before loading aspirational actor source sketches in both legacy import merging and module graph loading.
- Record the actor stdlib import gate in V1 spec and audit docs.

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch actor-std-gate-evidence --event push --json databaseId,status,conclusion,name,headSha --limit 20` returned `[]`.