### PR TITLE
Pin diagnostics JSON generic association gate schema

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -4226,6 +4226,10 @@ and do not assume Phase 4 is ready without evidence.
   `kind: "feature_gate"` and a note directing users to non-generic explicit behavior associations until generic behavior target templates exist. Covered by
   `emit_json_diagnostics_spans_full_gated_generic_association_target` and
   `generic_type_association_keywords_are_explicitly_gated`.
+- The generic association target feature-gate diagnostic shape is now pinned by
+  `emit_json_diagnostics_generic_association_gate_schema_matches_golden`,
+  covering stable diagnostics JSON for `Type<T>.derive(Behavior<T>)` while
+  generic behavior target templates remain gated.
 - Dev UX and Agent UX are now tracked as first-class roadmap lanes in
   `docs/PHASE_PLAN.md`, with MoonBit-style toolchain integration as the
   benchmark and concrete future surfaces for the VS Code extension,

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3945,7 +3945,9 @@ Agent UX deliverables:
   behavior argument token. They also carry diagnostics JSON `context` with
   `kind: "feature_gate"` and a note directing users to non-generic explicit behavior associations until generic behavior target templates exist. Guarded by
   `emit_json_diagnostics_spans_full_gated_generic_association_target` and the
-  existing parser gate
+  golden fixture test
+  `emit_json_diagnostics_generic_association_gate_schema_matches_golden`, plus
+  the existing parser gate
   `generic_type_association_keywords_are_explicitly_gated`.
 
 ## Current Phase

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -176,7 +176,9 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   explicit `Type.implements(Behavior) { ... }` blocks, pinned by
   `emit_json_diagnostics_behavior_derive_gate_schema_matches_golden`. Gated generic
   association targets such as `Type<T>.derive(...)` report the same
-  feature-gate context shape with a note to use non-generic explicit behavior associations until generic behavior target templates exist.
+  feature-gate context shape with a note to use non-generic explicit behavior associations
+  until generic behavior target templates exist, pinned by
+  `emit_json_diagnostics_generic_association_gate_schema_matches_golden`.
   Removed `return` keyword diagnostics are pinned by
   `emit_json_diagnostics_removed_return_schema_matches_golden`, including the
   stable code, span, and structured suggested fix payload for agent/editor
@@ -273,7 +275,7 @@ Generic behavior inheritance with child type-parameter parent args is covered by
 | Typechecked C backend for tested fixtures | implemented | `cargo test --tests` |
 | README and contributor truth assertions | implemented | `tests/docs_truth.rs` |
 | Strict resolver, symbol IDs, privacy | implemented | Resolver/module/privacy tests |
-| Diagnostics JSON emission | constrained | `emit_json_diagnostics_command_outputs_machine_readable_errors` checks machine-readable errors, `emit_json_diagnostics_removed_return_schema_matches_golden` pins removed-return suggested fix schema, `emit_json_diagnostics_behavior_derive_gate_schema_matches_golden` pins feature-gate context for reserved generated behavior association, `emit_json_diagnostics_generic_result_method_arity_schema_matches_golden` pins a hard generic `Result<T, E>` method arity diagnostic without followups, `emit_json_diagnostics_generic_result_method_bound_schema_matches_golden` pins a hard generic behavior-bound diagnostic without method-body followups, `emit_json_diagnostics_generic_result_method_inference_schema_matches_golden` pins a hard generic inference conflict without argument/return followups, `emit_json_diagnostics_rejects_hand_authored_json_before_diagnostic_override`; broader diagnostic-code catalog still required |
+| Diagnostics JSON emission | constrained | `emit_json_diagnostics_command_outputs_machine_readable_errors` checks machine-readable errors, `emit_json_diagnostics_removed_return_schema_matches_golden` pins removed-return suggested fix schema, `emit_json_diagnostics_behavior_derive_gate_schema_matches_golden` pins feature-gate context for reserved generated behavior association, `emit_json_diagnostics_generic_association_gate_schema_matches_golden` pins feature-gate context for reserved generic behavior association targets, `emit_json_diagnostics_generic_result_method_arity_schema_matches_golden` pins a hard generic `Result<T, E>` method arity diagnostic without followups, `emit_json_diagnostics_generic_result_method_bound_schema_matches_golden` pins a hard generic behavior-bound diagnostic without method-body followups, `emit_json_diagnostics_generic_result_method_inference_schema_matches_golden` pins a hard generic inference conflict without argument/return followups, `emit_json_diagnostics_rejects_hand_authored_json_before_diagnostic_override`; broader diagnostic-code catalog still required |
 | HIR JSON emission | constrained | `emit_json_hir_outputs_checked_declaration_graph` checks `schema_version: 0`, `emit_json_hir_outputs_enum_function_and_global_declarations` covers enum variants/payloads, function params/returns, and globals, `emit_json_hir_declaration_schema_matches_golden` pins the checked declaration schema, `emit_json_hir_rejects_hand_authored_json_before_ir_override`; broader golden tests still required |
 | MIR JSON emission | constrained | `emit_json_mir_outputs_checked_minimal_function_graph` checks `schema_version: 0`, `emit_json_mir_outputs_match_arm_schema` covers match kind, arm patterns/bindings, and block results, `emit_json_mir_match_schema_matches_golden` pins the checked match schema, `emit_json_mir_rejects_hand_authored_json_before_ir_override`; broader golden tests still required |
 | Layout JSON emission | constrained | `emit_json_layout_outputs_checked_type_layouts` checks primitive, `StaticString`, and struct layout facts, `emit_json_layout_outputs_compound_type_layout_entries` covers pointer, raw pointer, slice, array, and enum payload entries, `emit_json_layout_compound_schema_matches_golden` pins the checked compound layout schema, `emit_json_layout_rejects_hand_authored_json_before_layout_override`; broader ABI schemas still required |
@@ -323,7 +325,8 @@ explicit-impl note, covered by
 Gated generic association targets such as `Type<T>.derive(Json<T>)` are also
 localized over the full reserved association target in diagnostics JSON and now
 carry feature-gate context plus a non-generic-association note, covered by
-`emit_json_diagnostics_spans_full_gated_generic_association_target`.
+`emit_json_diagnostics_spans_full_gated_generic_association_target` and pinned by
+`emit_json_diagnostics_generic_association_gate_schema_matches_golden`.
 
 ## Stdlib Gate
 

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -114,6 +114,7 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "emit_json_diagnostics_rejects_hand_authored_json_before_diagnostic_override",
         "emit_json_diagnostics_removed_return_schema_matches_golden",
         "emit_json_diagnostics_behavior_derive_gate_schema_matches_golden",
+        "emit_json_diagnostics_generic_association_gate_schema_matches_golden",
         "emit_json_diagnostics_generic_result_method_arity_schema_matches_golden",
         "emit_json_diagnostics_generic_result_method_bound_schema_matches_golden",
         "emit_json_diagnostics_generic_result_method_inference_schema_matches_golden",

--- a/tests/fixtures/ir_json/diagnostics_generic_association_gate.golden.json
+++ b/tests/fixtures/ir_json/diagnostics_generic_association_gate.golden.json
@@ -1,0 +1,44 @@
+{
+  "format": "zen.diagnostics.v0",
+  "semantic_status": "diagnostic",
+  "files": [
+    {
+      "id": 0,
+      "path": "$TMP/generic_association_gate.zen"
+    }
+  ],
+  "diagnostics": [
+    {
+      "severity": "error",
+      "code": "E2000",
+      "message": "generic association target `Type<T>.derive` is gated; use non-generic `derive` associations or keep the generic behavior target deferred to docs/V1_SPEC.md",
+      "span": {
+        "file_id": 0,
+        "path": "$TMP/generic_association_gate.zen",
+        "start": 80,
+        "end": 102,
+        "line": 10,
+        "column": 1
+      },
+      "labels": [],
+      "notes": [
+        "Use a non-generic explicit behavior association until generic behavior target templates are implemented"
+      ],
+      "context": [
+        {
+          "span": {
+            "file_id": 0,
+            "path": "$TMP/generic_association_gate.zen",
+            "start": 80,
+            "end": 102,
+            "line": 10,
+            "column": 1
+          },
+          "kind": "feature_gate",
+          "message": "reserved generic behavior association target"
+        }
+      ],
+      "suggested_fixes": []
+    }
+  ]
+}

--- a/tests/integration/cli_build/frontend_json/diagnostics_golden.rs
+++ b/tests/integration/cli_build/frontend_json/diagnostics_golden.rs
@@ -93,6 +93,59 @@ Point.derive(Json)
 }
 
 #[test]
+fn emit_json_diagnostics_generic_association_gate_schema_matches_golden() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let zen_path = tmp.path().join("generic_association_gate.zen");
+    std::fs::write(
+        &zen_path,
+        r#"
+Box<T>: {
+    value: T
+}
+
+Json<T>: behavior {
+    to_json: (T) StaticString
+}
+
+Box<T>.derive(Json<T>)
+"#,
+    )
+    .expect("write gated generic association source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "diagnostics", zen_path.to_str().unwrap()])
+        .output()
+        .expect("run zen emit-json diagnostics");
+
+    assert!(
+        !output.status.success(),
+        "zen emit-json diagnostics should fail on gated generic association: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let actual = String::from_utf8(output.stdout).expect("diagnostics stdout is UTF-8");
+    let json: serde_json::Value =
+        serde_json::from_str(&actual).expect("diagnostics stdout is JSON");
+    assert_eq!(
+        json["diagnostics"]
+            .as_array()
+            .expect("diagnostics array")
+            .len(),
+        1,
+        "gated generic association diagnostics should emit one feature-gate diagnostic: {json}"
+    );
+
+    let normalized = actual.replace(tmp.path().to_str().expect("tmp path is UTF-8"), "$TMP");
+    let expected_path =
+        fixture("tests/fixtures/ir_json/diagnostics_generic_association_gate.golden.json");
+    let expected = std::fs::read_to_string(&expected_path)
+        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
+
+    assert_eq!(normalized.trim(), expected.trim());
+}
+
+#[test]
 fn emit_json_diagnostics_generic_result_method_arity_schema_matches_golden() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let zen_path = tmp.path().join("generic_result_method_arity.zen");


### PR DESCRIPTION
## Summary
- Add a diagnostics JSON golden fixture for reserved generic `Type<T>.derive(Behavior<T>)` association targets
- Pin the stable feature-gate error code, full-span localization, notes, context, and empty suggested-fix array
- Record the new diagnostics-boundary evidence in V1 spec, phase plan, completion audit, and docs-truth checks

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- Push-event workflow check: `[]`