### PR TITLE
Add AST JSON schema version

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -4175,10 +4175,11 @@ and do not assume Phase 4 is ready without evidence.
   language server, agent-readable diagnostics, machine-readable project graph,
   and structured fix suggestions. Covered by
   `phase_plan_records_recovered_progress_and_next_slice`.
-- HIR, MIR, layout, target-yaml, and build-graph JSON outputs now include numeric
-  `schema_version: 0` fields next to their `format` tags, so tools and agents
-  can pin the compiler-owned v0 schema without parsing the display format
-  string. Covered by
+- AST, HIR, MIR, layout, target-yaml, and build-graph JSON outputs now include
+  numeric `schema_version: 0` fields next to their `format` tags, so tools and
+  agents can pin the compiler-owned v0 schema without parsing the display
+  format string. Covered by
+  `emit_json_ast_command_outputs_resolved_module_graph`,
   `emit_json_hir_outputs_checked_declaration_graph` and
   `emit_json_mir_outputs_checked_minimal_function_graph` plus
   `emit_json_layout_outputs_checked_type_layouts` and

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -549,9 +549,11 @@ Agent UX deliverables:
 - Frontend JSON integration tests now keep AST and symbol module-graph
   serialization coverage in a focused child module, leaving typed-program and
   diagnostics JSON checks in the parent module.
-- AST JSON now carries `semantic_status: "unchecked"`, and the same integration
-  fixture proves a semantically invalid program can emit AST JSON while
+- AST JSON now carries `schema_version: 0` and
+  `semantic_status: "unchecked"`, and the same integration fixture proves a
+  semantically invalid program can emit AST JSON while
   `emit-json typed` rejects it. Covered by
+  `emit_json_ast_command_outputs_resolved_module_graph` and
   `emit_json_ast_marks_semantically_unchecked_sources_that_typed_json_rejects`.
 - AST traversal is no longer listed in the Required Test Backlog because the
   AST JSON tooling view has positive output evidence and negative semantic

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -162,9 +162,10 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   `zen emit-json typed <file>`, `zen emit-json diagnostics <file>`,
   `zen emit-json hir <file>`, `zen emit-json layout <file>`,
   `zen emit-json build-graph <file>`, and
-  `zen emit-json target-yaml <file>`. Hand-authored AST, symbols, typed, HIR,
-  and diagnostics JSON inputs are rejected before the frontend treats them as
-  Zen source or compiler-produced diagnostics, covered by
+  `zen emit-json target-yaml <file>`. AST JSON includes
+  `schema_version: 0` with `semantic_status: "unchecked"`. Hand-authored AST,
+  symbols, typed, HIR, and diagnostics JSON inputs are rejected before the
+  frontend treats them as Zen source or compiler-produced diagnostics, covered by
   `emit_json_ast_rejects_hand_authored_json_before_unchecked_ir_override`,
   `emit_json_symbols_rejects_hand_authored_json_before_resolver_override`,
   `emit_json_diagnostics_rejects_hand_authored_json_before_diagnostic_override`, and

--- a/src/ir_json.rs
+++ b/src/ir_json.rs
@@ -13,6 +13,7 @@ use crate::resolver::Symbol;
 #[derive(Serialize)]
 struct AstJsonGraph<'a> {
     format: &'static str,
+    schema_version: u32,
     semantic_status: &'static str,
     entry_module: u32,
     modules: Vec<AstJsonModule<'a>>,
@@ -92,6 +93,7 @@ pub fn ast_graph_to_json(graph: &ResolvedModuleGraph) -> serde_json::Result<Stri
 
     let graph = AstJsonGraph {
         format: "zen.ast.v0",
+        schema_version: 0,
         semantic_status: "unchecked",
         entry_module: graph.entry.0,
         modules: modules

--- a/tests/integration/cli_build/frontend_json/module_graph.rs
+++ b/tests/integration/cli_build/frontend_json/module_graph.rs
@@ -42,6 +42,7 @@ main = () i32 {
     let json: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("emit-json ast stdout is json");
     assert_eq!(json["format"], "zen.ast.v0");
+    assert_eq!(json["schema_version"], 0);
     assert_eq!(json["semantic_status"], "unchecked");
     assert_eq!(json["entry_module"], 0);
     assert_eq!(json["modules"].as_array().expect("modules array").len(), 2);


### PR DESCRIPTION
## Summary
- Add numeric `schema_version: 0` to unchecked AST JSON output
- Pin it in `emit_json_ast_command_outputs_resolved_module_graph`
- Update V1 spec, phase plan, and completion audit wording so AST joins the versioned JSON output contract

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- Push-event workflow check: `[]`