### PR TITLE
[codex] Span full gated derive association diagnostics

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -4153,6 +4153,11 @@ and do not assume Phase 4 is ready without evidence.
 - Dynamic `String` builtin recognition routes through the `GatedBuiltinType`
   enum table instead of a direct `DYNAMIC_STRING_TYPE_NAME` equality. Covered by
   `semantic_builtin_type_checks_use_shared_spelling_helper`.
+- The generated behavior association gate for `Type.derive(...)` now reports a
+  diagnostic span over the full gated association call instead of just the
+  receiver token, keeping generated/fallback association work gated while
+  improving editor and agent localization. Covered by
+  `emit_json_diagnostics_spans_full_gated_behavior_derive_association`.
 - Dev UX and Agent UX are now tracked as first-class roadmap lanes in
   `docs/PHASE_PLAN.md`, with MoonBit-style toolchain integration as the
   benchmark and concrete future surfaces for the VS Code extension,

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3876,6 +3876,12 @@ Agent UX deliverables:
 - Dynamic `String` builtin recognition now routes through the
   `GatedBuiltinType` enum table instead of a direct `DYNAMIC_STRING_TYPE_NAME`
   equality. Guarded by `semantic_builtin_type_checks_use_shared_spelling_helper`.
+- The generated behavior association gate for `Type.derive(...)` now reports a
+  machine-readable diagnostic span over the full gated association call instead
+  of only the receiver name. Guarded by
+  `emit_json_diagnostics_spans_full_gated_behavior_derive_association`, while
+  the feature remains gated until generated/fallback association semantics have
+  positive and negative solver tests.
 
 ## Current Phase
 

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -263,6 +263,9 @@ planned positive test and one planned negative test before implementation.
 Generated/fallback behavior association syntax is reserved but not implemented:
 `Type.derive(Json)` currently reports an explicit parser gate, covered by
 `parser::tests::generated_behavior_derive_association_is_explicitly_gated`.
+The diagnostics JSON path reports that gate over the full
+`Type.derive(...)` association call, covered by
+`emit_json_diagnostics_spans_full_gated_behavior_derive_association`.
 
 ## Stdlib Gate
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -126,6 +126,8 @@ pub const REMOVED_INFIX_AS_CAST_FIX_KIND: &str = "replace_infix_as_cast_with_pre
 pub const REMOVED_INFIX_AS_CAST_FIX_TITLE: &str =
     "Rewrite infix `as` cast to prefix `cast(value, Type)`";
 pub const REMOVED_INFIX_AS_CAST_REPLACEMENT: &str = "cast(value, Type)";
+pub const GATED_GENERATED_BEHAVIOR_DERIVE_MESSAGE: &str =
+    "generated behavior association `Type.derive(...)` is gated until derive fallback resolution and ambiguity diagnostics are implemented";
 
 #[derive(Debug, Clone)]
 pub struct TextEdit {

--- a/src/parser/declarations.rs
+++ b/src/parser/declarations.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::error::GATED_GENERATED_BEHAVIOR_DERIVE_MESSAGE;
 use crate::parser::keywords::ParserBehaviorKeyword;
 
 impl Parser {
@@ -205,12 +206,34 @@ impl Parser {
         ))
     }
 
-    fn reject_gated_generated_behavior_derive<T>(&self, span: Span) -> Result<T, CompileError> {
+    fn reject_gated_generated_behavior_derive<T>(
+        &mut self,
+        name_span: Span,
+    ) -> Result<T, CompileError> {
+        let span = self.gated_behavior_derive_span(name_span);
         Err(CompileError::Syntax(
-            "generated behavior association `Type.derive(...)` is gated until derive fallback resolution and ambiguity diagnostics are implemented"
-                .to_string(),
+            GATED_GENERATED_BEHAVIOR_DERIVE_MESSAGE.to_string(),
             Some(span),
         ))
+    }
+
+    fn gated_behavior_derive_span(&mut self, name_span: Span) -> Span {
+        if !matches!(self.peek(), Token::LParen) {
+            return name_span.merge(self.prev_span());
+        }
+
+        self.advance();
+        let behavior_span = self.expect_identifier().map(|(_, span)| span).ok();
+        if matches!(self.peek(), Token::Lt) {
+            let _ = self.parse_type_arg_list();
+        }
+        self.skip_newlines();
+        match self.expect(&Token::RParen) {
+            Ok(end) => name_span.merge(end),
+            Err(_) => behavior_span
+                .map(|span| name_span.merge(span))
+                .unwrap_or_else(|| name_span.merge(self.prev_span())),
+        }
     }
 
     fn parse_function_def(

--- a/tests/integration/cli_build/frontend_json/diagnostics_json.rs
+++ b/tests/integration/cli_build/frontend_json/diagnostics_json.rs
@@ -196,3 +196,56 @@ main = (x: i32) i64 {
     assert_eq!(edit["span"]["column"], 5);
     assert_eq!(edit["replacement"], "cast(value, Type)");
 }
+
+#[test]
+fn emit_json_diagnostics_spans_full_gated_behavior_derive_association() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let zen_path = tmp.path().join("derive_gate.zen");
+    let source = r#"
+Point: { x: i32 }
+
+Json: behavior {
+    to_json: (Self) StaticString
+}
+
+Point.derive(Json)
+"#;
+    let association = "Point.derive(Json)";
+    let association_start = source
+        .find(association)
+        .expect("source contains derive association") as u32;
+    let association_end = association_start + association.len() as u32;
+    std::fs::write(&zen_path, source).expect("write gated derive source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "diagnostics", zen_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json diagnostics");
+
+    assert!(
+        !output.status.success(),
+        "zen emit-json diagnostics should fail on gated derive association: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("diagnostics stdout is json");
+    let diagnostic = &json["diagnostics"][0];
+    assert_eq!(diagnostic["code"], "E2000");
+    assert!(
+        diagnostic["message"]
+            .as_str()
+            .expect("diagnostic message")
+            .contains("generated behavior association `Type.derive(...)` is gated"),
+        "unexpected diagnostic payload: {diagnostic}"
+    );
+    assert!(diagnostic["span"]["path"]
+        .as_str()
+        .expect("diagnostic span path")
+        .ends_with("derive_gate.zen"));
+    assert_eq!(diagnostic["span"]["start"], association_start);
+    assert_eq!(diagnostic["span"]["end"], association_end);
+    assert_eq!(diagnostic["span"]["line"], 8);
+    assert_eq!(diagnostic["span"]["column"], 1);
+}


### PR DESCRIPTION
## What changed

- Gated `Type.derive(...)` behavior-association diagnostics now span the full association call instead of only the receiver token.
- Moved the generated behavior derive gate message into a shared static diagnostic constant.
- Added diagnostics JSON coverage proving the span covers `Point.derive(Json)` end to end.
- Updated phase/spec/audit docs with the new evidence while keeping generated/fallback association semantics gated.

## Why

Generated/fallback behavior association is still not implemented, but editor and agent tooling need diagnostics that localize the full gated construct instead of a partial receiver span.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Verified push-event Actions are quiet with `gh run list --branch codex/derive-gate-full-span --event push --limit 10 --json databaseId,status,conclusion,workflowName,headSha,createdAt,url` returning `[]`.