### PR TITLE
Split HIR MIR generic enum golden tests

### DIFF
--- a/tests/integration/cli_build/frontend_json/hir_golden.rs
+++ b/tests/integration/cli_build/frontend_json/hir_golden.rs
@@ -1,6 +1,9 @@
 use std::path::Path;
 use std::process::Command;
 
+#[path = "hir_golden/generic_enums.rs"]
+mod generic_enums;
+
 fn fixture(path: &str) -> std::path::PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(path)
 }
@@ -49,126 +52,6 @@ main = () i32 { 0 }
     let actual = String::from_utf8(output.stdout).expect("HIR declarations stdout is UTF-8");
     serde_json::from_str::<serde_json::Value>(&actual).expect("HIR declarations stdout is JSON");
     let expected_path = fixture("tests/fixtures/ir_json/hir_declarations.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_hir_generic_result_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "hir",
-            fixture("tests/zen/generic_result_enum.zen")
-                .to_str()
-                .unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json hir on generic Result program input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json hir should emit checked generic Result HIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual = String::from_utf8(output.stdout).expect("HIR generic Result stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual).expect("HIR generic Result stdout is JSON");
-    let expected_path = fixture("tests/fixtures/ir_json/hir_generic_result.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_hir_generic_option_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "hir",
-            fixture("tests/zen/generic_enum_option.zen")
-                .to_str()
-                .unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json hir on generic Option program input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json hir should emit checked generic Option HIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual = String::from_utf8(output.stdout).expect("HIR generic Option stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual).expect("HIR generic Option stdout is JSON");
-    let expected_path = fixture("tests/fixtures/ir_json/hir_generic_option.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_hir_generic_option_multi_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "hir",
-            fixture("tests/zen/generic_enum_multi_specialization.zen")
-                .to_str()
-                .unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json hir on generic Option multi-specialization input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json hir should emit checked generic Option multi-specialization HIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual =
-        String::from_utf8(output.stdout).expect("HIR generic Option multi stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual)
-        .expect("HIR generic Option multi stdout is JSON");
-    let expected_path = fixture("tests/fixtures/ir_json/hir_generic_option_multi.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_hir_generic_result_multi_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "hir",
-            fixture("tests/zen/generic_result_enum_multi_specialization.zen")
-                .to_str()
-                .unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json hir on generic Result multi-specialization input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json hir should emit checked generic Result multi-specialization HIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual =
-        String::from_utf8(output.stdout).expect("HIR generic Result multi stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual)
-        .expect("HIR generic Result multi stdout is JSON");
-    let expected_path = fixture("tests/fixtures/ir_json/hir_generic_result_multi.golden.json");
     let expected = std::fs::read_to_string(&expected_path)
         .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
 

--- a/tests/integration/cli_build/frontend_json/hir_golden/generic_enums.rs
+++ b/tests/integration/cli_build/frontend_json/hir_golden/generic_enums.rs
@@ -1,0 +1,62 @@
+use super::fixture;
+use std::process::Command;
+
+fn assert_hir_golden(source: &str, golden: &str, description: &str) {
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "hir", fixture(source).to_str().unwrap()])
+        .output()
+        .unwrap_or_else(|err| panic!("run zen emit-json hir on {description}: {err}"));
+
+    assert!(
+        output.status.success(),
+        "zen emit-json hir should emit checked {description} HIR JSON: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let actual = String::from_utf8(output.stdout)
+        .unwrap_or_else(|err| panic!("HIR {description} stdout is UTF-8: {err}"));
+    serde_json::from_str::<serde_json::Value>(&actual)
+        .unwrap_or_else(|err| panic!("HIR {description} stdout is JSON: {err}"));
+    let expected_path = fixture(golden);
+    let expected = std::fs::read_to_string(&expected_path)
+        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
+
+    assert_eq!(actual.trim(), expected.trim());
+}
+
+#[test]
+fn emit_json_hir_generic_result_schema_matches_golden() {
+    assert_hir_golden(
+        "tests/zen/generic_result_enum.zen",
+        "tests/fixtures/ir_json/hir_generic_result.golden.json",
+        "generic Result program",
+    );
+}
+
+#[test]
+fn emit_json_hir_generic_option_schema_matches_golden() {
+    assert_hir_golden(
+        "tests/zen/generic_enum_option.zen",
+        "tests/fixtures/ir_json/hir_generic_option.golden.json",
+        "generic Option program",
+    );
+}
+
+#[test]
+fn emit_json_hir_generic_option_multi_schema_matches_golden() {
+    assert_hir_golden(
+        "tests/zen/generic_enum_multi_specialization.zen",
+        "tests/fixtures/ir_json/hir_generic_option_multi.golden.json",
+        "generic Option multi-specialization",
+    );
+}
+
+#[test]
+fn emit_json_hir_generic_result_multi_schema_matches_golden() {
+    assert_hir_golden(
+        "tests/zen/generic_result_enum_multi_specialization.zen",
+        "tests/fixtures/ir_json/hir_generic_result_multi.golden.json",
+        "generic Result multi-specialization",
+    );
+}

--- a/tests/integration/cli_build/frontend_json/mir_golden.rs
+++ b/tests/integration/cli_build/frontend_json/mir_golden.rs
@@ -1,6 +1,9 @@
 use std::path::Path;
 use std::process::Command;
 
+#[path = "mir_golden/generic_enums.rs"]
+mod generic_enums;
+
 fn fixture(path: &str) -> std::path::PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(path)
 }
@@ -80,126 +83,6 @@ main = () i32 {
     let actual = String::from_utf8(output.stdout).expect("MIR minimal stdout is UTF-8");
     serde_json::from_str::<serde_json::Value>(&actual).expect("MIR minimal stdout is JSON");
     let expected_path = fixture("tests/fixtures/ir_json/mir_minimal_function.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_mir_generic_result_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "mir",
-            fixture("tests/zen/generic_result_enum.zen")
-                .to_str()
-                .unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json mir on generic Result program input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json mir should emit checked generic Result MIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual = String::from_utf8(output.stdout).expect("MIR generic Result stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual).expect("MIR generic Result stdout is JSON");
-    let expected_path = fixture("tests/fixtures/ir_json/mir_generic_result.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_mir_generic_option_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "mir",
-            fixture("tests/zen/generic_enum_option.zen")
-                .to_str()
-                .unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json mir on generic Option program input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json mir should emit checked generic Option MIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual = String::from_utf8(output.stdout).expect("MIR generic Option stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual).expect("MIR generic Option stdout is JSON");
-    let expected_path = fixture("tests/fixtures/ir_json/mir_generic_option.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_mir_generic_option_multi_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "mir",
-            fixture("tests/zen/generic_enum_multi_specialization.zen")
-                .to_str()
-                .unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json mir on generic Option multi-specialization input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json mir should emit checked generic Option multi-specialization MIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual =
-        String::from_utf8(output.stdout).expect("MIR generic Option multi stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual)
-        .expect("MIR generic Option multi stdout is JSON");
-    let expected_path = fixture("tests/fixtures/ir_json/mir_generic_option_multi.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_mir_generic_result_multi_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "mir",
-            fixture("tests/zen/generic_result_enum_multi_specialization.zen")
-                .to_str()
-                .unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json mir on generic Result multi-specialization input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json mir should emit checked generic Result multi-specialization MIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual =
-        String::from_utf8(output.stdout).expect("MIR generic Result multi stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual)
-        .expect("MIR generic Result multi stdout is JSON");
-    let expected_path = fixture("tests/fixtures/ir_json/mir_generic_result_multi.golden.json");
     let expected = std::fs::read_to_string(&expected_path)
         .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
 

--- a/tests/integration/cli_build/frontend_json/mir_golden/generic_enums.rs
+++ b/tests/integration/cli_build/frontend_json/mir_golden/generic_enums.rs
@@ -1,0 +1,62 @@
+use super::fixture;
+use std::process::Command;
+
+fn assert_mir_golden(source: &str, golden: &str, description: &str) {
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "mir", fixture(source).to_str().unwrap()])
+        .output()
+        .unwrap_or_else(|err| panic!("run zen emit-json mir on {description}: {err}"));
+
+    assert!(
+        output.status.success(),
+        "zen emit-json mir should emit checked {description} MIR JSON: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let actual = String::from_utf8(output.stdout)
+        .unwrap_or_else(|err| panic!("MIR {description} stdout is UTF-8: {err}"));
+    serde_json::from_str::<serde_json::Value>(&actual)
+        .unwrap_or_else(|err| panic!("MIR {description} stdout is JSON: {err}"));
+    let expected_path = fixture(golden);
+    let expected = std::fs::read_to_string(&expected_path)
+        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
+
+    assert_eq!(actual.trim(), expected.trim());
+}
+
+#[test]
+fn emit_json_mir_generic_result_schema_matches_golden() {
+    assert_mir_golden(
+        "tests/zen/generic_result_enum.zen",
+        "tests/fixtures/ir_json/mir_generic_result.golden.json",
+        "generic Result program",
+    );
+}
+
+#[test]
+fn emit_json_mir_generic_option_schema_matches_golden() {
+    assert_mir_golden(
+        "tests/zen/generic_enum_option.zen",
+        "tests/fixtures/ir_json/mir_generic_option.golden.json",
+        "generic Option program",
+    );
+}
+
+#[test]
+fn emit_json_mir_generic_option_multi_schema_matches_golden() {
+    assert_mir_golden(
+        "tests/zen/generic_enum_multi_specialization.zen",
+        "tests/fixtures/ir_json/mir_generic_option_multi.golden.json",
+        "generic Option multi-specialization",
+    );
+}
+
+#[test]
+fn emit_json_mir_generic_result_multi_schema_matches_golden() {
+    assert_mir_golden(
+        "tests/zen/generic_result_enum_multi_specialization.zen",
+        "tests/fixtures/ir_json/mir_generic_result_multi.golden.json",
+        "generic Result multi-specialization",
+    );
+}


### PR DESCRIPTION
## Summary
- move HIR generic Option/Result golden tests into `hir_golden/generic_enums.rs`
- move MIR generic Option/Result golden tests into `mir_golden/generic_enums.rs`
- reduce `hir_golden.rs` and `mir_golden.rs` from near-threshold line counts to about 360 lines each

## Verification
- `cargo test --test integration emit_json_hir_generic_option_schema_matches_golden -- --nocapture`
- `cargo test --test integration emit_json_mir_generic_option_schema_matches_golden -- --nocapture`
- `cargo test --test integration emit_json_hir_generic_result_multi_schema_matches_golden -- --nocapture`
- `cargo test --test integration emit_json_mir_generic_result_multi_schema_matches_golden -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Push-event Actions check: `gh run list --branch codex/split-hir-mir-generic-enum-goldens --event push --limit 10 --json ...` returned `[]`.