### PR TITLE
Gate hand-authored HIR JSON IR inputs

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -4092,6 +4092,9 @@ and do not assume Phase 4 is ready without evidence.
 - Hand-authored JSON IR inputs to `emit-json mir` reject at the compiler-owned
   schema boundary before any forged type or layout override can be accepted.
   Covered by `emit_json_mir_rejects_hand_authored_json_before_ir_override`.
+- Hand-authored JSON IR inputs to `emit-json hir` reject at the same
+  compiler-owned schema boundary before forged typed HIR can be accepted.
+  Covered by `emit_json_hir_rejects_hand_authored_json_before_ir_override`.
 - Hand-authored target YAML remains outside the compiler-owned IR path:
   `emit-json target-yaml` rejects a real `.yaml` file at the schema-validation
   gate before emitting any JSON. Covered by

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3772,6 +3772,9 @@ checked-in docs, tests, and commits only.
   compiler-owned schema boundary before any forged type or layout override can
   be accepted. Guarded by
   `emit_json_mir_rejects_hand_authored_json_before_ir_override`.
+- Hand-authored JSON IR inputs to `emit-json hir` now reject at the same
+  compiler-owned schema boundary before forged typed HIR can be accepted.
+  Guarded by `emit_json_hir_rejects_hand_authored_json_before_ir_override`.
 - Hand-authored target YAML remains outside the compiler-owned IR path:
   `emit-json target-yaml` now has explicit coverage that a real `.yaml` file is
   rejected at the schema-validation gate before emitting any JSON. Guarded by

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -162,8 +162,10 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   HIR/MIR JSON emission, covered by
   `emit_json_hir_rejects_program_before_hir_json` and
   `emit_json_mir_rejects_program_before_mir_json`. Hand-authored JSON IR inputs
-  to `zen emit-json mir <file>` are also rejected at the compiler-owned schema
+  to `zen emit-json hir <file>` and `zen emit-json mir <file>` are also
+  rejected at the compiler-owned schema
   boundary before any type or layout override can be accepted, covered by
+  `emit_json_hir_rejects_hand_authored_json_before_ir_override` and
   `emit_json_mir_rejects_hand_authored_json_before_ir_override`.
   `zen emit-json layout <file>`
   is an explicit gated command and rejects until ABI layout tests exist; real

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -95,7 +95,9 @@ impl EmitJsonMode {
 
     fn gate_message(self) -> Option<&'static str> {
         match self {
-            Self::Hir => Some("HIR JSON emission is gated until schema and golden tests exist"),
+            Self::Hir => Some(
+                "HIR JSON emission is gated until schema and golden tests exist; compiler-owned IR schemas must reject hand-authored overrides",
+            ),
             Self::Mir => Some(
                 "MIR JSON emission is gated until schema and golden tests exist; compiler-owned IR schemas must reject hand-authored overrides",
             ),

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -107,6 +107,7 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "zen emit-json diagnostics <file>",
         "semantic acceptance must use typed",
         "emit_json_hir_rejects_program_before_hir_json",
+        "emit_json_hir_rejects_hand_authored_json_before_ir_override",
         "emit_json_mir_rejects_program_before_mir_json",
         "emit_json_mir_rejects_hand_authored_json_before_ir_override",
         "emit_json_layout_rejects_program_before_layout_json",

--- a/tests/integration/cli_build/frontend_json/ir_boundaries.rs
+++ b/tests/integration/cli_build/frontend_json/ir_boundaries.rs
@@ -1,6 +1,56 @@
 use std::process::Command;
 
 #[test]
+fn emit_json_hir_rejects_hand_authored_json_before_ir_override() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let json_path = tmp.path().join("forged_hir.json");
+    std::fs::write(
+        &json_path,
+        r#"
+{
+  "format": "zen.hir.v0",
+  "semantic_status": "checked",
+  "program": {
+    "types": {
+      "Forged": {
+        "fields": [{ "name": "ptr", "type": "RawPtr<i32>" }]
+      }
+    }
+  }
+}
+"#,
+    )
+    .expect("write forged HIR JSON");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "hir", json_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json hir on hand-authored JSON input");
+
+    assert!(
+        !output.status.success(),
+        "zen emit-json hir should gate hand-authored HIR before override: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.trim().is_empty(),
+        "gated HIR should not emit or accept hand-authored HIR JSON, stdout={stdout}"
+    );
+    assert!(
+        stderr.contains("compiler-owned IR schemas"),
+        "HIR gate should name the compiler-owned IR schema boundary, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("unknown command") && !stderr.contains("No such file"),
+        "HIR should reject through the IR-boundary gate, not command/path handling, stderr={stderr}"
+    );
+}
+
+#[test]
 fn emit_json_layout_rejects_hand_authored_json_before_layout_override() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let json_path = tmp.path().join("forged_layout.json");


### PR DESCRIPTION
## Summary
- Add an integration test proving hand-authored HIR JSON is rejected at the compiler-owned IR schema boundary before forged typed HIR can be accepted.
- Keep the HIR emit-json gate text owned by `EmitJsonMode` while making the compiler-owned IR boundary explicit.
- Record the new HIR JSON IR boundary evidence in V1 spec and audit docs.

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch gate-hand-authored-hir-json-ir --event push --json databaseId,status,conclusion,name,headSha --limit 20` returned `[]`.