### PR TITLE
Enum-own parser behavior keyword

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -4062,6 +4062,10 @@ and do not assume Phase 4 is ready without evidence.
 - Parser mutability markers now parse `mut` through `ParserMutabilityKeyword`
   and a shared parser helper for fields and parameters. Covered by
   `parser_mutability_keywords_use_owned_keyword_enum`.
+- Parser behavior declaration dispatch now parses `behavior` through
+  `ParserBehaviorKeyword` instead of raw declaration spelling checks. Covered by
+  `parser_behavior_declaration_keyword_uses_owned_keyword_enum` and parser
+  behavior declaration tests.
 - Gated `.raise()` and `.await()` method recognition now routes through
   `GatedMethod` enum-owned spellings, covered by
   `typechecker_gated_methods_use_owned_action_enum`,

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3739,6 +3739,10 @@ checked-in docs, tests, and commits only.
 - Parser mutability markers now parse `mut` through `ParserMutabilityKeyword`
   and a shared parser helper for fields and parameters. Guarded by
   `parser_mutability_keywords_use_owned_keyword_enum`.
+- Parser behavior declaration dispatch now parses `behavior` through
+  `ParserBehaviorKeyword` instead of raw declaration spelling checks. Guarded by
+  `parser_behavior_declaration_keyword_uses_owned_keyword_enum` and parser
+  behavior declaration tests.
 - Gated `.raise()` and `.await()` method recognition now dispatches through the
   `GatedMethod` enum-owned spellings rather than hand-rolled comparisons,
   preserving the focused Result propagation and Sync/Async effect gates. Guarded

--- a/src/parser/behavior_declarations.rs
+++ b/src/parser/behavior_declarations.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::ast::BehaviorMethod;
+use crate::parser::keywords::ParserBehaviorKeyword;
 
 type BehaviorMethodSignature = (Vec<Param>, Option<AstType>, Option<Expression>);
 
@@ -14,7 +15,7 @@ impl Parser {
         self.expect(&Token::Colon)?;
         self.skip_newlines();
         let (keyword, keyword_span) = self.expect_identifier()?;
-        if keyword != "behavior" {
+        if keyword.parse::<ParserBehaviorKeyword>() != Ok(ParserBehaviorKeyword::Behavior) {
             return Err(CompileError::Syntax(
                 format!("expected behavior declaration, found `{keyword}`"),
                 Some(keyword_span),

--- a/src/parser/declarations.rs
+++ b/src/parser/declarations.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::parser::keywords::ParserBehaviorKeyword;
 
 impl Parser {
     pub(super) fn consume_mutability_keyword(&mut self) -> bool {
@@ -39,7 +40,10 @@ impl Parser {
 
         match self.peek() {
             // Behavior: `Name: behavior { method: (Self) Return }`
-            Token::Colon if self.colon_is_followed_by_identifier("behavior") => {
+            Token::Colon
+                if self
+                    .colon_is_followed_by_identifier(ParserBehaviorKeyword::Behavior.as_str()) =>
+            {
                 self.parse_behavior_def(name, Vec::new(), public, name_span)
             }
 
@@ -101,7 +105,11 @@ impl Parser {
                     Token::Colon if self.is_struct_def() => {
                         self.parse_struct_def_with_params(name, type_params, public, name_span)
                     }
-                    Token::Colon if self.colon_is_followed_by_identifier("behavior") => {
+                    Token::Colon
+                        if self.colon_is_followed_by_identifier(
+                            ParserBehaviorKeyword::Behavior.as_str(),
+                        ) =>
+                    {
                         self.parse_behavior_def(name, type_params, public, name_span)
                     }
                     Token::Colon => {

--- a/src/parser/keywords.rs
+++ b/src/parser/keywords.rs
@@ -34,6 +34,11 @@ pub(super) enum ParserMutabilityKeyword {
     Mut,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ParserBehaviorKeyword {
+    Behavior,
+}
+
 impl ParserPrefixKeyword {
     const ALL: &[ParserPrefixKeyword] = &[
         ParserPrefixKeyword::True,
@@ -181,6 +186,30 @@ impl ParserMutabilityKeyword {
 }
 
 impl FromStr for ParserMutabilityKeyword {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|keyword| keyword.as_str() == value)
+            .ok_or(())
+    }
+}
+
+impl ParserBehaviorKeyword {
+    const ALL: &[ParserBehaviorKeyword] = &[ParserBehaviorKeyword::Behavior];
+
+    const BEHAVIOR: &'static str = "behavior";
+
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Behavior => Self::BEHAVIOR,
+        }
+    }
+}
+
+impl FromStr for ParserBehaviorKeyword {
     type Err = ();
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {

--- a/tests/docs_truth/repo_hygiene/parser_keywords.rs
+++ b/tests/docs_truth/repo_hygiene/parser_keywords.rs
@@ -152,3 +152,39 @@ fn parser_mutability_keywords_use_owned_keyword_enum() {
         );
     }
 }
+
+#[test]
+fn parser_behavior_declaration_keyword_uses_owned_keyword_enum() {
+    for path in [
+        "src/parser/declarations.rs",
+        "src/parser/behavior_declarations.rs",
+    ] {
+        let source = read(path);
+        for forbidden in [
+            r#"colon_is_followed_by_identifier("behavior")"#,
+            r#"keyword != "behavior""#,
+        ] {
+            assert!(
+                !source.contains(forbidden),
+                "{path} should parse behavior declarations through ParserBehaviorKeyword, not raw spelling checks: {forbidden}"
+            );
+        }
+    }
+
+    let keywords = read("src/parser/keywords.rs");
+    for required in [
+        "enum ParserBehaviorKeyword",
+        "const ALL: &[ParserBehaviorKeyword]",
+        "impl FromStr for ParserBehaviorKeyword",
+        ".find(|keyword| keyword.as_str() == value)",
+        "keyword.parse::<ParserBehaviorKeyword>()",
+        "ParserBehaviorKeyword::Behavior.as_str()",
+    ] {
+        assert!(
+            keywords.contains(required)
+                || read("src/parser/declarations.rs").contains(required)
+                || read("src/parser/behavior_declarations.rs").contains(required),
+            "parser behavior declaration spelling should live in ParserBehaviorKeyword: {required}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ParserBehaviorKeyword` so the parser owns the `behavior` declaration spelling through the same enum/static table pattern as other parser keywords.
- Route behavior declaration dispatch and validation through the owned keyword instead of raw string checks.
- Add docs-truth hygiene coverage and record the cleanup evidence in phase/audit docs.

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `gh run list --repo lantos1618/zenlang --branch enum-own-parser-behavior-keyword --event push --json databaseId,status,conclusion,name,headSha --limit 20` returned `[]`.