### PR TITLE
[codex] Route builtin literals through enum tables

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -4137,6 +4137,13 @@ and do not assume Phase 4 is ready without evidence.
   `emit-json target-yaml` rejects a real `.yaml` file at the schema-validation
   gate before emitting any JSON. Covered by
   `emit_json_target_yaml_rejects_hand_authored_yaml_before_validation`.
+- Typechecker boolean literal identifiers parse `true` and `false` through
+  `TypecheckerBoolLiteralKeyword::ALL` rather than direct spelling checks.
+  Covered by `typechecker_boolean_literals_use_owned_keyword_enum` and parser
+  boolean expression coverage.
+- Dynamic `String` builtin recognition routes through the `GatedBuiltinType`
+  enum table instead of a direct `DYNAMIC_STRING_TYPE_NAME` equality. Covered by
+  `semantic_builtin_type_checks_use_shared_spelling_helper`.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3816,6 +3816,13 @@ checked-in docs, tests, and commits only.
   `emit-json target-yaml` now has explicit coverage that a real `.yaml` file is
   rejected at the schema-validation gate before emitting any JSON. Guarded by
   `emit_json_target_yaml_rejects_hand_authored_yaml_before_validation`.
+- Typechecker boolean literal identifiers now parse `true` and `false` through
+  `TypecheckerBoolLiteralKeyword::ALL` instead of direct spelling checks.
+  Guarded by `typechecker_boolean_literals_use_owned_keyword_enum` and parser
+  boolean expression coverage.
+- Dynamic `String` builtin recognition now routes through the
+  `GatedBuiltinType` enum table instead of a direct `DYNAMIC_STRING_TYPE_NAME`
+  equality. Guarded by `semantic_builtin_type_checks_use_shared_spelling_helper`.
 
 ## Current Phase
 

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -210,10 +210,6 @@ impl FromStr for BuiltinGenericTypeName {
     }
 }
 
-pub fn is_builtin_type_name(name: &str) -> bool {
-    name == DYNAMIC_STRING_TYPE_NAME
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GatedBuiltinType {
     DynamicString,
@@ -290,6 +286,13 @@ impl GatedBuiltinType {
 
 pub fn gated_builtin_type_name(name: &str) -> Option<GatedBuiltinType> {
     GatedBuiltinType::from_name(name)
+}
+
+pub fn is_builtin_type_name(name: &str) -> bool {
+    matches!(
+        gated_builtin_type_name(name),
+        Some(GatedBuiltinType::DynamicString)
+    )
 }
 
 /// Parser-level type representation.

--- a/src/typechecker/expressions/simple_forms.rs
+++ b/src/typechecker/expressions/simple_forms.rs
@@ -1,4 +1,43 @@
 use super::*;
+use std::str::FromStr;
+
+#[derive(Clone, Copy)]
+enum TypecheckerBoolLiteralKeyword {
+    True,
+    False,
+}
+
+impl TypecheckerBoolLiteralKeyword {
+    const ALL: &[TypecheckerBoolLiteralKeyword] = &[Self::True, Self::False];
+    const TRUE: &'static str = "true";
+    const FALSE: &'static str = "false";
+
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::True => Self::TRUE,
+            Self::False => Self::FALSE,
+        }
+    }
+
+    const fn value(self) -> bool {
+        match self {
+            Self::True => true,
+            Self::False => false,
+        }
+    }
+}
+
+impl FromStr for TypecheckerBoolLiteralKeyword {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|keyword| keyword.as_str() == value)
+            .ok_or(())
+    }
+}
 
 impl TypeChecker {
     pub(super) fn check_identifier_expr(
@@ -6,16 +45,9 @@ impl TypeChecker {
         name: &str,
         span: Span,
     ) -> Result<TypedExpression, Diagnostic> {
-        if name == "true" {
+        if let Ok(keyword) = name.parse::<TypecheckerBoolLiteralKeyword>() {
             return Ok(TypedExpression {
-                kind: TypedExprKind::BoolLiteral(true),
-                ty: Type::Bool,
-                span,
-            });
-        }
-        if name == "false" {
-            return Ok(TypedExpression {
-                kind: TypedExprKind::BoolLiteral(false),
+                kind: TypedExprKind::BoolLiteral(keyword.value()),
                 ty: Type::Bool,
                 span,
             });

--- a/tests/docs_truth/repo_hygiene/builtin_type_spelling.rs
+++ b/tests/docs_truth/repo_hygiene/builtin_type_spelling.rs
@@ -41,6 +41,14 @@ fn semantic_builtin_type_checks_use_shared_spelling_helper() {
         helper.contains("pub fn is_builtin_type_name"),
         "builtin type-name recognition should be centralized"
     );
+    assert!(
+        !helper.contains("name == DYNAMIC_STRING_TYPE_NAME"),
+        "builtin type-name recognition should route through GatedBuiltinType, not a direct spelling check"
+    );
+    assert!(
+        helper.contains("Some(GatedBuiltinType::DynamicString)"),
+        "dynamic String recognition should be expressed through the gated builtin type enum"
+    );
 
     for path in [
         "src/resolver/type_validation.rs",

--- a/tests/docs_truth/repo_hygiene/typechecker_runtime.rs
+++ b/tests/docs_truth/repo_hygiene/typechecker_runtime.rs
@@ -35,3 +35,28 @@ fn root_std_runtime_calls_use_owned_intrinsic_enum() {
         );
     }
 }
+
+#[test]
+fn typechecker_boolean_literals_use_owned_keyword_enum() {
+    let simple_forms = read("src/typechecker/expressions/simple_forms.rs");
+
+    for forbidden in [r#"name == "true""#, r#"name == "false""#] {
+        assert!(
+            !simple_forms.contains(forbidden),
+            "typechecker boolean literal identifiers should parse through an owned keyword enum: {forbidden}"
+        );
+    }
+
+    for required in [
+        "enum TypecheckerBoolLiteralKeyword",
+        "const ALL: &[TypecheckerBoolLiteralKeyword]",
+        "impl FromStr for TypecheckerBoolLiteralKeyword",
+        ".find(|keyword| keyword.as_str() == value)",
+        "name.parse::<TypecheckerBoolLiteralKeyword>()",
+    ] {
+        assert!(
+            simple_forms.contains(required),
+            "typechecker boolean literal spelling should live in TypecheckerBoolLiteralKeyword: {required}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- route typechecker boolean literal identifiers through `TypecheckerBoolLiteralKeyword::ALL` instead of direct `true` / `false` spelling checks
- route dynamic `String` builtin recognition through `GatedBuiltinType` instead of a direct `DYNAMIC_STRING_TYPE_NAME` equality
- add docs-truth guards and audit notes for both enum-table cleanups

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

## Push workflow

`gh run list --branch typechecker-bool-literal-keyword-table --event push --limit 10 --json databaseId,status,conclusion,workflowName,headSha,createdAt,url` returned `[]`.