### PR TITLE
Gate hand-authored JSON IR inputs

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -4085,6 +4085,9 @@ and do not assume Phase 4 is ready without evidence.
   schema/golden-test gate before emitting HIR or MIR JSON. Covered by
   `emit_json_hir_rejects_program_before_hir_json` and
   `emit_json_mir_rejects_program_before_mir_json`.
+- Hand-authored JSON IR inputs to `emit-json mir` reject at the compiler-owned
+  schema boundary before any forged type or layout override can be accepted.
+  Covered by `emit_json_mir_rejects_hand_authored_json_before_ir_override`.
 - Hand-authored target YAML remains outside the compiler-owned IR path:
   `emit-json target-yaml` rejects a real `.yaml` file at the schema-validation
   gate before emitting any JSON. Covered by

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3764,6 +3764,10 @@ checked-in docs, tests, and commits only.
   schema/golden-test gate before emitting HIR or MIR JSON. Guarded by
   `emit_json_hir_rejects_program_before_hir_json` and
   `emit_json_mir_rejects_program_before_mir_json`.
+- Hand-authored JSON IR inputs to `emit-json mir` now reject at the
+  compiler-owned schema boundary before any forged type or layout override can
+  be accepted. Guarded by
+  `emit_json_mir_rejects_hand_authored_json_before_ir_override`.
 - Hand-authored target YAML remains outside the compiler-owned IR path:
   `emit-json target-yaml` now has explicit coverage that a real `.yaml` file is
   rejected at the schema-validation gate before emitting any JSON. Guarded by

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -161,7 +161,11 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   `zen emit-json hir <file>` and `zen emit-json mir <file>` are rejected before
   HIR/MIR JSON emission, covered by
   `emit_json_hir_rejects_program_before_hir_json` and
-  `emit_json_mir_rejects_program_before_mir_json`. `zen emit-json layout <file>`
+  `emit_json_mir_rejects_program_before_mir_json`. Hand-authored JSON IR inputs
+  to `zen emit-json mir <file>` are also rejected at the compiler-owned schema
+  boundary before any type or layout override can be accepted, covered by
+  `emit_json_mir_rejects_hand_authored_json_before_ir_override`.
+  `zen emit-json layout <file>`
   is an explicit gated command and rejects until ABI layout tests exist; real
   program inputs are rejected before layout JSON emission, covered by
   `emit_json_layout_rejects_program_before_layout_json`. AST JSON is explicitly

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -96,7 +96,9 @@ impl EmitJsonMode {
     fn gate_message(self) -> Option<&'static str> {
         match self {
             Self::Hir => Some("HIR JSON emission is gated until schema and golden tests exist"),
-            Self::Mir => Some("MIR JSON emission is gated until schema and golden tests exist"),
+            Self::Mir => Some(
+                "MIR JSON emission is gated until schema and golden tests exist; compiler-owned IR schemas must reject hand-authored overrides",
+            ),
             Self::Layout => Some("type layout JSON emission is gated until ABI layout tests exist"),
             Self::TargetYaml => Some(
                 "target YAML validation is gated until schemas and negative validation tests exist",

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -108,6 +108,7 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "semantic acceptance must use typed",
         "emit_json_hir_rejects_program_before_hir_json",
         "emit_json_mir_rejects_program_before_mir_json",
+        "emit_json_mir_rejects_hand_authored_json_before_ir_override",
         "emit_json_layout_rejects_program_before_layout_json",
         "emit_json_target_yaml_rejects_hand_authored_yaml_before_validation",
         "build.zen",

--- a/tests/integration/cli_build/frontend_json.rs
+++ b/tests/integration/cli_build/frontend_json.rs
@@ -214,6 +214,54 @@ main = () i32 {
 }
 
 #[test]
+fn emit_json_mir_rejects_hand_authored_json_before_ir_override() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let json_path = tmp.path().join("forged_mir.json");
+    std::fs::write(
+        &json_path,
+        r#"
+{
+  "format": "zen.mir.v0",
+  "semantic_status": "checked",
+  "program": {
+    "types": {
+      "i32": { "layout": "forged-i64" }
+    }
+  }
+}
+"#,
+    )
+    .expect("write forged MIR JSON");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "mir", json_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json mir on hand-authored JSON input");
+
+    assert!(
+        !output.status.success(),
+        "zen emit-json mir should gate hand-authored IR before override: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.trim().is_empty(),
+        "gated MIR should not emit or accept hand-authored JSON IR, stdout={stdout}"
+    );
+    assert!(
+        stderr.contains("compiler-owned IR schemas"),
+        "MIR gate should name the compiler-owned IR schema boundary, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("unknown command") && !stderr.contains("No such file"),
+        "MIR should reject through the IR-boundary gate, not command/path handling, stderr={stderr}"
+    );
+}
+
+#[test]
 fn emit_json_hir_command_is_explicitly_gated() {
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
         .args([


### PR DESCRIPTION
## Summary
- Add an integration test proving hand-authored MIR JSON is rejected at the compiler-owned IR schema boundary before forged type/layout overrides can be accepted.
- Keep the emit-json MIR gate text owned by `EmitJsonMode` while making the compiler-owned IR boundary explicit.
- Record the new JSON IR boundary evidence in V1 spec and audit docs.

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch gate-hand-authored-json-ir --event push --json databaseId,status,conclusion,name,headSha --limit 20` returned `[]`.