### PR TITLE
Add IR JSON schema version fields

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -4173,6 +4173,11 @@ and do not assume Phase 4 is ready without evidence.
   language server, agent-readable diagnostics, machine-readable project graph,
   and structured fix suggestions. Covered by
   `phase_plan_records_recovered_progress_and_next_slice`.
+- HIR and MIR JSON outputs now include numeric `schema_version: 0` fields next
+  to their `format` tags, so tools and agents can pin the compiler-owned v0
+  schema without parsing the display format string. Covered by
+  `emit_json_hir_outputs_checked_declaration_graph` and
+  `emit_json_mir_outputs_checked_minimal_function_graph`.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3829,9 +3829,11 @@ Agent UX deliverables:
   `EmitJsonMode`, keeping mode text attached to the enum that owns parsing and
   usage. Guarded by `cli_emit_json_modes_use_owned_mode_enum`.
 - Real program inputs to `emit-json hir` now emit checked declaration-level HIR
-  JSON, guarded by `emit_json_hir_outputs_checked_declaration_graph`. Real
-  program inputs to `emit-json mir` now emit checked minimal function/block MIR
-  JSON. Guarded by `emit_json_mir_outputs_checked_minimal_function_graph`.
+  JSON with `schema_version: 0`, guarded by
+  `emit_json_hir_outputs_checked_declaration_graph`. Real program inputs to
+  `emit-json mir` now emit checked minimal function/block MIR JSON with
+  `schema_version: 0`. Guarded by
+  `emit_json_mir_outputs_checked_minimal_function_graph`.
 - Hand-authored typed JSON inputs to `emit-json typed` now reject at the
   compiler-owned typed JSON boundary before forged checked IR can be treated as
   Zen source or accepted as semantic evidence. Guarded by

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -179,11 +179,12 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   path validation can stand in for the compiler-owned graph boundary, covered by
   `emit_json_build_graph_rejects_hand_authored_json_before_graph_override`.
   `zen emit-json hir <file>` emits `format: "zen.hir.v0"` with
-  `semantic_status: "checked"` and a declaration graph for checked types,
-  functions, and globals, covered by
+  `schema_version: 0`, `semantic_status: "checked"`, and a declaration graph
+  for checked types, functions, and globals, covered by
   `emit_json_hir_outputs_checked_declaration_graph`. `zen emit-json mir <file>`
-  emits `format: "zen.mir.v0"` with `semantic_status: "checked"` and a minimal
-  function/block/terminator graph over typed program bodies, covered by
+  emits `format: "zen.mir.v0"` with `schema_version: 0`,
+  `semantic_status: "checked"`, and a minimal function/block/terminator graph
+  over typed program bodies, covered by
   `emit_json_mir_outputs_checked_minimal_function_graph`. Hand-authored JSON IR
   inputs to `zen emit-json hir <file>` and `zen emit-json mir <file>` are
   rejected at the compiler-owned schema boundary before any type or layout
@@ -248,8 +249,8 @@ Generic behavior inheritance with child type-parameter parent args is covered by
 | Typechecked C backend for tested fixtures | implemented | `cargo test --tests` |
 | README and contributor truth assertions | implemented | `tests/docs_truth.rs` |
 | Strict resolver, symbol IDs, privacy | implemented | Resolver/module/privacy tests |
-| HIR JSON emission | constrained | `emit_json_hir_outputs_checked_declaration_graph`, `emit_json_hir_rejects_hand_authored_json_before_ir_override`; broader HIR schema and golden tests still required |
-| MIR JSON emission | constrained | `emit_json_mir_outputs_checked_minimal_function_graph`, `emit_json_mir_rejects_hand_authored_json_before_ir_override`; broader MIR lowering, schema, and golden tests still required |
+| HIR JSON emission | constrained | `emit_json_hir_outputs_checked_declaration_graph` checks `schema_version: 0`, `emit_json_hir_rejects_hand_authored_json_before_ir_override`; broader HIR schema and golden tests still required |
+| MIR JSON emission | constrained | `emit_json_mir_outputs_checked_minimal_function_graph` checks `schema_version: 0`, `emit_json_mir_rejects_hand_authored_json_before_ir_override`; broader MIR lowering, schema, and golden tests still required |
 | Target/build YAML validation | constrained | `emit_json_target_yaml_validates_minimal_target_schema`, `emit_json_target_yaml_validates_backend_schema`, `emit_json_target_yaml_validates_c_backend_flags`, `emit_json_target_yaml_rejects_empty_c_backend_flags`, `emit_json_target_yaml_rejects_layout_overrides`, `emit_json_target_yaml_rejects_unsupported_backend_codegen`; broader ABI/backend option schemas still required |
 | Behaviors and type association | gated | Positive/negative behavior solver tests |
 | `Sync/Async effects` | gated | `async_scheduler_intrinsics_are_rejected_as_gated_not_unknown`, `effect_await_is_rejected_until_async_lowering_exists`, `atomic_intrinsics_are_rejected_as_effect_gates`; effect checker positive/negative tests still required |

--- a/src/ir_json/hir.rs
+++ b/src/ir_json/hir.rs
@@ -5,6 +5,7 @@ use crate::ast::typed::{Type, TypeDefKind, TypedFunction, TypedProgram, TypedTyp
 #[derive(Serialize)]
 struct HirJsonProgram {
     format: &'static str,
+    schema_version: u32,
     semantic_status: &'static str,
     declarations: HirDeclarations,
 }
@@ -60,6 +61,7 @@ struct HirGlobalDecl {
 pub(super) fn program_to_json(program: &TypedProgram) -> serde_json::Result<String> {
     let graph = HirJsonProgram {
         format: "zen.hir.v0",
+        schema_version: 0,
         semantic_status: "checked",
         declarations: HirDeclarations {
             types: program.types.iter().map(hir_type_decl).collect(),

--- a/src/ir_json/mir.rs
+++ b/src/ir_json/mir.rs
@@ -8,6 +8,7 @@ use crate::ast::typed::{
 #[derive(Serialize)]
 struct MirJsonProgram {
     format: &'static str,
+    schema_version: u32,
     semantic_status: &'static str,
     lowering_status: &'static str,
     functions: Vec<MirFunction>,
@@ -82,6 +83,7 @@ struct MirExpression {
 pub(super) fn program_to_json(program: &TypedProgram) -> serde_json::Result<String> {
     let graph = MirJsonProgram {
         format: "zen.mir.v0",
+        schema_version: 0,
         semantic_status: "checked",
         lowering_status: "minimal",
         functions: program.functions.iter().map(mir_function).collect(),

--- a/tests/docs_truth/phase_audit.rs
+++ b/tests/docs_truth/phase_audit.rs
@@ -42,6 +42,7 @@ fn phase_plan_records_recovered_progress_and_next_slice() {
         "build_graph_rejects_self_target_dependencies",
         "build_program_lowering_rejects_self_target_dependencies",
         "emit_json_hir_outputs_checked_declaration_graph",
+        "schema_version: 0",
         "emit_json_mir_outputs_checked_minimal_function_graph",
         "emit_json_target_yaml_validates_minimal_target_schema",
         "emit_json_target_yaml_validates_backend_schema",

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -114,6 +114,7 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "emit_json_diagnostics_rejects_hand_authored_json_before_diagnostic_override",
         "emit_json_typed_rejects_hand_authored_json_before_checked_ir_override",
         "emit_json_build_graph_rejects_hand_authored_json_before_graph_override",
+        "schema_version: 0",
         "emit_json_hir_outputs_checked_declaration_graph",
         "emit_json_hir_rejects_hand_authored_json_before_ir_override",
         "emit_json_mir_outputs_checked_minimal_function_graph",

--- a/tests/integration/cli_build/frontend_json.rs
+++ b/tests/integration/cli_build/frontend_json.rs
@@ -129,6 +129,7 @@ main = () i32 {
     let json: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("MIR stdout is json");
     assert_eq!(json["format"], "zen.mir.v0");
+    assert_eq!(json["schema_version"], 0);
     assert_eq!(json["semantic_status"], "checked");
     assert_eq!(json["lowering_status"], "minimal");
 
@@ -232,6 +233,7 @@ main = () i32 { 0 }
     let json: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("HIR stdout is json");
     assert_eq!(json["format"], "zen.hir.v0");
+    assert_eq!(json["schema_version"], 0);
     assert_eq!(json["semantic_status"], "checked");
 
     let types = json["declarations"]["types"]


### PR DESCRIPTION
## Summary
- Add numeric `schema_version: 0` to compiler-owned HIR and MIR JSON outputs
- Pin the new schema field in the existing HIR/MIR emit-json integration tests
- Update V1 spec, phase plan, completion audit, and docs truth checks with the stronger IR schema evidence

## Verification
- cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests
- gh run list --branch ir-json-schema-version --event push --limit 10 --json databaseId,status,conclusion,workflowName,headSha,createdAt,url => []