### PR TITLE
Add target YAML schema version

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -4139,9 +4139,9 @@ and do not assume Phase 4 is ready without evidence.
   Covered by `emit_json_hir_rejects_hand_authored_json_before_ir_override`.
 - Hand-authored target YAML remains outside the compiler-owned IR path:
   `emit-json target-yaml` validates a minimal schema plus the current C backend
-  schema into `zen.target.v0` JSON, accepts optional `backend.c_flags`, rejects
-  empty C flag entries, rejects attempts to override compiler-owned type
-  layouts, and rejects unsupported backend code generators.
+  schema into `zen.target.v0` JSON with `schema_version: 0`, accepts optional
+  `backend.c_flags`, rejects empty C flag entries, rejects attempts to override
+  compiler-owned type layouts, and rejects unsupported backend code generators.
   Covered by `emit_json_target_yaml_validates_minimal_target_schema`,
   `emit_json_target_yaml_validates_backend_schema`,
   `emit_json_target_yaml_validates_c_backend_flags`,
@@ -4174,12 +4174,14 @@ and do not assume Phase 4 is ready without evidence.
   language server, agent-readable diagnostics, machine-readable project graph,
   and structured fix suggestions. Covered by
   `phase_plan_records_recovered_progress_and_next_slice`.
-- HIR, MIR, and layout JSON outputs now include numeric `schema_version: 0`
-  fields next to their `format` tags, so tools and agents can pin the
-  compiler-owned v0 schema without parsing the display format string. Covered by
+- HIR, MIR, layout, and target-yaml JSON outputs now include numeric
+  `schema_version: 0` fields next to their `format` tags, so tools and agents
+  can pin the compiler-owned v0 schema without parsing the display format
+  string. Covered by
   `emit_json_hir_outputs_checked_declaration_graph` and
   `emit_json_mir_outputs_checked_minimal_function_graph` plus
-  `emit_json_layout_outputs_checked_type_layouts`.
+  `emit_json_layout_outputs_checked_type_layouts` and
+  `emit_json_target_yaml_validates_minimal_target_schema`.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3864,9 +3864,10 @@ Agent UX deliverables:
   Guarded by `emit_json_hir_rejects_hand_authored_json_before_ir_override`.
 - Hand-authored target YAML remains outside the compiler-owned IR path:
   `emit-json target-yaml` now validates a minimal target schema plus the current
-  C backend schema into `zen.target.v0` JSON, accepts optional
-  `backend.c_flags`, rejects empty C flag entries, rejects attempts to override
-  compiler-owned type layouts, and rejects unsupported backend code generators.
+  C backend schema into `zen.target.v0` JSON with `schema_version: 0`, accepts
+  optional `backend.c_flags`, rejects empty C flag entries, rejects attempts to
+  override compiler-owned type layouts, and rejects unsupported backend code
+  generators.
   Guarded by `emit_json_target_yaml_validates_minimal_target_schema`,
   `emit_json_target_yaml_validates_backend_schema`,
   `emit_json_target_yaml_validates_c_backend_flags`,

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -204,9 +204,10 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   marked diagnostic. semantic acceptance must use typed JSON, diagnostics,
   check, build, or test paths. Hand-authored target YAML validates through a
   minimal target schema plus an optional current-backend schema into
-  `zen.target.v0` JSON. The current C backend schema accepts optional
-  `backend.c_flags`, rejects empty C flag entries, and rejects compiler-owned
-  layout overrides or unsupported backend code generators, covered by
+  `zen.target.v0` JSON with `schema_version: 0`. The current C backend schema
+  accepts optional `backend.c_flags`, rejects empty C flag entries, and rejects
+  compiler-owned layout overrides or unsupported backend code generators,
+  covered by
   `emit_json_target_yaml_validates_minimal_target_schema`,
   `emit_json_target_yaml_validates_backend_schema`,
   `emit_json_target_yaml_validates_c_backend_flags`,
@@ -251,7 +252,7 @@ Generic behavior inheritance with child type-parameter parent args is covered by
 | Strict resolver, symbol IDs, privacy | implemented | Resolver/module/privacy tests |
 | HIR JSON emission | constrained | `emit_json_hir_outputs_checked_declaration_graph` checks `schema_version: 0`, `emit_json_hir_rejects_hand_authored_json_before_ir_override`; broader HIR schema and golden tests still required |
 | MIR JSON emission | constrained | `emit_json_mir_outputs_checked_minimal_function_graph` checks `schema_version: 0`, `emit_json_mir_rejects_hand_authored_json_before_ir_override`; broader MIR lowering, schema, and golden tests still required |
-| Target/build YAML validation | constrained | `emit_json_target_yaml_validates_minimal_target_schema`, `emit_json_target_yaml_validates_backend_schema`, `emit_json_target_yaml_validates_c_backend_flags`, `emit_json_target_yaml_rejects_empty_c_backend_flags`, `emit_json_target_yaml_rejects_layout_overrides`, `emit_json_target_yaml_rejects_unsupported_backend_codegen`; broader ABI/backend option schemas still required |
+| Target/build YAML validation | constrained | `emit_json_target_yaml_validates_minimal_target_schema` checks `schema_version: 0`, `emit_json_target_yaml_validates_backend_schema`, `emit_json_target_yaml_validates_c_backend_flags`, `emit_json_target_yaml_rejects_empty_c_backend_flags`, `emit_json_target_yaml_rejects_layout_overrides`, `emit_json_target_yaml_rejects_unsupported_backend_codegen`; broader ABI/backend option schemas still required |
 | Behaviors and type association | gated | Positive/negative behavior solver tests |
 | `Sync/Async effects` | gated | `async_scheduler_intrinsics_are_rejected_as_gated_not_unknown`, `effect_await_is_rejected_until_async_lowering_exists`, `atomic_intrinsics_are_rejected_as_effect_gates`; effect checker positive/negative tests still required |
 | `Typed allocators` | gated | `dynamic_string_type_is_rejected_as_allocator_backed_gate`, `typed_allocator_type_is_rejected_as_gated_not_unknown`, `sync_and_async_typed_allocator_modes_are_rejected_as_gated_not_unknown`, `raw_memory_intrinsics_are_rejected_as_allocator_gates`, `byte_memory_intrinsics_are_rejected_as_allocator_gates`; positive allocator semantics tests still required |

--- a/src/target_yaml.rs
+++ b/src/target_yaml.rs
@@ -100,6 +100,7 @@ enum Endianness {
 #[derive(Serialize)]
 struct TargetJson {
     format: &'static str,
+    schema_version: u32,
     semantic_status: &'static str,
     target: TargetJsonBody,
 }
@@ -133,6 +134,7 @@ pub fn target_yaml_to_json(source: &str) -> Result<String, TargetYamlError> {
     validate_target_yaml(&input)?;
     let json = TargetJson {
         format: "zen.target.v0",
+        schema_version: 0,
         semantic_status: "validated",
         target: TargetJsonBody {
             triple: input.triple,

--- a/tests/integration/cli_build/frontend_json/target_yaml.rs
+++ b/tests/integration/cli_build/frontend_json/target_yaml.rs
@@ -30,6 +30,7 @@ abi: sysv
     let json: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("target-yaml stdout is json");
     assert_eq!(json["format"], "zen.target.v0");
+    assert_eq!(json["schema_version"], 0);
     assert_eq!(json["semantic_status"], "validated");
     assert_eq!(json["target"]["triple"], "x86_64-unknown-linux-gnu");
     assert_eq!(json["target"]["pointer_width"], 64);


### PR DESCRIPTION
## Summary
- Add numeric `schema_version: 0` to validated target-yaml JSON output
- Pin the field in the minimal target-yaml emit-json integration test
- Update V1 spec, phase plan, and completion audit wording so target-yaml joins the versioned JSON output contract

## Verification
- cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests
- gh run list --branch target-yaml-schema-version --event push --limit 10 --json databaseId,status,conclusion,workflowName,headSha,createdAt,url => []