### PR TITLE
Pin HIR and MIR generic Result method JSON

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -649,6 +649,14 @@ Agent UX deliverables:
 - Checked MIR JSON for generic method worklist specialization is now pinned by
   `emit_json_mir_generic_method_worklist_schema_matches_golden`, covering
   `Box.get_inner_i32` lowering to a concrete `inner_i32(self.value)` call.
+- Checked HIR JSON for generic `Result<T, E>` enum method specialization is
+  now pinned by `emit_json_hir_generic_result_method_schema_matches_golden`,
+  covering concrete `Result_i32_StaticString` payloads and the
+  `Result.unwrap_or_i32_StaticString` method signature.
+- Checked MIR JSON for generic `Result<T, E>` enum method specialization is
+  now pinned by `emit_json_mir_generic_result_method_schema_matches_golden`,
+  covering `Result.unwrap_or_i32_StaticString` lowering to an enum match over
+  `Result_i32_StaticString.Ok` and `Result_i32_StaticString.Err`.
 - Checked typed JSON for generic `Option<T>` enum specialization is now pinned
   by `emit_json_typed_generic_option_schema_matches_golden`, covering concrete
   `Option_i32` enum payloads, `unwrap_or_i32`, and typed call sites.

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -329,6 +329,10 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   method worklist HIR output is pinned by
   `emit_json_hir_generic_method_worklist_schema_matches_golden`, covering
   concrete `Box_i32`, `inner_i32`, and `Box.get_inner_i32` declarations.
+  Generic `Result<T, E>` enum method HIR output is pinned by
+  `emit_json_hir_generic_result_method_schema_matches_golden`, covering
+  concrete `Result_i32_StaticString` payloads and
+  `Result.unwrap_or_i32_StaticString` method signature lowering.
   Nested
   generic HIR specialization is pinned by
   `emit_json_hir_nested_generic_result_schema_matches_golden`, covering
@@ -351,6 +355,10 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   match-arm lowering. Generic method worklist MIR output is pinned by
   `emit_json_mir_generic_method_worklist_schema_matches_golden`, covering
   `Box.get_inner_i32` lowering to a concrete `inner_i32(self.value)` call.
+  Generic `Result<T, E>` enum method MIR output is pinned by
+  `emit_json_mir_generic_result_method_schema_matches_golden`, covering
+  `Result.unwrap_or_i32_StaticString` lowering to an enum match over
+  `Result_i32_StaticString.Ok` and `Result_i32_StaticString.Err`.
   Nested generic MIR specialization is pinned by
   `emit_json_mir_nested_generic_result_schema_matches_golden`, covering nested
   `Result_Option_i32_StaticString.Ok(Option_i32.Some(...))`, dependent

--- a/tests/fixtures/ir_json/hir_generic_result_method.golden.json
+++ b/tests/fixtures/ir_json/hir_generic_result_method.golden.json
@@ -1,0 +1,58 @@
+{
+  "format": "zen.hir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "declarations": {
+    "types": [
+      {
+        "name": "Result_i32_StaticString",
+        "kind": "enum",
+        "fields": [],
+        "variants": [
+          {
+            "name": "Ok",
+            "tag": 0,
+            "payload": [
+              {
+                "name": "payload",
+                "type": "i32"
+              }
+            ]
+          },
+          {
+            "name": "Err",
+            "tag": 1,
+            "payload": [
+              {
+                "name": "payload",
+                "type": "StaticString"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "functions": [
+      {
+        "name": "main",
+        "params": [],
+        "return_type": "i32"
+      },
+      {
+        "name": "Result.unwrap_or_i32_StaticString",
+        "params": [
+          {
+            "name": "self",
+            "type": "Result_i32_StaticString"
+          },
+          {
+            "name": "fallback",
+            "type": "i32"
+          }
+        ],
+        "return_type": "i32"
+      }
+    ],
+    "globals": []
+  }
+}

--- a/tests/fixtures/ir_json/mir_generic_result_method.golden.json
+++ b/tests/fixtures/ir_json/mir_generic_result_method.golden.json
@@ -1,0 +1,192 @@
+{
+  "format": "zen.mir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "lowering_status": "minimal",
+  "functions": [
+    {
+      "name": "main",
+      "params": [],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [
+            {
+              "kind": "let",
+              "name": "ok",
+              "type": "Result_i32_StaticString",
+              "mutable": false,
+              "value": {
+                "kind": "enum_variant",
+                "type": "Result_i32_StaticString",
+                "name": "Result_i32_StaticString.Ok",
+                "args": [
+                  {
+                    "kind": "int",
+                    "type": "i32",
+                    "value": 21
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "let",
+              "name": "err",
+              "type": "Result_i32_StaticString",
+              "mutable": false,
+              "value": {
+                "kind": "enum_variant",
+                "type": "Result_i32_StaticString",
+                "name": "Result_i32_StaticString.Err",
+                "args": [
+                  {
+                    "kind": "static_string",
+                    "type": "StaticString",
+                    "value": "bad"
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "expr",
+              "value": {
+                "kind": "call",
+                "type": "void",
+                "function": "io_println",
+                "args": [
+                  {
+                    "kind": "string_interpolation",
+                    "type": "StaticString",
+                    "value": {
+                      "parts": 1
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "expr",
+              "value": {
+                "kind": "call",
+                "type": "void",
+                "function": "io_println",
+                "args": [
+                  {
+                    "kind": "string_interpolation",
+                    "type": "StaticString",
+                    "value": {
+                      "parts": 1
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "int",
+              "type": "i32",
+              "value": 0
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Result.unwrap_or_i32_StaticString",
+      "params": [
+        {
+          "name": "self",
+          "type": "Result_i32_StaticString"
+        },
+        {
+          "name": "fallback",
+          "type": "i32"
+        }
+      ],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "match",
+              "type": "i32",
+              "target": {
+                "kind": "local",
+                "type": "Result_i32_StaticString",
+                "name": "self"
+              },
+              "match_kind": "enum",
+              "arms": [
+                {
+                  "pattern": {
+                    "kind": "enum_variant",
+                    "name": "Result_i32_StaticString.Ok",
+                    "bindings": [
+                      {
+                        "name": "inner",
+                        "type": "i32"
+                      }
+                    ]
+                  },
+                  "body": {
+                    "label": "entry",
+                    "statements": [],
+                    "terminator": {
+                      "kind": "return",
+                      "value": {
+                        "kind": "block",
+                        "type": "i32",
+                        "value": {
+                          "has_result": true,
+                          "result": {
+                            "kind": "local",
+                            "name": "inner",
+                            "type": "i32"
+                          },
+                          "statement_count": 0
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "pattern": {
+                    "kind": "enum_variant",
+                    "name": "Result_i32_StaticString.Err",
+                    "bindings": []
+                  },
+                  "body": {
+                    "label": "entry",
+                    "statements": [],
+                    "terminator": {
+                      "kind": "return",
+                      "value": {
+                        "kind": "block",
+                        "type": "i32",
+                        "value": {
+                          "has_result": true,
+                          "result": {
+                            "kind": "local",
+                            "name": "fallback",
+                            "type": "i32"
+                          },
+                          "statement_count": 0
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/integration/cli_build/frontend_json/hir_golden.rs
+++ b/tests/integration/cli_build/frontend_json/hir_golden.rs
@@ -145,6 +145,37 @@ fn emit_json_hir_generic_method_worklist_schema_matches_golden() {
 }
 
 #[test]
+fn emit_json_hir_generic_result_method_schema_matches_golden() {
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args([
+            "emit-json",
+            "hir",
+            fixture("tests/zen/generic_result_enum_method.zen")
+                .to_str()
+                .unwrap(),
+        ])
+        .output()
+        .expect("run zen emit-json hir on generic Result method program input");
+
+    assert!(
+        output.status.success(),
+        "zen emit-json hir should emit checked generic Result method HIR JSON: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let actual =
+        String::from_utf8(output.stdout).expect("HIR generic Result method stdout is UTF-8");
+    serde_json::from_str::<serde_json::Value>(&actual)
+        .expect("HIR generic Result method stdout is JSON");
+    let expected_path = fixture("tests/fixtures/ir_json/hir_generic_result_method.golden.json");
+    let expected = std::fs::read_to_string(&expected_path)
+        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
+
+    assert_eq!(actual.trim(), expected.trim());
+}
+
+#[test]
 fn emit_json_hir_nested_generic_result_schema_matches_golden() {
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
         .args([

--- a/tests/integration/cli_build/frontend_json/mir_golden.rs
+++ b/tests/integration/cli_build/frontend_json/mir_golden.rs
@@ -176,6 +176,37 @@ fn emit_json_mir_generic_method_worklist_schema_matches_golden() {
 }
 
 #[test]
+fn emit_json_mir_generic_result_method_schema_matches_golden() {
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args([
+            "emit-json",
+            "mir",
+            fixture("tests/zen/generic_result_enum_method.zen")
+                .to_str()
+                .unwrap(),
+        ])
+        .output()
+        .expect("run zen emit-json mir on generic Result method program input");
+
+    assert!(
+        output.status.success(),
+        "zen emit-json mir should emit checked generic Result method MIR JSON: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let actual =
+        String::from_utf8(output.stdout).expect("MIR generic Result method stdout is UTF-8");
+    serde_json::from_str::<serde_json::Value>(&actual)
+        .expect("MIR generic Result method stdout is JSON");
+    let expected_path = fixture("tests/fixtures/ir_json/mir_generic_result_method.golden.json");
+    let expected = std::fs::read_to_string(&expected_path)
+        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
+
+    assert_eq!(actual.trim(), expected.trim());
+}
+
+#[test]
 fn emit_json_mir_nested_generic_result_schema_matches_golden() {
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
         .args([


### PR DESCRIPTION
## Summary
- add HIR/MIR golden coverage for `tests/zen/generic_result_enum_method.zen`
- pin concrete `Result_i32_StaticString` payloads and `Result.unwrap_or_i32_StaticString` method lowering
- document the new HIR/MIR coverage in the V1 spec and phase plan

## Validation
- TDD failure first: focused HIR/MIR tests failed on missing golden fixtures
- `cargo test --test integration emit_json_hir_generic_result_method_schema_matches_golden -- --nocapture`
- `cargo test --test integration emit_json_mir_generic_result_method_schema_matches_golden -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- push-event guard returned `[]`