### PR TITLE
Add layout JSON compound golden fixture

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3922,6 +3922,9 @@ and do not assume Phase 4 is ready without evidence.
   raw-pointer, slice, and fixed-array field types, and preserves simple enum
   variant tag/payload layout facts. Covered by
   `emit_json_layout_outputs_compound_type_layout_entries`.
+- The checked compound layout schema is now pinned by the golden fixture test
+  `emit_json_layout_compound_schema_matches_golden`, reducing the IR boundary
+  backlog without treating broader ABI schema work as complete.
 - Static string literals no longer implicitly satisfy allocator-backed
   `String`; `String` is recognized as a builtin dynamic text type, but
   allocation must remain explicit. Covered by

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3642,6 +3642,8 @@ Agent UX deliverables:
   raw-pointer, slice, and fixed-array field types, and preserves simple enum
   variant tag/payload layout facts. Guarded by
   `emit_json_layout_outputs_compound_type_layout_entries`.
+- The checked compound layout schema is now pinned by a golden JSON fixture,
+  guarded by `emit_json_layout_compound_schema_matches_golden`.
 - `StaticString` and allocator-backed `String` are no longer type-compatible:
   static string literals stay baked into program storage and cannot implicitly
   allocate dynamic `String` values. Covered by

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -204,7 +204,9 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   baked `StaticString`, pointer/slice/array layout entries, struct field
   offsets, and simple enum variant tags/payloads, covered by
   `emit_json_layout_outputs_checked_type_layouts` and
-  `emit_json_layout_outputs_compound_type_layout_entries`. Hand-authored layout JSON
+  `emit_json_layout_outputs_compound_type_layout_entries`. The checked
+  compound layout schema is also pinned by
+  `emit_json_layout_compound_schema_matches_golden`. Hand-authored layout JSON
   inputs are rejected at the compiler-owned layout schema boundary before any
   ABI override can be accepted, covered by
   `emit_json_layout_rejects_hand_authored_json_before_layout_override`.
@@ -263,6 +265,7 @@ Generic behavior inheritance with child type-parameter parent args is covered by
 | Strict resolver, symbol IDs, privacy | implemented | Resolver/module/privacy tests |
 | HIR JSON emission | constrained | `emit_json_hir_outputs_checked_declaration_graph` checks `schema_version: 0`, `emit_json_hir_outputs_enum_function_and_global_declarations` covers enum variants/payloads, function params/returns, and globals, `emit_json_hir_declaration_schema_matches_golden` pins the checked declaration schema, `emit_json_hir_rejects_hand_authored_json_before_ir_override`; broader golden tests still required |
 | MIR JSON emission | constrained | `emit_json_mir_outputs_checked_minimal_function_graph` checks `schema_version: 0`, `emit_json_mir_outputs_match_arm_schema` covers match kind, arm patterns/bindings, and block results, `emit_json_mir_match_schema_matches_golden` pins the checked match schema, `emit_json_mir_rejects_hand_authored_json_before_ir_override`; broader golden tests still required |
+| Layout JSON emission | constrained | `emit_json_layout_outputs_checked_type_layouts` checks primitive, `StaticString`, and struct layout facts, `emit_json_layout_outputs_compound_type_layout_entries` covers pointer, raw pointer, slice, array, and enum payload entries, `emit_json_layout_compound_schema_matches_golden` pins the checked compound layout schema, `emit_json_layout_rejects_hand_authored_json_before_layout_override`; broader ABI schemas still required |
 | Target/build YAML validation | constrained | `emit_json_target_yaml_validates_minimal_target_schema` checks `schema_version: 0`, `emit_json_target_yaml_validates_backend_schema`, `emit_json_target_yaml_validates_c_backend_flags`, `emit_json_target_yaml_rejects_empty_c_backend_flags`, `emit_json_target_yaml_rejects_layout_overrides`, `emit_json_target_yaml_rejects_unsupported_backend_codegen`; broader ABI/backend option schemas still required |
 | Behaviors and type association | gated | Positive/negative behavior solver tests |
 | `Sync/Async effects` | gated | `async_scheduler_intrinsics_are_rejected_as_gated_not_unknown`, `effect_await_is_rejected_until_async_lowering_exists`, `atomic_intrinsics_are_rejected_as_effect_gates`; effect checker positive/negative tests still required |

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -124,6 +124,8 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "emit_json_mir_match_schema_matches_golden",
         "emit_json_mir_rejects_hand_authored_json_before_ir_override",
         "emit_json_layout_outputs_checked_type_layouts",
+        "emit_json_layout_outputs_compound_type_layout_entries",
+        "emit_json_layout_compound_schema_matches_golden",
         "emit_json_layout_rejects_hand_authored_json_before_layout_override",
         "emit_json_target_yaml_validates_minimal_target_schema",
         "emit_json_target_yaml_validates_backend_schema",

--- a/tests/fixtures/ir_json/layout_compound.golden.json
+++ b/tests/fixtures/ir_json/layout_compound.golden.json
@@ -1,0 +1,156 @@
+{
+  "format": "zen.layout.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "target": {
+    "pointer_size": 8,
+    "pointer_alignment": 8,
+    "usize_size": 8
+  },
+  "layouts": {
+    "Choice": {
+      "kind": "enum",
+      "size": 56,
+      "alignment": 8,
+      "variants": [
+        {
+          "name": "Empty",
+          "tag": 0
+        },
+        {
+          "name": "WithPayload",
+          "tag": 1,
+          "payload_fields": [
+            {
+              "name": "payload",
+              "type": "Handles",
+              "offset": 0
+            }
+          ]
+        }
+      ]
+    },
+    "Handles": {
+      "kind": "struct",
+      "size": 48,
+      "alignment": 8,
+      "fields": [
+        {
+          "name": "ptr",
+          "type": "Ptr<i32>",
+          "offset": 0
+        },
+        {
+          "name": "raw",
+          "type": "RawPtr<i32>",
+          "offset": 8
+        },
+        {
+          "name": "slice",
+          "type": "[i32]",
+          "offset": 16
+        },
+        {
+          "name": "fixed",
+          "type": "[i32; 4]",
+          "offset": 32
+        }
+      ]
+    },
+    "Ptr<i32>": {
+      "kind": "pointer",
+      "size": 8,
+      "alignment": 8
+    },
+    "RawPtr<i32>": {
+      "kind": "pointer",
+      "size": 8,
+      "alignment": 8
+    },
+    "StaticString": {
+      "kind": "static_string",
+      "size": 16,
+      "alignment": 8
+    },
+    "String": {
+      "kind": "dynamic_string",
+      "size": 32,
+      "alignment": 8
+    },
+    "[i32; 4]": {
+      "kind": "array",
+      "size": 16,
+      "alignment": 4
+    },
+    "[i32]": {
+      "kind": "slice",
+      "size": 16,
+      "alignment": 8
+    },
+    "bool": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "f32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "f64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "i16": {
+      "kind": "primitive",
+      "size": 2,
+      "alignment": 2
+    },
+    "i32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "i64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "i8": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "u16": {
+      "kind": "primitive",
+      "size": 2,
+      "alignment": 2
+    },
+    "u32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "u64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "u8": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "usize": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "void": {
+      "kind": "primitive",
+      "size": 0,
+      "alignment": 1
+    }
+  }
+}

--- a/tests/integration/cli_build/frontend_json.rs
+++ b/tests/integration/cli_build/frontend_json.rs
@@ -7,6 +7,8 @@ mod diagnostics_json;
 mod hir_golden;
 #[path = "frontend_json/ir_boundaries.rs"]
 mod ir_boundaries;
+#[path = "frontend_json/layout_golden.rs"]
+mod layout_golden;
 #[path = "frontend_json/layout_json.rs"]
 mod layout_json;
 #[path = "frontend_json/mir_golden.rs"]

--- a/tests/integration/cli_build/frontend_json/layout_golden.rs
+++ b/tests/integration/cli_build/frontend_json/layout_golden.rs
@@ -1,0 +1,50 @@
+use std::path::Path;
+use std::process::Command;
+
+fn fixture(path: &str) -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(path)
+}
+
+#[test]
+fn emit_json_layout_compound_schema_matches_golden() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let zen_path = tmp.path().join("compound_layout_subject.zen");
+    std::fs::write(
+        &zen_path,
+        r#"
+Handles: {
+    ptr: Ptr<i32>,
+    raw: RawPtr<i32>,
+    slice: Slice<i32>,
+    fixed: [i32; 4],
+}
+
+Choice:
+    Empty,
+    WithPayload(Handles)
+
+main = () i32 { 0 }
+"#,
+    )
+    .expect("write compound layout subject");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "layout", zen_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json layout on compound program input");
+
+    assert!(
+        output.status.success(),
+        "zen emit-json layout should emit checked compound layout JSON: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let actual = String::from_utf8(output.stdout).expect("layout stdout is UTF-8");
+    serde_json::from_str::<serde_json::Value>(&actual).expect("layout stdout is JSON");
+    let expected_path = fixture("tests/fixtures/ir_json/layout_compound.golden.json");
+    let expected = std::fs::read_to_string(&expected_path)
+        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
+
+    assert_eq!(actual.trim(), expected.trim());
+}


### PR DESCRIPTION
## Summary
- Add a golden fixture for checked compound layout JSON output
- Wire the fixture through a focused frontend JSON integration test
- Record the layout golden evidence in V1 spec, phase plan, completion audit, and docs-truth checks

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- Push-event workflow check: `[]`