### PR TITLE
Add layout JSON schema version

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3907,9 +3907,10 @@ and do not assume Phase 4 is ready without evidence.
 - Build graph JSON now carries `format: "zen.build_graph.v0"` and
   `semantic_status: "deterministic"` while preserving the existing graph
   payload keys, covered by `emit_json_build_graph_outputs_project_build_graph`.
-- `emit-json layout` now has checked compiler-owned layout JSON for the stable
-  subset: primitive sizes, baked `StaticString`, pointer-sized views, and struct
-  field offsets. Covered by `emit_json_layout_outputs_checked_type_layouts`,
+- `emit-json layout` now has checked compiler-owned layout JSON with
+  `schema_version: 0` for the stable subset: primitive sizes, baked
+  `StaticString`, pointer-sized views, and struct field offsets. Covered by
+  `emit_json_layout_outputs_checked_type_layouts`,
   `emit_json_usage_lists_supported_and_gated_modes`, and
   `root_usage_lists_supported_and_gated_emit_json_modes`.
 - Hand-authored layout JSON inputs to `emit-json layout` reject at the
@@ -4173,11 +4174,12 @@ and do not assume Phase 4 is ready without evidence.
   language server, agent-readable diagnostics, machine-readable project graph,
   and structured fix suggestions. Covered by
   `phase_plan_records_recovered_progress_and_next_slice`.
-- HIR and MIR JSON outputs now include numeric `schema_version: 0` fields next
-  to their `format` tags, so tools and agents can pin the compiler-owned v0
-  schema without parsing the display format string. Covered by
+- HIR, MIR, and layout JSON outputs now include numeric `schema_version: 0`
+  fields next to their `format` tags, so tools and agents can pin the
+  compiler-owned v0 schema without parsing the display format string. Covered by
   `emit_json_hir_outputs_checked_declaration_graph` and
-  `emit_json_mir_outputs_checked_minimal_function_graph`.
+  `emit_json_mir_outputs_checked_minimal_function_graph` plus
+  `emit_json_layout_outputs_checked_type_layouts`.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3626,9 +3626,10 @@ Agent UX deliverables:
   existing target, dependency, feature, and host-effect payload keys. Covered by
   `emit_json_build_graph_outputs_project_build_graph`.
 - `emit-json layout` now emits checked compiler-owned layout JSON for the
-  stable subset: primitive sizes, baked `StaticString`, pointer-sized views, and
-  struct field offsets. The mode remains listed in both root and emit-json
-  usage, and is covered by `emit_json_layout_outputs_checked_type_layouts`,
+  stable subset with `schema_version: 0`: primitive sizes, baked
+  `StaticString`, pointer-sized views, and struct field offsets. The mode
+  remains listed in both root and emit-json usage, and is covered by
+  `emit_json_layout_outputs_checked_type_layouts`,
   `emit_json_usage_lists_supported_and_gated_modes`, and
   `root_usage_lists_supported_and_gated_emit_json_modes`.
 - Hand-authored layout JSON inputs to `emit-json layout` now reject at the

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -191,9 +191,9 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   override can be accepted, covered by
   `emit_json_hir_rejects_hand_authored_json_before_ir_override` and
   `emit_json_mir_rejects_hand_authored_json_before_ir_override`.
-  `zen emit-json layout <file>` emits checked compiler-owned layout JSON for
-  the current stable subset, including primitive sizes, baked `StaticString`,
-  and struct field offsets, covered by
+  `zen emit-json layout <file>` emits checked compiler-owned layout JSON with
+  `schema_version: 0` for the current stable subset, including primitive sizes,
+  baked `StaticString`, and struct field offsets, covered by
   `emit_json_layout_outputs_checked_type_layouts`. Hand-authored layout JSON
   inputs are rejected at the compiler-owned layout schema boundary before any
   ABI override can be accepted, covered by

--- a/src/ir_json/layout.rs
+++ b/src/ir_json/layout.rs
@@ -7,6 +7,7 @@ use crate::ast::typed::{Type, TypeDefKind, TypedProgram, TypedTypeDef};
 #[derive(Serialize)]
 struct LayoutJsonProgram {
     format: &'static str,
+    schema_version: u32,
     semantic_status: &'static str,
     target: LayoutJsonTarget,
     layouts: BTreeMap<String, LayoutJsonType>,
@@ -49,6 +50,7 @@ pub(super) fn program_to_json(program: &TypedProgram) -> serde_json::Result<Stri
     let context = LayoutContext::new(program);
     let graph = LayoutJsonProgram {
         format: "zen.layout.v0",
+        schema_version: 0,
         semantic_status: "checked",
         target: LayoutJsonTarget {
             pointer_size: POINTER_SIZE,

--- a/tests/integration/cli_build/frontend_json.rs
+++ b/tests/integration/cli_build/frontend_json.rs
@@ -292,6 +292,7 @@ main = () i32 { 0 }
     let json: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("layout stdout is json");
     assert_eq!(json["format"], "zen.layout.v0");
+    assert_eq!(json["schema_version"], 0);
     assert_eq!(json["semantic_status"], "checked");
     assert_eq!(json["target"]["pointer_size"], 8);
     assert_eq!(json["target"]["usize_size"], 8);


### PR DESCRIPTION
## Summary
- Add numeric `schema_version: 0` to compiler-owned layout JSON output
- Pin the field in the existing layout emit-json integration test
- Update spec, phase plan, and completion audit wording so layout joins the versioned IR boundary evidence

## Verification
- cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests
- gh run list --branch layout-json-schema-version --event push --limit 10 --json databaseId,status,conclusion,workflowName,headSha,createdAt,url => []