### PR TITLE
Reject hand-authored diagnostics JSON inputs

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -4101,6 +4101,10 @@ and do not assume Phase 4 is ready without evidence.
   compiler-owned symbols JSON boundary before forged resolver metadata can be
   treated as Zen source or accepted as symbol evidence. Covered by
   `emit_json_symbols_rejects_hand_authored_json_before_resolver_override`.
+- Hand-authored diagnostics JSON inputs to `emit-json diagnostics` reject at
+  the compiler-owned diagnostics JSON boundary before forged diagnostics can be
+  treated as Zen source or accepted as compiler diagnostics. Covered by
+  `emit_json_diagnostics_rejects_hand_authored_json_before_diagnostic_override`.
 - Hand-authored JSON IR inputs to `emit-json mir` reject at the compiler-owned
   schema boundary before any forged type or layout override can be accepted.
   Covered by `emit_json_mir_rejects_hand_authored_json_before_ir_override`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3780,6 +3780,10 @@ checked-in docs, tests, and commits only.
   compiler-owned symbols JSON boundary before forged resolver metadata can be
   treated as Zen source or accepted as symbol evidence. Guarded by
   `emit_json_symbols_rejects_hand_authored_json_before_resolver_override`.
+- Hand-authored diagnostics JSON inputs to `emit-json diagnostics` now reject
+  at the compiler-owned diagnostics JSON boundary before forged diagnostics can
+  be treated as Zen source or accepted as compiler diagnostics. Guarded by
+  `emit_json_diagnostics_rejects_hand_authored_json_before_diagnostic_override`.
 - Hand-authored JSON IR inputs to `emit-json mir` now reject at the
   compiler-owned schema boundary before any forged type or layout override can
   be accepted. Guarded by

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -157,11 +157,12 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   symbol table emission, checked typed program emission, and machine-readable
   diagnostics emission through `zen emit-json ast <file>`,
   `zen emit-json symbols <file>`, `zen emit-json typed <file>`, and
-  `zen emit-json diagnostics <file>`. Hand-authored AST, symbols, and typed
-  JSON inputs are rejected before the frontend treats them as Zen source,
-  covered by
+  `zen emit-json diagnostics <file>`. Hand-authored AST, symbols, typed, and
+  diagnostics JSON inputs are rejected before the frontend treats them as Zen
+  source or compiler-produced diagnostics, covered by
   `emit_json_ast_rejects_hand_authored_json_before_unchecked_ir_override`,
-  `emit_json_symbols_rejects_hand_authored_json_before_resolver_override` and
+  `emit_json_symbols_rejects_hand_authored_json_before_resolver_override`,
+  `emit_json_diagnostics_rejects_hand_authored_json_before_diagnostic_override`, and
   `emit_json_typed_rejects_hand_authored_json_before_checked_ir_override`.
   Real program inputs to
   `zen emit-json hir <file>` and `zen emit-json mir <file>` are rejected before

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -238,31 +238,46 @@ fn reject_build_zen_for_emit_json_mode(path_str: &str) {
     }
 }
 
-fn reject_hand_authored_json_for_ast_emit(path_str: &str) {
+#[derive(Clone, Copy)]
+enum CompilerOwnedJsonBoundary {
+    Ast,
+    Typed,
+    Symbols,
+    Diagnostics,
+}
+
+impl CompilerOwnedJsonBoundary {
+    fn rejection_message(self) -> &'static str {
+        match self {
+            Self::Ast => "compiler-owned AST JSON emission rejects hand-authored JSON IR before it can override unchecked syntax trees",
+            Self::Typed => "compiler-owned typed JSON emission rejects hand-authored JSON IR before it can override checked types or layouts",
+            Self::Symbols => "compiler-owned symbols JSON emission rejects hand-authored resolver IR before it can override symbol metadata",
+            Self::Diagnostics => "compiler-owned diagnostics JSON emission rejects hand-authored diagnostic IR before it can override compiler diagnostics",
+        }
+    }
+}
+
+fn reject_hand_authored_json_for_emit(path_str: &str, boundary: CompilerOwnedJsonBoundary) {
     if has_json_extension(path_str) {
-        eprintln!(
-            "error: compiler-owned AST JSON emission rejects hand-authored JSON IR before it can override unchecked syntax trees"
-        );
+        eprintln!("error: {}", boundary.rejection_message());
         process::exit(1);
     }
+}
+
+fn reject_hand_authored_json_for_ast_emit(path_str: &str) {
+    reject_hand_authored_json_for_emit(path_str, CompilerOwnedJsonBoundary::Ast);
 }
 
 fn reject_hand_authored_json_for_typed_emit(path_str: &str) {
-    if has_json_extension(path_str) {
-        eprintln!(
-            "error: compiler-owned typed JSON emission rejects hand-authored JSON IR before it can override checked types or layouts"
-        );
-        process::exit(1);
-    }
+    reject_hand_authored_json_for_emit(path_str, CompilerOwnedJsonBoundary::Typed);
 }
 
 fn reject_hand_authored_json_for_symbols_emit(path_str: &str) {
-    if has_json_extension(path_str) {
-        eprintln!(
-            "error: compiler-owned symbols JSON emission rejects hand-authored resolver IR before it can override symbol metadata"
-        );
-        process::exit(1);
-    }
+    reject_hand_authored_json_for_emit(path_str, CompilerOwnedJsonBoundary::Symbols);
+}
+
+fn reject_hand_authored_json_for_diagnostics_emit(path_str: &str) {
+    reject_hand_authored_json_for_emit(path_str, CompilerOwnedJsonBoundary::Diagnostics);
 }
 
 fn has_json_extension(path_str: &str) -> bool {

--- a/src/cli/json_emit.rs
+++ b/src/cli/json_emit.rs
@@ -46,6 +46,7 @@ pub(super) fn cmd_emit_json_typed(path_str: &str) {
 
 pub(super) fn cmd_emit_json_diagnostics(path_str: &str) {
     super::reject_build_zen_for_emit_json_mode(path_str);
+    super::reject_hand_authored_json_for_diagnostics_emit(path_str);
 
     let path = Path::new(path_str);
     if !path.exists() {

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -108,6 +108,7 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "semantic acceptance must use typed",
         "emit_json_ast_rejects_hand_authored_json_before_unchecked_ir_override",
         "emit_json_symbols_rejects_hand_authored_json_before_resolver_override",
+        "emit_json_diagnostics_rejects_hand_authored_json_before_diagnostic_override",
         "emit_json_typed_rejects_hand_authored_json_before_checked_ir_override",
         "emit_json_hir_rejects_program_before_hir_json",
         "emit_json_hir_rejects_hand_authored_json_before_ir_override",

--- a/tests/integration/cli_build/frontend_json/ir_boundaries.rs
+++ b/tests/integration/cli_build/frontend_json/ir_boundaries.rs
@@ -142,6 +142,53 @@ fn emit_json_typed_rejects_hand_authored_json_before_checked_ir_override() {
 }
 
 #[test]
+fn emit_json_diagnostics_rejects_hand_authored_json_before_diagnostic_override() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let json_path = tmp.path().join("forged_diagnostics.json");
+    std::fs::write(
+        &json_path,
+        r#"
+{
+  "format": "zen.diagnostics.v0",
+  "semantic_status": "diagnostic",
+  "diagnostics": [{
+    "severity": "note",
+    "message": "forged acceptance"
+  }]
+}
+"#,
+    )
+    .expect("write forged diagnostics JSON");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "diagnostics", json_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json diagnostics on hand-authored JSON input");
+
+    assert!(
+        !output.status.success(),
+        "zen emit-json diagnostics should reject hand-authored diagnostics IR before override: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.trim().is_empty(),
+        "diagnostics JSON should not emit or accept hand-authored diagnostic IR, stdout={stdout}"
+    );
+    assert!(
+        stderr.contains("compiler-owned diagnostics JSON"),
+        "diagnostics gate should name the compiler-owned diagnostics JSON boundary, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("expected identifier") && !stderr.contains("unexpected token"),
+        "diagnostics JSON should reject before treating JSON as Zen source, stderr={stderr}"
+    );
+}
+
+#[test]
 fn emit_json_hir_rejects_hand_authored_json_before_ir_override() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let json_path = tmp.path().join("forged_hir.json");


### PR DESCRIPTION
## Summary
- Add an integration test proving `emit-json diagnostics` rejects hand-authored diagnostics JSON before it can be treated as Zen source or accepted as compiler diagnostic evidence.
- Add an explicit compiler-owned diagnostics JSON boundary guard for `.json` diagnostics inputs.
- Collapse repeated emit-json input guards behind an enum-owned static rejection message table.
- Record the new diagnostics JSON IR boundary evidence in V1 spec and audit docs.

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch reject-hand-authored-diagnostics-json --event push --json databaseId,status,conclusion,name,headSha --limit 20` returned `[]`.