### PR TITLE
Split typed generic method golden tests

### DIFF
--- a/tests/integration/cli_build/frontend_json/typed_golden.rs
+++ b/tests/integration/cli_build/frontend_json/typed_golden.rs
@@ -2,6 +2,9 @@ use crate::support::*;
 use std::path::Path;
 use std::process::Command;
 
+#[path = "typed_golden/methods.rs"]
+mod methods;
+
 fn fixture(path: &str) -> std::path::PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(path)
 }
@@ -28,98 +31,6 @@ fn assert_typed_golden(source: &str, golden: &str, description: &str) {
     serde_json::from_str::<serde_json::Value>(&actual)
         .unwrap_or_else(|err| panic!("{description} stdout is JSON: {err}"));
     let expected_path = fixture(golden);
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_typed_generic_method_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "typed",
-            test_dir().join("generic_method.zen").to_str().unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json typed");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json typed failed: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual = String::from_utf8(output.stdout).expect("typed stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual).expect("typed stdout is JSON");
-    let expected_path = fixture("tests/fixtures/ir_json/typed_generic_method.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_typed_generic_method_worklist_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "typed",
-            test_dir()
-                .join("generic_method_worklist.zen")
-                .to_str()
-                .unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json typed on generic method worklist input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json typed should emit checked generic method worklist JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual =
-        String::from_utf8(output.stdout).expect("typed generic method worklist stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual)
-        .expect("typed generic method worklist stdout is JSON");
-    let expected_path = fixture("tests/fixtures/ir_json/typed_generic_method_worklist.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_typed_generic_method_nested_result_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "typed",
-            test_dir()
-                .join("generic_method_nested_result.zen")
-                .to_str()
-                .unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json typed on generic method nested Result input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json typed should emit checked generic method nested Result JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual = String::from_utf8(output.stdout)
-        .expect("typed generic method nested Result stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual)
-        .expect("typed generic method nested Result stdout is JSON");
-    let expected_path =
-        fixture("tests/fixtures/ir_json/typed_generic_method_nested_result.golden.json");
     let expected = std::fs::read_to_string(&expected_path)
         .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
 

--- a/tests/integration/cli_build/frontend_json/typed_golden/methods.rs
+++ b/tests/integration/cli_build/frontend_json/typed_golden/methods.rs
@@ -1,0 +1,28 @@
+use super::assert_typed_golden;
+
+#[test]
+fn emit_json_typed_generic_method_schema_matches_golden() {
+    assert_typed_golden(
+        "generic_method.zen",
+        "tests/fixtures/ir_json/typed_generic_method.golden.json",
+        "generic method",
+    );
+}
+
+#[test]
+fn emit_json_typed_generic_method_worklist_schema_matches_golden() {
+    assert_typed_golden(
+        "generic_method_worklist.zen",
+        "tests/fixtures/ir_json/typed_generic_method_worklist.golden.json",
+        "generic method worklist",
+    );
+}
+
+#[test]
+fn emit_json_typed_generic_method_nested_result_schema_matches_golden() {
+    assert_typed_golden(
+        "generic_method_nested_result.zen",
+        "tests/fixtures/ir_json/typed_generic_method_nested_result.golden.json",
+        "generic method nested Result",
+    );
+}


### PR DESCRIPTION
## Summary
- move typed generic method golden tests into a focused child module
- reuse the shared typed golden assertion helper for the moved method tests
- reduce `typed_golden.rs` from 482 lines to 393 lines before adding more Phase 5 coverage

## Verification
- `cargo test --test integration emit_json_typed_generic_method_schema_matches_golden -- --nocapture`
- `cargo test --test integration emit_json_typed_generic_method_worklist_schema_matches_golden -- --nocapture`
- `cargo test --test integration emit_json_typed_generic_method_nested_result_schema_matches_golden -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Push-event Actions check: `gh run list --branch codex/split-typed-golden-tests --event push --limit 10 --json ...` returned `[]`.