### PR TITLE
Gate std async runtime imports

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3924,6 +3924,11 @@ and do not assume Phase 4 is ready without evidence.
   builtins. Covered by
   `async_scheduler_intrinsics_are_rejected_as_gated_not_unknown` and
   `typechecker_gated_intrinsics_use_owned_name_enum`.
+- Std async runtime module imports now reject before loading aspirational
+  scheduler/task source sketches, so parser diagnostics from Sync/Async
+  prototypes do not leak into stable compiler paths. Covered by
+  `stdlib_async_runtime_import_is_gated_before_loading_sketch` and
+  `module_graph_gates_stdlib_async_runtime_import_before_loading_sketch`.
 - C runtime layout now keeps the same split: static string literals emit as
   direct `zen_str` compound literals with `sizeof`-derived compile-time length,
   while dynamic `zen_string` carries an allocator pointer. Covered by

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3600,6 +3600,11 @@ checked-in docs, tests, and commits only.
   builtins. Covered by
   `async_scheduler_intrinsics_are_rejected_as_gated_not_unknown` and
   `typechecker_gated_intrinsics_use_owned_name_enum`.
+- Std async runtime module imports now reject before loading aspirational
+  scheduler/task source sketches, so parser diagnostics from Sync/Async
+  prototypes do not leak into stable compiler paths. Guarded by
+  `stdlib_async_runtime_import_is_gated_before_loading_sketch` and
+  `module_graph_gates_stdlib_async_runtime_import_before_loading_sketch`.
 - C runtime layout now mirrors that public model: static string literals emit
   as direct `zen_str` compound literals whose length is derived with `sizeof`,
   while dynamic `zen_string` carries an allocator pointer. Covered by

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -87,7 +87,11 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   queue, scheduler, yield, and await-like APIs. `@builtin.async_enqueue(...)`
   and `@builtin.async_yield()` currently report that async task enqueue and
   async yield are gated until Sync/Async effect checking and task lowering
-  exist. Atomic compiler intrinsics `@builtin.atomic_load(...)`,
+  exist. Imports of std async runtime sketches are gated before loading
+  aspirational scheduler/task source files, covered by
+  `stdlib_async_runtime_import_is_gated_before_loading_sketch` and
+  `module_graph_gates_stdlib_async_runtime_import_before_loading_sketch`.
+  Atomic compiler intrinsics `@builtin.atomic_load(...)`,
   `@builtin.atomic_store(...)`, `@builtin.atomic_add(...)`,
   `@builtin.atomic_sub(...)`, `@builtin.atomic_cas(...)`,
   `@builtin.atomic_xchg(...)`, and `@builtin.fence()` report gated diagnostics

--- a/src/module_system/import_resolution.rs
+++ b/src/module_system/import_resolution.rs
@@ -11,11 +11,13 @@ use super::ModuleSystem;
 enum GatedStdlibModule {
     ActorFramework,
     AllocatorFramework,
+    AsyncRuntime,
 }
 
 impl GatedStdlibModule {
     const CONCURRENCY_SEGMENT: &'static str = "concurrency";
     const ACTOR_SEGMENT: &'static str = "actor";
+    const ASYNC_SEGMENT: &'static str = "async";
     const MEMORY_SEGMENT: &'static str = "memory";
     const ALLOCATOR_SEGMENT: &'static str = "allocator";
 
@@ -28,6 +30,15 @@ impl GatedStdlibModule {
                 .is_some_and(|segment| segment == Self::ACTOR_SEGMENT)
         {
             return Some(Self::ActorFramework);
+        }
+        if sub_path
+            .first()
+            .is_some_and(|segment| segment == Self::CONCURRENCY_SEGMENT)
+            && sub_path
+                .get(1)
+                .is_some_and(|segment| segment == Self::ASYNC_SEGMENT)
+        {
+            return Some(Self::AsyncRuntime);
         }
         if sub_path
             .first()
@@ -48,6 +59,9 @@ impl GatedStdlibModule {
             }
             Self::AllocatorFramework => {
                 "std allocator modules are gated until allocator ownership and effect semantics are implemented"
+            }
+            Self::AsyncRuntime => {
+                "std async runtime modules are gated until Sync/Async effect checking and task lowering are implemented"
             }
         }
     }

--- a/src/module_system/tests.rs
+++ b/src/module_system/tests.rs
@@ -216,6 +216,42 @@ fn stdlib_allocator_import_is_gated_before_loading_sketch() {
 }
 
 #[test]
+fn stdlib_async_runtime_import_is_gated_before_loading_sketch() {
+    let tmp = setup_temp_dir();
+    let async_dir = tmp.path().join("stdlib/concurrency/async");
+    fs::create_dir_all(&async_dir).unwrap();
+    fs::write(async_dir.join("scheduler.zen"), "this is not valid zen\n").unwrap();
+
+    let main_path = tmp.path().join("main.zen");
+    fs::write(
+        &main_path,
+        "{ Scheduler } = @std.concurrency.async.scheduler\n\nmain = () i32 { 0 }\n",
+    )
+    .unwrap();
+
+    let mut files = FileTable::new();
+    let mut ms = ModuleSystem::with_stdlib_root(tmp.path().join("stdlib"));
+
+    let errors = ms
+        .load_with_imports(&main_path, &mut files)
+        .expect_err("async stdlib imports should be gated before parsing sketches");
+    let messages = errors
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(
+        messages.contains("std async runtime modules are gated"),
+        "expected async stdlib gate diagnostic, got {messages}"
+    );
+    assert!(
+        !messages.contains("expected") && !messages.contains("unexpected token"),
+        "async stdlib gate should not leak parser diagnostics from sketches, got {messages}"
+    );
+}
+
+#[test]
 fn cached_module_not_reloaded() {
     let tmp = setup_temp_dir();
 

--- a/src/module_system/tests/graph_loading.rs
+++ b/src/module_system/tests/graph_loading.rs
@@ -223,6 +223,42 @@ fn module_graph_gates_stdlib_allocator_import_before_loading_sketch() {
 }
 
 #[test]
+fn module_graph_gates_stdlib_async_runtime_import_before_loading_sketch() {
+    let tmp = setup_temp_dir();
+    let async_dir = tmp.path().join("stdlib/concurrency/async");
+    fs::create_dir_all(&async_dir).unwrap();
+    fs::write(async_dir.join("scheduler.zen"), "this is not valid zen\n").unwrap();
+
+    let main_path = tmp.path().join("main.zen");
+    fs::write(
+        &main_path,
+        "{ Scheduler } = @std.concurrency.async.scheduler\n\nmain = () i32 { 0 }\n",
+    )
+    .unwrap();
+
+    let mut files = FileTable::new();
+    let mut ms = ModuleSystem::with_stdlib_root(tmp.path().join("stdlib"));
+
+    let errors = ms
+        .load_module_graph(&main_path, &mut files)
+        .expect_err("async stdlib imports should be gated before graph loading sketches");
+    let messages = errors
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(
+        messages.contains("std async runtime modules are gated"),
+        "expected async stdlib gate diagnostic, got {messages}"
+    );
+    assert!(
+        !messages.contains("expected") && !messages.contains("unexpected token"),
+        "async stdlib gate should not leak parser diagnostics from sketches, got {messages}"
+    );
+}
+
+#[test]
 fn module_graph_detects_circular_imports() {
     let tmp = setup_temp_dir();
 

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -45,6 +45,8 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "removed",
         "Sync/Async effects",
         "async_scheduler_intrinsics_are_rejected_as_gated_not_unknown",
+        "stdlib_async_runtime_import_is_gated_before_loading_sketch",
+        "module_graph_gates_stdlib_async_runtime_import_before_loading_sketch",
         "async task enqueue",
         "async yield",
         "atomic_intrinsics_are_rejected_as_effect_gates",


### PR DESCRIPTION
## Summary
- Extend the stdlib module gate to reject `@std.concurrency.async.*` imports before loading aspirational async runtime sketches.
- Cover both legacy import merging and module graph loading so parser diagnostics do not leak from scheduler/task prototype files.
- Record the async stdlib import gate in V1 spec and audit docs.

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch async-std-gate-evidence --event push --json databaseId,status,conclusion,name,headSha --limit 20` returned `[]`.