### PR TITLE
[codex] Add structured infix as-cast diagnostics

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -118,6 +118,14 @@ pub const REMOVED_RETURN_KEYWORD_MESSAGE: &str =
 pub const REMOVED_RETURN_FIX_KIND: &str = "replace_removed_return_with_final_expression";
 pub const REMOVED_RETURN_FIX_TITLE: &str =
     "Remove `return` and use the value as the final expression";
+pub const REMOVED_AS_CAST_MESSAGE: &str =
+    "`as` cast syntax has been removed; use cast(value, Type)";
+pub const REMOVED_INFIX_AS_CAST_MESSAGE: &str =
+    "`as` cast syntax has been removed; use prefix cast(value, Type)";
+pub const REMOVED_INFIX_AS_CAST_FIX_KIND: &str = "replace_infix_as_cast_with_prefix_cast";
+pub const REMOVED_INFIX_AS_CAST_FIX_TITLE: &str =
+    "Rewrite infix `as` cast to prefix `cast(value, Type)`";
+pub const REMOVED_INFIX_AS_CAST_REPLACEMENT: &str = "cast(value, Type)";
 
 #[derive(Debug, Clone)]
 pub struct TextEdit {
@@ -272,7 +280,9 @@ impl From<CompileError> for Diagnostic {
                     context: Vec::new(),
                     suggested_fixes: Vec::new(),
                 };
-                diagnostic.with_removed_return_fix()
+                diagnostic
+                    .with_removed_return_fix()
+                    .with_removed_infix_as_cast_fix()
             }
             CompileError::Type(msg, span) => Diagnostic {
                 severity: Severity::Error,
@@ -322,6 +332,22 @@ impl Diagnostic {
             REMOVED_RETURN_FIX_KIND,
             REMOVED_RETURN_FIX_TITLE,
             vec![TextEdit::new(span, "")],
+        ))
+    }
+
+    fn with_removed_infix_as_cast_fix(self) -> Self {
+        if self.message != REMOVED_INFIX_AS_CAST_MESSAGE {
+            return self;
+        }
+
+        let Some(span) = self.span else {
+            return self;
+        };
+
+        self.with_suggested_fix(SuggestedFix::new(
+            REMOVED_INFIX_AS_CAST_FIX_KIND,
+            REMOVED_INFIX_AS_CAST_FIX_TITLE,
+            vec![TextEdit::new(span, REMOVED_INFIX_AS_CAST_REPLACEMENT)],
         ))
     }
 }

--- a/src/parser/atoms.rs
+++ b/src/parser/atoms.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::error::REMOVED_RETURN_KEYWORD_MESSAGE;
+use crate::error::{REMOVED_AS_CAST_MESSAGE, REMOVED_RETURN_KEYWORD_MESSAGE};
 use crate::parser::keywords::{ParserModuleRoot, ParserPrefixKeyword, ParserThisMethod};
 
 mod forms;
@@ -86,7 +86,7 @@ impl Parser {
                             Some(span),
                         )),
                         ParserPrefixKeyword::As => Err(CompileError::Syntax(
-                            "`as` cast syntax has been removed; use cast(value, Type)".into(),
+                            REMOVED_AS_CAST_MESSAGE.into(),
                             Some(span),
                         )),
                         ParserPrefixKeyword::Break => Ok(Expression::Break { span }),

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -1,9 +1,12 @@
 use super::*;
+use crate::error::REMOVED_INFIX_AS_CAST_MESSAGE;
+use crate::parser::keywords::ParserPrefixKeyword;
 
 mod suffixes;
 
 impl Parser {
     // ── Expressions (Pratt parser) ────────────────────────────
+    const REMOVED_AS_CAST_L_BP: u8 = 1;
 
     pub(super) fn parse_expression(&mut self) -> Result<Expression, CompileError> {
         self.parse_expr_bp(0)
@@ -155,6 +158,22 @@ impl Parser {
                 }
 
                 _ => {}
+            }
+
+            if matches!(
+                self.peek(),
+                Token::Identifier(name)
+                    if matches!(name.parse::<ParserPrefixKeyword>(), Ok(ParserPrefixKeyword::As))
+            ) {
+                if Self::REMOVED_AS_CAST_L_BP < min_bp {
+                    break;
+                }
+                self.advance();
+                self.parse_type()?;
+                return Err(CompileError::Syntax(
+                    REMOVED_INFIX_AS_CAST_MESSAGE.into(),
+                    Some(lhs.span().merge(self.prev_span())),
+                ));
             }
 
             // Infix binary operators

--- a/tests/integration/cli_build/frontend_json/diagnostics_json.rs
+++ b/tests/integration/cli_build/frontend_json/diagnostics_json.rs
@@ -125,3 +125,74 @@ main = () i32 {
     assert_eq!(edit["span"]["column"], 5);
     assert_eq!(edit["replacement"], "");
 }
+
+#[test]
+fn emit_json_diagnostics_includes_structured_infix_as_cast_fix() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let zen_path = tmp.path().join("as_cast.zen");
+    let source = r#"
+main = (x: i32) i64 {
+    x + 1 as i64
+}
+"#;
+    let expression = "x + 1 as i64";
+    let expression_start = source.find(expression).expect("source contains as-cast") as u32;
+    let expression_end = expression_start + expression.len() as u32;
+    std::fs::write(&zen_path, source).expect("write removed as-cast source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "diagnostics", zen_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json diagnostics");
+
+    assert!(
+        !output.status.success(),
+        "zen emit-json diagnostics should fail on removed as-cast syntax: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("diagnostics stdout is json");
+    let diagnostic = &json["diagnostics"][0];
+    assert_eq!(diagnostic["code"], "E2000");
+    assert!(
+        diagnostic["message"]
+            .as_str()
+            .expect("diagnostic message")
+            .contains("`as` cast syntax has been removed"),
+        "unexpected diagnostic payload: {diagnostic}"
+    );
+
+    let suggestions = diagnostic["suggested_fixes"]
+        .as_array()
+        .expect("diagnostic should carry structured suggested fixes");
+    assert_eq!(
+        suggestions.len(),
+        1,
+        "unexpected suggestions: {suggestions:?}"
+    );
+
+    let fix = &suggestions[0];
+    assert_eq!(fix["kind"], "replace_infix_as_cast_with_prefix_cast");
+    assert_eq!(
+        fix["title"],
+        "Rewrite infix `as` cast to prefix `cast(value, Type)`"
+    );
+
+    let edit = &fix["edits"][0];
+    assert_eq!(
+        fix["edits"].as_array().expect("fix edits array").len(),
+        1,
+        "as-cast fix should carry exactly one text edit: {fix}"
+    );
+    assert!(edit["span"]["path"]
+        .as_str()
+        .expect("edit span path")
+        .ends_with("as_cast.zen"));
+    assert_eq!(edit["span"]["start"], expression_start);
+    assert_eq!(edit["span"]["end"], expression_end);
+    assert_eq!(edit["span"]["line"], 3);
+    assert_eq!(edit["span"]["column"], 5);
+    assert_eq!(edit["replacement"], "cast(value, Type)");
+}


### PR DESCRIPTION
## What changed

- Added static diagnostic/fix constants for removed infix `as` casts.
- Detects removed infix `as` casts in the Pratt parser through `ParserPrefixKeyword::As` instead of raw string matching.
- Emits a structured JSON suggested fix for `x + 1 as i64`-style syntax with a text edit spanning the full removed expression.

## Why

The language is prefix-only for casts, and removed syntax should produce machine-readable guidance for tooling and agents instead of vague text-only diagnostics.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Verified push-event Actions are quiet with `gh run list --branch diagnostics-suggest-as-cast-prefix --event push --limit 10 --json databaseId,status,conclusion,workflowName,headSha,createdAt,url` returning `[]`.