### PR TITLE
Reject hand-authored build graph JSON inputs

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -4105,6 +4105,10 @@ and do not assume Phase 4 is ready without evidence.
   the compiler-owned diagnostics JSON boundary before forged diagnostics can be
   treated as Zen source or accepted as compiler diagnostics. Covered by
   `emit_json_diagnostics_rejects_hand_authored_json_before_diagnostic_override`.
+- Hand-authored build graph JSON inputs to `emit-json build-graph` reject at
+  the compiler-owned build graph JSON boundary before generic `build.zen` path
+  validation can stand in for deterministic graph provenance. Covered by
+  `emit_json_build_graph_rejects_hand_authored_json_before_graph_override`.
 - Hand-authored JSON IR inputs to `emit-json mir` reject at the compiler-owned
   schema boundary before any forged type or layout override can be accepted.
   Covered by `emit_json_mir_rejects_hand_authored_json_before_ir_override`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3784,6 +3784,10 @@ checked-in docs, tests, and commits only.
   at the compiler-owned diagnostics JSON boundary before forged diagnostics can
   be treated as Zen source or accepted as compiler diagnostics. Guarded by
   `emit_json_diagnostics_rejects_hand_authored_json_before_diagnostic_override`.
+- Hand-authored build graph JSON inputs to `emit-json build-graph` now reject
+  at the compiler-owned build graph JSON boundary before generic `build.zen`
+  path validation can stand in for deterministic graph provenance. Guarded by
+  `emit_json_build_graph_rejects_hand_authored_json_before_graph_override`.
 - Hand-authored JSON IR inputs to `emit-json mir` now reject at the
   compiler-owned schema boundary before any forged type or layout override can
   be accepted. Guarded by

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -150,9 +150,10 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   `Channel` remains an experimental stdlib channel sketch until promoted, so it
   is not a global actor builtin type spelling.
 - `JSON/YAML IR boundaries`: gated. JSON is the machine-readable exchange format
-  for compiler-owned AST, typed HIR, MIR, symbol tables, type layouts, and
-  diagnostics. YAML is the human-authored format for target descriptions, ABI
-  rules, intrinsic tables, allocator templates, backend options, and build graphs.
+  for compiler-owned AST, typed HIR, MIR, symbol tables, type layouts,
+  diagnostics, and deterministic build graphs. YAML is the human-authored
+  format for target descriptions, ABI rules, intrinsic tables, allocator
+  templates, backend options, and build graphs.
   Current JSON evidence is limited to resolved AST graph emission, resolver
   symbol table emission, checked typed program emission, and machine-readable
   diagnostics emission through `zen emit-json ast <file>`,
@@ -164,6 +165,9 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   `emit_json_symbols_rejects_hand_authored_json_before_resolver_override`,
   `emit_json_diagnostics_rejects_hand_authored_json_before_diagnostic_override`, and
   `emit_json_typed_rejects_hand_authored_json_before_checked_ir_override`.
+  Hand-authored build graph JSON inputs are rejected before generic build.zen
+  path validation can stand in for the compiler-owned graph boundary, covered by
+  `emit_json_build_graph_rejects_hand_authored_json_before_graph_override`.
   Real program inputs to
   `zen emit-json hir <file>` and `zen emit-json mir <file>` are rejected before
   HIR/MIR JSON emission, covered by

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -244,6 +244,7 @@ enum CompilerOwnedJsonBoundary {
     Typed,
     Symbols,
     Diagnostics,
+    BuildGraph,
 }
 
 impl CompilerOwnedJsonBoundary {
@@ -253,6 +254,7 @@ impl CompilerOwnedJsonBoundary {
             Self::Typed => "compiler-owned typed JSON emission rejects hand-authored JSON IR before it can override checked types or layouts",
             Self::Symbols => "compiler-owned symbols JSON emission rejects hand-authored resolver IR before it can override symbol metadata",
             Self::Diagnostics => "compiler-owned diagnostics JSON emission rejects hand-authored diagnostic IR before it can override compiler diagnostics",
+            Self::BuildGraph => "compiler-owned build graph JSON emission rejects hand-authored graph IR before it can override deterministic build metadata",
         }
     }
 }
@@ -278,6 +280,10 @@ fn reject_hand_authored_json_for_symbols_emit(path_str: &str) {
 
 fn reject_hand_authored_json_for_diagnostics_emit(path_str: &str) {
     reject_hand_authored_json_for_emit(path_str, CompilerOwnedJsonBoundary::Diagnostics);
+}
+
+fn reject_hand_authored_json_for_build_graph_emit(path_str: &str) {
+    reject_hand_authored_json_for_emit(path_str, CompilerOwnedJsonBoundary::BuildGraph);
 }
 
 fn has_json_extension(path_str: &str) -> bool {

--- a/src/cli/json_emit.rs
+++ b/src/cli/json_emit.rs
@@ -89,6 +89,7 @@ pub(super) fn cmd_emit_json_diagnostics(path_str: &str) {
 }
 
 pub(super) fn cmd_emit_json_build_graph(path_str: &str) {
+    super::reject_hand_authored_json_for_build_graph_emit(path_str);
     let graph = super::load_build_graph(path_str);
     match graph.canonical_json() {
         Ok(json) => println!("{json}"),

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -110,6 +110,7 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "emit_json_symbols_rejects_hand_authored_json_before_resolver_override",
         "emit_json_diagnostics_rejects_hand_authored_json_before_diagnostic_override",
         "emit_json_typed_rejects_hand_authored_json_before_checked_ir_override",
+        "emit_json_build_graph_rejects_hand_authored_json_before_graph_override",
         "emit_json_hir_rejects_program_before_hir_json",
         "emit_json_hir_rejects_hand_authored_json_before_ir_override",
         "emit_json_mir_rejects_program_before_mir_json",

--- a/tests/integration/cli_build/frontend_json/ir_boundaries.rs
+++ b/tests/integration/cli_build/frontend_json/ir_boundaries.rs
@@ -189,6 +189,54 @@ fn emit_json_diagnostics_rejects_hand_authored_json_before_diagnostic_override()
 }
 
 #[test]
+fn emit_json_build_graph_rejects_hand_authored_json_before_graph_override() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let json_path = tmp.path().join("forged_build_graph.json");
+    std::fs::write(
+        &json_path,
+        r#"
+{
+  "format": "zen.build_graph.v0",
+  "semantic_status": "validated",
+  "targets": [{
+    "name": "forged",
+    "kind": "executable",
+    "sources": ["forged.zen"]
+  }]
+}
+"#,
+    )
+    .expect("write forged build graph JSON");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "build-graph", json_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json build-graph on hand-authored JSON input");
+
+    assert!(
+        !output.status.success(),
+        "zen emit-json build-graph should reject hand-authored build graph IR before override: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.trim().is_empty(),
+        "build graph JSON should not emit or accept hand-authored build graph IR, stdout={stdout}"
+    );
+    assert!(
+        stderr.contains("compiler-owned build graph JSON"),
+        "build graph gate should name the compiler-owned build graph JSON boundary, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("expects a build.zen file"),
+        "build graph JSON should reject before generic build.zen path validation, stderr={stderr}"
+    );
+}
+
+#[test]
 fn emit_json_hir_rejects_hand_authored_json_before_ir_override() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let json_path = tmp.path().join("forged_hir.json");


### PR DESCRIPTION
## Summary
- Add an integration test proving `emit-json build-graph` rejects hand-authored build graph JSON at the compiler-owned graph boundary.
- Route build graph JSON inputs through the shared enum-owned static rejection message table.
- Record the new build graph JSON boundary evidence in V1 spec and audit docs.

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch reject-hand-authored-build-graph-json --event push --json databaseId,status,conclusion,name,headSha --limit 20` returned `[]`.