### PR TITLE
Parse reserved derive associations

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -84,11 +84,13 @@ and do not assume Phase 4 is ready without evidence.
   avoiding accidental partial promotion before the behavior solver can model
   generic target templates.
 - Generated/fallback behavior association remains gated deliberately. The
-  parser now reserves `Type.derive(Json)` through the enum-owned type
-  declaration suffix table and reports the generated association gate through
-  `parser::tests::generated_behavior_derive_association_is_explicitly_gated`,
-  keeping derive fallback syntax out of ordinary method parsing until fallback
-  resolution and ambiguity diagnostics exist.
+  parser now reserves `Type.derive(Json)` as an AST declaration through the
+  enum-owned type declaration suffix table, and resolver validation reports
+  the generated association gate through
+  `parser::tests::parse_generated_behavior_derive_association` and
+  `resolver_gates_generated_behavior_derive_association`, keeping derive
+  fallback lowering blocked until fallback resolution and ambiguity diagnostics
+  exist.
 - Generic method specializations that call generic functions have executable
   and generated-C coverage in `tests/zen/generic_method_worklist.zen`, including
   call-resolution assertions for the reached generic function dependency.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -150,10 +150,11 @@ Agent UX deliverables:
   keeping the unsupported behavior-solver boundary separate from supported
   generic non-behavior `Type<T>.impl` blocks.
 - Generated/fallback behavior association syntax such as `Type.derive(Json)`
-  is now reserved and explicitly gated through the same enum-owned type
-  declaration suffix table, guarded by
-  `parser::tests::generated_behavior_derive_association_is_explicitly_gated`
-  and `parser_type_declaration_suffixes_use_owned_keyword_enum`.
+  is now parsed into a reserved AST declaration for non-generic receivers, then
+  explicitly gated during resolver validation. Guarded by
+  `parser::tests::parse_generated_behavior_derive_association`,
+  `resolver_gates_generated_behavior_derive_association`, and
+  `parser_type_declaration_suffixes_use_owned_keyword_enum`.
 - Resolver symbol table data-model definitions now live in a focused core
   include, leaving symbol-table lookup and definition behavior in the parent
   implementation file.

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -275,8 +275,10 @@ planned positive test and one planned negative test before implementation.
 | JSON/YAML IR boundaries | Checked layout JSON, checked MIR JSON, and target YAML validate against schemas | Hand-authored JSON IR cannot override compiler-owned types or layouts |
 
 Generated/fallback behavior association syntax is reserved but not implemented:
-`Type.derive(Json)` currently reports an explicit parser gate, covered by
-`parser::tests::generated_behavior_derive_association_is_explicitly_gated`.
+`Type.derive(Json)` currently parses into a reserved AST declaration and then
+reports an explicit resolver gate, covered by
+`parser::tests::parse_generated_behavior_derive_association` and
+`resolver_gates_generated_behavior_derive_association`.
 The diagnostics JSON path reports that gate over the full
 `Type.derive(...)` association call, covered by
 `emit_json_diagnostics_spans_full_gated_behavior_derive_association`.

--- a/docs/learn_zen_in_y_minutes.md
+++ b/docs/learn_zen_in_y_minutes.md
@@ -297,6 +297,9 @@ that a type must have a behavior implementation.
 
 ## Loops
 
+Zen has one loop form. There are no `for` or `while` keywords, and loop exits
+are explicit calls instead of `break` or `continue`.
+
 ```zen
 sum_to = (limit: i32) i32 {
     total ::= 0
@@ -316,10 +319,9 @@ sum_to = (limit: i32) i32 {
 }
 ```
 
-Loops use prefix `loop((l) { ... })` with explicit loop-control calls:
-`l.done()` exits the target loop and `l.next()` continues it. The same control
-operations can be called in UFC form as `done(l)` and `next(l)`. See
-`examples/05_loops.zen` for the tutorial version.
+Loops use prefix `loop((l) { ... })` with explicit loop-control calls. The
+control parameter names the loop target: `l.done()` exits that target and
+`l.next()` continues it. See `examples/05_loops.zen` for the tutorial version.
 
 Nested loops can target an outer label directly:
 
@@ -344,7 +346,7 @@ nested = (stop: bool) i32 {
 }
 ```
 
-The loop controls are ordinary calls, so UFC form is equivalent:
+Loop controls are ordinary calls, so UFC form is equivalent:
 
 ```zen
 single_step = (ready: bool) i32 {
@@ -362,6 +364,9 @@ single_step = (ready: bool) i32 {
     value
 }
 ```
+
+The same rule applies in nested loops: `done(outer)` exits the outer loop, and
+`next(inner)` continues only the inner loop.
 
 ## Defer
 
@@ -421,7 +426,25 @@ literals, and interpolation does not implicitly construct allocator-backed
 
 The following syntax and APIs are gated design goals, not stable compiler
 behavior yet. They are included here because they are central to the intended
-language shape.
+language shape: allocation is explicit, async work is effect-aware, and sync
+code cannot accidentally call async operations.
+
+`Sync` and `Async` are effect modes. They are part of the type contract, not
+marker-only names:
+
+```zen
+read_now = (file: File, allocator: Allocator<u8, Sync>) Result<Buffer<u8>, IoError> {
+    bytes = file.read_all(allocator).raise()
+    Result<Buffer<u8>, IoError>.Ok(bytes)
+}
+
+read_later = (file: File, allocator: Allocator<u8, Async>) Task<Result<Buffer<u8>, IoError>> {
+    file.read_all_async(allocator)
+}
+```
+
+The intended rule is that sync code either stays sync or crosses an explicit
+runtime boundary. It does not implicitly await async work.
 
 ```zen
 Allocator<T, Sync>: behavior {
@@ -448,7 +471,24 @@ make_buffer<T, A: Allocator<T, Sync>> = (allocator: A, len: usize) Result<Buffer
 }
 ```
 
-The intended model is:
+Allocators are typed by the value they allocate and by the effect mode they run
+under. A sync allocator returns a direct checked result. An async allocator
+returns a task-shaped result:
+
+```zen
+make_async_buffer<T, A: Allocator<T, Async>> =
+    (allocator: A, len: usize) Task<Result<Buffer<T, A>, AllocError>> {
+    allocator.alloc(len).then((ptr) {
+        Result<Buffer<T, A>, AllocError>.Ok(Buffer<T, A> {
+            ptr: ptr,
+            len: len,
+            allocator: allocator
+        })
+    })
+}
+```
+
+The model is:
 
 - `Sync` and `Async` are real effects, not marker-only names.
 - Sync code cannot call async operations without an explicit runtime boundary.
@@ -457,6 +497,8 @@ The intended model is:
   exceptions.
 - `.raise()` is the planned Result propagation operator, but it is gated until
   typechecked propagation and lowering are implemented.
+- Task chaining and async scheduler APIs are gated until Sync/Async effect
+  checking and task lowering are implemented.
 
 For the current contract and gate status, see `docs/V1_SPEC.md`.
 

--- a/src/ast/declarations.rs
+++ b/src/ast/declarations.rs
@@ -174,6 +174,14 @@ pub enum Declaration {
         span: Span,
     },
 
+    /// Generated/fallback behavior association: `Point.derive(Json)`
+    Derive {
+        type_name: String,
+        behavior: String,
+        behavior_type_args: Vec<AstType>,
+        span: Span,
+    },
+
     /// Behavior inheritance: `PrettyPrint.extends(Serializable)`
     BehaviorExtends {
         behavior: String,
@@ -201,6 +209,7 @@ impl Declaration {
             | Declaration::Behavior { span, .. }
             | Declaration::ImplBlock { span, .. }
             | Declaration::Requires { span, .. }
+            | Declaration::Derive { span, .. }
             | Declaration::BehaviorExtends { span, .. }
             | Declaration::TopLevelExpr { span, .. }
             | Declaration::Error { span, .. } => *span,

--- a/src/error.rs
+++ b/src/error.rs
@@ -296,16 +296,23 @@ impl From<CompileError> for Diagnostic {
                 context: Vec::new(),
                 suggested_fixes: Vec::new(),
             },
-            CompileError::Resolution(msg, span) => Diagnostic {
-                severity: Severity::Error,
-                code: "E3500".to_string(),
-                message: msg,
-                span,
-                labels: Vec::new(),
-                notes: Vec::new(),
-                context: Vec::new(),
-                suggested_fixes: Vec::new(),
-            },
+            CompileError::Resolution(msg, span) => {
+                let code = if msg == GATED_GENERATED_BEHAVIOR_DERIVE_MESSAGE {
+                    "E2000"
+                } else {
+                    "E3500"
+                };
+                Diagnostic {
+                    severity: Severity::Error,
+                    code: code.to_string(),
+                    message: msg,
+                    span,
+                    labels: Vec::new(),
+                    notes: Vec::new(),
+                    context: Vec::new(),
+                    suggested_fixes: Vec::new(),
+                }
+            }
             CompileError::Internal(msg) => Diagnostic {
                 severity: Severity::Error,
                 code: "E9999".to_string(),

--- a/src/parser/behavior_declarations.rs
+++ b/src/parser/behavior_declarations.rs
@@ -263,6 +263,30 @@ impl Parser {
         })
     }
 
+    pub(super) fn parse_behavior_derive(
+        &mut self,
+        type_name: String,
+        name_span: Span,
+    ) -> Result<Declaration, CompileError> {
+        self.skip_newlines();
+        self.expect(&Token::LParen)?;
+        self.skip_newlines();
+        let (behavior, behavior_span) = self.expect_identifier()?;
+        let behavior_type_args = if matches!(self.peek(), Token::Lt) {
+            self.parse_type_arg_list()?
+        } else {
+            Vec::new()
+        };
+        self.skip_newlines();
+        let end = self.expect(&Token::RParen)?;
+        Ok(Declaration::Derive {
+            type_name,
+            behavior,
+            behavior_type_args,
+            span: name_span.merge(behavior_span).merge(end),
+        })
+    }
+
     pub(super) fn parse_behavior_extends(
         &mut self,
         behavior: String,

--- a/src/parser/declarations.rs
+++ b/src/parser/declarations.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::error::GATED_GENERATED_BEHAVIOR_DERIVE_MESSAGE;
 use crate::parser::keywords::ParserBehaviorKeyword;
 
 impl Parser {
@@ -143,7 +142,7 @@ impl Parser {
                             self.parse_behavior_extends(name, name_span)
                         }
                         TypeDeclarationKeyword::Derive => {
-                            self.reject_gated_generated_behavior_derive(name_span)
+                            self.parse_behavior_derive(name, name_span)
                         }
                     };
                 }
@@ -205,17 +204,6 @@ impl Parser {
             format!(
                 "generic association target `Type<T>.{keyword}` is gated; use non-generic `{keyword}` associations or keep the generic behavior target deferred to docs/V1_SPEC.md"
             ),
-            Some(span),
-        ))
-    }
-
-    fn reject_gated_generated_behavior_derive<T>(
-        &mut self,
-        name_span: Span,
-    ) -> Result<T, CompileError> {
-        let span = self.gated_association_call_span(name_span);
-        Err(CompileError::Syntax(
-            GATED_GENERATED_BEHAVIOR_DERIVE_MESSAGE.to_string(),
             Some(span),
         ))
     }

--- a/src/parser/tests/behaviors.rs
+++ b/src/parser/tests/behaviors.rs
@@ -188,17 +188,21 @@ fn generic_type_association_keywords_are_explicitly_gated() {
 }
 
 #[test]
-fn generated_behavior_derive_association_is_explicitly_gated() {
-    let errors = parse_err("Point.derive(Json)");
-    let message = errors
-        .first()
-        .map(ToString::to_string)
-        .unwrap_or_else(|| "missing parser error".to_string());
-
-    assert!(
-        message.contains("generated behavior association `Type.derive(...)` is gated"),
-        "expected explicit generated behavior association gate, got {errors:?}"
-    );
+fn parse_generated_behavior_derive_association() {
+    let prog = parse_ok("Point.derive(Json)");
+    match &prog.declarations[0] {
+        Declaration::Derive {
+            type_name,
+            behavior,
+            behavior_type_args,
+            ..
+        } => {
+            assert_eq!(type_name, "Point");
+            assert_eq!(behavior, "Json");
+            assert!(behavior_type_args.is_empty());
+        }
+        other => panic!("expected Derive, got {:?}", other),
+    }
 }
 
 #[test]

--- a/src/resolver/declaration_definition.rs
+++ b/src/resolver/declaration_definition.rs
@@ -159,6 +159,7 @@ impl Resolver {
                 }
             }
             Declaration::Requires { .. }
+            | Declaration::Derive { .. }
             | Declaration::BehaviorExtends { .. }
             | Declaration::TopLevelExpr { .. }
             | Declaration::Error { .. } => {}

--- a/src/resolver/declaration_validation.rs
+++ b/src/resolver/declaration_validation.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use crate::ast::Declaration;
-use crate::error::Diagnostic;
+use crate::error::{Diagnostic, GATED_GENERATED_BEHAVIOR_DERIVE_MESSAGE};
 
 use super::metadata_helpers::behavior_ref_display;
 use super::symbol_table::ScopeStack;
@@ -292,6 +292,35 @@ impl Resolver {
                 for type_arg in behavior_type_args {
                     self.validate_type_ref(table, &[], type_arg, *span, false, diagnostics);
                 }
+            }
+            Declaration::Derive {
+                type_name,
+                behavior,
+                behavior_type_args,
+                span,
+            } => {
+                if !self.is_known_type_name(table, &[], type_name) {
+                    diagnostics.push(Diagnostic::error(
+                        "E0201",
+                        format!("unknown type symbol '{type_name}'"),
+                        *span,
+                    ));
+                }
+                if !self.is_known_behavior_name(table, behavior) {
+                    diagnostics.push(Diagnostic::error(
+                        "E0202",
+                        format!("unknown behavior symbol '{behavior}'"),
+                        *span,
+                    ));
+                }
+                for type_arg in behavior_type_args {
+                    self.validate_type_ref(table, &[], type_arg, *span, false, diagnostics);
+                }
+                diagnostics.push(Diagnostic::error(
+                    "E2000",
+                    GATED_GENERATED_BEHAVIOR_DERIVE_MESSAGE,
+                    *span,
+                ));
             }
             Declaration::BehaviorExtends {
                 behavior,

--- a/src/typechecker/resolver_validation/entry_symbols.rs
+++ b/src/typechecker/resolver_validation/entry_symbols.rs
@@ -245,7 +245,7 @@ impl TypeChecker {
                 Declaration::TopLevelExpr { expr, .. } => {
                     self.require_resolver_scoped_expr_locals(symbols, expr, &mut scope_cursor);
                 }
-                Declaration::Error { .. } => {}
+                Declaration::Derive { .. } | Declaration::Error { .. } => {}
             }
         }
         let replay_tasks = Self::collect_resolver_validation_replay_tasks(program, symbols);

--- a/src/typechecker/self_type_validation.rs
+++ b/src/typechecker/self_type_validation.rs
@@ -81,7 +81,8 @@ impl TypeChecker {
             Declaration::TopLevelExpr { expr, .. } => {
                 tasks.push(SelfTypeContextValidationTask::TopLevelExpr { expr });
             }
-            Declaration::Import { .. } | Declaration::Error { .. } => {}
+            Declaration::Derive { .. } | Declaration::Import { .. } | Declaration::Error { .. } => {
+            }
         }
     }
 

--- a/tests/resolver_phase2/generic_behavior_associations.rs
+++ b/tests/resolver_phase2/generic_behavior_associations.rs
@@ -77,6 +77,33 @@ Point.requires(Json<StaticString>)
 }
 
 #[test]
+fn resolver_gates_generated_behavior_derive_association() {
+    let program = parse_program(
+        r#"
+Json: behavior {
+    encode: (Self) StaticString
+}
+
+Point: { x: i32 }
+
+Point.derive(Json)
+"#,
+    );
+
+    let err = Resolver::new()
+        .resolve_program(&program)
+        .expect_err("generated derive associations should stay gated");
+
+    assert!(
+        err.iter().any(|d| {
+            d.message
+                .contains("generated behavior association `Type.derive(...)` is gated")
+        }),
+        "expected generated behavior association gate, got {err:?}"
+    );
+}
+
+#[test]
 fn resolver_records_generic_behavior_parent_names() {
     let program = parse_program(
         r#"


### PR DESCRIPTION
## Summary
- parse non-generic Type.derive(Behavior) into a reserved AST declaration
- keep derive fallback semantics gated in resolver diagnostics with the existing E2000 feature gate
- expand Learn Zen loops and gated Sync/Async allocator examples

## Verification
- cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests
- gh run list --branch codex/parse-derive-association --event push --limit 10 --json databaseId,status,conclusion,workflowName,headSha,createdAt,url => []