### PR TITLE
Pin typed generic UFC function JSON

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -222,6 +222,10 @@ Agent UX deliverables:
   `emit_json_hir_generic_ufc_dedup_schema_matches_golden` and
   `emit_json_mir_generic_ufc_dedup_schema_matches_golden`, covering one
   concrete `id_i32` specialization reused by both call spellings.
+- Generic UFC-only function specialization is now pinned in typed JSON by
+  `emit_json_typed_generic_ufc_function_schema_matches_golden`, covering
+  `12.id<i32>()` lowering inside string interpolation to the concrete
+  `id_i32` specialization.
 - Generic diagnostics now cover explicit type-argument arity failures for
   two-parameter `Result<T, E>` enum methods without noisy followup diagnostics.
   Diagnostics JSON pins this machine-readable shape through

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -262,9 +262,12 @@ Generic behavior inheritance with child type-parameter parent args is covered by
   JSON for generic method worklist specialization is pinned by
   `emit_json_typed_generic_method_worklist_schema_matches_golden`, covering
   `Box.get_inner_i32` calling the concrete `inner_i32` specialization from the
-  method body. Checked typed JSON for generic direct-call/UFC-call
-  deduplication is pinned by `emit_json_typed_generic_ufc_dedup_schema_matches_golden`,
-  covering both call-site spellings feeding the same concrete `id_i32`.
+  method body. Checked typed JSON for generic UFC-only function calls is pinned
+  by `emit_json_typed_generic_ufc_function_schema_matches_golden`, proving
+  `12.id<i32>()` lowers to the concrete `id_i32` specialization. Checked typed
+  JSON for generic direct-call/UFC-call deduplication is pinned by
+  `emit_json_typed_generic_ufc_dedup_schema_matches_golden`, covering both
+  call-site spellings feeding the same concrete `id_i32`.
   Checked typed JSON for generic function worklist deduplication is pinned by
   `emit_json_typed_generic_worklist_dedup_schema_matches_golden`, covering
   `left_i32` and `right_i32` calling the same concrete `inner_i32`. Checked typed

--- a/tests/docs_truth/v1_spec.rs
+++ b/tests/docs_truth/v1_spec.rs
@@ -190,6 +190,7 @@ fn v1_spec_records_phase_one_feature_gates_and_test_backlog() {
         "emit_json_typed_generic_type_impl_methods_schema_matches_golden",
         "emit_json_typed_generic_self_method_schema_matches_golden",
         "emit_json_typed_generic_method_worklist_schema_matches_golden",
+        "emit_json_typed_generic_ufc_function_schema_matches_golden",
         "emit_json_typed_generic_option_schema_matches_golden",
         "emit_json_typed_generic_result_schema_matches_golden",
         "emit_json_typed_generic_result_method_schema_matches_golden",

--- a/tests/fixtures/ir_json/typed_generic_ufc_function.golden.json
+++ b/tests/fixtures/ir_json/typed_generic_ufc_function.golden.json
@@ -1,0 +1,150 @@
+{
+  "format": "zen.typed.v0",
+  "semantic_status": "checked",
+  "program": {
+    "functions": [
+      {
+        "name": "main",
+        "params": [],
+        "return_type": "I32",
+        "body": {
+          "statements": [
+            {
+              "kind": {
+                "Expression": {
+                  "kind": {
+                    "FunctionCall": {
+                      "function": "io_println",
+                      "args": [
+                        {
+                          "kind": {
+                            "StringInterpolation": {
+                              "parts": [
+                                {
+                                  "Expr": {
+                                    "kind": {
+                                      "FunctionCall": {
+                                        "function": "id_i32",
+                                        "args": [
+                                          {
+                                            "kind": {
+                                              "IntLiteral": 12
+                                            },
+                                            "ty": "I32",
+                                            "span": {
+                                              "file_id": 0,
+                                              "start": 84,
+                                              "end": 86
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "ty": "I32",
+                                    "span": {
+                                      "file_id": 0,
+                                      "start": 84,
+                                      "end": 96
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "ty": "Str",
+                          "span": {
+                            "file_id": 0,
+                            "start": 82,
+                            "end": 97
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "ty": "Void",
+                  "span": {
+                    "file_id": 0,
+                    "start": 70,
+                    "end": 99
+                  }
+                }
+              },
+              "span": {
+                "file_id": 0,
+                "start": 70,
+                "end": 99
+              }
+            }
+          ],
+          "expr": {
+            "kind": {
+              "IntLiteral": 0
+            },
+            "ty": "I32",
+            "span": {
+              "file_id": 0,
+              "start": 104,
+              "end": 105
+            }
+          },
+          "ty": "I32",
+          "span": {
+            "file_id": 0,
+            "start": 64,
+            "end": 107
+          }
+        },
+        "defers": [],
+        "span": {
+          "file_id": 0,
+          "start": 50,
+          "end": 107
+        }
+      },
+      {
+        "name": "id_i32",
+        "params": [
+          {
+            "name": "value",
+            "ty": "I32",
+            "span": {
+              "file_id": 0,
+              "start": 23,
+              "end": 31
+            }
+          }
+        ],
+        "return_type": "I32",
+        "body": {
+          "statements": [],
+          "expr": {
+            "kind": {
+              "Variable": "value"
+            },
+            "ty": "I32",
+            "span": {
+              "file_id": 0,
+              "start": 41,
+              "end": 46
+            }
+          },
+          "ty": "I32",
+          "span": {
+            "file_id": 0,
+            "start": 35,
+            "end": 48
+          }
+        },
+        "defers": [],
+        "span": {
+          "file_id": 0,
+          "start": 14,
+          "end": 48
+        }
+      }
+    ],
+    "types": [],
+    "globals": [],
+    "entry_point": "main"
+  }
+}

--- a/tests/integration/cli_build/frontend_json/typed_golden.rs
+++ b/tests/integration/cli_build/frontend_json/typed_golden.rs
@@ -84,6 +84,15 @@ fn emit_json_typed_generic_ufc_dedup_schema_matches_golden() {
 }
 
 #[test]
+fn emit_json_typed_generic_ufc_function_schema_matches_golden() {
+    assert_typed_golden(
+        "generic_ufc_function.zen",
+        "tests/fixtures/ir_json/typed_generic_ufc_function.golden.json",
+        "generic UFC function",
+    );
+}
+
+#[test]
 fn emit_json_typed_generic_worklist_dedup_schema_matches_golden() {
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
         .args([


### PR DESCRIPTION
## Summary
- add checked typed JSON golden coverage for `tests/zen/generic_ufc_function.zen`
- pin `12.id<i32>()` lowering inside interpolation to the concrete `id_i32` specialization
- record the new Phase 5 evidence in the V1 spec, phase plan, and docs-truth checklist

## Verification
- `cargo test --test integration emit_json_typed_generic_ufc_function_schema_matches_golden -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Push-event Actions check: `gh run list --branch codex/pin-typed-generic-ufc-function-json --event push --limit 10 --json ...` returned `[]`.