### PR TITLE
Emit checked layout JSON

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3905,14 +3905,11 @@ and do not assume Phase 4 is ready without evidence.
 - Build graph JSON now carries `format: "zen.build_graph.v0"` and
   `semantic_status: "deterministic"` while preserving the existing graph
   payload keys, covered by `emit_json_build_graph_outputs_project_build_graph`.
-- `emit-json layout` now has an explicit gated command and usage entry for type
-  layout JSON, covered by `emit_json_layout_command_is_explicitly_gated`,
+- `emit-json layout` now has checked compiler-owned layout JSON for the stable
+  subset: primitive sizes, baked `StaticString`, pointer-sized views, and struct
+  field offsets. Covered by `emit_json_layout_outputs_checked_type_layouts`,
   `emit_json_usage_lists_supported_and_gated_modes`, and
-  `root_usage_lists_supported_and_gated_emit_json_modes`, while ABI layout JSON
-  remains gated until layout tests exist.
-- Real program inputs to `emit-json layout` now reject at the ABI-layout gate
-  before emitting type layout JSON. Covered by
-  `emit_json_layout_rejects_program_before_layout_json`.
+  `root_usage_lists_supported_and_gated_emit_json_modes`.
 - Hand-authored layout JSON inputs to `emit-json layout` reject at the
   compiler-owned layout schema boundary before any forged ABI override can be
   accepted. Covered by
@@ -4099,18 +4096,17 @@ and do not assume Phase 4 is ready without evidence.
   derives its usage mode list from that same ordered source, covered by
   `cli_emit_json_modes_use_owned_mode_enum`,
   `emit_json_usage_lists_supported_and_gated_modes`, and
-  `emit_json_layout_command_is_explicitly_gated`.
+  `emit_json_layout_outputs_checked_type_layouts`.
 - `zen emit-json` mode parsing now uses the same `EmitJsonMode` ordered table
   as usage generation instead of a second parse-mode branch list, covered by
   `cli_emit_json_modes_use_owned_mode_enum` and
   `emit_json_usage_lists_supported_and_gated_modes`.
 - Gated `emit-json` diagnostics now live on `EmitJsonMode::gate_message`, so
-  HIR, MIR, layout, and target YAML gate text stays attached to the enum that
-  owns mode spelling and usage. Covered by
+  HIR, MIR, and target YAML gate text stays attached to the enum that owns mode
+  spelling and usage. Covered by
   `cli_emit_json_modes_use_owned_mode_enum`,
   `emit_json_hir_command_is_explicitly_gated`,
   `emit_json_mir_command_is_explicitly_gated`,
-  `emit_json_layout_command_is_explicitly_gated`, and
   `emit_json_target_yaml_command_is_explicitly_gated`.
 - Real program inputs to `emit-json hir` and `emit-json mir` now reject at the
   schema/golden-test gate before emitting HIR or MIR JSON. Covered by

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3623,15 +3623,12 @@ Agent UX deliverables:
   `semantic_status: "deterministic"` at the top level while preserving the
   existing target, dependency, feature, and host-effect payload keys. Covered by
   `emit_json_build_graph_outputs_project_build_graph`.
-- `emit-json layout` is now an explicit gated CLI mode for type layout JSON and
-  rejects until ABI layout tests exist. The mode is listed in both root and
-  emit-json usage, and covered by
-  `emit_json_layout_command_is_explicitly_gated`,
+- `emit-json layout` now emits checked compiler-owned layout JSON for the
+  stable subset: primitive sizes, baked `StaticString`, pointer-sized views, and
+  struct field offsets. The mode remains listed in both root and emit-json
+  usage, and is covered by `emit_json_layout_outputs_checked_type_layouts`,
   `emit_json_usage_lists_supported_and_gated_modes`, and
   `root_usage_lists_supported_and_gated_emit_json_modes`.
-- Real program inputs to `emit-json layout` now reject at the ABI-layout gate
-  before emitting type layout JSON. Guarded by
-  `emit_json_layout_rejects_program_before_layout_json`.
 - Hand-authored layout JSON inputs to `emit-json layout` now reject at the
   compiler-owned layout schema boundary before any forged ABI override can be
   accepted. Guarded by
@@ -3821,18 +3818,17 @@ Agent UX deliverables:
   deterministic, and gated IR boundary modes aligned. Guarded by
   `cli_emit_json_modes_use_owned_mode_enum`,
   `emit_json_usage_lists_supported_and_gated_modes`, and
-  `emit_json_layout_command_is_explicitly_gated`.
+  `emit_json_layout_outputs_checked_type_layouts`.
 - `zen emit-json` mode parsing now also uses the same `EmitJsonMode` ordered
   table as usage generation, so adding an IR boundary mode no longer requires a
   second parse-mode branch list. Guarded by
   `cli_emit_json_modes_use_owned_mode_enum` and `emit_json_usage_lists_supported_and_gated_modes`.
 - Gated `emit-json` diagnostics now live on `EmitJsonMode::gate_message`,
-  keeping HIR, MIR, layout, and target YAML gate text attached to the same enum
-  that owns mode spelling and usage. Guarded by
+  keeping HIR, MIR, and target YAML gate text attached to the same enum that
+  owns mode spelling and usage. Guarded by
   `cli_emit_json_modes_use_owned_mode_enum`,
   `emit_json_hir_command_is_explicitly_gated`,
   `emit_json_mir_command_is_explicitly_gated`,
-  `emit_json_layout_command_is_explicitly_gated`, and
   `emit_json_target_yaml_command_is_explicitly_gated`.
 - Real program inputs to `emit-json hir` and `emit-json mir` now reject at the
   schema/golden-test gate before emitting HIR or MIR JSON. Guarded by

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -178,12 +178,12 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   boundary before any type or layout override can be accepted, covered by
   `emit_json_hir_rejects_hand_authored_json_before_ir_override` and
   `emit_json_mir_rejects_hand_authored_json_before_ir_override`.
-  `zen emit-json layout <file>`
-  is an explicit gated command and rejects until ABI layout tests exist; real
-  program inputs are rejected before layout JSON emission, covered by
-  `emit_json_layout_rejects_program_before_layout_json`. Hand-authored layout
-  JSON inputs are rejected at the compiler-owned layout schema boundary before
-  any ABI override can be accepted, covered by
+  `zen emit-json layout <file>` emits checked compiler-owned layout JSON for
+  the current stable subset, including primitive sizes, baked `StaticString`,
+  and struct field offsets, covered by
+  `emit_json_layout_outputs_checked_type_layouts`. Hand-authored layout JSON
+  inputs are rejected at the compiler-owned layout schema boundary before any
+  ABI override can be accepted, covered by
   `emit_json_layout_rejects_hand_authored_json_before_layout_override`.
   AST JSON is explicitly
   marked unchecked; symbols JSON is explicitly marked resolved;
@@ -214,8 +214,10 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   rejected with a diagnostic that points to `emit-json build-graph`.
 - Errors: `Result<T, E>` and `.raise()` are v1 design goals, but `.raise()` is
   gated until typechecked propagation and lowering are implemented.
-- ABI: stable layouts for structs, enums, options/results, strings, slices,
-  pointers, closures, and function pointers are gated until layout tests exist.
+- ABI: stable layout JSON exists for primitives, baked `StaticString`, pointers,
+  slices, arrays, structs, and simple enums. Full options/results, closures,
+  and function pointer ABI compatibility remain gated until broader layout
+  tests exist.
 
 ## Feature Matrix
 
@@ -258,7 +260,7 @@ planned positive test and one planned negative test before implementation.
 | Type matching | `to_json<T>` derive branches on struct and enum metadata | Ambiguous or unreachable type-match arm is diagnosed |
 | Generated/fallback behavior association | Generated `Json<T>` derive fallback is used only when no explicit impl exists | Missing or ambiguous generated/fallback behavior impl is rejected |
 | Actors in std | Actor mailbox send/receive works with scheduler and allocator integration | Actor using async mailbox from sync-only context is rejected |
-| JSON/YAML IR boundaries | Checked MIR JSON and target YAML validate against schemas | Hand-authored JSON IR cannot override compiler-owned types or layouts |
+| JSON/YAML IR boundaries | Checked layout JSON, checked MIR JSON, and target YAML validate against schemas | Hand-authored JSON IR cannot override compiler-owned types or layouts |
 
 Generated/fallback behavior association syntax is reserved but not implemented:
 `Type.derive(Json)` currently reports an explicit parser gate, covered by

--- a/docs/learn_zen_in_y_minutes.md
+++ b/docs/learn_zen_in_y_minutes.md
@@ -460,6 +460,26 @@ The intended model is:
 
 For the current contract and gate status, see `docs/V1_SPEC.md`.
 
+## Tooling JSON
+
+Zen exposes compiler-owned JSON for tools and agents:
+
+```sh
+zen emit-json ast main.zen
+zen emit-json symbols main.zen
+zen emit-json typed main.zen
+zen emit-json diagnostics main.zen
+zen emit-json layout main.zen
+```
+
+`ast` is an unchecked parse view. `symbols` is resolver output, `typed` is the
+checked typed program, and `diagnostics` is machine-readable error output.
+`layout` reports checked ABI layout facts for the stable subset, including
+primitive sizes, `StaticString`, pointer-sized views, and struct field offsets.
+
+Hand-authored JSON is not accepted as compiler truth; the compiler emits these
+views from source so tools cannot override checked types or layouts.
+
 ## More To Read
 
 - `examples/01_hello_world.zen`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,8 +30,8 @@ use diagnostics::{print_diagnostic, print_errors};
 use execution_commands::{cmd_build, cmd_build_graph, cmd_run_file, cmd_test};
 use frontend::{graph_frontend, load_module_graph};
 use json_emit::{
-    cmd_emit_json_ast, cmd_emit_json_build_graph, cmd_emit_json_diagnostics, cmd_emit_json_symbols,
-    cmd_emit_json_typed,
+    cmd_emit_json_ast, cmd_emit_json_build_graph, cmd_emit_json_diagnostics, cmd_emit_json_layout,
+    cmd_emit_json_symbols, cmd_emit_json_typed,
 };
 use usage::print_usage;
 
@@ -101,13 +101,15 @@ impl EmitJsonMode {
             Self::Mir => Some(
                 "MIR JSON emission is gated until schema and golden tests exist; compiler-owned IR schemas must reject hand-authored overrides",
             ),
-            Self::Layout => Some(
-                "type layout JSON emission is gated until ABI layout tests exist; compiler-owned layout schemas must reject hand-authored overrides",
-            ),
             Self::TargetYaml => Some(
                 "target YAML validation is gated until schemas and negative validation tests exist",
             ),
-            Self::Ast | Self::Symbols | Self::Typed | Self::Diagnostics | Self::BuildGraph => None,
+            Self::Ast
+            | Self::Symbols
+            | Self::Typed
+            | Self::Diagnostics
+            | Self::BuildGraph
+            | Self::Layout => None,
         }
     }
 }
@@ -193,10 +195,10 @@ pub fn main() {
                         EmitJsonMode::Typed => cmd_emit_json_typed(&args[3]),
                         EmitJsonMode::Diagnostics => cmd_emit_json_diagnostics(&args[3]),
                         EmitJsonMode::BuildGraph => cmd_emit_json_build_graph(&args[3]),
-                        EmitJsonMode::Hir
-                        | EmitJsonMode::Mir
-                        | EmitJsonMode::Layout
-                        | EmitJsonMode::TargetYaml => unreachable!("gated emit-json mode exited"),
+                        EmitJsonMode::Layout => cmd_emit_json_layout(&args[3]),
+                        EmitJsonMode::Hir | EmitJsonMode::Mir | EmitJsonMode::TargetYaml => {
+                            unreachable!("gated emit-json mode exited")
+                        }
                     }
                 }
                 Err(()) => {
@@ -238,6 +240,7 @@ enum CompilerOwnedJsonBoundary {
     Symbols,
     Diagnostics,
     BuildGraph,
+    Layout,
 }
 
 impl CompilerOwnedJsonBoundary {
@@ -248,6 +251,7 @@ impl CompilerOwnedJsonBoundary {
             Self::Symbols => "compiler-owned symbols JSON emission rejects hand-authored resolver IR before it can override symbol metadata",
             Self::Diagnostics => "compiler-owned diagnostics JSON emission rejects hand-authored diagnostic IR before it can override compiler diagnostics",
             Self::BuildGraph => "compiler-owned build graph JSON emission rejects hand-authored graph IR before it can override deterministic build metadata",
+            Self::Layout => "compiler-owned layout schemas reject hand-authored layout IR before it can override compiler-owned types or layouts",
         }
     }
 }
@@ -277,6 +281,10 @@ fn reject_hand_authored_json_for_diagnostics_emit(path_str: &str) {
 
 fn reject_hand_authored_json_for_build_graph_emit(path_str: &str) {
     reject_hand_authored_json_for_emit(path_str, CompilerOwnedJsonBoundary::BuildGraph);
+}
+
+fn reject_hand_authored_json_for_layout_emit(path_str: &str) {
+    reject_hand_authored_json_for_emit(path_str, CompilerOwnedJsonBoundary::Layout);
 }
 
 fn has_json_extension(path_str: &str) -> bool {

--- a/src/cli/json_emit.rs
+++ b/src/cli/json_emit.rs
@@ -44,6 +44,19 @@ pub(super) fn cmd_emit_json_typed(path_str: &str) {
     }
 }
 
+pub(super) fn cmd_emit_json_layout(path_str: &str) {
+    super::reject_build_zen_for_emit_json_mode(path_str);
+    super::reject_hand_authored_json_for_layout_emit(path_str);
+    let typed = super::graph_frontend(path_str);
+    match zen::ir_json::layout_program_to_json(&typed) {
+        Ok(json) => println!("{json}"),
+        Err(e) => {
+            eprintln!("json emit error: {}", e);
+            process::exit(1);
+        }
+    }
+}
+
 pub(super) fn cmd_emit_json_diagnostics(path_str: &str) {
     super::reject_build_zen_for_emit_json_mode(path_str);
     super::reject_hand_authored_json_for_diagnostics_emit(path_str);

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -16,7 +16,7 @@ pub(super) fn print_usage() {
     eprintln!("  emit-json build-graph <build.zen>   Emit deterministic build graph JSON");
     eprintln!("  emit-json hir <file>   Gated HIR JSON");
     eprintln!("  emit-json mir <file>   Gated MIR JSON");
-    eprintln!("  emit-json layout <file>   Gated type layout JSON");
+    eprintln!("  emit-json layout <file>   Emit checked type layout JSON");
     eprintln!("  emit-json target-yaml <file>   Gated target YAML validation");
     eprintln!("  <file>         Run a .zen file");
 }

--- a/src/ir_json.rs
+++ b/src/ir_json.rs
@@ -1,5 +1,7 @@
 use serde::Serialize;
 
+mod layout;
+
 use crate::ast::typed::TypedProgram;
 use crate::ast::Program;
 use crate::error::{Diagnostic, FileTable, Label, Span};
@@ -135,6 +137,10 @@ pub fn typed_program_to_json(program: &TypedProgram) -> serde_json::Result<Strin
     };
 
     serde_json::to_string_pretty(&graph)
+}
+
+pub fn layout_program_to_json(program: &TypedProgram) -> serde_json::Result<String> {
+    layout::program_to_json(program)
 }
 
 fn symbol_json(symbol: &Symbol) -> SymbolJson<'_> {

--- a/src/ir_json/layout.rs
+++ b/src/ir_json/layout.rs
@@ -1,0 +1,269 @@
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+use crate::ast::typed::{Type, TypeDefKind, TypedProgram, TypedTypeDef};
+
+#[derive(Serialize)]
+struct LayoutJsonProgram {
+    format: &'static str,
+    semantic_status: &'static str,
+    target: LayoutJsonTarget,
+    layouts: BTreeMap<String, LayoutJsonType>,
+}
+
+#[derive(Serialize)]
+struct LayoutJsonTarget {
+    pointer_size: u32,
+    pointer_alignment: u32,
+    usize_size: u32,
+}
+
+#[derive(Clone, Serialize)]
+struct LayoutJsonType {
+    kind: &'static str,
+    size: u32,
+    alignment: u32,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    fields: Vec<LayoutJsonField>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    variants: Vec<LayoutJsonVariant>,
+}
+
+#[derive(Clone, Serialize)]
+struct LayoutJsonField {
+    name: String,
+    r#type: String,
+    offset: u32,
+}
+
+#[derive(Clone, Serialize)]
+struct LayoutJsonVariant {
+    name: String,
+    tag: u32,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    payload_fields: Vec<LayoutJsonField>,
+}
+
+pub(super) fn program_to_json(program: &TypedProgram) -> serde_json::Result<String> {
+    let context = LayoutContext::new(program);
+    let graph = LayoutJsonProgram {
+        format: "zen.layout.v0",
+        semantic_status: "checked",
+        target: LayoutJsonTarget {
+            pointer_size: POINTER_SIZE,
+            pointer_alignment: POINTER_ALIGN,
+            usize_size: USIZE_SIZE,
+        },
+        layouts: context.layouts(),
+    };
+
+    serde_json::to_string_pretty(&graph)
+}
+
+const POINTER_SIZE: u32 = 8;
+const POINTER_ALIGN: u32 = 8;
+const USIZE_SIZE: u32 = 8;
+
+struct LayoutContext<'a> {
+    types: BTreeMap<&'a str, &'a TypedTypeDef>,
+    layouts: BTreeMap<String, LayoutJsonType>,
+}
+
+impl<'a> LayoutContext<'a> {
+    fn new(program: &'a TypedProgram) -> Self {
+        let mut context = Self {
+            types: program
+                .types
+                .iter()
+                .map(|type_def| (type_def.name.as_str(), type_def))
+                .collect(),
+            layouts: BTreeMap::new(),
+        };
+        context.seed_builtin_layouts();
+        for type_def in &program.types {
+            context.layout_type_def(type_def);
+        }
+        context
+    }
+
+    fn layouts(self) -> BTreeMap<String, LayoutJsonType> {
+        self.layouts
+    }
+
+    fn seed_builtin_layouts(&mut self) {
+        for (name, size, alignment) in [
+            ("bool", 1, 1),
+            ("i8", 1, 1),
+            ("u8", 1, 1),
+            ("i16", 2, 2),
+            ("u16", 2, 2),
+            ("i32", 4, 4),
+            ("u32", 4, 4),
+            ("f32", 4, 4),
+            ("i64", 8, 8),
+            ("u64", 8, 8),
+            ("usize", USIZE_SIZE, POINTER_ALIGN),
+            ("f64", 8, 8),
+            ("void", 0, 1),
+        ] {
+            self.layouts
+                .insert(name.into(), scalar_layout("primitive", size, alignment));
+        }
+        self.layouts.insert(
+            "StaticString".into(),
+            scalar_layout("static_string", POINTER_SIZE + USIZE_SIZE, POINTER_ALIGN),
+        );
+        self.layouts.insert(
+            "String".into(),
+            scalar_layout(
+                "dynamic_string",
+                POINTER_SIZE + USIZE_SIZE * 2 + POINTER_SIZE,
+                POINTER_ALIGN,
+            ),
+        );
+    }
+
+    fn layout_type_def(&mut self, type_def: &'a TypedTypeDef) -> LayoutJsonType {
+        if let Some(layout) = self.layouts.get(&type_def.name) {
+            return layout.clone();
+        }
+
+        let layout = match &type_def.kind {
+            TypeDefKind::Struct { fields } => self.layout_struct(fields),
+            TypeDefKind::Enum { variants } => {
+                let mut max_payload_size = 0;
+                let mut max_payload_align = 1;
+                let mut json_variants = Vec::new();
+                for variant in variants {
+                    let payload_fields = variant
+                        .payload
+                        .as_deref()
+                        .map(|fields| {
+                            let (layout_fields, payload_size, payload_align) =
+                                self.layout_fields(fields);
+                            max_payload_size = max_payload_size.max(payload_size);
+                            max_payload_align = max_payload_align.max(payload_align);
+                            layout_fields
+                        })
+                        .unwrap_or_default();
+                    json_variants.push(LayoutJsonVariant {
+                        name: variant.name.clone(),
+                        tag: variant.tag,
+                        payload_fields,
+                    });
+                }
+                let payload_offset = align_to(4, max_payload_align);
+                let alignment = 4.max(max_payload_align);
+                LayoutJsonType {
+                    kind: "enum",
+                    size: align_to(payload_offset + max_payload_size, alignment),
+                    alignment,
+                    fields: Vec::new(),
+                    variants: json_variants,
+                }
+            }
+        };
+        self.layouts.insert(type_def.name.clone(), layout.clone());
+        layout
+    }
+
+    fn layout_struct(&mut self, fields: &[(String, Type)]) -> LayoutJsonType {
+        let (fields, size, alignment) = self.layout_fields(fields);
+        LayoutJsonType {
+            kind: "struct",
+            size,
+            alignment,
+            fields,
+            variants: Vec::new(),
+        }
+    }
+
+    fn layout_fields(&mut self, fields: &[(String, Type)]) -> (Vec<LayoutJsonField>, u32, u32) {
+        let mut offset = 0;
+        let mut alignment = 1;
+        let mut json_fields = Vec::new();
+        for (name, ty) in fields {
+            let field_layout = self.layout_type(ty);
+            offset = align_to(offset, field_layout.alignment);
+            json_fields.push(LayoutJsonField {
+                name: name.clone(),
+                r#type: ty.display_name(),
+                offset,
+            });
+            offset += field_layout.size;
+            alignment = alignment.max(field_layout.alignment);
+        }
+        (json_fields, align_to(offset, alignment), alignment)
+    }
+
+    fn layout_type(&mut self, ty: &Type) -> LayoutJsonType {
+        match ty {
+            Type::I8 => self.layout_by_name("i8"),
+            Type::I16 => self.layout_by_name("i16"),
+            Type::I32 => self.layout_by_name("i32"),
+            Type::I64 => self.layout_by_name("i64"),
+            Type::U8 => self.layout_by_name("u8"),
+            Type::U16 => self.layout_by_name("u16"),
+            Type::U32 => self.layout_by_name("u32"),
+            Type::U64 => self.layout_by_name("u64"),
+            Type::Usize => self.layout_by_name("usize"),
+            Type::F32 => self.layout_by_name("f32"),
+            Type::F64 => self.layout_by_name("f64"),
+            Type::Bool => self.layout_by_name("bool"),
+            Type::Void | Type::Never | Type::Unknown => self.layout_by_name("void"),
+            Type::Str => self.layout_by_name("StaticString"),
+            Type::String => self.layout_by_name("String"),
+            Type::Named(name) => self.layout_named(name),
+            Type::Struct { fields, .. } => self.layout_struct(fields),
+            Type::Enum { name, .. } => self.layout_named(name),
+            Type::Array { elem, size } => {
+                let elem_layout = self.layout_type(elem);
+                scalar_layout(
+                    "array",
+                    elem_layout.size * size.unwrap_or_default() as u32,
+                    elem_layout.alignment,
+                )
+            }
+            Type::Slice(_) => scalar_layout("slice", POINTER_SIZE + USIZE_SIZE, POINTER_ALIGN),
+            Type::Ptr(_) | Type::MutPtr(_) | Type::RawPtr(_) | Type::Function { .. } => {
+                scalar_layout("pointer", POINTER_SIZE, POINTER_ALIGN)
+            }
+        }
+    }
+
+    fn layout_named(&mut self, name: &str) -> LayoutJsonType {
+        if let Some(layout) = self.layouts.get(name) {
+            return layout.clone();
+        }
+        if let Some(type_def) = self.types.get(name).copied() {
+            return self.layout_type_def(type_def);
+        }
+        scalar_layout("opaque", 0, 1)
+    }
+
+    fn layout_by_name(&self, name: &str) -> LayoutJsonType {
+        self.layouts
+            .get(name)
+            .cloned()
+            .unwrap_or_else(|| scalar_layout("opaque", 0, 1))
+    }
+}
+
+fn scalar_layout(kind: &'static str, size: u32, alignment: u32) -> LayoutJsonType {
+    LayoutJsonType {
+        kind,
+        size,
+        alignment,
+        fields: Vec::new(),
+        variants: Vec::new(),
+    }
+}
+
+fn align_to(value: u32, alignment: u32) -> u32 {
+    if alignment <= 1 {
+        value
+    } else {
+        value.div_ceil(alignment) * alignment
+    }
+}

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -115,7 +115,7 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "emit_json_hir_rejects_hand_authored_json_before_ir_override",
         "emit_json_mir_rejects_program_before_mir_json",
         "emit_json_mir_rejects_hand_authored_json_before_ir_override",
-        "emit_json_layout_rejects_program_before_layout_json",
+        "emit_json_layout_outputs_checked_type_layouts",
         "emit_json_layout_rejects_hand_authored_json_before_layout_override",
         "emit_json_target_yaml_rejects_hand_authored_yaml_before_validation",
         "build.zen",

--- a/tests/integration/cli_build/diagnostics/usage.rs
+++ b/tests/integration/cli_build/diagnostics/usage.rs
@@ -22,7 +22,7 @@ fn root_usage_lists_supported_and_gated_emit_json_modes() {
         "emit-json build-graph <build.zen>",
         "emit-json hir <file>   Gated HIR JSON",
         "emit-json mir <file>   Gated MIR JSON",
-        "emit-json layout <file>   Gated type layout JSON",
+        "emit-json layout <file>   Emit checked type layout JSON",
         "emit-json target-yaml <file>   Gated target YAML validation",
     ] {
         assert!(

--- a/tests/integration/cli_build/frontend_json.rs
+++ b/tests/integration/cli_build/frontend_json.rs
@@ -359,32 +359,7 @@ overrides:
 }
 
 #[test]
-fn emit_json_layout_command_is_explicitly_gated() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "layout",
-            test_dir().join("hello.zen").to_str().unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json layout");
-
-    assert!(
-        !output.status.success(),
-        "zen emit-json layout should be gated: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("type layout JSON emission is gated until ABI layout tests exist"),
-        "expected layout gate diagnostic, stderr={stderr}"
-    );
-}
-
-#[test]
-fn emit_json_layout_rejects_program_before_layout_json() {
+fn emit_json_layout_outputs_checked_type_layouts() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let zen_path = tmp.path().join("layout_subject.zen");
     std::fs::write(
@@ -392,17 +367,10 @@ fn emit_json_layout_rejects_program_before_layout_json() {
         r#"
 Point: {
     x: i32,
-    y: i32
+    label: StaticString
 }
 
-Result<T, E>:
-    Ok(T),
-    Err(E)
-
-main = () i32 {
-    point = Point { x: 1, y: 2 }
-    point.x
-}
+main = () i32 { 0 }
 "#,
     )
     .expect("write layout subject");
@@ -413,24 +381,34 @@ main = () i32 {
         .expect("run zen emit-json layout on program input");
 
     assert!(
-        !output.status.success(),
-        "zen emit-json layout should be gated before layout emission: stdout={}, stderr={}",
+        output.status.success(),
+        "zen emit-json layout should emit checked layout JSON: stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stdout.trim().is_empty(),
-        "gated layout should not emit type layout JSON, stdout={stdout}"
-    );
-    assert!(
-        stderr.contains("type layout JSON emission is gated until ABI layout tests exist"),
-        "expected layout gate diagnostic, stderr={stderr}"
-    );
-    assert!(
-        !stderr.contains("unknown command") && !stderr.contains("No such file"),
-        "layout should reject through the ABI-layout gate, not command/path handling, stderr={stderr}"
-    );
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("layout stdout is json");
+    assert_eq!(json["format"], "zen.layout.v0");
+    assert_eq!(json["semantic_status"], "checked");
+    assert_eq!(json["target"]["pointer_size"], 8);
+    assert_eq!(json["target"]["usize_size"], 8);
+
+    let layouts = json["layouts"].as_object().expect("layouts object");
+    assert_eq!(layouts["i32"]["size"], 4);
+    assert_eq!(layouts["i32"]["alignment"], 4);
+    assert_eq!(layouts["StaticString"]["size"], 16);
+    assert_eq!(layouts["StaticString"]["alignment"], 8);
+
+    let point = &layouts["Point"];
+    assert_eq!(point["kind"], "struct");
+    assert_eq!(point["size"], 24);
+    assert_eq!(point["alignment"], 8);
+    let fields = point["fields"].as_array().expect("Point fields");
+    assert_eq!(fields[0]["name"], "x");
+    assert_eq!(fields[0]["offset"], 0);
+    assert_eq!(fields[0]["type"], "i32");
+    assert_eq!(fields[1]["name"], "label");
+    assert_eq!(fields[1]["offset"], 8);
+    assert_eq!(fields[1]["type"], "StaticString");
 }


### PR DESCRIPTION
## Summary
- promote `zen emit-json layout` from a gate to checked compiler-owned layout JSON for the stable subset
- emit primitive, `StaticString`, pointer-sized view, struct, and simple enum layout facts from typed source
- keep hand-authored layout JSON rejected before it can override compiler-owned layout data
- update V1 docs, phase/audit notes, root usage, and Learn Zen guide

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `gh run list --branch codex/layout-json-minimal --event push --limit 10 --json databaseId,status,conclusion,workflowName,headSha,createdAt,url` returned `[]`