### PR TITLE
Gate hand-authored layout JSON IR inputs

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3898,6 +3898,10 @@ and do not assume Phase 4 is ready without evidence.
 - Real program inputs to `emit-json layout` now reject at the ABI-layout gate
   before emitting type layout JSON. Covered by
   `emit_json_layout_rejects_program_before_layout_json`.
+- Hand-authored layout JSON inputs to `emit-json layout` reject at the
+  compiler-owned layout schema boundary before any forged ABI override can be
+  accepted. Covered by
+  `emit_json_layout_rejects_hand_authored_json_before_layout_override`.
 - Static string literals no longer implicitly satisfy allocator-backed
   `String`; `String` is recognized as a builtin dynamic text type, but
   allocation must remain explicit. Covered by

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3574,6 +3574,10 @@ checked-in docs, tests, and commits only.
 - Real program inputs to `emit-json layout` now reject at the ABI-layout gate
   before emitting type layout JSON. Guarded by
   `emit_json_layout_rejects_program_before_layout_json`.
+- Hand-authored layout JSON inputs to `emit-json layout` now reject at the
+  compiler-owned layout schema boundary before any forged ABI override can be
+  accepted. Guarded by
+  `emit_json_layout_rejects_hand_authored_json_before_layout_override`.
 - `StaticString` and allocator-backed `String` are no longer type-compatible:
   static string literals stay baked into program storage and cannot implicitly
   allocate dynamic `String` values. Covered by

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -168,7 +168,11 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   `zen emit-json layout <file>`
   is an explicit gated command and rejects until ABI layout tests exist; real
   program inputs are rejected before layout JSON emission, covered by
-  `emit_json_layout_rejects_program_before_layout_json`. AST JSON is explicitly
+  `emit_json_layout_rejects_program_before_layout_json`. Hand-authored layout
+  JSON inputs are rejected at the compiler-owned layout schema boundary before
+  any ABI override can be accepted, covered by
+  `emit_json_layout_rejects_hand_authored_json_before_layout_override`.
+  AST JSON is explicitly
   marked unchecked; symbols JSON is explicitly marked resolved;
   typed JSON is explicitly marked checked; diagnostics JSON is explicitly
   marked diagnostic. semantic acceptance must use typed JSON, diagnostics,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -99,7 +99,9 @@ impl EmitJsonMode {
             Self::Mir => Some(
                 "MIR JSON emission is gated until schema and golden tests exist; compiler-owned IR schemas must reject hand-authored overrides",
             ),
-            Self::Layout => Some("type layout JSON emission is gated until ABI layout tests exist"),
+            Self::Layout => Some(
+                "type layout JSON emission is gated until ABI layout tests exist; compiler-owned layout schemas must reject hand-authored overrides",
+            ),
             Self::TargetYaml => Some(
                 "target YAML validation is gated until schemas and negative validation tests exist",
             ),

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -110,6 +110,7 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "emit_json_mir_rejects_program_before_mir_json",
         "emit_json_mir_rejects_hand_authored_json_before_ir_override",
         "emit_json_layout_rejects_program_before_layout_json",
+        "emit_json_layout_rejects_hand_authored_json_before_layout_override",
         "emit_json_target_yaml_rejects_hand_authored_yaml_before_validation",
         "build.zen",
         "zen test build.zen",

--- a/tests/integration/cli_build/frontend_json.rs
+++ b/tests/integration/cli_build/frontend_json.rs
@@ -1,6 +1,8 @@
 use crate::support::*;
 use std::process::Command;
 
+#[path = "frontend_json/ir_boundaries.rs"]
+mod ir_boundaries;
 #[path = "frontend_json/module_graph.rs"]
 mod module_graph;
 

--- a/tests/integration/cli_build/frontend_json/ir_boundaries.rs
+++ b/tests/integration/cli_build/frontend_json/ir_boundaries.rs
@@ -1,0 +1,50 @@
+use std::process::Command;
+
+#[test]
+fn emit_json_layout_rejects_hand_authored_json_before_layout_override() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let json_path = tmp.path().join("forged_layout.json");
+    std::fs::write(
+        &json_path,
+        r#"
+{
+  "format": "zen.layout.v0",
+  "semantic_status": "checked",
+  "layouts": {
+    "StaticString": {
+      "size": 1,
+      "alignment": 1
+    }
+  }
+}
+"#,
+    )
+    .expect("write forged layout JSON");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "layout", json_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json layout on hand-authored JSON input");
+
+    assert!(
+        !output.status.success(),
+        "zen emit-json layout should gate hand-authored layout IR before override: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.trim().is_empty(),
+        "gated layout should not emit or accept hand-authored layout JSON, stdout={stdout}"
+    );
+    assert!(
+        stderr.contains("compiler-owned layout schemas"),
+        "layout gate should name the compiler-owned layout schema boundary, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("unknown command") && !stderr.contains("No such file"),
+        "layout should reject through the IR-boundary gate, not command/path handling, stderr={stderr}"
+    );
+}


### PR DESCRIPTION
## Summary
- Add an integration test proving hand-authored layout JSON is rejected at the compiler-owned layout schema boundary before forged ABI overrides can be accepted.
- Keep the layout emit-json gate text owned by `EmitJsonMode` while making the compiler-owned layout boundary explicit.
- Record the new layout JSON IR boundary evidence in V1 spec and audit docs.

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch gate-hand-authored-layout-json-ir --event push --json databaseId,status,conclusion,name,headSha --limit 20` returned `[]`.