### PR TITLE
Add MIR JSON match golden fixture

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -4196,6 +4196,9 @@ and do not assume Phase 4 is ready without evidence.
 - MIR JSON now exposes match kind, enum-pattern arm names, pattern bindings,
   and block result expressions for checked match expressions instead of only
   reporting the scrutinee. Covered by `emit_json_mir_outputs_match_arm_schema`.
+- The checked MIR match schema is now pinned by the golden fixture test
+  `emit_json_mir_match_schema_matches_golden`, reducing the IR boundary
+  backlog without treating the broader JSON/YAML schema work as complete.
 - Effect checking, typed allocator semantics, actors in std integration,
   JSON/YAML IR boundaries, and broader build graph execution remain gated by
   `docs/V1_SPEC.md`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3848,6 +3848,8 @@ Agent UX deliverables:
 - MIR JSON now exposes match kind, enum-pattern arm names, pattern bindings,
   and block result expressions for checked match expressions instead of only
   reporting the scrutinee. Guarded by `emit_json_mir_outputs_match_arm_schema`.
+- The same checked MIR match schema is now pinned by a golden JSON fixture,
+  guarded by `emit_json_mir_match_schema_matches_golden`.
 - Hand-authored typed JSON inputs to `emit-json typed` now reject at the
   compiler-owned typed JSON boundary before forged checked IR can be treated as
   Zen source or accepted as semantic evidence. Guarded by

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -190,8 +190,9 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   over typed program bodies. The current schema covers locals, returns, calls,
   enum construction, match kind, match arm patterns/bindings, and block result
   summaries, covered by `emit_json_mir_outputs_checked_minimal_function_graph`
-  and `emit_json_mir_outputs_match_arm_schema`. Hand-authored JSON IR
-  inputs to `zen emit-json hir <file>` and `zen emit-json mir <file>` are
+  and `emit_json_mir_outputs_match_arm_schema`. The checked match schema is
+  also pinned by `emit_json_mir_match_schema_matches_golden`. Hand-authored
+  JSON IR inputs to `zen emit-json hir <file>` and `zen emit-json mir <file>` are
   rejected at the compiler-owned schema boundary before any type or layout
   override can be accepted, covered by
   `emit_json_hir_rejects_hand_authored_json_before_ir_override` and
@@ -259,7 +260,7 @@ Generic behavior inheritance with child type-parameter parent args is covered by
 | README and contributor truth assertions | implemented | `tests/docs_truth.rs` |
 | Strict resolver, symbol IDs, privacy | implemented | Resolver/module/privacy tests |
 | HIR JSON emission | constrained | `emit_json_hir_outputs_checked_declaration_graph` checks `schema_version: 0`, `emit_json_hir_outputs_enum_function_and_global_declarations` covers enum variants/payloads, function params/returns, and globals, `emit_json_hir_rejects_hand_authored_json_before_ir_override`; golden tests still required |
-| MIR JSON emission | constrained | `emit_json_mir_outputs_checked_minimal_function_graph` checks `schema_version: 0`, `emit_json_mir_outputs_match_arm_schema` covers match kind, arm patterns/bindings, and block results, `emit_json_mir_rejects_hand_authored_json_before_ir_override`; golden tests still required |
+| MIR JSON emission | constrained | `emit_json_mir_outputs_checked_minimal_function_graph` checks `schema_version: 0`, `emit_json_mir_outputs_match_arm_schema` covers match kind, arm patterns/bindings, and block results, `emit_json_mir_match_schema_matches_golden` pins the checked match schema, `emit_json_mir_rejects_hand_authored_json_before_ir_override`; broader golden tests still required |
 | Target/build YAML validation | constrained | `emit_json_target_yaml_validates_minimal_target_schema` checks `schema_version: 0`, `emit_json_target_yaml_validates_backend_schema`, `emit_json_target_yaml_validates_c_backend_flags`, `emit_json_target_yaml_rejects_empty_c_backend_flags`, `emit_json_target_yaml_rejects_layout_overrides`, `emit_json_target_yaml_rejects_unsupported_backend_codegen`; broader ABI/backend option schemas still required |
 | Behaviors and type association | gated | Positive/negative behavior solver tests |
 | `Sync/Async effects` | gated | `async_scheduler_intrinsics_are_rejected_as_gated_not_unknown`, `effect_await_is_rejected_until_async_lowering_exists`, `atomic_intrinsics_are_rejected_as_effect_gates`; effect checker positive/negative tests still required |

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -120,6 +120,7 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "emit_json_hir_rejects_hand_authored_json_before_ir_override",
         "emit_json_mir_outputs_checked_minimal_function_graph",
         "emit_json_mir_outputs_match_arm_schema",
+        "emit_json_mir_match_schema_matches_golden",
         "emit_json_mir_rejects_hand_authored_json_before_ir_override",
         "emit_json_layout_outputs_checked_type_layouts",
         "emit_json_layout_rejects_hand_authored_json_before_layout_override",

--- a/tests/fixtures/ir_json/mir_match_schema.golden.json
+++ b/tests/fixtures/ir_json/mir_match_schema.golden.json
@@ -1,0 +1,131 @@
+{
+  "format": "zen.mir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "lowering_status": "minimal",
+  "functions": [
+    {
+      "name": "score",
+      "params": [
+        {
+          "name": "choice",
+          "type": "Choice"
+        }
+      ],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "match",
+              "type": "i32",
+              "target": {
+                "kind": "local",
+                "type": "Choice",
+                "name": "choice"
+              },
+              "match_kind": "enum",
+              "arms": [
+                {
+                  "pattern": {
+                    "kind": "enum_variant",
+                    "name": "Choice.Empty",
+                    "bindings": []
+                  },
+                  "body": {
+                    "label": "entry",
+                    "statements": [],
+                    "terminator": {
+                      "kind": "return",
+                      "value": {
+                        "kind": "block",
+                        "type": "i32",
+                        "value": {
+                          "has_result": true,
+                          "result": {
+                            "kind": "int",
+                            "type": "i32",
+                            "value": 0
+                          },
+                          "statement_count": 0
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "pattern": {
+                    "kind": "enum_variant",
+                    "name": "Choice.Value",
+                    "bindings": [
+                      {
+                        "name": "n",
+                        "type": "i32"
+                      }
+                    ]
+                  },
+                  "body": {
+                    "label": "entry",
+                    "statements": [],
+                    "terminator": {
+                      "kind": "return",
+                      "value": {
+                        "kind": "block",
+                        "type": "i32",
+                        "value": {
+                          "has_result": true,
+                          "result": {
+                            "kind": "local",
+                            "name": "n",
+                            "type": "i32"
+                          },
+                          "statement_count": 0
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "main",
+      "params": [],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "call",
+              "type": "i32",
+              "function": "score",
+              "args": [
+                {
+                  "kind": "enum_variant",
+                  "type": "Choice",
+                  "name": "Choice.Value",
+                  "args": [
+                    {
+                      "kind": "int",
+                      "type": "i32",
+                      "value": 42
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/integration/cli_build/frontend_json.rs
+++ b/tests/integration/cli_build/frontend_json.rs
@@ -7,6 +7,8 @@ mod diagnostics_json;
 mod ir_boundaries;
 #[path = "frontend_json/layout_json.rs"]
 mod layout_json;
+#[path = "frontend_json/mir_golden.rs"]
+mod mir_golden;
 #[path = "frontend_json/module_graph.rs"]
 mod module_graph;
 #[path = "frontend_json/target_yaml.rs"]

--- a/tests/integration/cli_build/frontend_json/mir_golden.rs
+++ b/tests/integration/cli_build/frontend_json/mir_golden.rs
@@ -1,0 +1,51 @@
+use std::path::Path;
+use std::process::Command;
+
+fn fixture(path: &str) -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(path)
+}
+
+#[test]
+fn emit_json_mir_match_schema_matches_golden() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let zen_path = tmp.path().join("mir_match_subject.zen");
+    std::fs::write(
+        &zen_path,
+        r#"
+Choice:
+    Empty,
+    Value(i32)
+
+score = (choice: Choice) i32 {
+    choice ?
+        | Empty { 0 }
+        | Value(n) { n }
+}
+
+main = () i32 {
+    score(Choice.Value(42))
+}
+"#,
+    )
+    .expect("write MIR match subject");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "mir", zen_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json mir on match program input");
+
+    assert!(
+        output.status.success(),
+        "zen emit-json mir should emit checked MIR match JSON: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let actual = String::from_utf8(output.stdout).expect("MIR match stdout is UTF-8");
+    serde_json::from_str::<serde_json::Value>(&actual).expect("MIR match stdout is JSON");
+    let expected_path = fixture("tests/fixtures/ir_json/mir_match_schema.golden.json");
+    let expected = std::fs::read_to_string(&expected_path)
+        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
+
+    assert_eq!(actual.trim(), expected.trim());
+}


### PR DESCRIPTION
## Summary
- Add a golden fixture for checked MIR JSON match schema output
- Wire the fixture through a focused frontend JSON integration test
- Record the MIR golden evidence in V1 spec, phase plan, completion audit, and docs-truth checks

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- Push-event workflow check: `[]`