### PR TITLE
Emit compound layout JSON entries

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3918,6 +3918,10 @@ and do not assume Phase 4 is ready without evidence.
   compiler-owned layout schema boundary before any forged ABI override can be
   accepted. Covered by
   `emit_json_layout_rejects_hand_authored_json_before_layout_override`.
+- Layout JSON now emits named compound layout entries for checked pointer,
+  raw-pointer, slice, and fixed-array field types, and preserves simple enum
+  variant tag/payload layout facts. Covered by
+  `emit_json_layout_outputs_compound_type_layout_entries`.
 - Static string literals no longer implicitly satisfy allocator-backed
   `String`; `String` is recognized as a builtin dynamic text type, but
   allocation must remain explicit. Covered by

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3638,6 +3638,10 @@ Agent UX deliverables:
   compiler-owned layout schema boundary before any forged ABI override can be
   accepted. Guarded by
   `emit_json_layout_rejects_hand_authored_json_before_layout_override`.
+- Layout JSON now emits named compound layout entries for checked pointer,
+  raw-pointer, slice, and fixed-array field types, and preserves simple enum
+  variant tag/payload layout facts. Guarded by
+  `emit_json_layout_outputs_compound_type_layout_entries`.
 - `StaticString` and allocator-backed `String` are no longer type-compatible:
   static string literals stay baked into program storage and cannot implicitly
   allocate dynamic `String` values. Covered by

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -194,8 +194,10 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   `emit_json_mir_rejects_hand_authored_json_before_ir_override`.
   `zen emit-json layout <file>` emits checked compiler-owned layout JSON with
   `schema_version: 0` for the current stable subset, including primitive sizes,
-  baked `StaticString`, and struct field offsets, covered by
-  `emit_json_layout_outputs_checked_type_layouts`. Hand-authored layout JSON
+  baked `StaticString`, pointer/slice/array layout entries, struct field
+  offsets, and simple enum variant tags/payloads, covered by
+  `emit_json_layout_outputs_checked_type_layouts` and
+  `emit_json_layout_outputs_compound_type_layout_entries`. Hand-authored layout JSON
   inputs are rejected at the compiler-owned layout schema boundary before any
   ABI override can be accepted, covered by
   `emit_json_layout_rejects_hand_authored_json_before_layout_override`.

--- a/src/ir_json/layout.rs
+++ b/src/ir_json/layout.rs
@@ -221,17 +221,34 @@ impl<'a> LayoutContext<'a> {
             Type::Enum { name, .. } => self.layout_named(name),
             Type::Array { elem, size } => {
                 let elem_layout = self.layout_type(elem);
-                scalar_layout(
+                self.cache_compound_layout(
+                    ty,
                     "array",
                     elem_layout.size * size.unwrap_or_default() as u32,
                     elem_layout.alignment,
                 )
             }
-            Type::Slice(_) => scalar_layout("slice", POINTER_SIZE + USIZE_SIZE, POINTER_ALIGN),
+            Type::Slice(_) => {
+                self.cache_compound_layout(ty, "slice", POINTER_SIZE + USIZE_SIZE, POINTER_ALIGN)
+            }
             Type::Ptr(_) | Type::MutPtr(_) | Type::RawPtr(_) | Type::Function { .. } => {
-                scalar_layout("pointer", POINTER_SIZE, POINTER_ALIGN)
+                self.cache_compound_layout(ty, "pointer", POINTER_SIZE, POINTER_ALIGN)
             }
         }
+    }
+
+    fn cache_compound_layout(
+        &mut self,
+        ty: &Type,
+        kind: &'static str,
+        size: u32,
+        alignment: u32,
+    ) -> LayoutJsonType {
+        let layout = scalar_layout(kind, size, alignment);
+        self.layouts
+            .entry(ty.display_name())
+            .or_insert_with(|| layout.clone());
+        layout
     }
 
     fn layout_named(&mut self, name: &str) -> LayoutJsonType {

--- a/tests/integration/cli_build/frontend_json.rs
+++ b/tests/integration/cli_build/frontend_json.rs
@@ -315,3 +315,83 @@ main = () i32 { 0 }
     assert_eq!(fields[1]["offset"], 8);
     assert_eq!(fields[1]["type"], "StaticString");
 }
+
+#[test]
+fn emit_json_layout_outputs_compound_type_layout_entries() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let zen_path = tmp.path().join("compound_layout_subject.zen");
+    std::fs::write(
+        &zen_path,
+        r#"
+Handles: {
+    ptr: Ptr<i32>,
+    raw: RawPtr<i32>,
+    slice: Slice<i32>,
+    fixed: [i32; 4],
+}
+
+Choice:
+    Empty,
+    WithPayload(Handles)
+
+main = () i32 { 0 }
+"#,
+    )
+    .expect("write compound layout subject");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "layout", zen_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json layout on compound program input");
+
+    assert!(
+        output.status.success(),
+        "zen emit-json layout should emit checked compound layout JSON: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("compound layout stdout is json");
+    assert_eq!(json["format"], "zen.layout.v0");
+    assert_eq!(json["schema_version"], 0);
+    assert_eq!(json["semantic_status"], "checked");
+
+    let layouts = json["layouts"].as_object().expect("layouts object");
+    for (name, kind, size, alignment) in [
+        ("Ptr<i32>", "pointer", 8, 8),
+        ("RawPtr<i32>", "pointer", 8, 8),
+        ("[i32]", "slice", 16, 8),
+        ("[i32; 4]", "array", 16, 4),
+    ] {
+        let layout = layouts
+            .get(name)
+            .unwrap_or_else(|| panic!("missing compound layout entry for {name}"));
+        assert_eq!(layout["kind"], kind, "unexpected layout kind for {name}");
+        assert_eq!(layout["size"], size, "unexpected layout size for {name}");
+        assert_eq!(
+            layout["alignment"], alignment,
+            "unexpected layout alignment for {name}"
+        );
+    }
+
+    let handles = &layouts["Handles"];
+    assert_eq!(handles["kind"], "struct");
+    let fields = handles["fields"].as_array().expect("Handles fields");
+    assert_eq!(fields[0]["type"], "Ptr<i32>");
+    assert_eq!(fields[1]["type"], "RawPtr<i32>");
+    assert_eq!(fields[2]["type"], "[i32]");
+    assert_eq!(fields[3]["type"], "[i32; 4]");
+
+    let choice = &layouts["Choice"];
+    assert_eq!(choice["kind"], "enum");
+    let variants = choice["variants"].as_array().expect("Choice variants");
+    assert_eq!(variants[0]["name"], "Empty");
+    assert_eq!(variants[0]["tag"], 0);
+    assert_eq!(variants[1]["name"], "WithPayload");
+    assert_eq!(variants[1]["tag"], 1);
+    let payload = variants[1]["payload_fields"]
+        .as_array()
+        .expect("WithPayload payload fields");
+    assert_eq!(payload[0]["type"], "Handles");
+}


### PR DESCRIPTION
## Summary
- Add layout JSON entries for checked pointer, raw-pointer, slice, and fixed-array field types
- Extend layout JSON integration coverage to simple enum tag/payload facts
- Record the new layout schema evidence in V1 spec, phase plan, and completion audit

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- Push-event workflow check: `[]`