### PR TITLE
Add build graph schema version

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3904,9 +3904,10 @@ and do not assume Phase 4 is ready without evidence.
   `emit_json_symbols_command_outputs_module_symbol_tables`, so resolver-owned
   symbol metadata is explicitly separated from unchecked AST JSON and checked
   typed JSON.
-- Build graph JSON now carries `format: "zen.build_graph.v0"` and
-  `semantic_status: "deterministic"` while preserving the existing graph
-  payload keys, covered by `emit_json_build_graph_outputs_project_build_graph`.
+- Build graph JSON now carries `format: "zen.build_graph.v0"`,
+  `schema_version: 0`, and `semantic_status: "deterministic"` while preserving
+  the existing graph payload keys, covered by
+  `emit_json_build_graph_outputs_project_build_graph`.
 - `emit-json layout` now has checked compiler-owned layout JSON with
   `schema_version: 0` for the stable subset: primitive sizes, baked
   `StaticString`, pointer-sized views, and struct field offsets. Covered by
@@ -4174,14 +4175,15 @@ and do not assume Phase 4 is ready without evidence.
   language server, agent-readable diagnostics, machine-readable project graph,
   and structured fix suggestions. Covered by
   `phase_plan_records_recovered_progress_and_next_slice`.
-- HIR, MIR, layout, and target-yaml JSON outputs now include numeric
+- HIR, MIR, layout, target-yaml, and build-graph JSON outputs now include numeric
   `schema_version: 0` fields next to their `format` tags, so tools and agents
   can pin the compiler-owned v0 schema without parsing the display format
   string. Covered by
   `emit_json_hir_outputs_checked_declaration_graph` and
   `emit_json_mir_outputs_checked_minimal_function_graph` plus
   `emit_json_layout_outputs_checked_type_layouts` and
-  `emit_json_target_yaml_validates_minimal_target_schema`.
+  `emit_json_target_yaml_validates_minimal_target_schema` plus
+  `emit_json_build_graph_outputs_project_build_graph`.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3621,10 +3621,10 @@ Agent UX deliverables:
   `format: "zen.symbols.v0"`, making resolver-owned metadata distinct from
   unchecked AST JSON and checked typed JSON. Covered by
   `emit_json_symbols_command_outputs_module_symbol_tables`.
-- Build graph JSON now carries `format: "zen.build_graph.v0"` and
-  `semantic_status: "deterministic"` at the top level while preserving the
-  existing target, dependency, feature, and host-effect payload keys. Covered by
-  `emit_json_build_graph_outputs_project_build_graph`.
+- Build graph JSON now carries `format: "zen.build_graph.v0"`,
+  `schema_version: 0`, and `semantic_status: "deterministic"` at the top level
+  while preserving the existing target, dependency, feature, and host-effect
+  payload keys. Covered by `emit_json_build_graph_outputs_project_build_graph`.
 - `emit-json layout` now emits checked compiler-owned layout JSON for the
   stable subset with `schema_version: 0`: primitive sizes, baked
   `StaticString`, pointer-sized views, and struct field offsets. The mode

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -219,8 +219,9 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   target C for one graph target, `zen build build.zen` compiles executable
   targets through that graph, and direct `zen build.zen` aliases that same graph
   build path. `zen test build.zen` compiles and runs test graph targets.
-  `zen emit-json build-graph <build.zen>` emits `format: "zen.build_graph.v0"`
-  and `semantic_status: "deterministic"` with the constrained graph payload.
+  `zen emit-json build-graph <build.zen>` emits `format: "zen.build_graph.v0"`,
+  `schema_version: 0`, and `semantic_status: "deterministic"` with the
+  constrained graph payload.
   Executable target dependencies compile before their dependents. Test targets
   are lowered, emitted in build graph JSON, compiled, and run through the
   constrained test command. Library targets are lowered and emitted in build

--- a/src/build_graph.rs
+++ b/src/build_graph.rs
@@ -67,6 +67,7 @@ pub struct BuildGraph {
 #[derive(Serialize)]
 struct BuildGraphJson<'a> {
     format: &'static str,
+    schema_version: u32,
     semantic_status: &'static str,
     targets: &'a [BuildTarget],
     declared_host_effects: &'a [HostEffect],
@@ -181,6 +182,7 @@ impl BuildGraph {
     pub fn canonical_json(&self) -> Result<String, serde_json::Error> {
         serde_json::to_string(&BuildGraphJson {
             format: "zen.build_graph.v0",
+            schema_version: 0,
             semantic_status: "deterministic",
             targets: &self.targets,
             declared_host_effects: &self.declared_host_effects,

--- a/tests/integration/cli_build/build_graph_json.rs
+++ b/tests/integration/cli_build/build_graph_json.rs
@@ -19,6 +19,7 @@ fn emit_json_build_graph_outputs_project_build_graph() {
 
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("build graph json");
     assert_eq!(json["format"], "zen.build_graph.v0");
+    assert_eq!(json["schema_version"], 0);
     assert_eq!(json["semantic_status"], "deterministic");
     assert_eq!(json["targets"][0]["name"], "myapp");
     assert_eq!(json["targets"][0]["kind"]["root_source_file"], "main.zen");


### PR DESCRIPTION
## Summary
- Add numeric `schema_version: 0` to deterministic build-graph JSON output
- Pin the field in the existing build-graph emit-json integration test
- Update V1 spec, phase plan, and completion audit wording so build-graph joins the versioned JSON output contract

## Verification
- cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests
- gh run list --branch build-graph-schema-version --event push --limit 10 --json databaseId,status,conclusion,workflowName,headSha,createdAt,url => []