### PR TITLE
Gate std sync runtime imports

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3929,6 +3929,11 @@ and do not assume Phase 4 is ready without evidence.
   prototypes do not leak into stable compiler paths. Covered by
   `stdlib_async_runtime_import_is_gated_before_loading_sketch` and
   `module_graph_gates_stdlib_async_runtime_import_before_loading_sketch`.
+- Std sync runtime module imports now reject before loading aspirational
+  channel source sketches, so parser diagnostics from blocking/channel
+  prototypes do not leak into stable compiler paths. Covered by
+  `stdlib_sync_runtime_import_is_gated_before_loading_sketch` and
+  `module_graph_gates_stdlib_sync_runtime_import_before_loading_sketch`.
 - C runtime layout now keeps the same split: static string literals emit as
   direct `zen_str` compound literals with `sizeof`-derived compile-time length,
   while dynamic `zen_string` carries an allocator pointer. Covered by

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3605,6 +3605,11 @@ checked-in docs, tests, and commits only.
   prototypes do not leak into stable compiler paths. Guarded by
   `stdlib_async_runtime_import_is_gated_before_loading_sketch` and
   `module_graph_gates_stdlib_async_runtime_import_before_loading_sketch`.
+- Std sync runtime module imports now reject before loading aspirational
+  channel source sketches, so parser diagnostics from blocking/channel
+  prototypes do not leak into stable compiler paths. Guarded by
+  `stdlib_sync_runtime_import_is_gated_before_loading_sketch` and
+  `module_graph_gates_stdlib_sync_runtime_import_before_loading_sketch`.
 - C runtime layout now mirrors that public model: static string literals emit
   as direct `zen_str` compound literals whose length is derived with `sizeof`,
   while dynamic `zen_string` carries an allocator pointer. Covered by

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -91,6 +91,10 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   aspirational scheduler/task source files, covered by
   `stdlib_async_runtime_import_is_gated_before_loading_sketch` and
   `module_graph_gates_stdlib_async_runtime_import_before_loading_sketch`.
+  Imports of std sync runtime sketches are likewise gated before loading
+  aspirational channel source files, covered by
+  `stdlib_sync_runtime_import_is_gated_before_loading_sketch` and
+  `module_graph_gates_stdlib_sync_runtime_import_before_loading_sketch`.
   Atomic compiler intrinsics `@builtin.atomic_load(...)`,
   `@builtin.atomic_store(...)`, `@builtin.atomic_add(...)`,
   `@builtin.atomic_sub(...)`, `@builtin.atomic_cas(...)`,

--- a/src/module_system/import_resolution.rs
+++ b/src/module_system/import_resolution.rs
@@ -12,12 +12,14 @@ enum GatedStdlibModule {
     ActorFramework,
     AllocatorFramework,
     AsyncRuntime,
+    SyncRuntime,
 }
 
 impl GatedStdlibModule {
     const CONCURRENCY_SEGMENT: &'static str = "concurrency";
     const ACTOR_SEGMENT: &'static str = "actor";
     const ASYNC_SEGMENT: &'static str = "async";
+    const SYNC_SEGMENT: &'static str = "sync";
     const MEMORY_SEGMENT: &'static str = "memory";
     const ALLOCATOR_SEGMENT: &'static str = "allocator";
 
@@ -42,6 +44,15 @@ impl GatedStdlibModule {
         }
         if sub_path
             .first()
+            .is_some_and(|segment| segment == Self::CONCURRENCY_SEGMENT)
+            && sub_path
+                .get(1)
+                .is_some_and(|segment| segment == Self::SYNC_SEGMENT)
+        {
+            return Some(Self::SyncRuntime);
+        }
+        if sub_path
+            .first()
             .is_some_and(|segment| segment == Self::MEMORY_SEGMENT)
             && sub_path
                 .get(1)
@@ -62,6 +73,9 @@ impl GatedStdlibModule {
             }
             Self::AsyncRuntime => {
                 "std async runtime modules are gated until Sync/Async effect checking and task lowering are implemented"
+            }
+            Self::SyncRuntime => {
+                "std sync runtime modules are gated until channel, mailbox, and blocking semantics are implemented"
             }
         }
     }

--- a/src/module_system/tests.rs
+++ b/src/module_system/tests.rs
@@ -7,6 +7,47 @@ fn setup_temp_dir() -> tempfile::TempDir {
     tempfile::tempdir().unwrap()
 }
 
+fn assert_stdlib_import_is_gated_before_loading_sketch(
+    sketch_dir: &str,
+    sketch_file: &str,
+    import_source: &str,
+    expected_gate: &str,
+    gate_name: &str,
+) {
+    let tmp = setup_temp_dir();
+    let sketch_dir = tmp.path().join("stdlib").join(sketch_dir);
+    fs::create_dir_all(&sketch_dir).unwrap();
+    fs::write(sketch_dir.join(sketch_file), "this is not valid zen\n").unwrap();
+
+    let main_path = tmp.path().join("main.zen");
+    fs::write(
+        &main_path,
+        format!("{import_source}\n\nmain = () i32 {{ 0 }}\n"),
+    )
+    .unwrap();
+
+    let mut files = FileTable::new();
+    let mut ms = ModuleSystem::with_stdlib_root(tmp.path().join("stdlib"));
+
+    let errors = ms
+        .load_with_imports(&main_path, &mut files)
+        .expect_err("stdlib import should be gated before parsing sketches");
+    let messages = errors
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(
+        messages.contains(expected_gate),
+        "expected {gate_name} stdlib gate diagnostic, got {messages}"
+    );
+    assert!(
+        !messages.contains("expected") && !messages.contains("unexpected token"),
+        "{gate_name} stdlib gate should not leak parser diagnostics from sketches, got {messages}"
+    );
+}
+
 #[test]
 fn load_file_with_relative_import() {
     let tmp = setup_temp_dir();
@@ -145,109 +186,45 @@ fn stdlib_submodule_import_loads_through_module_system() {
 
 #[test]
 fn stdlib_actor_framework_import_is_gated_before_loading_sketch() {
-    let tmp = setup_temp_dir();
-    let actor_dir = tmp.path().join("stdlib/concurrency/actor");
-    fs::create_dir_all(&actor_dir).unwrap();
-    fs::write(actor_dir.join("actor.zen"), "this is not valid zen\n").unwrap();
-
-    let main_path = tmp.path().join("main.zen");
-    fs::write(
-        &main_path,
-        "{ Actor } = @std.concurrency.actor.actor\n\nmain = () i32 { 0 }\n",
-    )
-    .unwrap();
-
-    let mut files = FileTable::new();
-    let mut ms = ModuleSystem::with_stdlib_root(tmp.path().join("stdlib"));
-
-    let errors = ms
-        .load_with_imports(&main_path, &mut files)
-        .expect_err("actor stdlib imports should be gated before parsing sketches");
-    let messages = errors
-        .iter()
-        .map(ToString::to_string)
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    assert!(
-        messages.contains("std actor framework modules are gated"),
-        "expected actor stdlib gate diagnostic, got {messages}"
-    );
-    assert!(
-        !messages.contains("expected") && !messages.contains("unexpected token"),
-        "actor stdlib gate should not leak parser diagnostics from sketches, got {messages}"
+    assert_stdlib_import_is_gated_before_loading_sketch(
+        "concurrency/actor",
+        "actor.zen",
+        "{ Actor } = @std.concurrency.actor.actor",
+        "std actor framework modules are gated",
+        "actor",
     );
 }
 
 #[test]
 fn stdlib_allocator_import_is_gated_before_loading_sketch() {
-    let tmp = setup_temp_dir();
-    let memory_dir = tmp.path().join("stdlib/memory");
-    fs::create_dir_all(&memory_dir).unwrap();
-    fs::write(memory_dir.join("allocator.zen"), "this is not valid zen\n").unwrap();
-
-    let main_path = tmp.path().join("main.zen");
-    fs::write(
-        &main_path,
-        "{ Allocator } = @std.memory.allocator\n\nmain = () i32 { 0 }\n",
-    )
-    .unwrap();
-
-    let mut files = FileTable::new();
-    let mut ms = ModuleSystem::with_stdlib_root(tmp.path().join("stdlib"));
-
-    let errors = ms
-        .load_with_imports(&main_path, &mut files)
-        .expect_err("allocator stdlib imports should be gated before parsing sketches");
-    let messages = errors
-        .iter()
-        .map(ToString::to_string)
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    assert!(
-        messages.contains("std allocator modules are gated"),
-        "expected allocator stdlib gate diagnostic, got {messages}"
-    );
-    assert!(
-        !messages.contains("expected") && !messages.contains("unexpected token"),
-        "allocator stdlib gate should not leak parser diagnostics from sketches, got {messages}"
+    assert_stdlib_import_is_gated_before_loading_sketch(
+        "memory",
+        "allocator.zen",
+        "{ Allocator } = @std.memory.allocator",
+        "std allocator modules are gated",
+        "allocator",
     );
 }
 
 #[test]
 fn stdlib_async_runtime_import_is_gated_before_loading_sketch() {
-    let tmp = setup_temp_dir();
-    let async_dir = tmp.path().join("stdlib/concurrency/async");
-    fs::create_dir_all(&async_dir).unwrap();
-    fs::write(async_dir.join("scheduler.zen"), "this is not valid zen\n").unwrap();
-
-    let main_path = tmp.path().join("main.zen");
-    fs::write(
-        &main_path,
-        "{ Scheduler } = @std.concurrency.async.scheduler\n\nmain = () i32 { 0 }\n",
-    )
-    .unwrap();
-
-    let mut files = FileTable::new();
-    let mut ms = ModuleSystem::with_stdlib_root(tmp.path().join("stdlib"));
-
-    let errors = ms
-        .load_with_imports(&main_path, &mut files)
-        .expect_err("async stdlib imports should be gated before parsing sketches");
-    let messages = errors
-        .iter()
-        .map(ToString::to_string)
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    assert!(
-        messages.contains("std async runtime modules are gated"),
-        "expected async stdlib gate diagnostic, got {messages}"
+    assert_stdlib_import_is_gated_before_loading_sketch(
+        "concurrency/async",
+        "scheduler.zen",
+        "{ Scheduler } = @std.concurrency.async.scheduler",
+        "std async runtime modules are gated",
+        "async",
     );
-    assert!(
-        !messages.contains("expected") && !messages.contains("unexpected token"),
-        "async stdlib gate should not leak parser diagnostics from sketches, got {messages}"
+}
+
+#[test]
+fn stdlib_sync_runtime_import_is_gated_before_loading_sketch() {
+    assert_stdlib_import_is_gated_before_loading_sketch(
+        "concurrency/sync",
+        "channel.zen",
+        "{ Channel } = @std.concurrency.sync.channel",
+        "std sync runtime modules are gated",
+        "sync",
     );
 }
 

--- a/src/module_system/tests/graph_loading.rs
+++ b/src/module_system/tests/graph_loading.rs
@@ -1,5 +1,46 @@
 use super::*;
 
+fn assert_graph_stdlib_import_is_gated_before_loading_sketch(
+    sketch_dir: &str,
+    sketch_file: &str,
+    import_source: &str,
+    expected_gate: &str,
+    gate_name: &str,
+) {
+    let tmp = setup_temp_dir();
+    let sketch_dir = tmp.path().join("stdlib").join(sketch_dir);
+    fs::create_dir_all(&sketch_dir).unwrap();
+    fs::write(sketch_dir.join(sketch_file), "this is not valid zen\n").unwrap();
+
+    let main_path = tmp.path().join("main.zen");
+    fs::write(
+        &main_path,
+        format!("{import_source}\n\nmain = () i32 {{ 0 }}\n"),
+    )
+    .unwrap();
+
+    let mut files = FileTable::new();
+    let mut ms = ModuleSystem::with_stdlib_root(tmp.path().join("stdlib"));
+
+    let errors = ms
+        .load_module_graph(&main_path, &mut files)
+        .expect_err("stdlib import should be gated before graph loading sketches");
+    let messages = errors
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(
+        messages.contains(expected_gate),
+        "expected {gate_name} stdlib gate diagnostic, got {messages}"
+    );
+    assert!(
+        !messages.contains("expected") && !messages.contains("unexpected token"),
+        "{gate_name} stdlib gate should not leak parser diagnostics from sketches, got {messages}"
+    );
+}
+
 #[test]
 fn module_graph_records_imports_without_merging_declarations() {
     let tmp = setup_temp_dir();
@@ -152,109 +193,45 @@ fn module_graph_reuses_export_visibility_errors() {
 
 #[test]
 fn module_graph_gates_stdlib_actor_framework_import_before_loading_sketch() {
-    let tmp = setup_temp_dir();
-    let actor_dir = tmp.path().join("stdlib/concurrency/actor");
-    fs::create_dir_all(&actor_dir).unwrap();
-    fs::write(actor_dir.join("actor.zen"), "this is not valid zen\n").unwrap();
-
-    let main_path = tmp.path().join("main.zen");
-    fs::write(
-        &main_path,
-        "{ Actor } = @std.concurrency.actor.actor\n\nmain = () i32 { 0 }\n",
-    )
-    .unwrap();
-
-    let mut files = FileTable::new();
-    let mut ms = ModuleSystem::with_stdlib_root(tmp.path().join("stdlib"));
-
-    let errors = ms
-        .load_module_graph(&main_path, &mut files)
-        .expect_err("actor stdlib imports should be gated before graph loading sketches");
-    let messages = errors
-        .iter()
-        .map(ToString::to_string)
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    assert!(
-        messages.contains("std actor framework modules are gated"),
-        "expected actor stdlib gate diagnostic, got {messages}"
-    );
-    assert!(
-        !messages.contains("expected") && !messages.contains("unexpected token"),
-        "actor stdlib gate should not leak parser diagnostics from sketches, got {messages}"
+    assert_graph_stdlib_import_is_gated_before_loading_sketch(
+        "concurrency/actor",
+        "actor.zen",
+        "{ Actor } = @std.concurrency.actor.actor",
+        "std actor framework modules are gated",
+        "actor",
     );
 }
 
 #[test]
 fn module_graph_gates_stdlib_allocator_import_before_loading_sketch() {
-    let tmp = setup_temp_dir();
-    let memory_dir = tmp.path().join("stdlib/memory");
-    fs::create_dir_all(&memory_dir).unwrap();
-    fs::write(memory_dir.join("allocator.zen"), "this is not valid zen\n").unwrap();
-
-    let main_path = tmp.path().join("main.zen");
-    fs::write(
-        &main_path,
-        "{ Allocator } = @std.memory.allocator\n\nmain = () i32 { 0 }\n",
-    )
-    .unwrap();
-
-    let mut files = FileTable::new();
-    let mut ms = ModuleSystem::with_stdlib_root(tmp.path().join("stdlib"));
-
-    let errors = ms
-        .load_module_graph(&main_path, &mut files)
-        .expect_err("allocator stdlib imports should be gated before graph loading sketches");
-    let messages = errors
-        .iter()
-        .map(ToString::to_string)
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    assert!(
-        messages.contains("std allocator modules are gated"),
-        "expected allocator stdlib gate diagnostic, got {messages}"
-    );
-    assert!(
-        !messages.contains("expected") && !messages.contains("unexpected token"),
-        "allocator stdlib gate should not leak parser diagnostics from sketches, got {messages}"
+    assert_graph_stdlib_import_is_gated_before_loading_sketch(
+        "memory",
+        "allocator.zen",
+        "{ Allocator } = @std.memory.allocator",
+        "std allocator modules are gated",
+        "allocator",
     );
 }
 
 #[test]
 fn module_graph_gates_stdlib_async_runtime_import_before_loading_sketch() {
-    let tmp = setup_temp_dir();
-    let async_dir = tmp.path().join("stdlib/concurrency/async");
-    fs::create_dir_all(&async_dir).unwrap();
-    fs::write(async_dir.join("scheduler.zen"), "this is not valid zen\n").unwrap();
-
-    let main_path = tmp.path().join("main.zen");
-    fs::write(
-        &main_path,
-        "{ Scheduler } = @std.concurrency.async.scheduler\n\nmain = () i32 { 0 }\n",
-    )
-    .unwrap();
-
-    let mut files = FileTable::new();
-    let mut ms = ModuleSystem::with_stdlib_root(tmp.path().join("stdlib"));
-
-    let errors = ms
-        .load_module_graph(&main_path, &mut files)
-        .expect_err("async stdlib imports should be gated before graph loading sketches");
-    let messages = errors
-        .iter()
-        .map(ToString::to_string)
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    assert!(
-        messages.contains("std async runtime modules are gated"),
-        "expected async stdlib gate diagnostic, got {messages}"
+    assert_graph_stdlib_import_is_gated_before_loading_sketch(
+        "concurrency/async",
+        "scheduler.zen",
+        "{ Scheduler } = @std.concurrency.async.scheduler",
+        "std async runtime modules are gated",
+        "async",
     );
-    assert!(
-        !messages.contains("expected") && !messages.contains("unexpected token"),
-        "async stdlib gate should not leak parser diagnostics from sketches, got {messages}"
+}
+
+#[test]
+fn module_graph_gates_stdlib_sync_runtime_import_before_loading_sketch() {
+    assert_graph_stdlib_import_is_gated_before_loading_sketch(
+        "concurrency/sync",
+        "channel.zen",
+        "{ Channel } = @std.concurrency.sync.channel",
+        "std sync runtime modules are gated",
+        "sync",
     );
 }
 

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -47,6 +47,8 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "async_scheduler_intrinsics_are_rejected_as_gated_not_unknown",
         "stdlib_async_runtime_import_is_gated_before_loading_sketch",
         "module_graph_gates_stdlib_async_runtime_import_before_loading_sketch",
+        "stdlib_sync_runtime_import_is_gated_before_loading_sketch",
+        "module_graph_gates_stdlib_sync_runtime_import_before_loading_sketch",
         "async task enqueue",
         "async yield",
         "atomic_intrinsics_are_rejected_as_effect_gates",


### PR DESCRIPTION
## Summary
- Extend the stdlib module gate to reject `@std.concurrency.sync.*` imports before loading aspirational sync/channel sketches.
- Cover both legacy import merging and module graph loading so parser diagnostics do not leak from channel prototype files.
- Refactor repeated stdlib gate tests through shared helpers and record sync runtime import evidence in V1 spec and audit docs.

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch sync-std-gate-and-test-helper --event push --json databaseId,status,conclusion,name,headSha --limit 20` returned `[]`.