### PR TITLE
Add diagnostics JSON return golden fixture

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -4135,6 +4135,10 @@ and do not assume Phase 4 is ready without evidence.
   the compiler-owned diagnostics JSON boundary before forged diagnostics can be
   treated as Zen source or accepted as compiler diagnostics. Covered by
   `emit_json_diagnostics_rejects_hand_authored_json_before_diagnostic_override`.
+- Removed `return` keyword diagnostics JSON is now pinned by the golden fixture
+  test `emit_json_diagnostics_removed_return_schema_matches_golden`, including
+  the stable code, span, and structured suggested-fix payload for agent/editor
+  consumers.
 - Hand-authored build graph JSON inputs to `emit-json build-graph` reject at
   the compiler-owned build graph JSON boundary before generic `build.zen` path
   validation can stand in for deterministic graph provenance. Covered by

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3870,6 +3870,9 @@ Agent UX deliverables:
   at the compiler-owned diagnostics JSON boundary before forged diagnostics can
   be treated as Zen source or accepted as compiler diagnostics. Guarded by
   `emit_json_diagnostics_rejects_hand_authored_json_before_diagnostic_override`.
+- Removed `return` keyword diagnostics JSON is now pinned by a golden fixture,
+  including the stable code, span, and structured suggested-fix payload.
+  Guarded by `emit_json_diagnostics_removed_return_schema_matches_golden`.
 - Hand-authored build graph JSON inputs to `emit-json build-graph` now reject
   at the compiler-owned build graph JSON boundary before generic `build.zen`
   path validation can stand in for deterministic graph provenance. Guarded by

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -176,6 +176,10 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   explicit `Type.implements(Behavior) { ... }` blocks. Gated generic
   association targets such as `Type<T>.derive(...)` report the same
   feature-gate context shape with a note to use non-generic explicit behavior associations until generic behavior target templates exist.
+  Removed `return` keyword diagnostics are pinned by
+  `emit_json_diagnostics_removed_return_schema_matches_golden`, including the
+  stable code, span, and structured suggested fix payload for agent/editor
+  consumers.
   Hand-authored build graph JSON inputs are rejected before generic build.zen
   path validation can stand in for the compiler-owned graph boundary, covered by
   `emit_json_build_graph_rejects_hand_authored_json_before_graph_override`.
@@ -264,6 +268,7 @@ Generic behavior inheritance with child type-parameter parent args is covered by
 | Typechecked C backend for tested fixtures | implemented | `cargo test --tests` |
 | README and contributor truth assertions | implemented | `tests/docs_truth.rs` |
 | Strict resolver, symbol IDs, privacy | implemented | Resolver/module/privacy tests |
+| Diagnostics JSON emission | constrained | `emit_json_diagnostics_command_outputs_machine_readable_errors` checks machine-readable errors, `emit_json_diagnostics_removed_return_schema_matches_golden` pins removed-return suggested fix schema, `emit_json_diagnostics_rejects_hand_authored_json_before_diagnostic_override`; broader diagnostic-code catalog still required |
 | HIR JSON emission | constrained | `emit_json_hir_outputs_checked_declaration_graph` checks `schema_version: 0`, `emit_json_hir_outputs_enum_function_and_global_declarations` covers enum variants/payloads, function params/returns, and globals, `emit_json_hir_declaration_schema_matches_golden` pins the checked declaration schema, `emit_json_hir_rejects_hand_authored_json_before_ir_override`; broader golden tests still required |
 | MIR JSON emission | constrained | `emit_json_mir_outputs_checked_minimal_function_graph` checks `schema_version: 0`, `emit_json_mir_outputs_match_arm_schema` covers match kind, arm patterns/bindings, and block results, `emit_json_mir_match_schema_matches_golden` pins the checked match schema, `emit_json_mir_rejects_hand_authored_json_before_ir_override`; broader golden tests still required |
 | Layout JSON emission | constrained | `emit_json_layout_outputs_checked_type_layouts` checks primitive, `StaticString`, and struct layout facts, `emit_json_layout_outputs_compound_type_layout_entries` covers pointer, raw pointer, slice, array, and enum payload entries, `emit_json_layout_compound_schema_matches_golden` pins the checked compound layout schema, `emit_json_layout_rejects_hand_authored_json_before_layout_override`; broader ABI schemas still required |

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -112,6 +112,7 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "emit_json_ast_rejects_hand_authored_json_before_unchecked_ir_override",
         "emit_json_symbols_rejects_hand_authored_json_before_resolver_override",
         "emit_json_diagnostics_rejects_hand_authored_json_before_diagnostic_override",
+        "emit_json_diagnostics_removed_return_schema_matches_golden",
         "emit_json_typed_rejects_hand_authored_json_before_checked_ir_override",
         "emit_json_build_graph_rejects_hand_authored_json_before_graph_override",
         "schema_version: 0",

--- a/tests/fixtures/ir_json/diagnostics_return.golden.json
+++ b/tests/fixtures/ir_json/diagnostics_return.golden.json
@@ -1,0 +1,47 @@
+{
+  "format": "zen.diagnostics.v0",
+  "semantic_status": "diagnostic",
+  "files": [
+    {
+      "id": 0,
+      "path": "$TMP/return_keyword.zen"
+    }
+  ],
+  "diagnostics": [
+    {
+      "severity": "error",
+      "code": "E2000",
+      "message": "return keyword has been removed; use the final expression in the block",
+      "span": {
+        "file_id": 0,
+        "path": "$TMP/return_keyword.zen",
+        "start": 21,
+        "end": 27,
+        "line": 3,
+        "column": 5
+      },
+      "labels": [],
+      "notes": [],
+      "context": [],
+      "suggested_fixes": [
+        {
+          "kind": "replace_removed_return_with_final_expression",
+          "title": "Remove `return` and use the value as the final expression",
+          "edits": [
+            {
+              "span": {
+                "file_id": 0,
+                "path": "$TMP/return_keyword.zen",
+                "start": 21,
+                "end": 27,
+                "line": 3,
+                "column": 5
+              },
+              "replacement": ""
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/integration/cli_build/frontend_json.rs
+++ b/tests/integration/cli_build/frontend_json.rs
@@ -1,6 +1,8 @@
 use crate::support::*;
 use std::process::Command;
 
+#[path = "frontend_json/diagnostics_golden.rs"]
+mod diagnostics_golden;
 #[path = "frontend_json/diagnostics_json.rs"]
 mod diagnostics_json;
 #[path = "frontend_json/hir_golden.rs"]

--- a/tests/integration/cli_build/frontend_json/diagnostics_golden.rs
+++ b/tests/integration/cli_build/frontend_json/diagnostics_golden.rs
@@ -1,0 +1,42 @@
+use std::path::Path;
+use std::process::Command;
+
+fn fixture(path: &str) -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(path)
+}
+
+#[test]
+fn emit_json_diagnostics_removed_return_schema_matches_golden() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let zen_path = tmp.path().join("return_keyword.zen");
+    std::fs::write(
+        &zen_path,
+        r#"
+main = () i32 {
+    return 1
+}
+"#,
+    )
+    .expect("write removed return source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "diagnostics", zen_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json diagnostics");
+
+    assert!(
+        !output.status.success(),
+        "zen emit-json diagnostics should fail on removed return syntax: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let actual = String::from_utf8(output.stdout).expect("diagnostics stdout is UTF-8");
+    serde_json::from_str::<serde_json::Value>(&actual).expect("diagnostics stdout is JSON");
+    let normalized = actual.replace(tmp.path().to_str().expect("tmp path is UTF-8"), "$TMP");
+    let expected_path = fixture("tests/fixtures/ir_json/diagnostics_return.golden.json");
+    let expected = std::fs::read_to_string(&expected_path)
+        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
+
+    assert_eq!(normalized.trim(), expected.trim());
+}


### PR DESCRIPTION
## Summary
- Add a normalized golden fixture for removed-return diagnostics JSON
- Pin the stable diagnostic code, span, and suggested-fix payload for agent/editor consumers
- Record the diagnostics golden evidence in V1 spec, phase plan, completion audit, and docs-truth checks

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- Push-event workflow check: `[]`