### PR TITLE
[codex] Span full gated generic association diagnostics

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -4158,6 +4158,11 @@ and do not assume Phase 4 is ready without evidence.
   receiver token, keeping generated/fallback association work gated while
   improving editor and agent localization. Covered by
   `emit_json_diagnostics_spans_full_gated_behavior_derive_association`.
+- Gated generic association targets such as `Type<T>.derive(Json<T>)` now
+  report diagnostics over the full reserved association target instead of only
+  the behavior argument token. Covered by
+  `emit_json_diagnostics_spans_full_gated_generic_association_target` and
+  `generic_type_association_keywords_are_explicitly_gated`.
 - Dev UX and Agent UX are now tracked as first-class roadmap lanes in
   `docs/PHASE_PLAN.md`, with MoonBit-style toolchain integration as the
   benchmark and concrete future surfaces for the VS Code extension,

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3882,6 +3882,12 @@ Agent UX deliverables:
   `emit_json_diagnostics_spans_full_gated_behavior_derive_association`, while
   the feature remains gated until generated/fallback association semantics have
   positive and negative solver tests.
+- Gated generic association targets such as `Type<T>.derive(Json<T>)` now report
+  diagnostics over the full reserved association target rather than only the
+  behavior argument token. Guarded by
+  `emit_json_diagnostics_spans_full_gated_generic_association_target` and the
+  existing parser gate
+  `generic_type_association_keywords_are_explicitly_gated`.
 
 ## Current Phase
 

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -266,6 +266,10 @@ Generated/fallback behavior association syntax is reserved but not implemented:
 The diagnostics JSON path reports that gate over the full
 `Type.derive(...)` association call, covered by
 `emit_json_diagnostics_spans_full_gated_behavior_derive_association`.
+Gated generic association targets such as `Type<T>.derive(Json<T>)` are also
+localized over the full reserved association target in diagnostics JSON,
+covered by
+`emit_json_diagnostics_spans_full_gated_generic_association_target`.
 
 ## Stdlib Gate
 

--- a/src/parser/declarations.rs
+++ b/src/parser/declarations.rs
@@ -77,7 +77,8 @@ impl Parser {
                                     name_span,
                                 );
                             }
-                            return self.reject_gated_generic_association_target(keyword);
+                            return self
+                                .reject_gated_generic_association_target(keyword, name_span);
                         }
 
                         let mut all_type_params = type_params;
@@ -195,15 +196,36 @@ impl Parser {
     // ── Function ──────────────────────────────────────────────
 
     fn reject_gated_generic_association_target<T>(
-        &self,
+        &mut self,
         keyword: TypeDeclarationKeyword,
+        name_span: Span,
     ) -> Result<T, CompileError> {
+        let span = self.gated_generic_association_span(name_span);
         Err(CompileError::Syntax(
             format!(
                 "generic association target `Type<T>.{keyword}` is gated; use non-generic `{keyword}` associations or keep the generic behavior target deferred to docs/V1_SPEC.md"
             ),
-            Some(self.peek_span()),
+            Some(span),
         ))
+    }
+
+    fn gated_generic_association_span(&mut self, name_span: Span) -> Span {
+        if !matches!(self.peek(), Token::LParen) {
+            return name_span.merge(self.prev_span());
+        }
+
+        self.advance();
+        let behavior_span = self.expect_identifier().map(|(_, span)| span).ok();
+        if matches!(self.peek(), Token::Lt) {
+            let _ = self.parse_type_arg_list();
+        }
+        self.skip_newlines();
+        match self.expect(&Token::RParen) {
+            Ok(end) => name_span.merge(end),
+            Err(_) => behavior_span
+                .map(|span| name_span.merge(span))
+                .unwrap_or_else(|| name_span.merge(self.prev_span())),
+        }
     }
 
     fn reject_gated_generated_behavior_derive<T>(

--- a/tests/integration/cli_build/frontend_json/diagnostics_json.rs
+++ b/tests/integration/cli_build/frontend_json/diagnostics_json.rs
@@ -249,3 +249,58 @@ Point.derive(Json)
     assert_eq!(diagnostic["span"]["line"], 8);
     assert_eq!(diagnostic["span"]["column"], 1);
 }
+
+#[test]
+fn emit_json_diagnostics_spans_full_gated_generic_association_target() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let zen_path = tmp.path().join("generic_association_gate.zen");
+    let source = r#"
+Box<T>: {
+    value: T
+}
+
+Json<T>: behavior {
+    to_json: (T) StaticString
+}
+
+Box<T>.derive(Json<T>)
+"#;
+    let association = "Box<T>.derive(Json<T>)";
+    let association_start = source
+        .find(association)
+        .expect("source contains generic association") as u32;
+    let association_end = association_start + association.len() as u32;
+    std::fs::write(&zen_path, source).expect("write gated generic association source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "diagnostics", zen_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json diagnostics");
+
+    assert!(
+        !output.status.success(),
+        "zen emit-json diagnostics should fail on gated generic association: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("diagnostics stdout is json");
+    let diagnostic = &json["diagnostics"][0];
+    assert_eq!(diagnostic["code"], "E2000");
+    assert!(
+        diagnostic["message"]
+            .as_str()
+            .expect("diagnostic message")
+            .contains("generic association target `Type<T>.derive` is gated"),
+        "unexpected diagnostic payload: {diagnostic}"
+    );
+    assert!(diagnostic["span"]["path"]
+        .as_str()
+        .expect("diagnostic span path")
+        .ends_with("generic_association_gate.zen"));
+    assert_eq!(diagnostic["span"]["start"], association_start);
+    assert_eq!(diagnostic["span"]["end"], association_end);
+    assert_eq!(diagnostic["span"]["line"], 10);
+    assert_eq!(diagnostic["span"]["column"], 1);
+}


### PR DESCRIPTION
## What changed

- Gated generic association targets like `Box<T>.derive(Json<T>)` now report diagnostics over the full reserved association target.
- Added diagnostics JSON coverage for the full `Box<T>.derive(Json<T>)` span.
- Updated phase/spec/audit docs with the new evidence while keeping generated/fallback association semantics gated.

## Why

Generated/fallback behavior association is still gated, but editor and agent diagnostics should localize the full reserved construct instead of only the behavior argument token.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Verified push-event Actions are quiet with `gh run list --branch codex/generic-association-gate-span --event push --limit 10 --json databaseId,status,conclusion,workflowName,headSha,createdAt,url` returning `[]`.