### PR TITLE
Split diagnostics JSON golden tests

### DIFF
--- a/tests/integration/cli_build/frontend_json/diagnostics_golden.rs
+++ b/tests/integration/cli_build/frontend_json/diagnostics_golden.rs
@@ -1,72 +1,38 @@
 use std::path::Path;
 use std::process::Command;
 
+#[path = "diagnostics_golden/behavior_association.rs"]
+mod behavior_association;
+#[path = "diagnostics_golden/generic_methods.rs"]
+mod generic_methods;
+#[path = "diagnostics_golden/removed_syntax.rs"]
+mod removed_syntax;
+
 fn fixture(path: &str) -> std::path::PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(path)
 }
 
-#[test]
-fn emit_json_diagnostics_removed_return_schema_matches_golden() {
+fn assert_diagnostics_golden(
+    file_name: &str,
+    source: &str,
+    golden: &str,
+    description: &str,
+    expected_diagnostic_count: usize,
+    followup_message: &str,
+) {
     let tmp = tempfile::tempdir().expect("create temp dir");
-    let zen_path = tmp.path().join("return_keyword.zen");
-    std::fs::write(
-        &zen_path,
-        r#"
-main = () i32 {
-    return 1
-}
-"#,
-    )
-    .expect("write removed return source");
+    let zen_path = tmp.path().join(file_name);
+    std::fs::write(&zen_path, source)
+        .unwrap_or_else(|err| panic!("write {description} source: {err}"));
 
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
         .args(["emit-json", "diagnostics", zen_path.to_str().unwrap()])
         .output()
-        .expect("run zen emit-json diagnostics");
+        .unwrap_or_else(|err| panic!("run zen emit-json diagnostics on {description}: {err}"));
 
     assert!(
         !output.status.success(),
-        "zen emit-json diagnostics should fail on removed return syntax: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual = String::from_utf8(output.stdout).expect("diagnostics stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual).expect("diagnostics stdout is JSON");
-    let normalized = actual.replace(tmp.path().to_str().expect("tmp path is UTF-8"), "$TMP");
-    let expected_path = fixture("tests/fixtures/ir_json/diagnostics_return.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(normalized.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_diagnostics_behavior_derive_gate_schema_matches_golden() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let zen_path = tmp.path().join("derive_gate.zen");
-    std::fs::write(
-        &zen_path,
-        r#"
-Point: { x: i32 }
-
-Json: behavior {
-    to_json: (Self) StaticString
-}
-
-Point.derive(Json)
-"#,
-    )
-    .expect("write gated derive source");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "diagnostics", zen_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json diagnostics");
-
-    assert!(
-        !output.status.success(),
-        "zen emit-json diagnostics should fail on gated derive association: stdout={}, stderr={}",
+        "zen emit-json diagnostics should fail on {description}: stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
@@ -79,313 +45,12 @@ Point.derive(Json)
             .as_array()
             .expect("diagnostics array")
             .len(),
-        1,
-        "gated derive diagnostics should emit one feature-gate diagnostic: {json}"
+        expected_diagnostic_count,
+        "{followup_message}: {json}"
     );
 
     let normalized = actual.replace(tmp.path().to_str().expect("tmp path is UTF-8"), "$TMP");
-    let expected_path =
-        fixture("tests/fixtures/ir_json/diagnostics_behavior_derive_gate.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(normalized.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_diagnostics_generic_association_gate_schema_matches_golden() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let zen_path = tmp.path().join("generic_association_gate.zen");
-    std::fs::write(
-        &zen_path,
-        r#"
-Box<T>: {
-    value: T
-}
-
-Json<T>: behavior {
-    to_json: (T) StaticString
-}
-
-Box<T>.derive(Json<T>)
-"#,
-    )
-    .expect("write gated generic association source");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "diagnostics", zen_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json diagnostics");
-
-    assert!(
-        !output.status.success(),
-        "zen emit-json diagnostics should fail on gated generic association: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual = String::from_utf8(output.stdout).expect("diagnostics stdout is UTF-8");
-    let json: serde_json::Value =
-        serde_json::from_str(&actual).expect("diagnostics stdout is JSON");
-    assert_eq!(
-        json["diagnostics"]
-            .as_array()
-            .expect("diagnostics array")
-            .len(),
-        1,
-        "gated generic association diagnostics should emit one feature-gate diagnostic: {json}"
-    );
-
-    let normalized = actual.replace(tmp.path().to_str().expect("tmp path is UTF-8"), "$TMP");
-    let expected_path =
-        fixture("tests/fixtures/ir_json/diagnostics_generic_association_gate.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(normalized.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_diagnostics_generic_behavior_overlap_schema_matches_golden() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let zen_path = tmp.path().join("generic_behavior_overlap.zen");
-    std::fs::write(
-        &zen_path,
-        r#"
-Point: { x: i32 }
-
-Json<T>: behavior {
-    encode: (Self) T
-}
-
-PrettyJson: behavior {
-    pretty: (Self) StaticString
-}
-
-PrettyJson.extends(Json<StaticString>)
-
-Point.implements(Json<StaticString>) {
-    encode = (value: Point) StaticString { "point" }
-}
-
-Point.implements(PrettyJson) {
-    encode = (value: Point) StaticString { "point" }
-    pretty = (value: Point) StaticString { "pretty" }
-}
-"#,
-    )
-    .expect("write generic behavior overlap source");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "diagnostics", zen_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json diagnostics");
-
-    assert!(
-        !output.status.success(),
-        "zen emit-json diagnostics should fail on overlapping generic behavior impls: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual = String::from_utf8(output.stdout).expect("diagnostics stdout is UTF-8");
-    let json: serde_json::Value =
-        serde_json::from_str(&actual).expect("diagnostics stdout is JSON");
-    assert_eq!(
-        json["diagnostics"]
-            .as_array()
-            .expect("diagnostics array")
-            .len(),
-        1,
-        "generic behavior overlap should emit one coherence diagnostic: {json}"
-    );
-
-    let normalized = actual.replace(tmp.path().to_str().expect("tmp path is UTF-8"), "$TMP");
-    let expected_path =
-        fixture("tests/fixtures/ir_json/diagnostics_generic_behavior_overlap.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(normalized.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_diagnostics_generic_result_method_arity_schema_matches_golden() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let zen_path = tmp.path().join("generic_result_method_arity.zen");
-    std::fs::write(
-        &zen_path,
-        r#"
-Result<T, E>:
-    Ok(T),
-    Err(E)
-
-Result.unwrap_or<T, E> = (self: Self, fallback: T) T {
-    self ?
-        | Ok(value) { value }
-        | Err(_) { fallback }
-}
-
-main = () i32 {
-    value = Result<i32, StaticString>.Ok(1)
-    value.unwrap_or<i32>(0)
-}
-"#,
-    )
-    .expect("write generic method arity source");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "diagnostics", zen_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json diagnostics");
-
-    assert!(
-        !output.status.success(),
-        "zen emit-json diagnostics should fail on generic method arity: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual = String::from_utf8(output.stdout).expect("diagnostics stdout is UTF-8");
-    let json: serde_json::Value =
-        serde_json::from_str(&actual).expect("diagnostics stdout is JSON");
-    assert_eq!(
-        json["diagnostics"]
-            .as_array()
-            .expect("diagnostics array")
-            .len(),
-        1,
-        "generic arity diagnostics should not emit inference or argument followups: {json}"
-    );
-
-    let normalized = actual.replace(tmp.path().to_str().expect("tmp path is UTF-8"), "$TMP");
-    let expected_path =
-        fixture("tests/fixtures/ir_json/diagnostics_generic_result_method_arity.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(normalized.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_diagnostics_generic_result_method_bound_schema_matches_golden() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let zen_path = tmp.path().join("generic_result_method_bound.zen");
-    std::fs::write(
-        &zen_path,
-        r#"
-Json: behavior {
-    encode: (Self) StaticString
-}
-
-Point: {
-    x: i32
-}
-
-Result<T, E>:
-    Ok(T),
-    Err(E)
-
-Result.map<T, E, U: Json> = (self: Self, fallback: U) U {
-    fallback.encode()
-    fallback
-}
-
-main = () i32 {
-    value = Result<i32, StaticString>.Ok(1)
-    point = Point { x: 1 }
-    bad = value.map(point)
-    0
-}
-"#,
-    )
-    .expect("write generic method bound source");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "diagnostics", zen_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json diagnostics");
-
-    assert!(
-        !output.status.success(),
-        "zen emit-json diagnostics should fail on generic method bound: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual = String::from_utf8(output.stdout).expect("diagnostics stdout is UTF-8");
-    let json: serde_json::Value =
-        serde_json::from_str(&actual).expect("diagnostics stdout is JSON");
-    assert_eq!(
-        json["diagnostics"]
-            .as_array()
-            .expect("diagnostics array")
-            .len(),
-        1,
-        "generic bound diagnostics should not emit method-body followups: {json}"
-    );
-
-    let normalized = actual.replace(tmp.path().to_str().expect("tmp path is UTF-8"), "$TMP");
-    let expected_path =
-        fixture("tests/fixtures/ir_json/diagnostics_generic_result_method_bound.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(normalized.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_diagnostics_generic_result_method_inference_schema_matches_golden() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let zen_path = tmp.path().join("generic_result_method_inference.zen");
-    std::fs::write(
-        &zen_path,
-        r#"
-Result<T, E>:
-    Ok(T),
-    Err(E)
-
-Result.unwrap_or<T, E> = (self: Self, fallback: T) T {
-    self ?
-        | Ok(value) { value }
-        | Err(_) { fallback }
-}
-
-main = () i32 {
-    value = Result<i32, StaticString>.Ok(1)
-    value.unwrap_or("bad")
-}
-"#,
-    )
-    .expect("write generic method inference source");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "diagnostics", zen_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json diagnostics");
-
-    assert!(
-        !output.status.success(),
-        "zen emit-json diagnostics should fail on generic method inference: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual = String::from_utf8(output.stdout).expect("diagnostics stdout is UTF-8");
-    let json: serde_json::Value =
-        serde_json::from_str(&actual).expect("diagnostics stdout is JSON");
-    assert_eq!(
-        json["diagnostics"]
-            .as_array()
-            .expect("diagnostics array")
-            .len(),
-        1,
-        "generic inference diagnostics should not emit argument or return followups: {json}"
-    );
-
-    let normalized = actual.replace(tmp.path().to_str().expect("tmp path is UTF-8"), "$TMP");
-    let expected_path =
-        fixture("tests/fixtures/ir_json/diagnostics_generic_result_method_inference.golden.json");
+    let expected_path = fixture(golden);
     let expected = std::fs::read_to_string(&expected_path)
         .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
 

--- a/tests/integration/cli_build/frontend_json/diagnostics_golden/behavior_association.rs
+++ b/tests/integration/cli_build/frontend_json/diagnostics_golden/behavior_association.rs
@@ -1,0 +1,76 @@
+use super::assert_diagnostics_golden;
+
+#[test]
+fn emit_json_diagnostics_behavior_derive_gate_schema_matches_golden() {
+    assert_diagnostics_golden(
+        "derive_gate.zen",
+        r#"
+Point: { x: i32 }
+
+Json: behavior {
+    to_json: (Self) StaticString
+}
+
+Point.derive(Json)
+"#,
+        "tests/fixtures/ir_json/diagnostics_behavior_derive_gate.golden.json",
+        "gated derive association",
+        1,
+        "gated derive diagnostics should emit one feature-gate diagnostic",
+    );
+}
+
+#[test]
+fn emit_json_diagnostics_generic_association_gate_schema_matches_golden() {
+    assert_diagnostics_golden(
+        "generic_association_gate.zen",
+        r#"
+Box<T>: {
+    value: T
+}
+
+Json<T>: behavior {
+    to_json: (T) StaticString
+}
+
+Box<T>.derive(Json<T>)
+"#,
+        "tests/fixtures/ir_json/diagnostics_generic_association_gate.golden.json",
+        "gated generic association",
+        1,
+        "gated generic association diagnostics should emit one feature-gate diagnostic",
+    );
+}
+
+#[test]
+fn emit_json_diagnostics_generic_behavior_overlap_schema_matches_golden() {
+    assert_diagnostics_golden(
+        "generic_behavior_overlap.zen",
+        r#"
+Point: { x: i32 }
+
+Json<T>: behavior {
+    encode: (Self) T
+}
+
+PrettyJson: behavior {
+    pretty: (Self) StaticString
+}
+
+PrettyJson.extends(Json<StaticString>)
+
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
+}
+
+Point.implements(PrettyJson) {
+    encode = (value: Point) StaticString { "point" }
+    pretty = (value: Point) StaticString { "pretty" }
+}
+"#,
+        "tests/fixtures/ir_json/diagnostics_generic_behavior_overlap.golden.json",
+        "overlapping generic behavior impls",
+        1,
+        "generic behavior overlap should emit one coherence diagnostic",
+    );
+}

--- a/tests/integration/cli_build/frontend_json/diagnostics_golden/generic_methods.rs
+++ b/tests/integration/cli_build/frontend_json/diagnostics_golden/generic_methods.rs
@@ -1,0 +1,91 @@
+use super::assert_diagnostics_golden;
+
+#[test]
+fn emit_json_diagnostics_generic_result_method_arity_schema_matches_golden() {
+    assert_diagnostics_golden(
+        "generic_result_method_arity.zen",
+        r#"
+Result<T, E>:
+    Ok(T),
+    Err(E)
+
+Result.unwrap_or<T, E> = (self: Self, fallback: T) T {
+    self ?
+        | Ok(value) { value }
+        | Err(_) { fallback }
+}
+
+main = () i32 {
+    value = Result<i32, StaticString>.Ok(1)
+    value.unwrap_or<i32>(0)
+}
+"#,
+        "tests/fixtures/ir_json/diagnostics_generic_result_method_arity.golden.json",
+        "generic method arity",
+        1,
+        "generic arity diagnostics should not emit inference or argument followups",
+    );
+}
+
+#[test]
+fn emit_json_diagnostics_generic_result_method_bound_schema_matches_golden() {
+    assert_diagnostics_golden(
+        "generic_result_method_bound.zen",
+        r#"
+Json: behavior {
+    encode: (Self) StaticString
+}
+
+Point: {
+    x: i32
+}
+
+Result<T, E>:
+    Ok(T),
+    Err(E)
+
+Result.map<T, E, U: Json> = (self: Self, fallback: U) U {
+    fallback.encode()
+    fallback
+}
+
+main = () i32 {
+    value = Result<i32, StaticString>.Ok(1)
+    point = Point { x: 1 }
+    bad = value.map(point)
+    0
+}
+"#,
+        "tests/fixtures/ir_json/diagnostics_generic_result_method_bound.golden.json",
+        "generic method bound",
+        1,
+        "generic bound diagnostics should not emit method-body followups",
+    );
+}
+
+#[test]
+fn emit_json_diagnostics_generic_result_method_inference_schema_matches_golden() {
+    assert_diagnostics_golden(
+        "generic_result_method_inference.zen",
+        r#"
+Result<T, E>:
+    Ok(T),
+    Err(E)
+
+Result.unwrap_or<T, E> = (self: Self, fallback: T) T {
+    self ?
+        | Ok(value) { value }
+        | Err(_) { fallback }
+}
+
+main = () i32 {
+    value = Result<i32, StaticString>.Ok(1)
+    value.unwrap_or("bad")
+}
+"#,
+        "tests/fixtures/ir_json/diagnostics_generic_result_method_inference.golden.json",
+        "generic method inference",
+        1,
+        "generic inference diagnostics should not emit argument or return followups",
+    );
+}

--- a/tests/integration/cli_build/frontend_json/diagnostics_golden/removed_syntax.rs
+++ b/tests/integration/cli_build/frontend_json/diagnostics_golden/removed_syntax.rs
@@ -1,0 +1,17 @@
+use super::assert_diagnostics_golden;
+
+#[test]
+fn emit_json_diagnostics_removed_return_schema_matches_golden() {
+    assert_diagnostics_golden(
+        "return_keyword.zen",
+        r#"
+main = () i32 {
+    return 1
+}
+"#,
+        "tests/fixtures/ir_json/diagnostics_return.golden.json",
+        "removed return syntax",
+        1,
+        "removed return diagnostics should emit one removed-syntax diagnostic",
+    );
+}


### PR DESCRIPTION
## Summary

- split diagnostics frontend JSON golden tests into focused modules for removed syntax, behavior association diagnostics, and generic method diagnostics
- shrink `diagnostics_golden.rs` to a shared helper plus module index
- preserve every golden fixture and test name while routing repeated temp-file/normalization logic through `assert_diagnostics_golden`

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test integration -- cli_build::frontend_json::diagnostics_golden --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Push-event workflow check for `codex/split-diagnostics-json-golden-tests` returned `[]`.