### PR TITLE
Emit checked HIR JSON

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -340,10 +340,10 @@ and do not assume Phase 4 is ready without evidence.
   `return` keyword, giving agent/editor clients a span-addressed replacement
   edit that removes `return` and leaves the expression as the block result.
   Covered by `emit_json_diagnostics_includes_structured_return_keyword_fix`.
-- `emit-json hir` and `emit-json mir` now reject with explicit gated
-  diagnostics tied to the v1 JSON backlog. Coverage:
-  `emit_json_hir_command_is_explicitly_gated` and
-  `emit_json_mir_command_is_explicitly_gated`.
+- `emit-json hir` now emits checked declaration-level `zen.hir.v0` JSON.
+  Coverage: `emit_json_hir_outputs_checked_declaration_graph`. `emit-json mir`
+  still rejects with an explicit gated diagnostic tied to the v1 JSON backlog.
+  Coverage: `emit_json_mir_command_is_explicitly_gated`.
 - Build-graph JSON host-effect tests now split declared file-read fallback
   accept/reject coverage into
   `tests/integration/cli_build/build_graph_json_host_effects/file_reads.rs`,
@@ -3890,10 +3890,10 @@ and do not assume Phase 4 is ready without evidence.
   is covered by
   `emit_json_usage_lists_supported_and_gated_modes`, preserving the IR-boundary
   gate in user-facing CLI errors.
-- The root `zen` usage banner now lists the same gated `emit-json hir` and
-  `emit-json mir` commands plus validated `emit-json target-yaml`, covered by
+- The root `zen` usage banner now lists the checked `emit-json hir` command,
+  gated `emit-json mir` command, and validated `emit-json target-yaml`, covered by
   `root_usage_lists_supported_and_gated_emit_json_modes`, so top-level help
-  does not hide the explicitly gated IR/YAML surface.
+  does not hide the checked or gated IR/YAML surface.
 - The root `zen` usage banner now labels `emit-json ast` as unchecked AST JSON,
   matching its `semantic_status: "unchecked"` payload instead of implying
   semantic acceptance. Covered by
@@ -4102,14 +4102,13 @@ and do not assume Phase 4 is ready without evidence.
   `cli_emit_json_modes_use_owned_mode_enum` and
   `emit_json_usage_lists_supported_and_gated_modes`.
 - Gated `emit-json` diagnostics now live on `EmitJsonMode::gate_message`, so
-  HIR and MIR gate text stays attached to the enum that owns mode spelling and
-  usage. Covered by
-  `cli_emit_json_modes_use_owned_mode_enum`,
-  `emit_json_hir_command_is_explicitly_gated`,
+  MIR gate text stays attached to the enum that owns mode spelling and usage.
+  Covered by `cli_emit_json_modes_use_owned_mode_enum` and
   `emit_json_mir_command_is_explicitly_gated`.
-- Real program inputs to `emit-json hir` and `emit-json mir` now reject at the
-  schema/golden-test gate before emitting HIR or MIR JSON. Covered by
-  `emit_json_hir_rejects_program_before_hir_json` and
+- Real program inputs to `emit-json hir` now emit checked declaration-level HIR
+  JSON. Covered by `emit_json_hir_outputs_checked_declaration_graph`. Real
+  program inputs to `emit-json mir` still reject at the schema/golden-test gate
+  before emitting MIR JSON. Covered by
   `emit_json_mir_rejects_program_before_mir_json`.
 - Hand-authored typed JSON inputs to `emit-json typed` reject at the
   compiler-owned typed JSON boundary before forged checked IR can be treated as

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -567,10 +567,11 @@ Agent UX deliverables:
   `return` keyword, giving agents and editor clients a span-addressed edit to
   remove `return` and use the expression as the block result. Guarded by
   `emit_json_diagnostics_includes_structured_return_keyword_fix`.
-- `emit-json hir` and `emit-json mir` now reject with explicit gated diagnostics
-  tied to the v1 JSON backlog, covered by
-  `emit_json_hir_command_is_explicitly_gated`,
-  `emit_json_mir_command_is_explicitly_gated`.
+- `emit-json hir` now emits checked declaration-level `zen.hir.v0` JSON for
+  tools and agents, covered by
+  `emit_json_hir_outputs_checked_declaration_graph`. `emit-json mir` still
+  rejects with an explicit gated diagnostic tied to the v1 JSON backlog, covered
+  by `emit_json_mir_command_is_explicitly_gated`.
 - Build-graph JSON host-effect tests now keep declared file-read fallback
   accept/reject cases in a focused child module, leaving env-effect rejection
   ordering coverage in the parent integration module.
@@ -3602,13 +3603,12 @@ Agent UX deliverables:
   coverage already has positive and negative evidence. Guarded by
   `v1_spec_records_phase_one_feature_gates_and_test_backlog`.
 - `zen emit-json` usage diagnostics now advertise the complete current JSON
-  boundary surface, including checked `ast`/`symbols`/`typed`/`diagnostics`,
-  deterministic `build-graph`, validated `target-yaml`, and gated `hir`/`mir`
-  modes.
+  boundary surface, including checked `ast`/`symbols`/`typed`/`diagnostics`/`hir`,
+  deterministic `build-graph`, validated `target-yaml`, and gated `mir` mode.
   Covered by `emit_json_usage_lists_supported_and_gated_modes`, so the CLI
-  help text cannot hide gated IR/YAML modes from users.
+  help text cannot hide checked or gated IR/YAML modes from users.
 - The root `zen` usage banner now mirrors that IR/YAML boundary by listing the
-  gated `emit-json hir` and `emit-json mir` commands plus validated
+  checked `emit-json hir` command, gated `emit-json mir` command, and validated
   `emit-json target-yaml` instead of omitting them. Covered by
   `root_usage_lists_supported_and_gated_emit_json_modes`.
 - The root `zen` usage banner now labels `emit-json ast` as unchecked AST JSON,
@@ -3824,14 +3824,13 @@ Agent UX deliverables:
   second parse-mode branch list. Guarded by
   `cli_emit_json_modes_use_owned_mode_enum` and `emit_json_usage_lists_supported_and_gated_modes`.
 - Gated `emit-json` diagnostics now live on `EmitJsonMode::gate_message`,
-  keeping HIR and MIR gate text attached to the same enum that owns mode
-  spelling and usage. Guarded by
-  `cli_emit_json_modes_use_owned_mode_enum`,
-  `emit_json_hir_command_is_explicitly_gated`,
+  keeping MIR gate text attached to the same enum that owns mode spelling and
+  usage. Guarded by `cli_emit_json_modes_use_owned_mode_enum` and
   `emit_json_mir_command_is_explicitly_gated`.
-- Real program inputs to `emit-json hir` and `emit-json mir` now reject at the
-  schema/golden-test gate before emitting HIR or MIR JSON. Guarded by
-  `emit_json_hir_rejects_program_before_hir_json` and
+- Real program inputs to `emit-json hir` now emit checked declaration-level HIR
+  JSON, guarded by `emit_json_hir_outputs_checked_declaration_graph`. Real
+  program inputs to `emit-json mir` still reject at the schema/golden-test gate
+  before emitting MIR JSON. Guarded by
   `emit_json_mir_rejects_program_before_mir_json`.
 - Hand-authored typed JSON inputs to `emit-json typed` now reject at the
   compiler-owned typed JSON boundary before forged checked IR can be treated as

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -154,13 +154,17 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   diagnostics, and deterministic build graphs. YAML is the human-authored
   format for target descriptions, ABI rules, intrinsic tables, allocator
   templates, backend options, and build graphs.
-  Current JSON evidence is limited to resolved AST graph emission, resolver
-  symbol table emission, checked typed program emission, and machine-readable
-  diagnostics emission through `zen emit-json ast <file>`,
-  `zen emit-json symbols <file>`, `zen emit-json typed <file>`, and
-  `zen emit-json diagnostics <file>`. Hand-authored AST, symbols, typed, and
-  diagnostics JSON inputs are rejected before the frontend treats them as Zen
-  source or compiler-produced diagnostics, covered by
+  Current JSON evidence includes resolved AST graph emission, resolver symbol
+  table emission, checked typed program emission, machine-readable diagnostics
+  emission, checked declaration-level HIR emission, checked layout emission,
+  deterministic build graph emission, and validated target YAML emission through
+  `zen emit-json ast <file>`, `zen emit-json symbols <file>`,
+  `zen emit-json typed <file>`, `zen emit-json diagnostics <file>`,
+  `zen emit-json hir <file>`, `zen emit-json layout <file>`,
+  `zen emit-json build-graph <file>`, and
+  `zen emit-json target-yaml <file>`. Hand-authored AST, symbols, typed, HIR,
+  and diagnostics JSON inputs are rejected before the frontend treats them as
+  Zen source or compiler-produced diagnostics, covered by
   `emit_json_ast_rejects_hand_authored_json_before_unchecked_ir_override`,
   `emit_json_symbols_rejects_hand_authored_json_before_resolver_override`,
   `emit_json_diagnostics_rejects_hand_authored_json_before_diagnostic_override`, and
@@ -168,14 +172,15 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   Hand-authored build graph JSON inputs are rejected before generic build.zen
   path validation can stand in for the compiler-owned graph boundary, covered by
   `emit_json_build_graph_rejects_hand_authored_json_before_graph_override`.
-  Real program inputs to
-  `zen emit-json hir <file>` and `zen emit-json mir <file>` are rejected before
-  HIR/MIR JSON emission, covered by
-  `emit_json_hir_rejects_program_before_hir_json` and
+  `zen emit-json hir <file>` emits `format: "zen.hir.v0"` with
+  `semantic_status: "checked"` and a declaration graph for checked types,
+  functions, and globals, covered by
+  `emit_json_hir_outputs_checked_declaration_graph`. Real program inputs to
+  `zen emit-json mir <file>` are rejected before MIR JSON emission, covered by
   `emit_json_mir_rejects_program_before_mir_json`. Hand-authored JSON IR inputs
-  to `zen emit-json hir <file>` and `zen emit-json mir <file>` are also
-  rejected at the compiler-owned schema
-  boundary before any type or layout override can be accepted, covered by
+  to `zen emit-json hir <file>` and `zen emit-json mir <file>` are rejected at
+  the compiler-owned schema boundary before any type or layout override can be
+  accepted, covered by
   `emit_json_hir_rejects_hand_authored_json_before_ir_override` and
   `emit_json_mir_rejects_hand_authored_json_before_ir_override`.
   `zen emit-json layout <file>` emits checked compiler-owned layout JSON for
@@ -229,7 +234,8 @@ Generic behavior inheritance with child type-parameter parent args is covered by
 | Typechecked C backend for tested fixtures | implemented | `cargo test --tests` |
 | README and contributor truth assertions | implemented | `tests/docs_truth.rs` |
 | Strict resolver, symbol IDs, privacy | implemented | Resolver/module/privacy tests |
-| HIR/MIR JSON emission | gated | Schema and golden tests |
+| HIR JSON emission | constrained | `emit_json_hir_outputs_checked_declaration_graph`, `emit_json_hir_rejects_hand_authored_json_before_ir_override`; broader HIR schema and golden tests still required |
+| MIR JSON emission | gated | `emit_json_mir_command_is_explicitly_gated`, `emit_json_mir_rejects_program_before_mir_json`, `emit_json_mir_rejects_hand_authored_json_before_ir_override`; schema and golden tests still required |
 | Target/build YAML validation | constrained | `emit_json_target_yaml_validates_minimal_target_schema`, `emit_json_target_yaml_rejects_layout_overrides`; broader ABI/backend option schemas still required |
 | Behaviors and type association | gated | Positive/negative behavior solver tests |
 | `Sync/Async effects` | gated | `async_scheduler_intrinsics_are_rejected_as_gated_not_unknown`, `effect_await_is_rejected_until_async_lowering_exists`, `atomic_intrinsics_are_rejected_as_effect_gates`; effect checker positive/negative tests still required |

--- a/docs/learn_zen_in_y_minutes.md
+++ b/docs/learn_zen_in_y_minutes.md
@@ -470,6 +470,7 @@ zen emit-json symbols main.zen
 zen emit-json typed main.zen
 zen emit-json diagnostics main.zen
 zen emit-json layout main.zen
+zen emit-json hir main.zen
 zen emit-json target-yaml target.yaml
 ```
 
@@ -477,6 +478,8 @@ zen emit-json target-yaml target.yaml
 checked typed program, and `diagnostics` is machine-readable error output.
 `layout` reports checked ABI layout facts for the stable subset, including
 primitive sizes, `StaticString`, pointer-sized views, and struct field offsets.
+`hir` reports checked declaration-level HIR for tools and agents that need a
+stable graph of types, functions, and globals without owning compiler truth.
 `target-yaml` validates a human-authored target description into canonical
 `zen.target.v0` JSON while rejecting attempts to override compiler-owned type
 layouts.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,8 +30,8 @@ use diagnostics::{print_diagnostic, print_errors};
 use execution_commands::{cmd_build, cmd_build_graph, cmd_run_file, cmd_test};
 use frontend::{graph_frontend, load_module_graph};
 use json_emit::{
-    cmd_emit_json_ast, cmd_emit_json_build_graph, cmd_emit_json_diagnostics, cmd_emit_json_layout,
-    cmd_emit_json_symbols, cmd_emit_json_target_yaml, cmd_emit_json_typed,
+    cmd_emit_json_ast, cmd_emit_json_build_graph, cmd_emit_json_diagnostics, cmd_emit_json_hir,
+    cmd_emit_json_layout, cmd_emit_json_symbols, cmd_emit_json_target_yaml, cmd_emit_json_typed,
 };
 use usage::print_usage;
 
@@ -95,9 +95,6 @@ impl EmitJsonMode {
 
     fn gate_message(self) -> Option<&'static str> {
         match self {
-            Self::Hir => Some(
-                "HIR JSON emission is gated until schema and golden tests exist; compiler-owned IR schemas must reject hand-authored overrides",
-            ),
             Self::Mir => Some(
                 "MIR JSON emission is gated until schema and golden tests exist; compiler-owned IR schemas must reject hand-authored overrides",
             ),
@@ -106,6 +103,7 @@ impl EmitJsonMode {
             | Self::Typed
             | Self::Diagnostics
             | Self::BuildGraph
+            | Self::Hir
             | Self::Layout
             | Self::TargetYaml => None,
         }
@@ -193,11 +191,10 @@ pub fn main() {
                         EmitJsonMode::Typed => cmd_emit_json_typed(&args[3]),
                         EmitJsonMode::Diagnostics => cmd_emit_json_diagnostics(&args[3]),
                         EmitJsonMode::BuildGraph => cmd_emit_json_build_graph(&args[3]),
+                        EmitJsonMode::Hir => cmd_emit_json_hir(&args[3]),
                         EmitJsonMode::Layout => cmd_emit_json_layout(&args[3]),
                         EmitJsonMode::TargetYaml => cmd_emit_json_target_yaml(&args[3]),
-                        EmitJsonMode::Hir | EmitJsonMode::Mir => {
-                            unreachable!("gated emit-json mode exited")
-                        }
+                        EmitJsonMode::Mir => unreachable!("gated emit-json mode exited"),
                     }
                 }
                 Err(()) => {
@@ -239,6 +236,7 @@ enum CompilerOwnedJsonBoundary {
     Symbols,
     Diagnostics,
     BuildGraph,
+    Hir,
     Layout,
 }
 
@@ -250,6 +248,7 @@ impl CompilerOwnedJsonBoundary {
             Self::Symbols => "compiler-owned symbols JSON emission rejects hand-authored resolver IR before it can override symbol metadata",
             Self::Diagnostics => "compiler-owned diagnostics JSON emission rejects hand-authored diagnostic IR before it can override compiler diagnostics",
             Self::BuildGraph => "compiler-owned build graph JSON emission rejects hand-authored graph IR before it can override deterministic build metadata",
+            Self::Hir => "compiler-owned IR schemas reject hand-authored HIR JSON before it can override checked types or layouts",
             Self::Layout => "compiler-owned layout schemas reject hand-authored layout IR before it can override compiler-owned types or layouts",
         }
     }
@@ -280,6 +279,10 @@ fn reject_hand_authored_json_for_diagnostics_emit(path_str: &str) {
 
 fn reject_hand_authored_json_for_build_graph_emit(path_str: &str) {
     reject_hand_authored_json_for_emit(path_str, CompilerOwnedJsonBoundary::BuildGraph);
+}
+
+fn reject_hand_authored_json_for_hir_emit(path_str: &str) {
+    reject_hand_authored_json_for_emit(path_str, CompilerOwnedJsonBoundary::Hir);
 }
 
 fn reject_hand_authored_json_for_layout_emit(path_str: &str) {

--- a/src/cli/json_emit.rs
+++ b/src/cli/json_emit.rs
@@ -57,6 +57,19 @@ pub(super) fn cmd_emit_json_layout(path_str: &str) {
     }
 }
 
+pub(super) fn cmd_emit_json_hir(path_str: &str) {
+    super::reject_build_zen_for_emit_json_mode(path_str);
+    super::reject_hand_authored_json_for_hir_emit(path_str);
+    let typed = super::graph_frontend(path_str);
+    match zen::ir_json::hir_program_to_json(&typed) {
+        Ok(json) => println!("{json}"),
+        Err(e) => {
+            eprintln!("json emit error: {}", e);
+            process::exit(1);
+        }
+    }
+}
+
 pub(super) fn cmd_emit_json_diagnostics(path_str: &str) {
     super::reject_build_zen_for_emit_json_mode(path_str);
     super::reject_hand_authored_json_for_diagnostics_emit(path_str);

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -14,7 +14,7 @@ pub(super) fn print_usage() {
     eprintln!("  emit-json typed <file>   Emit checked typed program JSON");
     eprintln!("  emit-json diagnostics <file>   Emit diagnostics JSON");
     eprintln!("  emit-json build-graph <build.zen>   Emit deterministic build graph JSON");
-    eprintln!("  emit-json hir <file>   Gated HIR JSON");
+    eprintln!("  emit-json hir <file>   Emit checked HIR JSON");
     eprintln!("  emit-json mir <file>   Gated MIR JSON");
     eprintln!("  emit-json layout <file>   Emit checked type layout JSON");
     eprintln!("  emit-json target-yaml <file>   Validate target YAML");

--- a/src/ir_json.rs
+++ b/src/ir_json.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
 
+mod hir;
 mod layout;
 
 use crate::ast::typed::TypedProgram;
@@ -137,6 +138,10 @@ pub fn typed_program_to_json(program: &TypedProgram) -> serde_json::Result<Strin
     };
 
     serde_json::to_string_pretty(&graph)
+}
+
+pub fn hir_program_to_json(program: &TypedProgram) -> serde_json::Result<String> {
+    hir::program_to_json(program)
 }
 
 pub fn layout_program_to_json(program: &TypedProgram) -> serde_json::Result<String> {

--- a/src/ir_json/hir.rs
+++ b/src/ir_json/hir.rs
@@ -1,0 +1,133 @@
+use serde::Serialize;
+
+use crate::ast::typed::{Type, TypeDefKind, TypedFunction, TypedProgram, TypedTypeDef};
+
+#[derive(Serialize)]
+struct HirJsonProgram {
+    format: &'static str,
+    semantic_status: &'static str,
+    declarations: HirDeclarations,
+}
+
+#[derive(Serialize)]
+struct HirDeclarations {
+    types: Vec<HirTypeDecl>,
+    functions: Vec<HirFunctionDecl>,
+    globals: Vec<HirGlobalDecl>,
+}
+
+#[derive(Serialize)]
+struct HirTypeDecl {
+    name: String,
+    kind: &'static str,
+    fields: Vec<HirField>,
+    variants: Vec<HirVariant>,
+}
+
+#[derive(Serialize)]
+struct HirField {
+    name: String,
+    r#type: String,
+}
+
+#[derive(Serialize)]
+struct HirVariant {
+    name: String,
+    tag: u32,
+    payload: Vec<HirField>,
+}
+
+#[derive(Serialize)]
+struct HirFunctionDecl {
+    name: String,
+    params: Vec<HirParam>,
+    return_type: String,
+}
+
+#[derive(Serialize)]
+struct HirParam {
+    name: String,
+    r#type: String,
+}
+
+#[derive(Serialize)]
+struct HirGlobalDecl {
+    name: String,
+    r#type: String,
+    mutable: bool,
+}
+
+pub(super) fn program_to_json(program: &TypedProgram) -> serde_json::Result<String> {
+    let graph = HirJsonProgram {
+        format: "zen.hir.v0",
+        semantic_status: "checked",
+        declarations: HirDeclarations {
+            types: program.types.iter().map(hir_type_decl).collect(),
+            functions: program.functions.iter().map(hir_function_decl).collect(),
+            globals: program
+                .globals
+                .iter()
+                .map(|global| HirGlobalDecl {
+                    name: global.name.clone(),
+                    r#type: global.ty.display_name(),
+                    mutable: global.mutable,
+                })
+                .collect(),
+        },
+    };
+
+    serde_json::to_string_pretty(&graph)
+}
+
+fn hir_type_decl(type_def: &TypedTypeDef) -> HirTypeDecl {
+    match &type_def.kind {
+        TypeDefKind::Struct { fields } => HirTypeDecl {
+            name: type_def.name.clone(),
+            kind: "struct",
+            fields: hir_fields(fields),
+            variants: Vec::new(),
+        },
+        TypeDefKind::Enum { variants } => HirTypeDecl {
+            name: type_def.name.clone(),
+            kind: "enum",
+            fields: Vec::new(),
+            variants: variants
+                .iter()
+                .map(|variant| HirVariant {
+                    name: variant.name.clone(),
+                    tag: variant.tag,
+                    payload: variant
+                        .payload
+                        .as_deref()
+                        .map(hir_fields)
+                        .unwrap_or_default(),
+                })
+                .collect(),
+        },
+    }
+}
+
+fn hir_function_decl(function: &TypedFunction) -> HirFunctionDecl {
+    HirFunctionDecl {
+        name: function.name.clone(),
+        params: function
+            .params
+            .iter()
+            .map(|param| HirParam {
+                name: param.name.clone(),
+                r#type: param.ty.display_name(),
+            })
+            .collect(),
+        return_type: function.return_type.display_name(),
+    }
+}
+
+fn hir_fields(fields: &[(String, Type)]) -> Vec<HirField> {
+    fields
+        .iter()
+        .map(|(name, ty)| HirField {
+            name: name.clone(),
+            r#type: ty.display_name(),
+        })
+        .collect()
+}

--- a/tests/docs_truth/phase_audit.rs
+++ b/tests/docs_truth/phase_audit.rs
@@ -41,7 +41,7 @@ fn phase_plan_records_recovered_progress_and_next_slice() {
         "build_program_lowering_rejects_cyclic_target_dependencies",
         "build_graph_rejects_self_target_dependencies",
         "build_program_lowering_rejects_self_target_dependencies",
-        "emit_json_hir_command_is_explicitly_gated",
+        "emit_json_hir_outputs_checked_declaration_graph",
         "emit_json_mir_command_is_explicitly_gated",
         "emit_json_target_yaml_validates_minimal_target_schema",
         "emit_json_target_yaml_rejects_layout_overrides",

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -111,7 +111,7 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "emit_json_diagnostics_rejects_hand_authored_json_before_diagnostic_override",
         "emit_json_typed_rejects_hand_authored_json_before_checked_ir_override",
         "emit_json_build_graph_rejects_hand_authored_json_before_graph_override",
-        "emit_json_hir_rejects_program_before_hir_json",
+        "emit_json_hir_outputs_checked_declaration_graph",
         "emit_json_hir_rejects_hand_authored_json_before_ir_override",
         "emit_json_mir_rejects_program_before_mir_json",
         "emit_json_mir_rejects_hand_authored_json_before_ir_override",

--- a/tests/integration/cli_build/diagnostics/usage.rs
+++ b/tests/integration/cli_build/diagnostics/usage.rs
@@ -20,7 +20,7 @@ fn root_usage_lists_supported_and_gated_emit_json_modes() {
         "emit-json typed <file>",
         "emit-json diagnostics <file>",
         "emit-json build-graph <build.zen>",
-        "emit-json hir <file>   Gated HIR JSON",
+        "emit-json hir <file>   Emit checked HIR JSON",
         "emit-json mir <file>   Gated MIR JSON",
         "emit-json layout <file>   Emit checked type layout JSON",
         "emit-json target-yaml <file>   Validate target YAML",

--- a/tests/integration/cli_build/frontend_json.rs
+++ b/tests/integration/cli_build/frontend_json.rs
@@ -214,45 +214,18 @@ fn emit_json_mir_rejects_hand_authored_json_before_ir_override() {
 }
 
 #[test]
-fn emit_json_hir_command_is_explicitly_gated() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "hir",
-            test_dir().join("hello.zen").to_str().unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json hir");
-
-    assert!(
-        !output.status.success(),
-        "zen emit-json hir should be gated: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("HIR JSON emission is gated until schema and golden tests exist"),
-        "expected HIR gate diagnostic, stderr={stderr}"
-    );
-}
-
-#[test]
-fn emit_json_hir_rejects_program_before_hir_json() {
+fn emit_json_hir_outputs_checked_declaration_graph() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let zen_path = tmp.path().join("hir_subject.zen");
     std::fs::write(
         &zen_path,
         r#"
-Box<T>: {
-    value: T
+Point: {
+    x: i32,
+    label: StaticString
 }
 
-main = () i32 {
-    box = Box<i32> { value: 7 }
-    box.value
-}
+main = () i32 { 0 }
 "#,
     )
     .expect("write HIR subject");
@@ -263,26 +236,39 @@ main = () i32 {
         .expect("run zen emit-json hir on program input");
 
     assert!(
-        !output.status.success(),
-        "zen emit-json hir should be gated before HIR emission: stdout={}, stderr={}",
+        output.status.success(),
+        "zen emit-json hir should emit checked HIR JSON: stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stdout.trim().is_empty(),
-        "gated HIR should not emit HIR JSON, stdout={stdout}"
-    );
-    assert!(
-        stderr.contains("HIR JSON emission is gated until schema and golden tests exist"),
-        "expected HIR gate diagnostic, stderr={stderr}"
-    );
-    assert!(
-        !stderr.contains("unknown command") && !stderr.contains("No such file"),
-        "HIR should reject through the schema/golden-test gate, not command/path handling, stderr={stderr}"
-    );
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("HIR stdout is json");
+    assert_eq!(json["format"], "zen.hir.v0");
+    assert_eq!(json["semantic_status"], "checked");
+
+    let types = json["declarations"]["types"]
+        .as_array()
+        .expect("HIR types array");
+    let point = types
+        .iter()
+        .find(|ty| ty["name"] == "Point")
+        .expect("Point type in HIR");
+    assert_eq!(point["kind"], "struct");
+    assert_eq!(point["fields"][0]["name"], "x");
+    assert_eq!(point["fields"][0]["type"], "i32");
+    assert_eq!(point["fields"][1]["name"], "label");
+    assert_eq!(point["fields"][1]["type"], "StaticString");
+
+    let functions = json["declarations"]["functions"]
+        .as_array()
+        .expect("HIR functions array");
+    let main = functions
+        .iter()
+        .find(|function| function["name"] == "main")
+        .expect("main function in HIR");
+    assert_eq!(main["return_type"], "i32");
+    assert!(main["params"].as_array().expect("main params").is_empty());
 }
 
 #[test]

--- a/tests/integration/cli_build/frontend_json/ir_boundaries.rs
+++ b/tests/integration/cli_build/frontend_json/ir_boundaries.rs
@@ -265,7 +265,7 @@ fn emit_json_hir_rejects_hand_authored_json_before_ir_override() {
 
     assert!(
         !output.status.success(),
-        "zen emit-json hir should gate hand-authored HIR before override: stdout={}, stderr={}",
+        "zen emit-json hir should reject hand-authored HIR before override: stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
@@ -274,7 +274,7 @@ fn emit_json_hir_rejects_hand_authored_json_before_ir_override() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stdout.trim().is_empty(),
-        "gated HIR should not emit or accept hand-authored HIR JSON, stdout={stdout}"
+        "forged HIR should not emit or accept hand-authored HIR JSON, stdout={stdout}"
     );
     assert!(
         stderr.contains("compiler-owned IR schemas"),


### PR DESCRIPTION
## Summary
- promote `zen emit-json hir` to checked declaration-level `zen.hir.v0` output
- keep hand-authored HIR JSON rejected at the compiler-owned IR boundary
- update Learn Zen, V1 spec, phase plan, and completion audit docs for HIR checked output while MIR remains gated

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `cargo test --test integration emit_json_hir -- --nocapture`
- push-event Actions check: `[]`