### PR TITLE
Add HIR JSON declaration golden fixture

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -4193,6 +4193,9 @@ and do not assume Phase 4 is ready without evidence.
   function parameter and return types, and named mutable top-level globals
   instead of anonymous top-level blocks. Covered by
   `emit_json_hir_outputs_enum_function_and_global_declarations`.
+- The checked HIR declaration schema is now pinned by the golden fixture test
+  `emit_json_hir_declaration_schema_matches_golden`, reducing the IR boundary
+  backlog without treating broader JSON/YAML schema work as complete.
 - MIR JSON now exposes match kind, enum-pattern arm names, pattern bindings,
   and block result expressions for checked match expressions instead of only
   reporting the scrutinee. Covered by `emit_json_mir_outputs_match_arm_schema`.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3845,6 +3845,8 @@ Agent UX deliverables:
   function parameter and return types, and named mutable top-level globals
   instead of anonymous top-level blocks. Guarded by
   `emit_json_hir_outputs_enum_function_and_global_declarations`.
+- The same checked HIR declaration schema is now pinned by a golden JSON
+  fixture, guarded by `emit_json_hir_declaration_schema_matches_golden`.
 - MIR JSON now exposes match kind, enum-pattern arm names, pattern bindings,
   and block result expressions for checked match expressions instead of only
   reporting the scrutinee. Guarded by `emit_json_mir_outputs_match_arm_schema`.

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -183,7 +183,9 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   `schema_version: 0`, `semantic_status: "checked"`, and a declaration graph
   for checked types, enum variants/payloads, function parameters/returns, and
   globals, covered by `emit_json_hir_outputs_checked_declaration_graph` and
-  `emit_json_hir_outputs_enum_function_and_global_declarations`.
+  `emit_json_hir_outputs_enum_function_and_global_declarations`. The checked
+  declaration schema is also pinned by
+  `emit_json_hir_declaration_schema_matches_golden`.
   `zen emit-json mir <file>`
   emits `format: "zen.mir.v0"` with `schema_version: 0`,
   `semantic_status: "checked"`, and a minimal function/block/terminator graph
@@ -259,7 +261,7 @@ Generic behavior inheritance with child type-parameter parent args is covered by
 | Typechecked C backend for tested fixtures | implemented | `cargo test --tests` |
 | README and contributor truth assertions | implemented | `tests/docs_truth.rs` |
 | Strict resolver, symbol IDs, privacy | implemented | Resolver/module/privacy tests |
-| HIR JSON emission | constrained | `emit_json_hir_outputs_checked_declaration_graph` checks `schema_version: 0`, `emit_json_hir_outputs_enum_function_and_global_declarations` covers enum variants/payloads, function params/returns, and globals, `emit_json_hir_rejects_hand_authored_json_before_ir_override`; golden tests still required |
+| HIR JSON emission | constrained | `emit_json_hir_outputs_checked_declaration_graph` checks `schema_version: 0`, `emit_json_hir_outputs_enum_function_and_global_declarations` covers enum variants/payloads, function params/returns, and globals, `emit_json_hir_declaration_schema_matches_golden` pins the checked declaration schema, `emit_json_hir_rejects_hand_authored_json_before_ir_override`; broader golden tests still required |
 | MIR JSON emission | constrained | `emit_json_mir_outputs_checked_minimal_function_graph` checks `schema_version: 0`, `emit_json_mir_outputs_match_arm_schema` covers match kind, arm patterns/bindings, and block results, `emit_json_mir_match_schema_matches_golden` pins the checked match schema, `emit_json_mir_rejects_hand_authored_json_before_ir_override`; broader golden tests still required |
 | Target/build YAML validation | constrained | `emit_json_target_yaml_validates_minimal_target_schema` checks `schema_version: 0`, `emit_json_target_yaml_validates_backend_schema`, `emit_json_target_yaml_validates_c_backend_flags`, `emit_json_target_yaml_rejects_empty_c_backend_flags`, `emit_json_target_yaml_rejects_layout_overrides`, `emit_json_target_yaml_rejects_unsupported_backend_codegen`; broader ABI/backend option schemas still required |
 | Behaviors and type association | gated | Positive/negative behavior solver tests |

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -117,6 +117,7 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "schema_version: 0",
         "emit_json_hir_outputs_checked_declaration_graph",
         "emit_json_hir_outputs_enum_function_and_global_declarations",
+        "emit_json_hir_declaration_schema_matches_golden",
         "emit_json_hir_rejects_hand_authored_json_before_ir_override",
         "emit_json_mir_outputs_checked_minimal_function_graph",
         "emit_json_mir_outputs_match_arm_schema",

--- a/tests/fixtures/ir_json/hir_declarations.golden.json
+++ b/tests/fixtures/ir_json/hir_declarations.golden.json
@@ -1,0 +1,74 @@
+{
+  "format": "zen.hir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "declarations": {
+    "types": [
+      {
+        "name": "Pair",
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "left",
+            "type": "i32"
+          },
+          {
+            "name": "right",
+            "type": "i32"
+          }
+        ],
+        "variants": []
+      },
+      {
+        "name": "MaybePair",
+        "kind": "enum",
+        "fields": [],
+        "variants": [
+          {
+            "name": "None",
+            "tag": 0,
+            "payload": []
+          },
+          {
+            "name": "Some",
+            "tag": 1,
+            "payload": [
+              {
+                "name": "payload",
+                "type": "Pair"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "functions": [
+      {
+        "name": "choose",
+        "params": [
+          {
+            "name": "candidate",
+            "type": "Pair"
+          },
+          {
+            "name": "enabled",
+            "type": "bool"
+          }
+        ],
+        "return_type": "MaybePair"
+      },
+      {
+        "name": "main",
+        "params": [],
+        "return_type": "i32"
+      }
+    ],
+    "globals": [
+      {
+        "name": "threshold",
+        "type": "i32",
+        "mutable": true
+      }
+    ]
+  }
+}

--- a/tests/integration/cli_build/frontend_json.rs
+++ b/tests/integration/cli_build/frontend_json.rs
@@ -3,6 +3,8 @@ use std::process::Command;
 
 #[path = "frontend_json/diagnostics_json.rs"]
 mod diagnostics_json;
+#[path = "frontend_json/hir_golden.rs"]
+mod hir_golden;
 #[path = "frontend_json/ir_boundaries.rs"]
 mod ir_boundaries;
 #[path = "frontend_json/layout_json.rs"]

--- a/tests/integration/cli_build/frontend_json/hir_golden.rs
+++ b/tests/integration/cli_build/frontend_json/hir_golden.rs
@@ -1,0 +1,56 @@
+use std::path::Path;
+use std::process::Command;
+
+fn fixture(path: &str) -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(path)
+}
+
+#[test]
+fn emit_json_hir_declaration_schema_matches_golden() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let zen_path = tmp.path().join("hir_declarations_subject.zen");
+    std::fs::write(
+        &zen_path,
+        r#"
+Pair: {
+    left: i32,
+    right: i32,
+}
+
+MaybePair:
+    None,
+    Some(Pair)
+
+threshold ::= 10
+
+choose = (candidate: Pair, enabled: bool) MaybePair {
+    enabled ?
+        | true { MaybePair.Some(candidate) }
+        | false { MaybePair.None }
+}
+
+main = () i32 { 0 }
+"#,
+    )
+    .expect("write HIR declarations subject");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "hir", zen_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json hir on declaration-rich program input");
+
+    assert!(
+        output.status.success(),
+        "zen emit-json hir should emit checked declaration-rich HIR JSON: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let actual = String::from_utf8(output.stdout).expect("HIR declarations stdout is UTF-8");
+    serde_json::from_str::<serde_json::Value>(&actual).expect("HIR declarations stdout is JSON");
+    let expected_path = fixture("tests/fixtures/ir_json/hir_declarations.golden.json");
+    let expected = std::fs::read_to_string(&expected_path)
+        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
+
+    assert_eq!(actual.trim(), expected.trim());
+}


### PR DESCRIPTION
## Summary
- Add a golden fixture for checked HIR declaration JSON output
- Wire the fixture through a focused frontend JSON integration test
- Record the HIR golden evidence in V1 spec, phase plan, completion audit, and docs-truth checks

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- Push-event workflow check: `[]`