### PR TITLE
Pin AST and symbols JSON module graph schemas

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -327,6 +327,11 @@ and do not assume Phase 4 is ready without evidence.
   fixture proves a semantically invalid program can emit AST JSON while
   `emit-json typed` rejects it. Coverage:
   `emit_json_ast_marks_semantically_unchecked_sources_that_typed_json_rejects`.
+- AST and symbols module-graph JSON schemas are now pinned by
+  `emit_json_ast_module_graph_schema_matches_golden` and
+  `emit_json_symbols_module_graph_schema_matches_golden`, covering portable
+  canonical-path shape, imports, declarations, symbol namespaces, visibility,
+  spans, and function signatures.
 - AST traversal is no longer listed in the Required Test Backlog because the
   AST JSON tooling view has positive output evidence and negative semantic
   bypass evidence. Covered by

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -564,6 +564,11 @@ Agent UX deliverables:
   `emit-json typed` rejects it. Covered by
   `emit_json_ast_command_outputs_resolved_module_graph` and
   `emit_json_ast_marks_semantically_unchecked_sources_that_typed_json_rejects`.
+- AST and symbols module-graph JSON schemas are now pinned by
+  `emit_json_ast_module_graph_schema_matches_golden` and
+  `emit_json_symbols_module_graph_schema_matches_golden`, covering portable
+  canonical-path shape, imports, declarations, symbol namespaces, visibility,
+  spans, and function signatures.
 - AST traversal is no longer listed in the Required Test Backlog because the
   AST JSON tooling view has positive output evidence and negative semantic
   bypass evidence. Guarded by

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -170,6 +170,11 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   `emit_json_symbols_rejects_hand_authored_json_before_resolver_override`,
   `emit_json_diagnostics_rejects_hand_authored_json_before_diagnostic_override`, and
   `emit_json_typed_rejects_hand_authored_json_before_checked_ir_override`.
+  AST and symbols module-graph schemas are pinned by
+  `emit_json_ast_module_graph_schema_matches_golden` and
+  `emit_json_symbols_module_graph_schema_matches_golden`, covering portable
+  module IDs, canonical path shape, imports, declarations, symbol namespaces,
+  visibility, spans, and function signatures.
   Checked typed JSON for generic method specialization is pinned by
   `emit_json_typed_generic_method_schema_matches_golden`, covering the
   specialized `Box_i32` type and `Box.get_i32` method output.
@@ -282,6 +287,7 @@ Generic behavior inheritance with child type-parameter parent args is covered by
 | Typechecked C backend for tested fixtures | implemented | `cargo test --tests` |
 | README and contributor truth assertions | implemented | `tests/docs_truth.rs` |
 | Strict resolver, symbol IDs, privacy | implemented | Resolver/module/privacy tests |
+| AST/symbols JSON emission | constrained | `emit_json_ast_command_outputs_resolved_module_graph` checks unchecked AST module-graph output, `emit_json_ast_module_graph_schema_matches_golden` pins the unchecked AST module graph schema, `emit_json_symbols_command_outputs_module_symbol_tables` checks resolved symbol table output, `emit_json_symbols_module_graph_schema_matches_golden` pins the resolved symbols module graph schema, `emit_json_ast_rejects_hand_authored_json_before_unchecked_ir_override`, `emit_json_symbols_rejects_hand_authored_json_before_resolver_override` |
 | Diagnostics JSON emission | constrained | `emit_json_diagnostics_command_outputs_machine_readable_errors` checks machine-readable errors, `emit_json_diagnostics_removed_return_schema_matches_golden` pins removed-return suggested fix schema, `emit_json_diagnostics_behavior_derive_gate_schema_matches_golden` pins feature-gate context for reserved generated behavior association, `emit_json_diagnostics_generic_association_gate_schema_matches_golden` pins feature-gate context for reserved generic behavior association targets, `emit_json_diagnostics_generic_result_method_arity_schema_matches_golden` pins a hard generic `Result<T, E>` method arity diagnostic without followups, `emit_json_diagnostics_generic_result_method_bound_schema_matches_golden` pins a hard generic behavior-bound diagnostic without method-body followups, `emit_json_diagnostics_generic_result_method_inference_schema_matches_golden` pins a hard generic inference conflict without argument/return followups, `emit_json_diagnostics_rejects_hand_authored_json_before_diagnostic_override`; broader diagnostic-code catalog still required |
 | HIR JSON emission | constrained | `emit_json_hir_outputs_checked_declaration_graph` checks `schema_version: 0`, `emit_json_hir_outputs_enum_function_and_global_declarations` covers enum variants/payloads, function params/returns, and globals, `emit_json_hir_declaration_schema_matches_golden` pins the checked declaration schema, `emit_json_hir_rejects_hand_authored_json_before_ir_override`; broader golden tests still required |
 | MIR JSON emission | constrained | `emit_json_mir_outputs_checked_minimal_function_graph` checks `schema_version: 0`, `emit_json_mir_minimal_function_schema_matches_golden` pins the checked minimal function/block/terminator schema, `emit_json_mir_outputs_match_arm_schema` covers match kind, arm patterns/bindings, and block results, `emit_json_mir_match_schema_matches_golden` pins the checked match schema, `emit_json_mir_rejects_hand_authored_json_before_ir_override`; broader golden tests still required |

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -111,6 +111,8 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "semantic acceptance must use typed",
         "emit_json_ast_rejects_hand_authored_json_before_unchecked_ir_override",
         "emit_json_symbols_rejects_hand_authored_json_before_resolver_override",
+        "emit_json_ast_module_graph_schema_matches_golden",
+        "emit_json_symbols_module_graph_schema_matches_golden",
         "emit_json_diagnostics_rejects_hand_authored_json_before_diagnostic_override",
         "emit_json_diagnostics_removed_return_schema_matches_golden",
         "emit_json_diagnostics_behavior_derive_gate_schema_matches_golden",

--- a/tests/fixtures/ir_json/ast_module_graph.golden.json
+++ b/tests/fixtures/ir_json/ast_module_graph.golden.json
@@ -1,0 +1,189 @@
+{
+  "format": "zen.ast.v0",
+  "schema_version": 0,
+  "semantic_status": "unchecked",
+  "entry_module": 0,
+  "modules": [
+    {
+      "id": 0,
+      "package_id": 0,
+      "canonical_path": "main.zen",
+      "imports": [
+        {
+          "local_name": "add",
+          "source_module": 1,
+          "source_symbol": "add",
+          "span": {
+            "file_id": 0,
+            "start": 1,
+            "end": 15
+          }
+        }
+      ],
+      "program": {
+        "declarations": [
+          {
+            "Import": {
+              "names": [
+                "add"
+              ],
+              "module_path": [
+                "math"
+              ],
+              "span": {
+                "file_id": 0,
+                "start": 1,
+                "end": 15
+              }
+            }
+          },
+          {
+            "Function": {
+              "name": "main",
+              "type_params": [],
+              "params": [],
+              "return_type": "I32",
+              "body": {
+                "Block": {
+                  "statements": [],
+                  "expr": {
+                    "FunctionCall": {
+                      "name": "add",
+                      "module": null,
+                      "type_args": [],
+                      "args": [
+                        {
+                          "IntLiteral": {
+                            "value": 20,
+                            "span": {
+                              "file_id": 0,
+                              "start": 41,
+                              "end": 43
+                            }
+                          }
+                        },
+                        {
+                          "IntLiteral": {
+                            "value": 22,
+                            "span": {
+                              "file_id": 0,
+                              "start": 45,
+                              "end": 47
+                            }
+                          }
+                        }
+                      ],
+                      "span": {
+                        "file_id": 0,
+                        "start": 37,
+                        "end": 48
+                      }
+                    }
+                  },
+                  "span": {
+                    "file_id": 0,
+                    "start": 31,
+                    "end": 50
+                  }
+                }
+              },
+              "public": false,
+              "span": {
+                "file_id": 0,
+                "start": 17,
+                "end": 50
+              }
+            }
+          }
+        ],
+        "file_id": 0
+      }
+    },
+    {
+      "id": 1,
+      "package_id": 0,
+      "canonical_path": "math.zen",
+      "imports": [],
+      "program": {
+        "declarations": [
+          {
+            "Function": {
+              "name": "add",
+              "type_params": [],
+              "params": [
+                {
+                  "name": "a",
+                  "ty": "I32",
+                  "mutable": false,
+                  "span": {
+                    "file_id": 1,
+                    "start": 12,
+                    "end": 18
+                  }
+                },
+                {
+                  "name": "b",
+                  "ty": "I32",
+                  "mutable": false,
+                  "span": {
+                    "file_id": 1,
+                    "start": 20,
+                    "end": 26
+                  }
+                }
+              ],
+              "return_type": "I32",
+              "body": {
+                "Block": {
+                  "statements": [],
+                  "expr": {
+                    "BinaryOp": {
+                      "op": "Add",
+                      "left": {
+                        "Identifier": {
+                          "name": "a",
+                          "span": {
+                            "file_id": 1,
+                            "start": 38,
+                            "end": 39
+                          }
+                        }
+                      },
+                      "right": {
+                        "Identifier": {
+                          "name": "b",
+                          "span": {
+                            "file_id": 1,
+                            "start": 42,
+                            "end": 43
+                          }
+                        }
+                      },
+                      "span": {
+                        "file_id": 1,
+                        "start": 38,
+                        "end": 43
+                      }
+                    }
+                  },
+                  "span": {
+                    "file_id": 1,
+                    "start": 32,
+                    "end": 45
+                  }
+                }
+              },
+              "public": true,
+              "span": {
+                "file_id": 1,
+                "start": 5,
+                "end": 45
+              }
+            }
+          }
+        ],
+        "file_id": 1
+      }
+    }
+  ]
+}

--- a/tests/fixtures/ir_json/symbols_module_graph.golden.json
+++ b/tests/fixtures/ir_json/symbols_module_graph.golden.json
@@ -1,0 +1,207 @@
+{
+  "format": "zen.symbols.v0",
+  "semantic_status": "resolved",
+  "entry_module": 0,
+  "modules": [
+    {
+      "id": 0,
+      "package_id": 0,
+      "canonical_path": "main.zen",
+      "symbols": [
+        {
+          "id": 0,
+          "namespace": "Module",
+          "name": "math",
+          "is_public": false,
+          "import_source": null,
+          "parameter_count": null,
+          "parameter_names": null,
+          "parameter_type_names": null,
+          "return_type_name": null,
+          "type_parameter_count": null,
+          "type_parameter_names": null,
+          "field_count": null,
+          "field_type_names": null,
+          "variant_names": null,
+          "variant_owner_name": null,
+          "variant_payload_count": null,
+          "variant_payload_type_name": null,
+          "behavior_method_signatures": null,
+          "behavior_parent_names": null,
+          "behavior_impl_names": null,
+          "behavior_required_names": null,
+          "is_mutable": null,
+          "scope_id": 0,
+          "definition_span": {
+            "file_id": 0,
+            "start": 1,
+            "end": 15
+          }
+        },
+        {
+          "id": 1,
+          "namespace": "Import",
+          "name": "add",
+          "is_public": false,
+          "import_source": "math",
+          "parameter_count": null,
+          "parameter_names": null,
+          "parameter_type_names": null,
+          "return_type_name": null,
+          "type_parameter_count": null,
+          "type_parameter_names": null,
+          "field_count": null,
+          "field_type_names": null,
+          "variant_names": null,
+          "variant_owner_name": null,
+          "variant_payload_count": null,
+          "variant_payload_type_name": null,
+          "behavior_method_signatures": null,
+          "behavior_parent_names": null,
+          "behavior_impl_names": null,
+          "behavior_required_names": null,
+          "is_mutable": null,
+          "scope_id": 0,
+          "definition_span": {
+            "file_id": 0,
+            "start": 1,
+            "end": 15
+          }
+        },
+        {
+          "id": 2,
+          "namespace": "Value",
+          "name": "main",
+          "is_public": false,
+          "import_source": null,
+          "parameter_count": 0,
+          "parameter_names": [],
+          "parameter_type_names": [],
+          "return_type_name": "i32",
+          "type_parameter_count": 0,
+          "type_parameter_names": [],
+          "field_count": null,
+          "field_type_names": null,
+          "variant_names": null,
+          "variant_owner_name": null,
+          "variant_payload_count": null,
+          "variant_payload_type_name": null,
+          "behavior_method_signatures": null,
+          "behavior_parent_names": null,
+          "behavior_impl_names": null,
+          "behavior_required_names": null,
+          "is_mutable": null,
+          "scope_id": 0,
+          "definition_span": {
+            "file_id": 0,
+            "start": 17,
+            "end": 50
+          }
+        }
+      ]
+    },
+    {
+      "id": 1,
+      "package_id": 0,
+      "canonical_path": "math.zen",
+      "symbols": [
+        {
+          "id": 0,
+          "namespace": "Value",
+          "name": "add",
+          "is_public": true,
+          "import_source": null,
+          "parameter_count": 2,
+          "parameter_names": [
+            "a",
+            "b"
+          ],
+          "parameter_type_names": [
+            "i32",
+            "i32"
+          ],
+          "return_type_name": "i32",
+          "type_parameter_count": 0,
+          "type_parameter_names": [],
+          "field_count": null,
+          "field_type_names": null,
+          "variant_names": null,
+          "variant_owner_name": null,
+          "variant_payload_count": null,
+          "variant_payload_type_name": null,
+          "behavior_method_signatures": null,
+          "behavior_parent_names": null,
+          "behavior_impl_names": null,
+          "behavior_required_names": null,
+          "is_mutable": null,
+          "scope_id": 0,
+          "definition_span": {
+            "file_id": 1,
+            "start": 5,
+            "end": 45
+          }
+        },
+        {
+          "id": 1,
+          "namespace": "Local",
+          "name": "a",
+          "is_public": false,
+          "import_source": null,
+          "parameter_count": null,
+          "parameter_names": null,
+          "parameter_type_names": null,
+          "return_type_name": null,
+          "type_parameter_count": null,
+          "type_parameter_names": null,
+          "field_count": null,
+          "field_type_names": null,
+          "variant_names": null,
+          "variant_owner_name": null,
+          "variant_payload_count": null,
+          "variant_payload_type_name": null,
+          "behavior_method_signatures": null,
+          "behavior_parent_names": null,
+          "behavior_impl_names": null,
+          "behavior_required_names": null,
+          "is_mutable": false,
+          "scope_id": 1,
+          "definition_span": {
+            "file_id": 1,
+            "start": 12,
+            "end": 18
+          }
+        },
+        {
+          "id": 2,
+          "namespace": "Local",
+          "name": "b",
+          "is_public": false,
+          "import_source": null,
+          "parameter_count": null,
+          "parameter_names": null,
+          "parameter_type_names": null,
+          "return_type_name": null,
+          "type_parameter_count": null,
+          "type_parameter_names": null,
+          "field_count": null,
+          "field_type_names": null,
+          "variant_names": null,
+          "variant_owner_name": null,
+          "variant_payload_count": null,
+          "variant_payload_type_name": null,
+          "behavior_method_signatures": null,
+          "behavior_parent_names": null,
+          "behavior_impl_names": null,
+          "behavior_required_names": null,
+          "is_mutable": false,
+          "scope_id": 1,
+          "definition_span": {
+            "file_id": 1,
+            "start": 20,
+            "end": 26
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/integration/cli_build/frontend_json.rs
+++ b/tests/integration/cli_build/frontend_json.rs
@@ -17,6 +17,8 @@ mod layout_json;
 mod mir_golden;
 #[path = "frontend_json/module_graph.rs"]
 mod module_graph;
+#[path = "frontend_json/module_graph_golden.rs"]
+mod module_graph_golden;
 #[path = "frontend_json/target_yaml.rs"]
 mod target_yaml;
 #[path = "frontend_json/target_yaml_golden.rs"]

--- a/tests/integration/cli_build/frontend_json/module_graph_golden.rs
+++ b/tests/integration/cli_build/frontend_json/module_graph_golden.rs
@@ -1,0 +1,96 @@
+use serde_json::Value;
+use std::path::Path;
+use std::process::Command;
+
+fn fixture(path: &str) -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(path)
+}
+
+fn write_subject(tmp: &tempfile::TempDir) -> std::path::PathBuf {
+    let math_path = tmp.path().join("math.zen");
+    std::fs::write(
+        &math_path,
+        r#"
+pub add = (a: i32, b: i32) i32 {
+    a + b
+}
+"#,
+    )
+    .expect("write imported module");
+
+    let main_path = tmp.path().join("main.zen");
+    std::fs::write(
+        &main_path,
+        r#"
+{ add } = math
+
+main = () i32 {
+    add(20, 22)
+}
+"#,
+    )
+    .expect("write entry module");
+
+    main_path
+}
+
+fn normalized_module_graph_json(mode: &str) -> String {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let main_path = write_subject(&tmp);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", mode, main_path.to_str().unwrap()])
+        .output()
+        .unwrap_or_else(|err| panic!("run zen emit-json {mode}: {err}"));
+
+    assert!(
+        output.status.success(),
+        "zen emit-json {mode} failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let mut json: Value =
+        serde_json::from_slice(&output.stdout).expect("module graph JSON stdout is JSON");
+    for module in json["modules"]
+        .as_array_mut()
+        .expect("module graph modules array")
+    {
+        let path = module["canonical_path"]
+            .as_str()
+            .expect("module canonical path");
+        module["canonical_path"] = Path::new(path)
+            .file_name()
+            .expect("module file name")
+            .to_string_lossy()
+            .into_owned()
+            .into();
+    }
+
+    serde_json::to_string_pretty(&json).expect("serialize normalized module graph JSON")
+}
+
+fn normalized_fixture(path: &str) -> String {
+    let expected_path = fixture(path);
+    let expected = std::fs::read_to_string(&expected_path)
+        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
+    let json: Value = serde_json::from_str(&expected)
+        .unwrap_or_else(|err| panic!("parse {}: {err}", expected_path.display()));
+    serde_json::to_string_pretty(&json).expect("serialize normalized fixture JSON")
+}
+
+#[test]
+fn emit_json_ast_module_graph_schema_matches_golden() {
+    let actual = normalized_module_graph_json("ast");
+    let expected = normalized_fixture("tests/fixtures/ir_json/ast_module_graph.golden.json");
+
+    assert_eq!(actual.trim(), expected.trim());
+}
+
+#[test]
+fn emit_json_symbols_module_graph_schema_matches_golden() {
+    let actual = normalized_module_graph_json("symbols");
+    let expected = normalized_fixture("tests/fixtures/ir_json/symbols_module_graph.golden.json");
+
+    assert_eq!(actual.trim(), expected.trim());
+}


### PR DESCRIPTION
## Summary
- Add golden fixtures for unchecked AST JSON and resolved symbols JSON module graphs
- Normalize module `canonical_path` values in the golden tests so fixtures are checkout-portable
- Record AST/symbols schema evidence in the V1 spec, phase plan, completion audit, and docs-truth checks

## Verification
- `cargo test --test integration module_graph_schema_matches_golden -- --nocapture`
- `cargo test --test docs_truth v1_spec -- --nocapture`
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- Push-event workflow check: `[]`