### PR TITLE
Gate std allocator imports

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3938,6 +3938,11 @@ and do not assume Phase 4 is ready without evidence.
 - Sync and Async typed allocator annotations now both reject through the
   allocator gate rather than falling through to unknown-type diagnostics.
   Covered by `sync_and_async_typed_allocator_modes_are_rejected_as_gated_not_unknown`.
+- Std allocator module imports now reject before loading aspirational allocator
+  source sketches, so parser diagnostics from allocator/effect prototypes do
+  not leak into stable compiler paths. Covered by
+  `stdlib_allocator_import_is_gated_before_loading_sketch` and
+  `module_graph_gates_stdlib_allocator_import_before_loading_sketch`.
 - Actor framework type spellings `Actor`, `ActorRef`, `Mailbox`, and
   `Supervisor` now use AST gated builtin type metadata and produce actor-specific
   gated diagnostics rather than ordinary unknown-type errors. Covered by

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3613,6 +3613,11 @@ checked-in docs, tests, and commits only.
 - Sync and Async typed allocator annotations now both reject through the
   allocator gate instead of falling through to unknown-type diagnostics. Guarded
   by `sync_and_async_typed_allocator_modes_are_rejected_as_gated_not_unknown`.
+- Std allocator module imports now reject before loading aspirational allocator
+  source sketches, so parser diagnostics from allocator/effect prototypes do
+  not leak into stable compiler paths. Guarded by
+  `stdlib_allocator_import_is_gated_before_loading_sketch` and
+  `module_graph_gates_stdlib_allocator_import_before_loading_sketch`.
 - Actor framework type spellings `Actor`, `ActorRef`, `Mailbox`, and
   `Supervisor` now share the same AST-owned gated builtin type path and report
   actor-specific gated diagnostics instead of unknown-type errors. Covered by

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -101,7 +101,10 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   report raw memory operation gates until allocator ownership and effect
   semantics exist. Byte-memory intrinsics `@builtin.memcpy(...)`,
   `@builtin.memmove(...)`, `@builtin.memset(...)`, and `@builtin.memcmp(...)`
-  report the same allocator/effect gate.
+  report the same allocator/effect gate. Imports of std allocator sketches are
+  gated before loading aspirational allocator source files, covered by
+  `stdlib_allocator_import_is_gated_before_loading_sketch` and
+  `module_graph_gates_stdlib_allocator_import_before_loading_sketch`.
 - `Type matching`: gated. Comptime type matching operates on typed metadata for
   primitives, structs, enums, fields, variants, behaviors, allocator modes, and
   effect modes. It is separate from runtime value matching.

--- a/src/module_system/import_resolution.rs
+++ b/src/module_system/import_resolution.rs
@@ -10,11 +10,14 @@ use super::ModuleSystem;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum GatedStdlibModule {
     ActorFramework,
+    AllocatorFramework,
 }
 
 impl GatedStdlibModule {
     const CONCURRENCY_SEGMENT: &'static str = "concurrency";
     const ACTOR_SEGMENT: &'static str = "actor";
+    const MEMORY_SEGMENT: &'static str = "memory";
+    const ALLOCATOR_SEGMENT: &'static str = "allocator";
 
     fn from_sub_path(sub_path: &[String]) -> Option<Self> {
         if sub_path
@@ -26,6 +29,15 @@ impl GatedStdlibModule {
         {
             return Some(Self::ActorFramework);
         }
+        if sub_path
+            .first()
+            .is_some_and(|segment| segment == Self::MEMORY_SEGMENT)
+            && sub_path
+                .get(1)
+                .is_some_and(|segment| segment == Self::ALLOCATOR_SEGMENT)
+        {
+            return Some(Self::AllocatorFramework);
+        }
         None
     }
 
@@ -33,6 +45,9 @@ impl GatedStdlibModule {
         match self {
             Self::ActorFramework => {
                 "std actor framework modules are gated until mailbox, scheduling, supervisor, and allocator semantics are implemented"
+            }
+            Self::AllocatorFramework => {
+                "std allocator modules are gated until allocator ownership and effect semantics are implemented"
             }
         }
     }

--- a/src/module_system/tests.rs
+++ b/src/module_system/tests.rs
@@ -180,6 +180,42 @@ fn stdlib_actor_framework_import_is_gated_before_loading_sketch() {
 }
 
 #[test]
+fn stdlib_allocator_import_is_gated_before_loading_sketch() {
+    let tmp = setup_temp_dir();
+    let memory_dir = tmp.path().join("stdlib/memory");
+    fs::create_dir_all(&memory_dir).unwrap();
+    fs::write(memory_dir.join("allocator.zen"), "this is not valid zen\n").unwrap();
+
+    let main_path = tmp.path().join("main.zen");
+    fs::write(
+        &main_path,
+        "{ Allocator } = @std.memory.allocator\n\nmain = () i32 { 0 }\n",
+    )
+    .unwrap();
+
+    let mut files = FileTable::new();
+    let mut ms = ModuleSystem::with_stdlib_root(tmp.path().join("stdlib"));
+
+    let errors = ms
+        .load_with_imports(&main_path, &mut files)
+        .expect_err("allocator stdlib imports should be gated before parsing sketches");
+    let messages = errors
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(
+        messages.contains("std allocator modules are gated"),
+        "expected allocator stdlib gate diagnostic, got {messages}"
+    );
+    assert!(
+        !messages.contains("expected") && !messages.contains("unexpected token"),
+        "allocator stdlib gate should not leak parser diagnostics from sketches, got {messages}"
+    );
+}
+
+#[test]
 fn cached_module_not_reloaded() {
     let tmp = setup_temp_dir();
 

--- a/src/module_system/tests/graph_loading.rs
+++ b/src/module_system/tests/graph_loading.rs
@@ -187,6 +187,42 @@ fn module_graph_gates_stdlib_actor_framework_import_before_loading_sketch() {
 }
 
 #[test]
+fn module_graph_gates_stdlib_allocator_import_before_loading_sketch() {
+    let tmp = setup_temp_dir();
+    let memory_dir = tmp.path().join("stdlib/memory");
+    fs::create_dir_all(&memory_dir).unwrap();
+    fs::write(memory_dir.join("allocator.zen"), "this is not valid zen\n").unwrap();
+
+    let main_path = tmp.path().join("main.zen");
+    fs::write(
+        &main_path,
+        "{ Allocator } = @std.memory.allocator\n\nmain = () i32 { 0 }\n",
+    )
+    .unwrap();
+
+    let mut files = FileTable::new();
+    let mut ms = ModuleSystem::with_stdlib_root(tmp.path().join("stdlib"));
+
+    let errors = ms
+        .load_module_graph(&main_path, &mut files)
+        .expect_err("allocator stdlib imports should be gated before graph loading sketches");
+    let messages = errors
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(
+        messages.contains("std allocator modules are gated"),
+        "expected allocator stdlib gate diagnostic, got {messages}"
+    );
+    assert!(
+        !messages.contains("expected") && !messages.contains("unexpected token"),
+        "allocator stdlib gate should not leak parser diagnostics from sketches, got {messages}"
+    );
+}
+
+#[test]
 fn module_graph_detects_circular_imports() {
     let tmp = setup_temp_dir();
 

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -59,6 +59,8 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "raw_memory_intrinsics_are_rejected_as_allocator_gates",
         "byte_memory_intrinsics_are_rejected_as_allocator_gates",
         "sync_and_async_typed_allocator_modes_are_rejected_as_gated_not_unknown",
+        "stdlib_allocator_import_is_gated_before_loading_sketch",
+        "module_graph_gates_stdlib_allocator_import_before_loading_sketch",
         "@builtin.raw_allocate",
         "@builtin.raw_deallocate",
         "@builtin.raw_reallocate",


### PR DESCRIPTION
## Summary
- Extend the stdlib module gate to reject `@std.memory.allocator` imports before loading aspirational allocator sketches.
- Cover both legacy import merging and module graph loading so parser diagnostics do not leak from allocator prototype files.
- Record the allocator stdlib import gate in V1 spec and audit docs.

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch allocator-std-gate-evidence --event push --json databaseId,status,conclusion,name,headSha --limit 20` returned `[]`.