### PR TITLE
Pin typed JSON generic method schema and update Learn guide

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -334,6 +334,9 @@ and do not assume Phase 4 is ready without evidence.
 - Typed JSON now carries `semantic_status: "checked"`, covered by
   `emit_json_typed_command_outputs_checked_program`, keeping the checked output
   boundary explicit alongside the unchecked AST marker.
+- Checked typed JSON for generic method specialization is now pinned by
+  `emit_json_typed_generic_method_schema_matches_golden`, covering the
+  specialized `Box_i32` type and `Box.get_i32` method output.
 - Diagnostics JSON now carries `semantic_status: "diagnostic"`, covered by
   `emit_json_diagnostics_command_outputs_machine_readable_errors`, so the
   machine-readable diagnostics path is distinct from both unchecked AST and

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -571,6 +571,9 @@ Agent UX deliverables:
 - Typed JSON now carries `semantic_status: "checked"`, covered by
   `emit_json_typed_command_outputs_checked_program`, keeping the checked output
   boundary explicit alongside the unchecked AST marker.
+- Checked typed JSON for generic method specialization is now pinned by
+  `emit_json_typed_generic_method_schema_matches_golden`, covering the
+  specialized `Box_i32` type and `Box.get_i32` method output.
 - Diagnostics JSON now carries `semantic_status: "diagnostic"`, covered by
   `emit_json_diagnostics_command_outputs_machine_readable_errors`, so the
   machine-readable diagnostics path is distinct from both unchecked AST and

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -170,6 +170,9 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   `emit_json_symbols_rejects_hand_authored_json_before_resolver_override`,
   `emit_json_diagnostics_rejects_hand_authored_json_before_diagnostic_override`, and
   `emit_json_typed_rejects_hand_authored_json_before_checked_ir_override`.
+  Checked typed JSON for generic method specialization is pinned by
+  `emit_json_typed_generic_method_schema_matches_golden`, covering the
+  specialized `Box_i32` type and `Box.get_i32` method output.
   Diagnostics JSON carries structured notes, suggested fixes, and context
   frames for agent/editor consumers; the `Type.derive(...)` feature gate now
   reports `context.kind = "feature_gate"` with a note pointing users to

--- a/docs/learn_zen_in_y_minutes.md
+++ b/docs/learn_zen_in_y_minutes.md
@@ -6,6 +6,40 @@ shapes, pattern matching, generics, behaviors, and predictable native output.
 Runnable examples live in `tests/zen/` and `examples/`. Gated design previews
 are called out explicitly.
 
+## The Shape
+
+Zen reads name-first. A declaration starts with the thing being introduced or
+attached, then gives its shape:
+
+```zen
+{ io } = std
+
+Point: {
+    x: i32,
+    y: i32,
+}
+
+Point.length = (self: Point) i32 {
+    self.x + self.y
+}
+
+main = () i32 {
+    point = Point { x: 20, y: 22 }
+    point.length()
+}
+```
+
+The common forms are:
+
+- `{ name } = module.path` imports names from a module.
+- `Name: { field: Type }` declares a struct.
+- `Name: Variant, Variant(Payload)` declares an enum.
+- `name = (...) ReturnType { ... }` declares a function.
+- `Type.method = (...) ReturnType { ... }` declares an attached method.
+- `Type.impl = { ... }` groups methods for a type.
+- `Name: behavior { ... }` declares a behavior contract.
+- `Type.implements(Behavior) { ... }` gives a type that behavior.
+
 ## Hello
 
 ```zen
@@ -26,6 +60,19 @@ Top-level declarations use prefix-first forms:
 - methods: `Type.method = (...) ReturnType { ... }`
 - impl blocks: `Type.impl = { ... }`
 - behaviors: `Name: behavior { ... }`
+
+Top-level `pub` exposes a declaration across modules:
+
+```zen
+pub Point: {
+    x: i32,
+    y: i32,
+}
+
+pub origin = () Point {
+    Point { x: 0, y: 0 }
+}
+```
 
 ## Comments
 
@@ -97,6 +144,10 @@ main = () i32 {
 Numeric conversions are explicit. Mixed numeric widths need casts instead of
 implicit widening.
 
+String literals are `StaticString` values: the bytes are baked into the
+program, and the value carries a pointer and length. Dynamic `String` is a
+separate allocator-backed text type and is not created implicitly by a literal.
+
 ## Operators And Casts
 
 ```zen
@@ -136,6 +187,7 @@ main = () i32 {
 
 Functions have typed parameters and an explicit result type. A non-void
 function's final expression must produce that result on every non-error path.
+Use `void` for functions that only perform effects.
 
 ## Blocks Return Their Final Expression
 
@@ -306,7 +358,8 @@ main = () i32 {
 ```
 
 Methods are declared as `Type.method = (...) ReturnType { ... }`. Calls use dot
-syntax.
+syntax. A method is still a function with an explicit receiver; Zen does not
+hide data behind classes or an object model.
 
 ## Impl Blocks
 
@@ -331,7 +384,20 @@ main = () i32 {
 }
 ```
 
-Non-behavior `Type.impl = { ... }` groups methods under a type.
+Non-behavior `Type.impl = { ... }` groups methods under a type. Generic impl
+blocks use the same attached shape:
+
+```zen
+Box<T>: {
+    value: T
+}
+
+Box<T>.impl = {
+    get = (self: Box<T>) T {
+        self.value
+    }
+}
+```
 
 ## Generics
 
@@ -381,6 +447,18 @@ encode<T: Json> = (value: T) StaticString {
 
 Behaviors describe required methods. Generic functions can use behavior bounds
 with `T: BehaviorName`.
+
+Behavior association is explicit:
+
+```zen
+Point.implements(Json) {
+    encode = (self: Point) StaticString {
+        "point"
+    }
+}
+```
+
+This keeps capability lookup visible at the type boundary.
 
 ## Behavior Inheritance And Requires
 
@@ -474,6 +552,10 @@ single_step = (ready: bool) i32 {
 The same rule applies in nested loops: `done(outer)` exits the outer loop, and
 `next(inner)` continues only the inner loop.
 
+Loops are expressions in the same block language as the rest of Zen, but the
+loop's purpose is control flow. Accumulated values are usually kept in explicit
+mutable bindings outside the loop and read after `done`.
+
 ## Defer
 
 ```zen
@@ -502,6 +584,20 @@ Imports use destructuring-style binding from a module path. Local files import
 by module name, and dotted paths resolve through subdirectories. See
 `examples/project/main.zen` for the project-style example.
 
+Imported declarations have to be public in the source module:
+
+```zen
+pub clamp = (value: i32, low: i32, high: i32) i32 {
+    value < low ?
+        | true { low }
+        | false {
+            value > high ?
+                | true { high }
+                | false { value }
+        }
+}
+```
+
 ## Memory And Ownership
 
 Allocation is explicit in Zen's language model. The stable subset does not hide
@@ -522,6 +618,10 @@ Values name their shape directly. Static text is a non-owning program value.
 Owned dynamic storage is modeled with allocator-aware types once typed
 allocators are promoted. Until then, the compiler rejects allocator-backed
 source types instead of pretending allocation is free.
+
+The practical rule is simple: if a value needs heap memory, the API must show
+the allocator path. Literals and interpolation do not smuggle allocation into
+ordinary expressions.
 
 ## Pointer, Slice, And Array Types
 
@@ -665,6 +765,17 @@ The model is:
   typechecked propagation and lowering are implemented.
 - Task chaining and async scheduler APIs are gated until Sync/Async effect
   checking and task lowering are implemented.
+
+The intended call shape stays ordinary Zen:
+
+```zen
+work = (allocator: Allocator<u8, Sync>) Result<RawPtr<u8>, AllocError> {
+    allocator.alloc(64)
+}
+```
+
+The effect mode is part of the allocator capability, so the type system can
+distinguish synchronous allocation from task-returning asynchronous allocation.
 
 ### Ownership Preview
 

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -119,6 +119,7 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "emit_json_diagnostics_generic_result_method_bound_schema_matches_golden",
         "emit_json_diagnostics_generic_result_method_inference_schema_matches_golden",
         "emit_json_typed_rejects_hand_authored_json_before_checked_ir_override",
+        "emit_json_typed_generic_method_schema_matches_golden",
         "emit_json_build_graph_rejects_hand_authored_json_before_graph_override",
         "schema_version: 0",
         "emit_json_hir_outputs_checked_declaration_graph",

--- a/tests/fixtures/ir_json/typed_generic_method.golden.json
+++ b/tests/fixtures/ir_json/typed_generic_method.golden.json
@@ -1,0 +1,276 @@
+{
+  "format": "zen.typed.v0",
+  "semantic_status": "checked",
+  "program": {
+    "functions": [
+      {
+        "name": "main",
+        "params": [],
+        "return_type": "I32",
+        "body": {
+          "statements": [
+            {
+              "kind": {
+                "VarDecl": {
+                  "name": "box",
+                  "ty": {
+                    "Struct": {
+                      "name": "Box_i32",
+                      "fields": [
+                        [
+                          "value",
+                          "I32"
+                        ]
+                      ]
+                    }
+                  },
+                  "value": {
+                    "kind": {
+                      "StructLiteral": {
+                        "type_name": "Box_i32",
+                        "fields": [
+                          [
+                            "value",
+                            {
+                              "kind": {
+                                "IntLiteral": 99
+                              },
+                              "ty": "I32",
+                              "span": {
+                                "file_id": 0,
+                                "start": 134,
+                                "end": 136
+                              }
+                            }
+                          ]
+                        ]
+                      }
+                    },
+                    "ty": {
+                      "Struct": {
+                        "name": "Box_i32",
+                        "fields": [
+                          [
+                            "value",
+                            "I32"
+                          ]
+                        ]
+                      }
+                    },
+                    "span": {
+                      "file_id": 0,
+                      "start": 116,
+                      "end": 138
+                    }
+                  },
+                  "mutable": false
+                }
+              },
+              "span": {
+                "file_id": 0,
+                "start": 110,
+                "end": 138
+              }
+            },
+            {
+              "kind": {
+                "Expression": {
+                  "kind": {
+                    "FunctionCall": {
+                      "function": "io_println",
+                      "args": [
+                        {
+                          "kind": {
+                            "StringInterpolation": {
+                              "parts": [
+                                {
+                                  "Expr": {
+                                    "kind": {
+                                      "FunctionCall": {
+                                        "function": "Box.get_i32",
+                                        "args": [
+                                          {
+                                            "kind": {
+                                              "Variable": "box"
+                                            },
+                                            "ty": {
+                                              "Struct": {
+                                                "name": "Box_i32",
+                                                "fields": [
+                                                  [
+                                                    "value",
+                                                    "I32"
+                                                  ]
+                                                ]
+                                              }
+                                            },
+                                            "span": {
+                                              "file_id": 0,
+                                              "start": 157,
+                                              "end": 160
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "ty": "I32",
+                                    "span": {
+                                      "file_id": 0,
+                                      "start": 157,
+                                      "end": 171
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "ty": "Str",
+                          "span": {
+                            "file_id": 0,
+                            "start": 155,
+                            "end": 172
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "ty": "Void",
+                  "span": {
+                    "file_id": 0,
+                    "start": 143,
+                    "end": 174
+                  }
+                }
+              },
+              "span": {
+                "file_id": 0,
+                "start": 143,
+                "end": 174
+              }
+            }
+          ],
+          "expr": {
+            "kind": {
+              "IntLiteral": 0
+            },
+            "ty": "I32",
+            "span": {
+              "file_id": 0,
+              "start": 179,
+              "end": 180
+            }
+          },
+          "ty": "I32",
+          "span": {
+            "file_id": 0,
+            "start": 104,
+            "end": 182
+          }
+        },
+        "defers": [],
+        "span": {
+          "file_id": 0,
+          "start": 90,
+          "end": 182
+        }
+      },
+      {
+        "name": "Box.get_i32",
+        "params": [
+          {
+            "name": "self",
+            "ty": {
+              "Struct": {
+                "name": "Box_i32",
+                "fields": [
+                  [
+                    "value",
+                    "I32"
+                  ]
+                ]
+              }
+            },
+            "span": {
+              "file_id": 0,
+              "start": 54,
+              "end": 66
+            }
+          }
+        ],
+        "return_type": "I32",
+        "body": {
+          "statements": [],
+          "expr": {
+            "kind": {
+              "FieldAccess": {
+                "object": {
+                  "kind": {
+                    "Variable": "self"
+                  },
+                  "ty": {
+                    "Struct": {
+                      "name": "Box_i32",
+                      "fields": [
+                        [
+                          "value",
+                          "I32"
+                        ]
+                      ]
+                    }
+                  },
+                  "span": {
+                    "file_id": 0,
+                    "start": 76,
+                    "end": 80
+                  }
+                },
+                "field": "value"
+              }
+            },
+            "ty": "I32",
+            "span": {
+              "file_id": 0,
+              "start": 76,
+              "end": 86
+            }
+          },
+          "ty": "I32",
+          "span": {
+            "file_id": 0,
+            "start": 70,
+            "end": 88
+          }
+        },
+        "defers": [],
+        "span": {
+          "file_id": 0,
+          "start": 40,
+          "end": 88
+        }
+      }
+    ],
+    "types": [
+      {
+        "name": "Box_i32",
+        "kind": {
+          "Struct": {
+            "fields": [
+              [
+                "value",
+                "I32"
+              ]
+            ]
+          }
+        },
+        "methods": [],
+        "span": {
+          "file_id": 0,
+          "start": 116,
+          "end": 138
+        }
+      }
+    ],
+    "globals": [],
+    "entry_point": "main"
+  }
+}

--- a/tests/integration/cli_build/frontend_json.rs
+++ b/tests/integration/cli_build/frontend_json.rs
@@ -21,6 +21,8 @@ mod module_graph;
 mod target_yaml;
 #[path = "frontend_json/target_yaml_golden.rs"]
 mod target_yaml_golden;
+#[path = "frontend_json/typed_golden.rs"]
+mod typed_golden;
 
 #[test]
 fn emit_json_usage_lists_supported_and_gated_modes() {

--- a/tests/integration/cli_build/frontend_json/typed_golden.rs
+++ b/tests/integration/cli_build/frontend_json/typed_golden.rs
@@ -1,0 +1,34 @@
+use crate::support::*;
+use std::path::Path;
+use std::process::Command;
+
+fn fixture(path: &str) -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(path)
+}
+
+#[test]
+fn emit_json_typed_generic_method_schema_matches_golden() {
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args([
+            "emit-json",
+            "typed",
+            test_dir().join("generic_method.zen").to_str().unwrap(),
+        ])
+        .output()
+        .expect("run zen emit-json typed");
+
+    assert!(
+        output.status.success(),
+        "zen emit-json typed failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let actual = String::from_utf8(output.stdout).expect("typed stdout is UTF-8");
+    serde_json::from_str::<serde_json::Value>(&actual).expect("typed stdout is JSON");
+    let expected_path = fixture("tests/fixtures/ir_json/typed_generic_method.golden.json");
+    let expected = std::fs::read_to_string(&expected_path)
+        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
+
+    assert_eq!(actual.trim(), expected.trim());
+}


### PR DESCRIPTION
## Summary
- Add a golden fixture for checked typed JSON generic method specialization
- Pin the specialized `Box_i32` type and `Box.get_i32` method output in `zen.typed.v0`
- Expand Learn Zen In Y Minutes with clearer name-first syntax, public module exports, generic impls, behavior association, loop control, and allocator/effect preview language
- Record the typed JSON schema evidence in V1 spec, phase plan, completion audit, and docs-truth checks

## Verification
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- Push-event workflow check: `[]`