### PR TITLE
Expand HIR JSON declaration coverage

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -4189,6 +4189,10 @@ and do not assume Phase 4 is ready without evidence.
   `emit_json_layout_outputs_checked_type_layouts` and
   `emit_json_target_yaml_validates_minimal_target_schema` plus
   `emit_json_build_graph_outputs_project_build_graph`.
+- HIR JSON declaration coverage now includes enum variant tags/payload fields,
+  function parameter and return types, and named mutable top-level globals
+  instead of anonymous top-level blocks. Covered by
+  `emit_json_hir_outputs_enum_function_and_global_declarations`.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3841,6 +3841,10 @@ Agent UX deliverables:
   `emit-json mir` now emit checked minimal function/block MIR JSON with
   `schema_version: 0`. Guarded by
   `emit_json_mir_outputs_checked_minimal_function_graph`.
+- HIR JSON declaration coverage now includes enum variant tags/payload fields,
+  function parameter and return types, and named mutable top-level globals
+  instead of anonymous top-level blocks. Guarded by
+  `emit_json_hir_outputs_enum_function_and_global_declarations`.
 - Hand-authored typed JSON inputs to `emit-json typed` now reject at the
   compiler-owned typed JSON boundary before forged checked IR can be treated as
   Zen source or accepted as semantic evidence. Guarded by

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -181,8 +181,10 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   `emit_json_build_graph_rejects_hand_authored_json_before_graph_override`.
   `zen emit-json hir <file>` emits `format: "zen.hir.v0"` with
   `schema_version: 0`, `semantic_status: "checked"`, and a declaration graph
-  for checked types, functions, and globals, covered by
-  `emit_json_hir_outputs_checked_declaration_graph`. `zen emit-json mir <file>`
+  for checked types, enum variants/payloads, function parameters/returns, and
+  globals, covered by `emit_json_hir_outputs_checked_declaration_graph` and
+  `emit_json_hir_outputs_enum_function_and_global_declarations`.
+  `zen emit-json mir <file>`
   emits `format: "zen.mir.v0"` with `schema_version: 0`,
   `semantic_status: "checked"`, and a minimal function/block/terminator graph
   over typed program bodies, covered by
@@ -254,7 +256,7 @@ Generic behavior inheritance with child type-parameter parent args is covered by
 | Typechecked C backend for tested fixtures | implemented | `cargo test --tests` |
 | README and contributor truth assertions | implemented | `tests/docs_truth.rs` |
 | Strict resolver, symbol IDs, privacy | implemented | Resolver/module/privacy tests |
-| HIR JSON emission | constrained | `emit_json_hir_outputs_checked_declaration_graph` checks `schema_version: 0`, `emit_json_hir_rejects_hand_authored_json_before_ir_override`; broader HIR schema and golden tests still required |
+| HIR JSON emission | constrained | `emit_json_hir_outputs_checked_declaration_graph` checks `schema_version: 0`, `emit_json_hir_outputs_enum_function_and_global_declarations` covers enum variants/payloads, function params/returns, and globals, `emit_json_hir_rejects_hand_authored_json_before_ir_override`; golden tests still required |
 | MIR JSON emission | constrained | `emit_json_mir_outputs_checked_minimal_function_graph` checks `schema_version: 0`, `emit_json_mir_rejects_hand_authored_json_before_ir_override`; broader MIR lowering, schema, and golden tests still required |
 | Target/build YAML validation | constrained | `emit_json_target_yaml_validates_minimal_target_schema` checks `schema_version: 0`, `emit_json_target_yaml_validates_backend_schema`, `emit_json_target_yaml_validates_c_backend_flags`, `emit_json_target_yaml_rejects_empty_c_backend_flags`, `emit_json_target_yaml_rejects_layout_overrides`, `emit_json_target_yaml_rejects_unsupported_backend_codegen`; broader ABI/backend option schemas still required |
 | Behaviors and type association | gated | Positive/negative behavior solver tests |

--- a/src/typechecker/program_checking.rs
+++ b/src/typechecker/program_checking.rs
@@ -124,13 +124,7 @@ impl TypeChecker {
                     // Top-level expressions like main() call
                     match self.check_expr(expr) {
                         Ok(typed_expr) => {
-                            globals.push(TypedGlobal {
-                                name: "__top_level__".into(),
-                                ty: typed_expr.ty.clone(),
-                                value: typed_expr,
-                                mutable: false,
-                                span: *span,
-                            });
+                            push_typed_global(&mut globals, typed_expr, *span);
                         }
                         Err(d) => self.diagnostics.push(d),
                     }
@@ -329,4 +323,35 @@ impl TypeChecker {
     pub fn diagnostics(&self) -> &[Diagnostic] {
         &self.diagnostics
     }
+}
+
+fn push_typed_global(globals: &mut Vec<TypedGlobal>, typed_expr: TypedExpression, span: Span) {
+    if let TypedExprKind::Block(block) = &typed_expr.kind {
+        if block.expr.is_none() && block.statements.len() == 1 {
+            if let TypedStatementKind::VarDecl {
+                name,
+                ty,
+                value,
+                mutable,
+            } = &block.statements[0].kind
+            {
+                globals.push(TypedGlobal {
+                    name: name.clone(),
+                    ty: ty.clone(),
+                    value: value.clone(),
+                    mutable: *mutable,
+                    span,
+                });
+                return;
+            }
+        }
+    }
+
+    globals.push(TypedGlobal {
+        name: "__top_level__".into(),
+        ty: typed_expr.ty.clone(),
+        value: typed_expr,
+        mutable: false,
+        span,
+    });
 }

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -116,6 +116,7 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "emit_json_build_graph_rejects_hand_authored_json_before_graph_override",
         "schema_version: 0",
         "emit_json_hir_outputs_checked_declaration_graph",
+        "emit_json_hir_outputs_enum_function_and_global_declarations",
         "emit_json_hir_rejects_hand_authored_json_before_ir_override",
         "emit_json_mir_outputs_checked_minimal_function_graph",
         "emit_json_mir_rejects_hand_authored_json_before_ir_override",

--- a/tests/integration/cli_build/frontend_json.rs
+++ b/tests/integration/cli_build/frontend_json.rs
@@ -261,6 +261,96 @@ main = () i32 { 0 }
 }
 
 #[test]
+fn emit_json_hir_outputs_enum_function_and_global_declarations() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let zen_path = tmp.path().join("hir_declarations_subject.zen");
+    std::fs::write(
+        &zen_path,
+        r#"
+Pair: {
+    left: i32,
+    right: i32,
+}
+
+MaybePair:
+    None,
+    Some(Pair)
+
+threshold ::= 10
+
+choose = (candidate: Pair, enabled: bool) MaybePair {
+    enabled ?
+        | true { MaybePair.Some(candidate) }
+        | false { MaybePair.None }
+}
+
+main = () i32 { 0 }
+"#,
+    )
+    .expect("write HIR declarations subject");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "hir", zen_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json hir on declaration-rich program input");
+
+    assert!(
+        output.status.success(),
+        "zen emit-json hir should emit checked declaration-rich HIR JSON: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("declaration-rich HIR stdout is json");
+    assert_eq!(json["format"], "zen.hir.v0");
+    assert_eq!(json["schema_version"], 0);
+    assert_eq!(json["semantic_status"], "checked");
+
+    let types = json["declarations"]["types"]
+        .as_array()
+        .expect("HIR types array");
+    let maybe = types
+        .iter()
+        .find(|ty| ty["name"] == "MaybePair")
+        .expect("MaybePair enum in HIR");
+    assert_eq!(maybe["kind"], "enum");
+    let variants = maybe["variants"].as_array().expect("MaybePair variants");
+    assert_eq!(variants[0]["name"], "None");
+    assert_eq!(variants[0]["tag"], 0);
+    assert!(variants[0]["payload"]
+        .as_array()
+        .expect("None payload")
+        .is_empty());
+    assert_eq!(variants[1]["name"], "Some");
+    assert_eq!(variants[1]["tag"], 1);
+    assert_eq!(variants[1]["payload"][0]["type"], "Pair");
+
+    let functions = json["declarations"]["functions"]
+        .as_array()
+        .expect("HIR functions array");
+    let choose = functions
+        .iter()
+        .find(|function| function["name"] == "choose")
+        .expect("choose function in HIR");
+    assert_eq!(choose["return_type"], "MaybePair");
+    assert_eq!(choose["params"][0]["name"], "candidate");
+    assert_eq!(choose["params"][0]["type"], "Pair");
+    assert_eq!(choose["params"][1]["name"], "enabled");
+    assert_eq!(choose["params"][1]["type"], "bool");
+
+    let globals = json["declarations"]["globals"]
+        .as_array()
+        .expect("HIR globals array");
+    let threshold = globals
+        .iter()
+        .find(|global| global["name"] == "threshold")
+        .expect("threshold global in HIR");
+    assert_eq!(threshold["type"], "i32");
+    assert_eq!(threshold["mutable"], true);
+}
+
+#[test]
 fn emit_json_layout_outputs_checked_type_layouts() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let zen_path = tmp.path().join("layout_subject.zen");


### PR DESCRIPTION
## Summary
- Preserve named top-level var declarations as typed globals instead of anonymous top-level blocks
- Add HIR JSON coverage for enum variant tags/payloads, function params/returns, and mutable globals
- Record the broader HIR schema evidence in V1 spec, phase plan, completion audit, and docs-truth checks

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- Push-event workflow check: `[]`