### PR TITLE
[codex] Dedupe gated association span parsing

### DIFF
--- a/src/parser/declarations.rs
+++ b/src/parser/declarations.rs
@@ -200,7 +200,7 @@ impl Parser {
         keyword: TypeDeclarationKeyword,
         name_span: Span,
     ) -> Result<T, CompileError> {
-        let span = self.gated_generic_association_span(name_span);
+        let span = self.gated_association_call_span(name_span);
         Err(CompileError::Syntax(
             format!(
                 "generic association target `Type<T>.{keyword}` is gated; use non-generic `{keyword}` associations or keep the generic behavior target deferred to docs/V1_SPEC.md"
@@ -209,37 +209,18 @@ impl Parser {
         ))
     }
 
-    fn gated_generic_association_span(&mut self, name_span: Span) -> Span {
-        if !matches!(self.peek(), Token::LParen) {
-            return name_span.merge(self.prev_span());
-        }
-
-        self.advance();
-        let behavior_span = self.expect_identifier().map(|(_, span)| span).ok();
-        if matches!(self.peek(), Token::Lt) {
-            let _ = self.parse_type_arg_list();
-        }
-        self.skip_newlines();
-        match self.expect(&Token::RParen) {
-            Ok(end) => name_span.merge(end),
-            Err(_) => behavior_span
-                .map(|span| name_span.merge(span))
-                .unwrap_or_else(|| name_span.merge(self.prev_span())),
-        }
-    }
-
     fn reject_gated_generated_behavior_derive<T>(
         &mut self,
         name_span: Span,
     ) -> Result<T, CompileError> {
-        let span = self.gated_behavior_derive_span(name_span);
+        let span = self.gated_association_call_span(name_span);
         Err(CompileError::Syntax(
             GATED_GENERATED_BEHAVIOR_DERIVE_MESSAGE.to_string(),
             Some(span),
         ))
     }
 
-    fn gated_behavior_derive_span(&mut self, name_span: Span) -> Span {
+    fn gated_association_call_span(&mut self, name_span: Span) -> Span {
         if !matches!(self.peek(), Token::LParen) {
             return name_span.merge(self.prev_span());
         }


### PR DESCRIPTION
## What changed

- Replaced the duplicate gated association span parsers with one shared `gated_association_call_span` helper.
- Preserved the existing behavior for both `Type.derive(...)` and generic `Type<T>.derive(...)` gates.

## Why

The generated/fallback behavior-association gate paths should not drift while the feature remains reserved and gated.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Focused checks: `cargo test --test integration diagnostics_spans_full_gated -- --nocapture`, `cargo test --lib parser::tests::behaviors -- --nocapture`
- Verified push-event Actions are quiet with `gh run list --branch codex/dedupe-association-gate-span --event push --limit 10 --json databaseId,status,conclusion,workflowName,headSha,createdAt,url` returning `[]`.