### PR TITLE
[codex] Table-drive emit-json mode parsing

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -4091,6 +4091,10 @@ and do not assume Phase 4 is ready without evidence.
   `cli_emit_json_modes_use_owned_mode_enum`,
   `emit_json_usage_lists_supported_and_gated_modes`, and
   `emit_json_layout_command_is_explicitly_gated`.
+- `zen emit-json` mode parsing now uses the same `EmitJsonMode` ordered table
+  as usage generation instead of a second parse-mode branch list, covered by
+  `cli_emit_json_modes_use_owned_mode_enum` and
+  `emit_json_usage_lists_supported_and_gated_modes`.
 - Gated `emit-json` diagnostics now live on `EmitJsonMode::gate_message`, so
   HIR, MIR, layout, and target YAML gate text stays attached to the enum that
   owns mode spelling and usage. Covered by

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3769,6 +3769,10 @@ checked-in docs, tests, and commits only.
   `cli_emit_json_modes_use_owned_mode_enum`,
   `emit_json_usage_lists_supported_and_gated_modes`, and
   `emit_json_layout_command_is_explicitly_gated`.
+- `zen emit-json` mode parsing now also uses the same `EmitJsonMode` ordered
+  table as usage generation, so adding an IR boundary mode no longer requires a
+  second parse-mode branch list. Guarded by
+  `cli_emit_json_modes_use_owned_mode_enum` and `emit_json_usage_lists_supported_and_gated_modes`.
 - Gated `emit-json` diagnostics now live on `EmitJsonMode::gate_message`,
   keeping HIR, MIR, layout, and target YAML gate text attached to the same enum
   that owns mode spelling and usage. Guarded by

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -116,18 +116,11 @@ impl FromStr for EmitJsonMode {
     type Err = ();
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            Self::AST => Ok(Self::Ast),
-            Self::SYMBOLS => Ok(Self::Symbols),
-            Self::TYPED => Ok(Self::Typed),
-            Self::DIAGNOSTICS => Ok(Self::Diagnostics),
-            Self::BUILD_GRAPH => Ok(Self::BuildGraph),
-            Self::HIR => Ok(Self::Hir),
-            Self::MIR => Ok(Self::Mir),
-            Self::LAYOUT => Ok(Self::Layout),
-            Self::TARGET_YAML => Ok(Self::TargetYaml),
-            _ => Err(()),
-        }
+        Self::ORDERED
+            .iter()
+            .copied()
+            .find(|mode| mode.as_str() == value)
+            .ok_or(())
     }
 }
 

--- a/tests/docs_truth/repo_hygiene/parser_enums.rs
+++ b/tests/docs_truth/repo_hygiene/parser_enums.rs
@@ -409,6 +409,10 @@ fn cli_emit_json_modes_use_owned_mode_enum() {
         "emit-json usage should be generated from EmitJsonMode"
     );
     assert!(
+        source.contains(".find(|mode| mode.as_str() == value)"),
+        "emit-json mode parsing should use the enum-owned ordered table"
+    );
+    assert!(
         source.contains("fn gate_message(self) -> Option<&'static str>"),
         "emit-json gated diagnostics should be owned by EmitJsonMode"
     );


### PR DESCRIPTION
## Summary

Routes `zen emit-json` mode parsing through the same `EmitJsonMode` ordered table used for usage generation.

## Details

- removes the duplicate parse-mode match list from `EmitJsonMode::from_str`
- adds docs-truth coverage requiring table-driven mode parsing
- records the cleanup in the phase plan and completion audit

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Push-event Actions were checked for this branch and returned no runs: `gh run list --branch target-yml-boundary-gate --event push --limit 10 --json ...` -> `[]`.