### PR TITLE
Reject hand-authored typed JSON inputs

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -4089,6 +4089,10 @@ and do not assume Phase 4 is ready without evidence.
   schema/golden-test gate before emitting HIR or MIR JSON. Covered by
   `emit_json_hir_rejects_program_before_hir_json` and
   `emit_json_mir_rejects_program_before_mir_json`.
+- Hand-authored typed JSON inputs to `emit-json typed` reject at the
+  compiler-owned typed JSON boundary before forged checked IR can be treated as
+  Zen source or accepted as semantic evidence. Covered by
+  `emit_json_typed_rejects_hand_authored_json_before_checked_ir_override`.
 - Hand-authored JSON IR inputs to `emit-json mir` reject at the compiler-owned
   schema boundary before any forged type or layout override can be accepted.
   Covered by `emit_json_mir_rejects_hand_authored_json_before_ir_override`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3768,6 +3768,10 @@ checked-in docs, tests, and commits only.
   schema/golden-test gate before emitting HIR or MIR JSON. Guarded by
   `emit_json_hir_rejects_program_before_hir_json` and
   `emit_json_mir_rejects_program_before_mir_json`.
+- Hand-authored typed JSON inputs to `emit-json typed` now reject at the
+  compiler-owned typed JSON boundary before forged checked IR can be treated as
+  Zen source or accepted as semantic evidence. Guarded by
+  `emit_json_typed_rejects_hand_authored_json_before_checked_ir_override`.
 - Hand-authored JSON IR inputs to `emit-json mir` now reject at the
   compiler-owned schema boundary before any forged type or layout override can
   be accepted. Guarded by

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -157,7 +157,10 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   symbol table emission, checked typed program emission, and machine-readable
   diagnostics emission through `zen emit-json ast <file>`,
   `zen emit-json symbols <file>`, `zen emit-json typed <file>`, and
-  `zen emit-json diagnostics <file>`. Real program inputs to
+  `zen emit-json diagnostics <file>`. Hand-authored typed JSON inputs are
+  rejected before the frontend treats them as Zen source, covered by
+  `emit_json_typed_rejects_hand_authored_json_before_checked_ir_override`.
+  Real program inputs to
   `zen emit-json hir <file>` and `zen emit-json mir <file>` are rejected before
   HIR/MIR JSON emission, covered by
   `emit_json_hir_rejects_program_before_hir_json` and

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -237,3 +237,16 @@ fn reject_build_zen_for_emit_json_mode(path_str: &str) {
         process::exit(1);
     }
 }
+
+fn reject_hand_authored_json_for_typed_emit(path_str: &str) {
+    let is_json = Path::new(path_str)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("json"));
+    if is_json {
+        eprintln!(
+            "error: compiler-owned typed JSON emission rejects hand-authored JSON IR before it can override checked types or layouts"
+        );
+        process::exit(1);
+    }
+}

--- a/src/cli/json_emit.rs
+++ b/src/cli/json_emit.rs
@@ -31,6 +31,7 @@ pub(super) fn cmd_emit_json_symbols(path_str: &str) {
 
 pub(super) fn cmd_emit_json_typed(path_str: &str) {
     super::reject_build_zen_for_emit_json_mode(path_str);
+    super::reject_hand_authored_json_for_typed_emit(path_str);
     let typed = super::graph_frontend(path_str);
     match zen::ir_json::typed_program_to_json(&typed) {
         Ok(json) => println!("{json}"),

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -106,6 +106,7 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "zen emit-json typed <file>",
         "zen emit-json diagnostics <file>",
         "semantic acceptance must use typed",
+        "emit_json_typed_rejects_hand_authored_json_before_checked_ir_override",
         "emit_json_hir_rejects_program_before_hir_json",
         "emit_json_hir_rejects_hand_authored_json_before_ir_override",
         "emit_json_mir_rejects_program_before_mir_json",

--- a/tests/integration/cli_build/frontend_json/ir_boundaries.rs
+++ b/tests/integration/cli_build/frontend_json/ir_boundaries.rs
@@ -1,6 +1,53 @@
 use std::process::Command;
 
 #[test]
+fn emit_json_typed_rejects_hand_authored_json_before_checked_ir_override() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let json_path = tmp.path().join("forged_typed.json");
+    std::fs::write(
+        &json_path,
+        r#"
+{
+  "format": "zen.typed.v0",
+  "semantic_status": "checked",
+  "program": {
+    "types": [{ "name": "i32", "kind": "forged-pointer" }],
+    "functions": [{ "name": "main", "return_type": "i32" }]
+  }
+}
+"#,
+    )
+    .expect("write forged typed JSON");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "typed", json_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json typed on hand-authored JSON input");
+
+    assert!(
+        !output.status.success(),
+        "zen emit-json typed should reject hand-authored checked IR before override: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.trim().is_empty(),
+        "typed JSON should not emit or accept hand-authored checked IR, stdout={stdout}"
+    );
+    assert!(
+        stderr.contains("compiler-owned typed JSON"),
+        "typed gate should name the compiler-owned typed JSON boundary, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("expected function name") && !stderr.contains("unexpected token"),
+        "typed JSON should reject before treating JSON as Zen source, stderr={stderr}"
+    );
+}
+
+#[test]
 fn emit_json_hir_rejects_hand_authored_json_before_ir_override() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let json_path = tmp.path().join("forged_hir.json");


### PR DESCRIPTION
## Summary
- Add an integration test proving `emit-json typed` rejects hand-authored checked JSON before it can be treated as Zen source or accepted as semantic evidence.
- Add an explicit compiler-owned typed JSON boundary guard for `.json` typed inputs.
- Record the new typed JSON IR boundary evidence in V1 spec and audit docs.

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch reject-hand-authored-typed-json --event push --json databaseId,status,conclusion,name,headSha --limit 20` returned `[]`.