### PR TITLE
Pin HIR and MIR generic method JSON

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -643,6 +643,12 @@ Agent UX deliverables:
   by `emit_json_typed_generic_method_worklist_schema_matches_golden`, covering
   `Box.get_inner_i32` calling the concrete `inner_i32` specialization from the
   method body.
+- Checked HIR JSON for generic method specialization is now pinned by
+  `emit_json_hir_generic_method_schema_matches_golden`, covering concrete
+  `Box_i32` and `Box.get_i32` declarations.
+- Checked MIR JSON for generic method specialization is now pinned by
+  `emit_json_mir_generic_method_schema_matches_golden`, covering `Box.get_i32`
+  lowering to `self.value`.
 - Checked HIR JSON for generic method worklist specialization is now pinned by
   `emit_json_hir_generic_method_worklist_schema_matches_golden`, covering
   concrete `Box_i32`, `inner_i32`, and `Box.get_inner_i32` declarations.

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -326,6 +326,9 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   `emit_json_hir_generic_result_schema_matches_golden`, covering concrete
   `Option_i32` and `Result_i32_StaticString` enum payloads plus specialized
   `unwrap_or_i32` and `unwrap_or_i32_StaticString` function signatures. Generic
+  method HIR output is pinned by
+  `emit_json_hir_generic_method_schema_matches_golden`, covering concrete
+  `Box_i32` and `Box.get_i32` declarations. Generic
   method worklist HIR output is pinned by
   `emit_json_hir_generic_method_worklist_schema_matches_golden`, covering
   concrete `Box_i32`, `inner_i32`, and `Box.get_inner_i32` declarations.
@@ -352,7 +355,9 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   `emit_json_mir_generic_option_schema_matches_golden` and
   `emit_json_mir_generic_result_schema_matches_golden`, covering concrete
   `Option_i32` and `Result_i32_StaticString` enum construction plus
-  match-arm lowering. Generic method worklist MIR output is pinned by
+  match-arm lowering. Generic method MIR output is pinned by
+  `emit_json_mir_generic_method_schema_matches_golden`, covering
+  `Box.get_i32` lowering to `self.value`. Generic method worklist MIR output is pinned by
   `emit_json_mir_generic_method_worklist_schema_matches_golden`, covering
   `Box.get_inner_i32` lowering to a concrete `inner_i32(self.value)` call.
   Generic `Result<T, E>` enum method MIR output is pinned by

--- a/tests/fixtures/ir_json/hir_generic_method.golden.json
+++ b/tests/fixtures/ir_json/hir_generic_method.golden.json
@@ -1,0 +1,38 @@
+{
+  "format": "zen.hir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "declarations": {
+    "types": [
+      {
+        "name": "Box_i32",
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "value",
+            "type": "i32"
+          }
+        ],
+        "variants": []
+      }
+    ],
+    "functions": [
+      {
+        "name": "main",
+        "params": [],
+        "return_type": "i32"
+      },
+      {
+        "name": "Box.get_i32",
+        "params": [
+          {
+            "name": "self",
+            "type": "Box_i32"
+          }
+        ],
+        "return_type": "i32"
+      }
+    ],
+    "globals": []
+  }
+}

--- a/tests/fixtures/ir_json/mir_generic_method.golden.json
+++ b/tests/fixtures/ir_json/mir_generic_method.golden.json
@@ -1,0 +1,92 @@
+{
+  "format": "zen.mir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "lowering_status": "minimal",
+  "functions": [
+    {
+      "name": "main",
+      "params": [],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [
+            {
+              "kind": "let",
+              "name": "box",
+              "type": "Box_i32",
+              "mutable": false,
+              "value": {
+                "kind": "struct",
+                "type": "Box_i32",
+                "name": "Box_i32",
+                "args": [
+                  {
+                    "kind": "int",
+                    "type": "i32",
+                    "value": 99
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "expr",
+              "value": {
+                "kind": "call",
+                "type": "void",
+                "function": "io_println",
+                "args": [
+                  {
+                    "kind": "string_interpolation",
+                    "type": "StaticString",
+                    "value": {
+                      "parts": 1
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "int",
+              "type": "i32",
+              "value": 0
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Box.get_i32",
+      "params": [
+        {
+          "name": "self",
+          "type": "Box_i32"
+        }
+      ],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "field",
+              "type": "i32",
+              "target": {
+                "kind": "local",
+                "type": "Box_i32",
+                "name": "self"
+              },
+              "field": "value"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/integration/cli_build/frontend_json/hir_golden.rs
+++ b/tests/integration/cli_build/frontend_json/hir_golden.rs
@@ -114,6 +114,33 @@ fn emit_json_hir_generic_option_schema_matches_golden() {
 }
 
 #[test]
+fn emit_json_hir_generic_method_schema_matches_golden() {
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args([
+            "emit-json",
+            "hir",
+            fixture("tests/zen/generic_method.zen").to_str().unwrap(),
+        ])
+        .output()
+        .expect("run zen emit-json hir on generic method input");
+
+    assert!(
+        output.status.success(),
+        "zen emit-json hir should emit checked generic method HIR JSON: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let actual = String::from_utf8(output.stdout).expect("HIR generic method stdout is UTF-8");
+    serde_json::from_str::<serde_json::Value>(&actual).expect("HIR generic method stdout is JSON");
+    let expected_path = fixture("tests/fixtures/ir_json/hir_generic_method.golden.json");
+    let expected = std::fs::read_to_string(&expected_path)
+        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
+
+    assert_eq!(actual.trim(), expected.trim());
+}
+
+#[test]
 fn emit_json_hir_generic_method_worklist_schema_matches_golden() {
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
         .args([

--- a/tests/integration/cli_build/frontend_json/mir_golden.rs
+++ b/tests/integration/cli_build/frontend_json/mir_golden.rs
@@ -145,6 +145,33 @@ fn emit_json_mir_generic_option_schema_matches_golden() {
 }
 
 #[test]
+fn emit_json_mir_generic_method_schema_matches_golden() {
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args([
+            "emit-json",
+            "mir",
+            fixture("tests/zen/generic_method.zen").to_str().unwrap(),
+        ])
+        .output()
+        .expect("run zen emit-json mir on generic method input");
+
+    assert!(
+        output.status.success(),
+        "zen emit-json mir should emit checked generic method MIR JSON: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let actual = String::from_utf8(output.stdout).expect("MIR generic method stdout is UTF-8");
+    serde_json::from_str::<serde_json::Value>(&actual).expect("MIR generic method stdout is JSON");
+    let expected_path = fixture("tests/fixtures/ir_json/mir_generic_method.golden.json");
+    let expected = std::fs::read_to_string(&expected_path)
+        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
+
+    assert_eq!(actual.trim(), expected.trim());
+}
+
+#[test]
 fn emit_json_mir_generic_method_worklist_schema_matches_golden() {
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
         .args([


### PR DESCRIPTION
## Summary
- add HIR/MIR golden coverage for `tests/zen/generic_method.zen`
- pin concrete `Box_i32` and `Box.get_i32` declaration/lowering artifacts
- document the HIR/MIR generic method coverage in the V1 spec and phase plan

## Validation
- TDD failure first: focused HIR/MIR tests failed on missing golden fixtures
- `cargo test --test integration emit_json_hir_generic_method_schema_matches_golden -- --nocapture`
- `cargo test --test integration emit_json_mir_generic_method_schema_matches_golden -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- push-event guard returned `[]`