### PR TITLE
[codex] Gate generated behavior derive syntax

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -78,6 +78,12 @@ and do not assume Phase 4 is ready without evidence.
   `parser::tests::generic_type_association_keywords_are_explicitly_gated`,
   avoiding accidental partial promotion before the behavior solver can model
   generic target templates.
+- Generated/fallback behavior association remains gated deliberately. The
+  parser now reserves `Type.derive(Json)` through the enum-owned type
+  declaration suffix table and reports the generated association gate through
+  `parser::tests::generated_behavior_derive_association_is_explicitly_gated`,
+  keeping derive fallback syntax out of ordinary method parsing until fallback
+  resolution and ambiguity diagnostics exist.
 - Generic method specializations that call generic functions have executable
   and generated-C coverage in `tests/zen/generic_method_worklist.zen`, including
   call-resolution assertions for the reached generic function dependency.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -100,6 +100,11 @@ checked-in docs, tests, and commits only.
   `parser::tests::generic_type_association_keywords_are_explicitly_gated`,
   keeping the unsupported behavior-solver boundary separate from supported
   generic non-behavior `Type<T>.impl` blocks.
+- Generated/fallback behavior association syntax such as `Type.derive(Json)`
+  is now reserved and explicitly gated through the same enum-owned type
+  declaration suffix table, guarded by
+  `parser::tests::generated_behavior_derive_association_is_explicitly_gated`
+  and `parser_type_declaration_suffixes_use_owned_keyword_enum`.
 - Resolver symbol table data-model definitions now live in a focused core
   include, leaving symbol-table lookup and definition behavior in the parent
   implementation file.

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -260,6 +260,10 @@ planned positive test and one planned negative test before implementation.
 | Actors in std | Actor mailbox send/receive works with scheduler and allocator integration | Actor using async mailbox from sync-only context is rejected |
 | JSON/YAML IR boundaries | Checked MIR JSON and target YAML validate against schemas | Hand-authored JSON IR cannot override compiler-owned types or layouts |
 
+Generated/fallback behavior association syntax is reserved but not implemented:
+`Type.derive(Json)` currently reports an explicit parser gate, covered by
+`parser::tests::generated_behavior_derive_association_is_explicitly_gated`.
+
 ## Stdlib Gate
 
 Files under `stdlib/` are experimental unless a test proves they parse, typecheck,

--- a/src/ast/declarations.rs
+++ b/src/ast/declarations.rs
@@ -11,6 +11,7 @@ pub enum TypeDeclarationKeyword {
     Implements,
     Requires,
     Extends,
+    Derive,
 }
 
 impl TypeDeclarationKeyword {
@@ -19,11 +20,13 @@ impl TypeDeclarationKeyword {
         TypeDeclarationKeyword::Implements,
         TypeDeclarationKeyword::Requires,
         TypeDeclarationKeyword::Extends,
+        TypeDeclarationKeyword::Derive,
     ];
     pub const IMPL: &'static str = "impl";
     pub const IMPLEMENTS: &'static str = "implements";
     pub const REQUIRES: &'static str = "requires";
     pub const EXTENDS: &'static str = "extends";
+    pub const DERIVE: &'static str = "derive";
 
     pub const fn as_str(self) -> &'static str {
         match self {
@@ -31,6 +34,7 @@ impl TypeDeclarationKeyword {
             Self::Implements => Self::IMPLEMENTS,
             Self::Requires => Self::REQUIRES,
             Self::Extends => Self::EXTENDS,
+            Self::Derive => Self::DERIVE,
         }
     }
 }

--- a/src/parser/declarations.rs
+++ b/src/parser/declarations.rs
@@ -140,6 +140,9 @@ impl Parser {
                         TypeDeclarationKeyword::Extends => {
                             self.parse_behavior_extends(name, name_span)
                         }
+                        TypeDeclarationKeyword::Derive => {
+                            self.reject_gated_generated_behavior_derive(name_span)
+                        }
                     };
                 }
 
@@ -199,6 +202,14 @@ impl Parser {
                 "generic association target `Type<T>.{keyword}` is gated; use non-generic `{keyword}` associations or keep the generic behavior target deferred to docs/V1_SPEC.md"
             ),
             Some(self.peek_span()),
+        ))
+    }
+
+    fn reject_gated_generated_behavior_derive<T>(&self, span: Span) -> Result<T, CompileError> {
+        Err(CompileError::Syntax(
+            "generated behavior association `Type.derive(...)` is gated until derive fallback resolution and ambiguity diagnostics are implemented"
+                .to_string(),
+            Some(span),
         ))
     }
 

--- a/src/parser/tests/behaviors.rs
+++ b/src/parser/tests/behaviors.rs
@@ -7,6 +7,7 @@ fn type_declaration_keyword_owns_text_spelling() {
     assert_eq!(TypeDeclarationKeyword::Implements.as_str(), "implements");
     assert_eq!(TypeDeclarationKeyword::Requires.as_str(), "requires");
     assert_eq!(TypeDeclarationKeyword::Extends.as_str(), "extends");
+    assert_eq!(TypeDeclarationKeyword::Derive.as_str(), "derive");
     assert_eq!(
         "impl".parse::<TypeDeclarationKeyword>(),
         Ok(TypeDeclarationKeyword::Impl)
@@ -22,6 +23,10 @@ fn type_declaration_keyword_owns_text_spelling() {
     assert_eq!(
         "extends".parse::<TypeDeclarationKeyword>(),
         Ok(TypeDeclarationKeyword::Extends)
+    );
+    assert_eq!(
+        "derive".parse::<TypeDeclarationKeyword>(),
+        Ok(TypeDeclarationKeyword::Derive)
     );
     assert!("implement".parse::<TypeDeclarationKeyword>().is_err());
     assert_eq!(TypeDeclarationKeyword::Implements.to_string(), "implements");
@@ -165,6 +170,7 @@ fn generic_type_association_keywords_are_explicitly_gated() {
         ("implements", "Box<T>.implements(Json<T>) { }"),
         ("requires", "Box<T>.requires(Json<T>)"),
         ("extends", "Box<T>.extends(Json<T>)"),
+        ("derive", "Box<T>.derive(Json<T>)"),
     ] {
         let errors = parse_err(source);
         let message = errors
@@ -179,6 +185,20 @@ fn generic_type_association_keywords_are_explicitly_gated() {
             "expected explicit generic association gate for {keyword}, got {errors:?}"
         );
     }
+}
+
+#[test]
+fn generated_behavior_derive_association_is_explicitly_gated() {
+    let errors = parse_err("Point.derive(Json)");
+    let message = errors
+        .first()
+        .map(ToString::to_string)
+        .unwrap_or_else(|| "missing parser error".to_string());
+
+    assert!(
+        message.contains("generated behavior association `Type.derive(...)` is gated"),
+        "expected explicit generated behavior association gate, got {errors:?}"
+    );
 }
 
 #[test]

--- a/tests/docs_truth/repo_hygiene/parser_enums.rs
+++ b/tests/docs_truth/repo_hygiene/parser_enums.rs
@@ -10,6 +10,7 @@ fn parser_type_declaration_suffixes_use_owned_keyword_enum() {
         r#"method_name == "implements""#,
         r#"method_name == "requires""#,
         r#"method_name == "extends""#,
+        r#"method_name == "derive""#,
         r#"matches!(method_name.as_str(), "implements" | "requires" | "extends")"#,
     ] {
         assert!(


### PR DESCRIPTION
## Summary

Reserves generated/fallback behavior association syntax as an explicit parser gate.

## Details

- adds `derive` to `TypeDeclarationKeyword` so the spelling is enum-owned
- gates `Type.derive(...)` with a generated behavior association diagnostic instead of letting it fall through as an ordinary method declaration
- extends generic association target gating to cover `Type<T>.derive(...)`
- records the boundary in the phase plan, completion audit, and V1 spec backlog

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Push-event Actions were checked for this branch and returned no runs: `gh run list --branch generated-behavior-fallback-gate --event push --limit 10 --json ...` -> `[]`.