### PR TITLE
Reject hand-authored symbols JSON inputs

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -4093,6 +4093,10 @@ and do not assume Phase 4 is ready without evidence.
   compiler-owned typed JSON boundary before forged checked IR can be treated as
   Zen source or accepted as semantic evidence. Covered by
   `emit_json_typed_rejects_hand_authored_json_before_checked_ir_override`.
+- Hand-authored symbols JSON inputs to `emit-json symbols` reject at the
+  compiler-owned symbols JSON boundary before forged resolver metadata can be
+  treated as Zen source or accepted as symbol evidence. Covered by
+  `emit_json_symbols_rejects_hand_authored_json_before_resolver_override`.
 - Hand-authored JSON IR inputs to `emit-json mir` reject at the compiler-owned
   schema boundary before any forged type or layout override can be accepted.
   Covered by `emit_json_mir_rejects_hand_authored_json_before_ir_override`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3772,6 +3772,10 @@ checked-in docs, tests, and commits only.
   compiler-owned typed JSON boundary before forged checked IR can be treated as
   Zen source or accepted as semantic evidence. Guarded by
   `emit_json_typed_rejects_hand_authored_json_before_checked_ir_override`.
+- Hand-authored symbols JSON inputs to `emit-json symbols` now reject at the
+  compiler-owned symbols JSON boundary before forged resolver metadata can be
+  treated as Zen source or accepted as symbol evidence. Guarded by
+  `emit_json_symbols_rejects_hand_authored_json_before_resolver_override`.
 - Hand-authored JSON IR inputs to `emit-json mir` now reject at the
   compiler-owned schema boundary before any forged type or layout override can
   be accepted. Guarded by

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -157,8 +157,9 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   symbol table emission, checked typed program emission, and machine-readable
   diagnostics emission through `zen emit-json ast <file>`,
   `zen emit-json symbols <file>`, `zen emit-json typed <file>`, and
-  `zen emit-json diagnostics <file>`. Hand-authored typed JSON inputs are
-  rejected before the frontend treats them as Zen source, covered by
+  `zen emit-json diagnostics <file>`. Hand-authored symbols and typed JSON
+  inputs are rejected before the frontend treats them as Zen source, covered by
+  `emit_json_symbols_rejects_hand_authored_json_before_resolver_override` and
   `emit_json_typed_rejects_hand_authored_json_before_checked_ir_override`.
   Real program inputs to
   `zen emit-json hir <file>` and `zen emit-json mir <file>` are rejected before

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -239,14 +239,26 @@ fn reject_build_zen_for_emit_json_mode(path_str: &str) {
 }
 
 fn reject_hand_authored_json_for_typed_emit(path_str: &str) {
-    let is_json = Path::new(path_str)
-        .extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| extension.eq_ignore_ascii_case("json"));
-    if is_json {
+    if has_json_extension(path_str) {
         eprintln!(
             "error: compiler-owned typed JSON emission rejects hand-authored JSON IR before it can override checked types or layouts"
         );
         process::exit(1);
     }
+}
+
+fn reject_hand_authored_json_for_symbols_emit(path_str: &str) {
+    if has_json_extension(path_str) {
+        eprintln!(
+            "error: compiler-owned symbols JSON emission rejects hand-authored resolver IR before it can override symbol metadata"
+        );
+        process::exit(1);
+    }
+}
+
+fn has_json_extension(path_str: &str) -> bool {
+    Path::new(path_str)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("json"))
 }

--- a/src/cli/json_emit.rs
+++ b/src/cli/json_emit.rs
@@ -19,6 +19,7 @@ pub(super) fn cmd_emit_json_ast(path_str: &str) {
 
 pub(super) fn cmd_emit_json_symbols(path_str: &str) {
     super::reject_build_zen_for_emit_json_mode(path_str);
+    super::reject_hand_authored_json_for_symbols_emit(path_str);
     let (graph, _files) = super::load_module_graph(path_str);
     match zen::ir_json::symbols_graph_to_json(&graph) {
         Ok(json) => println!("{json}"),

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -106,6 +106,7 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "zen emit-json typed <file>",
         "zen emit-json diagnostics <file>",
         "semantic acceptance must use typed",
+        "emit_json_symbols_rejects_hand_authored_json_before_resolver_override",
         "emit_json_typed_rejects_hand_authored_json_before_checked_ir_override",
         "emit_json_hir_rejects_program_before_hir_json",
         "emit_json_hir_rejects_hand_authored_json_before_ir_override",

--- a/tests/integration/cli_build/frontend_json/ir_boundaries.rs
+++ b/tests/integration/cli_build/frontend_json/ir_boundaries.rs
@@ -1,6 +1,53 @@
 use std::process::Command;
 
 #[test]
+fn emit_json_symbols_rejects_hand_authored_json_before_resolver_override() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let json_path = tmp.path().join("forged_symbols.json");
+    std::fs::write(
+        &json_path,
+        r#"
+{
+  "format": "zen.symbols.v0",
+  "semantic_status": "resolved",
+  "modules": [{
+    "name": "main",
+    "symbols": [{ "name": "Forged", "kind": "type", "visibility": "public" }]
+  }]
+}
+"#,
+    )
+    .expect("write forged symbols JSON");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "symbols", json_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json symbols on hand-authored JSON input");
+
+    assert!(
+        !output.status.success(),
+        "zen emit-json symbols should reject hand-authored symbol IR before override: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.trim().is_empty(),
+        "symbols JSON should not emit or accept hand-authored resolver IR, stdout={stdout}"
+    );
+    assert!(
+        stderr.contains("compiler-owned symbols JSON"),
+        "symbols gate should name the compiler-owned symbols JSON boundary, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("expected identifier") && !stderr.contains("unexpected token"),
+        "symbols JSON should reject before treating JSON as Zen source, stderr={stderr}"
+    );
+}
+
+#[test]
 fn emit_json_typed_rejects_hand_authored_json_before_checked_ir_override() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let json_path = tmp.path().join("forged_typed.json");


### PR DESCRIPTION
## Summary
- Add an integration test proving `emit-json symbols` rejects hand-authored resolver JSON before it can be treated as Zen source or accepted as symbol evidence.
- Add an explicit compiler-owned symbols JSON boundary guard for `.json` symbols inputs.
- Record the new symbols JSON IR boundary evidence in V1 spec and audit docs.

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch reject-hand-authored-symbols-json --event push --json databaseId,status,conclusion,name,headSha --limit 20` returned `[]`.