### PR TITLE
Emit minimal MIR JSON

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -342,8 +342,8 @@ and do not assume Phase 4 is ready without evidence.
   Covered by `emit_json_diagnostics_includes_structured_return_keyword_fix`.
 - `emit-json hir` now emits checked declaration-level `zen.hir.v0` JSON.
   Coverage: `emit_json_hir_outputs_checked_declaration_graph`. `emit-json mir`
-  still rejects with an explicit gated diagnostic tied to the v1 JSON backlog.
-  Coverage: `emit_json_mir_command_is_explicitly_gated`.
+  now emits checked minimal `zen.mir.v0` JSON for typed function bodies.
+  Coverage: `emit_json_mir_outputs_checked_minimal_function_graph`.
 - Build-graph JSON host-effect tests now split declared file-read fallback
   accept/reject coverage into
   `tests/integration/cli_build/build_graph_json_host_effects/file_reads.rs`,
@@ -3885,15 +3885,15 @@ and do not assume Phase 4 is ready without evidence.
   compiler-path evidence. Covered by
   `v1_spec_records_phase_one_feature_gates_and_test_backlog`.
 - `zen emit-json` usage diagnostics now list the full checked, deterministic,
-  validated, and gated JSON/YAML mode surface: `ast`, `symbols`, `typed`,
+  validated, and constrained JSON/YAML mode surface: `ast`, `symbols`, `typed`,
   `diagnostics`, `build-graph`, `layout`, `target-yaml`, `hir`, and `mir`. This
   is covered by
   `emit_json_usage_lists_supported_and_gated_modes`, preserving the IR-boundary
-  gate in user-facing CLI errors.
+  surface in user-facing CLI errors.
 - The root `zen` usage banner now lists the checked `emit-json hir` command,
-  gated `emit-json mir` command, and validated `emit-json target-yaml`, covered by
+  checked minimal `emit-json mir` command, and validated `emit-json target-yaml`, covered by
   `root_usage_lists_supported_and_gated_emit_json_modes`, so top-level help
-  does not hide the checked or gated IR/YAML surface.
+  does not hide the checked or constrained IR/YAML surface.
 - The root `zen` usage banner now labels `emit-json ast` as unchecked AST JSON,
   matching its `semantic_status: "unchecked"` payload instead of implying
   semantic acceptance. Covered by
@@ -4101,15 +4101,13 @@ and do not assume Phase 4 is ready without evidence.
   as usage generation instead of a second parse-mode branch list, covered by
   `cli_emit_json_modes_use_owned_mode_enum` and
   `emit_json_usage_lists_supported_and_gated_modes`.
-- Gated `emit-json` diagnostics now live on `EmitJsonMode::gate_message`, so
-  MIR gate text stays attached to the enum that owns mode spelling and usage.
-  Covered by `cli_emit_json_modes_use_owned_mode_enum` and
-  `emit_json_mir_command_is_explicitly_gated`.
+- `emit-json` mode spelling and any future gated diagnostics live on
+  `EmitJsonMode`, so mode text stays attached to the enum that owns parsing and
+  usage. Covered by `cli_emit_json_modes_use_owned_mode_enum`.
 - Real program inputs to `emit-json hir` now emit checked declaration-level HIR
   JSON. Covered by `emit_json_hir_outputs_checked_declaration_graph`. Real
-  program inputs to `emit-json mir` still reject at the schema/golden-test gate
-  before emitting MIR JSON. Covered by
-  `emit_json_mir_rejects_program_before_mir_json`.
+  program inputs to `emit-json mir` now emit checked minimal function/block MIR
+  JSON. Covered by `emit_json_mir_outputs_checked_minimal_function_graph`.
 - Hand-authored typed JSON inputs to `emit-json typed` reject at the
   compiler-owned typed JSON boundary before forged checked IR can be treated as
   Zen source or accepted as semantic evidence. Covered by

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -569,9 +569,9 @@ Agent UX deliverables:
   `emit_json_diagnostics_includes_structured_return_keyword_fix`.
 - `emit-json hir` now emits checked declaration-level `zen.hir.v0` JSON for
   tools and agents, covered by
-  `emit_json_hir_outputs_checked_declaration_graph`. `emit-json mir` still
-  rejects with an explicit gated diagnostic tied to the v1 JSON backlog, covered
-  by `emit_json_mir_command_is_explicitly_gated`.
+  `emit_json_hir_outputs_checked_declaration_graph`. `emit-json mir` now emits
+  checked minimal `zen.mir.v0` JSON for typed function bodies, covered by
+  `emit_json_mir_outputs_checked_minimal_function_graph`.
 - Build-graph JSON host-effect tests now keep declared file-read fallback
   accept/reject cases in a focused child module, leaving env-effect rejection
   ordering coverage in the parent integration module.
@@ -3603,12 +3603,13 @@ Agent UX deliverables:
   coverage already has positive and negative evidence. Guarded by
   `v1_spec_records_phase_one_feature_gates_and_test_backlog`.
 - `zen emit-json` usage diagnostics now advertise the complete current JSON
-  boundary surface, including checked `ast`/`symbols`/`typed`/`diagnostics`/`hir`,
-  deterministic `build-graph`, validated `target-yaml`, and gated `mir` mode.
+  boundary surface, including checked
+  `ast`/`symbols`/`typed`/`diagnostics`/`hir`/`mir`, deterministic
+  `build-graph`, and validated `target-yaml`.
   Covered by `emit_json_usage_lists_supported_and_gated_modes`, so the CLI
-  help text cannot hide checked or gated IR/YAML modes from users.
+  help text cannot hide checked or constrained IR/YAML modes from users.
 - The root `zen` usage banner now mirrors that IR/YAML boundary by listing the
-  checked `emit-json hir` command, gated `emit-json mir` command, and validated
+  checked `emit-json hir` command, checked minimal `emit-json mir` command, and validated
   `emit-json target-yaml` instead of omitting them. Covered by
   `root_usage_lists_supported_and_gated_emit_json_modes`.
 - The root `zen` usage banner now labels `emit-json ast` as unchecked AST JSON,
@@ -3823,15 +3824,13 @@ Agent UX deliverables:
   table as usage generation, so adding an IR boundary mode no longer requires a
   second parse-mode branch list. Guarded by
   `cli_emit_json_modes_use_owned_mode_enum` and `emit_json_usage_lists_supported_and_gated_modes`.
-- Gated `emit-json` diagnostics now live on `EmitJsonMode::gate_message`,
-  keeping MIR gate text attached to the same enum that owns mode spelling and
-  usage. Guarded by `cli_emit_json_modes_use_owned_mode_enum` and
-  `emit_json_mir_command_is_explicitly_gated`.
+- `emit-json` mode spelling and any future gated diagnostics live on
+  `EmitJsonMode`, keeping mode text attached to the enum that owns parsing and
+  usage. Guarded by `cli_emit_json_modes_use_owned_mode_enum`.
 - Real program inputs to `emit-json hir` now emit checked declaration-level HIR
   JSON, guarded by `emit_json_hir_outputs_checked_declaration_graph`. Real
-  program inputs to `emit-json mir` still reject at the schema/golden-test gate
-  before emitting MIR JSON. Guarded by
-  `emit_json_mir_rejects_program_before_mir_json`.
+  program inputs to `emit-json mir` now emit checked minimal function/block MIR
+  JSON. Guarded by `emit_json_mir_outputs_checked_minimal_function_graph`.
 - Hand-authored typed JSON inputs to `emit-json typed` now reject at the
   compiler-owned typed JSON boundary before forged checked IR can be treated as
   Zen source or accepted as semantic evidence. Guarded by

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -175,12 +175,13 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   `zen emit-json hir <file>` emits `format: "zen.hir.v0"` with
   `semantic_status: "checked"` and a declaration graph for checked types,
   functions, and globals, covered by
-  `emit_json_hir_outputs_checked_declaration_graph`. Real program inputs to
-  `zen emit-json mir <file>` are rejected before MIR JSON emission, covered by
-  `emit_json_mir_rejects_program_before_mir_json`. Hand-authored JSON IR inputs
-  to `zen emit-json hir <file>` and `zen emit-json mir <file>` are rejected at
-  the compiler-owned schema boundary before any type or layout override can be
-  accepted, covered by
+  `emit_json_hir_outputs_checked_declaration_graph`. `zen emit-json mir <file>`
+  emits `format: "zen.mir.v0"` with `semantic_status: "checked"` and a minimal
+  function/block/terminator graph over typed program bodies, covered by
+  `emit_json_mir_outputs_checked_minimal_function_graph`. Hand-authored JSON IR
+  inputs to `zen emit-json hir <file>` and `zen emit-json mir <file>` are
+  rejected at the compiler-owned schema boundary before any type or layout
+  override can be accepted, covered by
   `emit_json_hir_rejects_hand_authored_json_before_ir_override` and
   `emit_json_mir_rejects_hand_authored_json_before_ir_override`.
   `zen emit-json layout <file>` emits checked compiler-owned layout JSON for
@@ -239,7 +240,7 @@ Generic behavior inheritance with child type-parameter parent args is covered by
 | README and contributor truth assertions | implemented | `tests/docs_truth.rs` |
 | Strict resolver, symbol IDs, privacy | implemented | Resolver/module/privacy tests |
 | HIR JSON emission | constrained | `emit_json_hir_outputs_checked_declaration_graph`, `emit_json_hir_rejects_hand_authored_json_before_ir_override`; broader HIR schema and golden tests still required |
-| MIR JSON emission | gated | `emit_json_mir_command_is_explicitly_gated`, `emit_json_mir_rejects_program_before_mir_json`, `emit_json_mir_rejects_hand_authored_json_before_ir_override`; schema and golden tests still required |
+| MIR JSON emission | constrained | `emit_json_mir_outputs_checked_minimal_function_graph`, `emit_json_mir_rejects_hand_authored_json_before_ir_override`; broader MIR lowering, schema, and golden tests still required |
 | Target/build YAML validation | constrained | `emit_json_target_yaml_validates_minimal_target_schema`, `emit_json_target_yaml_validates_backend_schema`, `emit_json_target_yaml_rejects_layout_overrides`, `emit_json_target_yaml_rejects_unsupported_backend_codegen`; broader ABI/backend option schemas still required |
 | Behaviors and type association | gated | Positive/negative behavior solver tests |
 | `Sync/Async effects` | gated | `async_scheduler_intrinsics_are_rejected_as_gated_not_unknown`, `effect_await_is_rejected_until_async_lowering_exists`, `atomic_intrinsics_are_rejected_as_effect_gates`; effect checker positive/negative tests still required |

--- a/docs/learn_zen_in_y_minutes.md
+++ b/docs/learn_zen_in_y_minutes.md
@@ -471,6 +471,7 @@ zen emit-json typed main.zen
 zen emit-json diagnostics main.zen
 zen emit-json layout main.zen
 zen emit-json hir main.zen
+zen emit-json mir main.zen
 zen emit-json target-yaml target.yaml
 ```
 
@@ -480,6 +481,8 @@ checked typed program, and `diagnostics` is machine-readable error output.
 primitive sizes, `StaticString`, pointer-sized views, and struct field offsets.
 `hir` reports checked declaration-level HIR for tools and agents that need a
 stable graph of types, functions, and globals without owning compiler truth.
+`mir` reports checked minimal function/block MIR for tools that need a stable
+control-flow summary while broader MIR lowering is still being promoted.
 `target-yaml` validates a human-authored target description and current C
 backend options into canonical `zen.target.v0` JSON while rejecting attempts to
 override compiler-owned type layouts or select unsupported backends.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,7 +31,8 @@ use execution_commands::{cmd_build, cmd_build_graph, cmd_run_file, cmd_test};
 use frontend::{graph_frontend, load_module_graph};
 use json_emit::{
     cmd_emit_json_ast, cmd_emit_json_build_graph, cmd_emit_json_diagnostics, cmd_emit_json_hir,
-    cmd_emit_json_layout, cmd_emit_json_symbols, cmd_emit_json_target_yaml, cmd_emit_json_typed,
+    cmd_emit_json_layout, cmd_emit_json_mir, cmd_emit_json_symbols, cmd_emit_json_target_yaml,
+    cmd_emit_json_typed,
 };
 use usage::print_usage;
 
@@ -95,15 +96,13 @@ impl EmitJsonMode {
 
     fn gate_message(self) -> Option<&'static str> {
         match self {
-            Self::Mir => Some(
-                "MIR JSON emission is gated until schema and golden tests exist; compiler-owned IR schemas must reject hand-authored overrides",
-            ),
             Self::Ast
             | Self::Symbols
             | Self::Typed
             | Self::Diagnostics
             | Self::BuildGraph
             | Self::Hir
+            | Self::Mir
             | Self::Layout
             | Self::TargetYaml => None,
         }
@@ -192,9 +191,9 @@ pub fn main() {
                         EmitJsonMode::Diagnostics => cmd_emit_json_diagnostics(&args[3]),
                         EmitJsonMode::BuildGraph => cmd_emit_json_build_graph(&args[3]),
                         EmitJsonMode::Hir => cmd_emit_json_hir(&args[3]),
+                        EmitJsonMode::Mir => cmd_emit_json_mir(&args[3]),
                         EmitJsonMode::Layout => cmd_emit_json_layout(&args[3]),
                         EmitJsonMode::TargetYaml => cmd_emit_json_target_yaml(&args[3]),
-                        EmitJsonMode::Mir => unreachable!("gated emit-json mode exited"),
                     }
                 }
                 Err(()) => {
@@ -237,6 +236,7 @@ enum CompilerOwnedJsonBoundary {
     Diagnostics,
     BuildGraph,
     Hir,
+    Mir,
     Layout,
 }
 
@@ -249,6 +249,7 @@ impl CompilerOwnedJsonBoundary {
             Self::Diagnostics => "compiler-owned diagnostics JSON emission rejects hand-authored diagnostic IR before it can override compiler diagnostics",
             Self::BuildGraph => "compiler-owned build graph JSON emission rejects hand-authored graph IR before it can override deterministic build metadata",
             Self::Hir => "compiler-owned IR schemas reject hand-authored HIR JSON before it can override checked types or layouts",
+            Self::Mir => "compiler-owned IR schemas reject hand-authored MIR JSON before it can override checked types or layouts",
             Self::Layout => "compiler-owned layout schemas reject hand-authored layout IR before it can override compiler-owned types or layouts",
         }
     }
@@ -283,6 +284,10 @@ fn reject_hand_authored_json_for_build_graph_emit(path_str: &str) {
 
 fn reject_hand_authored_json_for_hir_emit(path_str: &str) {
     reject_hand_authored_json_for_emit(path_str, CompilerOwnedJsonBoundary::Hir);
+}
+
+fn reject_hand_authored_json_for_mir_emit(path_str: &str) {
+    reject_hand_authored_json_for_emit(path_str, CompilerOwnedJsonBoundary::Mir);
 }
 
 fn reject_hand_authored_json_for_layout_emit(path_str: &str) {

--- a/src/cli/json_emit.rs
+++ b/src/cli/json_emit.rs
@@ -70,6 +70,19 @@ pub(super) fn cmd_emit_json_hir(path_str: &str) {
     }
 }
 
+pub(super) fn cmd_emit_json_mir(path_str: &str) {
+    super::reject_build_zen_for_emit_json_mode(path_str);
+    super::reject_hand_authored_json_for_mir_emit(path_str);
+    let typed = super::graph_frontend(path_str);
+    match zen::ir_json::mir_program_to_json(&typed) {
+        Ok(json) => println!("{json}"),
+        Err(e) => {
+            eprintln!("json emit error: {}", e);
+            process::exit(1);
+        }
+    }
+}
+
 pub(super) fn cmd_emit_json_diagnostics(path_str: &str) {
     super::reject_build_zen_for_emit_json_mode(path_str);
     super::reject_hand_authored_json_for_diagnostics_emit(path_str);

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -15,7 +15,7 @@ pub(super) fn print_usage() {
     eprintln!("  emit-json diagnostics <file>   Emit diagnostics JSON");
     eprintln!("  emit-json build-graph <build.zen>   Emit deterministic build graph JSON");
     eprintln!("  emit-json hir <file>   Emit checked HIR JSON");
-    eprintln!("  emit-json mir <file>   Gated MIR JSON");
+    eprintln!("  emit-json mir <file>   Emit checked minimal MIR JSON");
     eprintln!("  emit-json layout <file>   Emit checked type layout JSON");
     eprintln!("  emit-json target-yaml <file>   Validate target YAML");
     eprintln!("  <file>         Run a .zen file");

--- a/src/ir_json.rs
+++ b/src/ir_json.rs
@@ -2,6 +2,7 @@ use serde::Serialize;
 
 mod hir;
 mod layout;
+mod mir;
 
 use crate::ast::typed::TypedProgram;
 use crate::ast::Program;
@@ -146,6 +147,10 @@ pub fn hir_program_to_json(program: &TypedProgram) -> serde_json::Result<String>
 
 pub fn layout_program_to_json(program: &TypedProgram) -> serde_json::Result<String> {
     layout::program_to_json(program)
+}
+
+pub fn mir_program_to_json(program: &TypedProgram) -> serde_json::Result<String> {
+    mir::program_to_json(program)
 }
 
 fn symbol_json(symbol: &Symbol) -> SymbolJson<'_> {

--- a/src/ir_json/mir.rs
+++ b/src/ir_json/mir.rs
@@ -1,0 +1,300 @@
+use serde::Serialize;
+
+use crate::ast::typed::{
+    TypedBlock, TypedExprKind, TypedExpression, TypedFunction, TypedParam, TypedProgram,
+    TypedStatement, TypedStatementKind,
+};
+
+#[derive(Serialize)]
+struct MirJsonProgram {
+    format: &'static str,
+    semantic_status: &'static str,
+    lowering_status: &'static str,
+    functions: Vec<MirFunction>,
+}
+
+#[derive(Serialize)]
+struct MirFunction {
+    name: String,
+    params: Vec<MirParam>,
+    return_type: String,
+    blocks: Vec<MirBlock>,
+}
+
+#[derive(Serialize)]
+struct MirParam {
+    name: String,
+    r#type: String,
+}
+
+#[derive(Serialize)]
+struct MirBlock {
+    label: &'static str,
+    statements: Vec<MirStatement>,
+    terminator: MirTerminator,
+}
+
+#[derive(Serialize)]
+struct MirStatement {
+    kind: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    ty: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mutable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    value: Option<MirExpression>,
+}
+
+#[derive(Serialize)]
+struct MirTerminator {
+    kind: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    value: Option<MirExpression>,
+}
+
+#[derive(Serialize)]
+struct MirExpression {
+    kind: &'static str,
+    #[serde(rename = "type")]
+    ty: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    value: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    op: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    left: Option<Box<MirExpression>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    right: Option<Box<MirExpression>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target: Option<Box<MirExpression>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    field: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    function: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    args: Vec<MirExpression>,
+}
+
+pub(super) fn program_to_json(program: &TypedProgram) -> serde_json::Result<String> {
+    let graph = MirJsonProgram {
+        format: "zen.mir.v0",
+        semantic_status: "checked",
+        lowering_status: "minimal",
+        functions: program.functions.iter().map(mir_function).collect(),
+    };
+
+    serde_json::to_string_pretty(&graph)
+}
+
+fn mir_function(function: &TypedFunction) -> MirFunction {
+    MirFunction {
+        name: function.name.clone(),
+        params: function.params.iter().map(mir_param).collect(),
+        return_type: function.return_type.display_name(),
+        blocks: vec![mir_entry_block(&function.body)],
+    }
+}
+
+fn mir_param(param: &TypedParam) -> MirParam {
+    MirParam {
+        name: param.name.clone(),
+        r#type: param.ty.display_name(),
+    }
+}
+
+fn mir_entry_block(body: &TypedBlock) -> MirBlock {
+    MirBlock {
+        label: "entry",
+        statements: body.statements.iter().map(mir_statement).collect(),
+        terminator: match &body.expr {
+            Some(expr) => MirTerminator {
+                kind: "return",
+                value: Some(mir_expression(expr)),
+            },
+            None => MirTerminator {
+                kind: "return_void",
+                value: None,
+            },
+        },
+    }
+}
+
+fn mir_statement(statement: &TypedStatement) -> MirStatement {
+    match &statement.kind {
+        TypedStatementKind::VarDecl {
+            name,
+            ty,
+            value,
+            mutable,
+        } => MirStatement {
+            kind: "let",
+            name: Some(name.clone()),
+            ty: Some(ty.display_name()),
+            mutable: Some(*mutable),
+            value: Some(mir_expression(value)),
+        },
+        TypedStatementKind::Expression(expr) => MirStatement {
+            kind: "expr",
+            name: None,
+            ty: None,
+            mutable: None,
+            value: Some(mir_expression(expr)),
+        },
+    }
+}
+
+fn mir_expression(expr: &TypedExpression) -> MirExpression {
+    let mut lowered = MirExpression {
+        kind: mir_expression_kind(expr),
+        ty: expr.ty.display_name(),
+        name: None,
+        value: None,
+        op: None,
+        left: None,
+        right: None,
+        target: None,
+        field: None,
+        function: None,
+        args: Vec::new(),
+    };
+
+    match &expr.kind {
+        TypedExprKind::IntLiteral(value) => {
+            lowered.value = Some(serde_json::json!(value));
+        }
+        TypedExprKind::FloatLiteral(value) => {
+            lowered.value = Some(serde_json::json!(value));
+        }
+        TypedExprKind::StringLiteral(value) => {
+            lowered.value = Some(serde_json::json!(value));
+        }
+        TypedExprKind::BoolLiteral(value) => {
+            lowered.value = Some(serde_json::json!(value));
+        }
+        TypedExprKind::Variable(name) => {
+            lowered.name = Some(name.clone());
+        }
+        TypedExprKind::BinaryOp { op, left, right } => {
+            lowered.op = Some(op.symbol());
+            lowered.left = Some(Box::new(mir_expression(left)));
+            lowered.right = Some(Box::new(mir_expression(right)));
+        }
+        TypedExprKind::UnaryOp { op, operand } => {
+            lowered.op = Some(op.symbol());
+            lowered.target = Some(Box::new(mir_expression(operand)));
+        }
+        TypedExprKind::FunctionCall { function, args } => {
+            lowered.function = Some(function.clone());
+            lowered.args = args.iter().map(mir_expression).collect();
+        }
+        TypedExprKind::FieldAccess { object, field } => {
+            lowered.target = Some(Box::new(mir_expression(object)));
+            lowered.field = Some(field.clone());
+        }
+        TypedExprKind::IndexAccess { object, index } => {
+            lowered.target = Some(Box::new(mir_expression(object)));
+            lowered.args = vec![mir_expression(index)];
+        }
+        TypedExprKind::StructLiteral { type_name, fields } => {
+            lowered.name = Some(type_name.clone());
+            lowered.args = fields
+                .iter()
+                .map(|(_, value)| mir_expression(value))
+                .collect();
+        }
+        TypedExprKind::EnumVariant {
+            type_name,
+            variant,
+            payload,
+        } => {
+            lowered.name = Some(format!("{type_name}.{variant}"));
+            if let Some(payload) = payload {
+                lowered.args = vec![mir_expression(payload)];
+            }
+        }
+        TypedExprKind::ArrayLiteral { elements } => {
+            lowered.args = elements.iter().map(mir_expression).collect();
+        }
+        TypedExprKind::Match { scrutinee, .. } => {
+            lowered.target = Some(Box::new(mir_expression(scrutinee)));
+        }
+        TypedExprKind::Cast {
+            expr,
+            from_type,
+            to_type,
+        } => {
+            lowered.target = Some(Box::new(mir_expression(expr)));
+            lowered.name = Some(format!(
+                "{}->{}",
+                from_type.display_name(),
+                to_type.display_name()
+            ));
+        }
+        TypedExprKind::Ref(inner) | TypedExprKind::MutRef(inner) | TypedExprKind::Deref(inner) => {
+            lowered.target = Some(Box::new(mir_expression(inner)));
+        }
+        TypedExprKind::Closure { fn_name, .. } => {
+            lowered.function = Some(fn_name.clone());
+        }
+        TypedExprKind::StringInterpolation { parts } => {
+            lowered.value = Some(serde_json::json!({ "parts": parts.len() }));
+        }
+        TypedExprKind::Intrinsic { name, args } => {
+            lowered.function = Some(name.clone());
+            lowered.args = args.iter().map(mir_expression).collect();
+        }
+        TypedExprKind::Assign { target, value } => {
+            lowered.target = Some(Box::new(mir_expression(target)));
+            lowered.value = Some(serde_json::to_value(mir_expression(value)).unwrap_or_default());
+        }
+        TypedExprKind::Block(block) => {
+            lowered.value = Some(serde_json::json!({
+                "statement_count": block.statements.len(),
+                "has_result": block.expr.is_some(),
+            }));
+        }
+        TypedExprKind::LoopControl { action, label } => {
+            lowered.op = Some(action.as_str());
+            lowered.name = Some(label.clone());
+        }
+        TypedExprKind::Break | TypedExprKind::Continue | TypedExprKind::Error => {}
+    }
+
+    lowered
+}
+
+fn mir_expression_kind(expr: &TypedExpression) -> &'static str {
+    match &expr.kind {
+        TypedExprKind::IntLiteral(_) => "int",
+        TypedExprKind::FloatLiteral(_) => "float",
+        TypedExprKind::StringLiteral(_) => "static_string",
+        TypedExprKind::BoolLiteral(_) => "bool",
+        TypedExprKind::Variable(_) => "local",
+        TypedExprKind::BinaryOp { .. } => "binary",
+        TypedExprKind::UnaryOp { .. } => "unary",
+        TypedExprKind::FunctionCall { .. } => "call",
+        TypedExprKind::FieldAccess { .. } => "field",
+        TypedExprKind::IndexAccess { .. } => "index",
+        TypedExprKind::StructLiteral { .. } => "struct",
+        TypedExprKind::EnumVariant { .. } => "enum_variant",
+        TypedExprKind::ArrayLiteral { .. } => "array",
+        TypedExprKind::Match { .. } => "match",
+        TypedExprKind::Cast { .. } => "cast",
+        TypedExprKind::Ref(_) => "ref",
+        TypedExprKind::MutRef(_) => "mut_ref",
+        TypedExprKind::Deref(_) => "deref",
+        TypedExprKind::Closure { .. } => "closure",
+        TypedExprKind::StringInterpolation { .. } => "string_interpolation",
+        TypedExprKind::Intrinsic { .. } => "intrinsic",
+        TypedExprKind::Assign { .. } => "assign",
+        TypedExprKind::Block(_) => "block",
+        TypedExprKind::Break => "break",
+        TypedExprKind::Continue => "continue",
+        TypedExprKind::LoopControl { .. } => "loop_control",
+        TypedExprKind::Error => "error",
+    }
+}

--- a/tests/docs_truth/phase_audit.rs
+++ b/tests/docs_truth/phase_audit.rs
@@ -42,7 +42,7 @@ fn phase_plan_records_recovered_progress_and_next_slice() {
         "build_graph_rejects_self_target_dependencies",
         "build_program_lowering_rejects_self_target_dependencies",
         "emit_json_hir_outputs_checked_declaration_graph",
-        "emit_json_mir_command_is_explicitly_gated",
+        "emit_json_mir_outputs_checked_minimal_function_graph",
         "emit_json_target_yaml_validates_minimal_target_schema",
         "emit_json_target_yaml_validates_backend_schema",
         "emit_json_target_yaml_rejects_layout_overrides",

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -113,7 +113,7 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "emit_json_build_graph_rejects_hand_authored_json_before_graph_override",
         "emit_json_hir_outputs_checked_declaration_graph",
         "emit_json_hir_rejects_hand_authored_json_before_ir_override",
-        "emit_json_mir_rejects_program_before_mir_json",
+        "emit_json_mir_outputs_checked_minimal_function_graph",
         "emit_json_mir_rejects_hand_authored_json_before_ir_override",
         "emit_json_layout_outputs_checked_type_layouts",
         "emit_json_layout_rejects_hand_authored_json_before_layout_override",

--- a/tests/integration/cli_build/diagnostics/usage.rs
+++ b/tests/integration/cli_build/diagnostics/usage.rs
@@ -21,7 +21,7 @@ fn root_usage_lists_supported_and_gated_emit_json_modes() {
         "emit-json diagnostics <file>",
         "emit-json build-graph <build.zen>",
         "emit-json hir <file>   Emit checked HIR JSON",
-        "emit-json mir <file>   Gated MIR JSON",
+        "emit-json mir <file>   Emit checked minimal MIR JSON",
         "emit-json layout <file>   Emit checked type layout JSON",
         "emit-json target-yaml <file>   Validate target YAML",
     ] {

--- a/tests/integration/cli_build/frontend_json.rs
+++ b/tests/integration/cli_build/frontend_json.rs
@@ -98,32 +98,7 @@ fn emit_json_typed_command_outputs_checked_program() {
 }
 
 #[test]
-fn emit_json_mir_command_is_explicitly_gated() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "mir",
-            test_dir().join("hello.zen").to_str().unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json mir");
-
-    assert!(
-        !output.status.success(),
-        "zen emit-json mir should be gated: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("MIR JSON emission is gated until schema and golden tests exist"),
-        "expected MIR gate diagnostic, stderr={stderr}"
-    );
-}
-
-#[test]
-fn emit_json_mir_rejects_program_before_mir_json() {
+fn emit_json_mir_outputs_checked_minimal_function_graph() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let zen_path = tmp.path().join("mir_subject.zen");
     std::fs::write(
@@ -143,26 +118,36 @@ main = () i32 {
         .expect("run zen emit-json mir on program input");
 
     assert!(
-        !output.status.success(),
-        "zen emit-json mir should be gated before MIR emission: stdout={}, stderr={}",
+        output.status.success(),
+        "zen emit-json mir should emit checked minimal MIR JSON: stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stdout.trim().is_empty(),
-        "gated MIR should not emit MIR JSON, stdout={stdout}"
-    );
-    assert!(
-        stderr.contains("MIR JSON emission is gated until schema and golden tests exist"),
-        "expected MIR gate diagnostic, stderr={stderr}"
-    );
-    assert!(
-        !stderr.contains("unknown command") && !stderr.contains("No such file"),
-        "MIR should reject through the schema/golden-test gate, not command/path handling, stderr={stderr}"
-    );
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("MIR stdout is json");
+    assert_eq!(json["format"], "zen.mir.v0");
+    assert_eq!(json["semantic_status"], "checked");
+    assert_eq!(json["lowering_status"], "minimal");
+
+    let functions = json["functions"].as_array().expect("MIR functions array");
+    let main = functions
+        .iter()
+        .find(|function| function["name"] == "main")
+        .expect("main function in MIR");
+    assert_eq!(main["return_type"], "i32");
+
+    let entry = &main["blocks"][0];
+    assert_eq!(entry["label"], "entry");
+    assert_eq!(entry["statements"][0]["kind"], "let");
+    assert_eq!(entry["statements"][0]["name"], "value");
+    assert_eq!(entry["statements"][0]["type"], "i32");
+    assert_eq!(entry["statements"][0]["value"]["kind"], "binary");
+    assert_eq!(entry["statements"][0]["value"]["op"], "+");
+    assert_eq!(entry["terminator"]["kind"], "return");
+    assert_eq!(entry["terminator"]["value"]["kind"], "local");
+    assert_eq!(entry["terminator"]["value"]["name"], "value");
+    assert_eq!(entry["terminator"]["value"]["type"], "i32");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- promote `zen emit-json mir` from a gate to checked minimal `zen.mir.v0` output
- emit function/block/statement/terminator summaries from typed program bodies
- keep hand-authored MIR JSON rejected at the compiler-owned IR boundary
- update usage, Learn Zen, V1 spec, phase plan, completion audit, and docs-truth anchors

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- `cargo test --test integration emit_json_mir -- --nocapture`
- push-event Actions check: `[]`