### PR TITLE
Split MIR golden tests

### DIFF
--- a/tests/integration/cli_build/frontend_json/mir_golden.rs
+++ b/tests/integration/cli_build/frontend_json/mir_golden.rs
@@ -1,360 +1,68 @@
 use std::path::Path;
 use std::process::Command;
 
+#[path = "mir_golden/basic.rs"]
+mod basic;
+#[path = "mir_golden/behavior_bounds.rs"]
+mod behavior_bounds;
 #[path = "mir_golden/generic_enums.rs"]
 mod generic_enums;
+#[path = "mir_golden/generic_methods.rs"]
+mod generic_methods;
+#[path = "mir_golden/generic_values.rs"]
+mod generic_values;
 
 fn fixture(path: &str) -> std::path::PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(path)
 }
 
-#[test]
-fn emit_json_mir_match_schema_matches_golden() {
+fn assert_mir_golden(source: &str, golden: &str, description: &str) {
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "mir", fixture(source).to_str().unwrap()])
+        .output()
+        .unwrap_or_else(|err| panic!("run zen emit-json mir on {description}: {err}"));
+
+    assert!(
+        output.status.success(),
+        "zen emit-json mir should emit checked {description} MIR JSON: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let actual = String::from_utf8(output.stdout)
+        .unwrap_or_else(|err| panic!("MIR {description} stdout is UTF-8: {err}"));
+    serde_json::from_str::<serde_json::Value>(&actual)
+        .unwrap_or_else(|err| panic!("MIR {description} stdout is JSON: {err}"));
+    let expected_path = fixture(golden);
+    let expected = std::fs::read_to_string(&expected_path)
+        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
+
+    assert_eq!(actual.trim(), expected.trim());
+}
+
+fn assert_mir_source_golden(source: &str, filename: &str, golden: &str, description: &str) {
     let tmp = tempfile::tempdir().expect("create temp dir");
-    let zen_path = tmp.path().join("mir_match_subject.zen");
-    std::fs::write(
-        &zen_path,
-        r#"
-Choice:
-    Empty,
-    Value(i32)
-
-score = (choice: Choice) i32 {
-    choice ?
-        | Empty { 0 }
-        | Value(n) { n }
-}
-
-main = () i32 {
-    score(Choice.Value(42))
-}
-"#,
-    )
-    .expect("write MIR match subject");
+    let zen_path = tmp.path().join(filename);
+    std::fs::write(&zen_path, source)
+        .unwrap_or_else(|err| panic!("write MIR {description} subject: {err}"));
 
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
         .args(["emit-json", "mir", zen_path.to_str().unwrap()])
         .output()
-        .expect("run zen emit-json mir on match program input");
+        .unwrap_or_else(|err| panic!("run zen emit-json mir on {description} input: {err}"));
 
     assert!(
         output.status.success(),
-        "zen emit-json mir should emit checked MIR match JSON: stdout={}, stderr={}",
+        "zen emit-json mir should emit checked {description} MIR JSON: stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let actual = String::from_utf8(output.stdout).expect("MIR match stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual).expect("MIR match stdout is JSON");
-    let expected_path = fixture("tests/fixtures/ir_json/mir_match_schema.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_mir_minimal_function_schema_matches_golden() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let zen_path = tmp.path().join("mir_subject.zen");
-    std::fs::write(
-        &zen_path,
-        r#"
-main = () i32 {
-    value = 40 + 2
-    value
-}
-"#,
-    )
-    .expect("write MIR subject");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "mir", zen_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json mir on program input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json mir should emit checked minimal MIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual = String::from_utf8(output.stdout).expect("MIR minimal stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual).expect("MIR minimal stdout is JSON");
-    let expected_path = fixture("tests/fixtures/ir_json/mir_minimal_function.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_mir_generic_vec_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "mir",
-            fixture("tests/zen/generic_vec.zen").to_str().unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json mir on generic Vec input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json mir should emit checked generic Vec MIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual = String::from_utf8(output.stdout).expect("MIR generic Vec stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual).expect("MIR generic Vec stdout is JSON");
-    let expected_path = fixture("tests/fixtures/ir_json/mir_generic_vec.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_mir_generic_method_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "mir",
-            fixture("tests/zen/generic_method.zen").to_str().unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json mir on generic method input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json mir should emit checked generic method MIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual = String::from_utf8(output.stdout).expect("MIR generic method stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual).expect("MIR generic method stdout is JSON");
-    let expected_path = fixture("tests/fixtures/ir_json/mir_generic_method.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_mir_generic_type_impl_methods_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "mir",
-            fixture("tests/zen/generic_type_impl_methods.zen")
-                .to_str()
-                .unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json mir on generic type impl methods input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json mir should emit checked generic type impl methods MIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual =
-        String::from_utf8(output.stdout).expect("MIR generic type impl methods stdout is UTF-8");
+    let actual = String::from_utf8(output.stdout)
+        .unwrap_or_else(|err| panic!("MIR {description} stdout is UTF-8: {err}"));
     serde_json::from_str::<serde_json::Value>(&actual)
-        .expect("MIR generic type impl methods stdout is JSON");
-    let expected_path = fixture("tests/fixtures/ir_json/mir_generic_type_impl_methods.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_mir_generic_self_method_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "mir",
-            fixture("tests/zen/generic_method_self.zen")
-                .to_str()
-                .unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json mir on generic Self method input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json mir should emit checked generic Self method MIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual = String::from_utf8(output.stdout).expect("MIR generic Self method stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual)
-        .expect("MIR generic Self method stdout is JSON");
-    let expected_path = fixture("tests/fixtures/ir_json/mir_generic_self_method.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_mir_generic_method_worklist_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "mir",
-            fixture("tests/zen/generic_method_worklist.zen")
-                .to_str()
-                .unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json mir on generic method worklist input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json mir should emit checked generic method worklist MIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual =
-        String::from_utf8(output.stdout).expect("MIR generic method worklist stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual)
-        .expect("MIR generic method worklist stdout is JSON");
-    let expected_path = fixture("tests/fixtures/ir_json/mir_generic_method_worklist.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_mir_generic_result_method_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "mir",
-            fixture("tests/zen/generic_result_enum_method.zen")
-                .to_str()
-                .unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json mir on generic Result method program input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json mir should emit checked generic Result method MIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual =
-        String::from_utf8(output.stdout).expect("MIR generic Result method stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual)
-        .expect("MIR generic Result method stdout is JSON");
-    let expected_path = fixture("tests/fixtures/ir_json/mir_generic_result_method.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_mir_nested_generic_result_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "mir",
-            fixture("tests/zen/generic_nested_result_enum.zen")
-                .to_str()
-                .unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json mir on nested generic Result program input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json mir should emit checked nested generic Result MIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual =
-        String::from_utf8(output.stdout).expect("MIR nested generic Result stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual)
-        .expect("MIR nested generic Result stdout is JSON");
-    let expected_path = fixture("tests/fixtures/ir_json/mir_nested_generic_result.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_mir_generic_behavior_association_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "mir",
-            fixture("tests/zen/behavior_json_generic_association.zen")
-                .to_str()
-                .unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json mir on generic behavior association input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json mir should emit checked generic behavior association MIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual =
-        String::from_utf8(output.stdout).expect("MIR generic behavior association stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual)
-        .expect("MIR generic behavior association stdout is JSON");
-    let expected_path =
-        fixture("tests/fixtures/ir_json/mir_generic_behavior_association.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_mir_generic_behavior_bound_ufcs_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "mir",
-            fixture("tests/zen/behavior_json_generic_bound_ufcs.zen")
-                .to_str()
-                .unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json mir on generic behavior-bound UFCS input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json mir should emit checked generic behavior-bound UFCS MIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual =
-        String::from_utf8(output.stdout).expect("MIR generic behavior-bound UFCS stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual)
-        .expect("MIR generic behavior-bound UFCS stdout is JSON");
-    let expected_path =
-        fixture("tests/fixtures/ir_json/mir_generic_behavior_bound_ufcs.golden.json");
+        .unwrap_or_else(|err| panic!("MIR {description} stdout is JSON: {err}"));
+    let expected_path = fixture(golden);
     let expected = std::fs::read_to_string(&expected_path)
         .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
 

--- a/tests/integration/cli_build/frontend_json/mir_golden/basic.rs
+++ b/tests/integration/cli_build/frontend_json/mir_golden/basic.rs
@@ -1,0 +1,40 @@
+use super::assert_mir_source_golden;
+
+#[test]
+fn emit_json_mir_match_schema_matches_golden() {
+    assert_mir_source_golden(
+        r#"
+Choice:
+    Empty,
+    Value(i32)
+
+score = (choice: Choice) i32 {
+    choice ?
+        | Empty { 0 }
+        | Value(n) { n }
+}
+
+main = () i32 {
+    score(Choice.Value(42))
+}
+"#,
+        "mir_match_subject.zen",
+        "tests/fixtures/ir_json/mir_match_schema.golden.json",
+        "match program",
+    );
+}
+
+#[test]
+fn emit_json_mir_minimal_function_schema_matches_golden() {
+    assert_mir_source_golden(
+        r#"
+main = () i32 {
+    value = 40 + 2
+    value
+}
+"#,
+        "mir_subject.zen",
+        "tests/fixtures/ir_json/mir_minimal_function.golden.json",
+        "minimal function",
+    );
+}

--- a/tests/integration/cli_build/frontend_json/mir_golden/behavior_bounds.rs
+++ b/tests/integration/cli_build/frontend_json/mir_golden/behavior_bounds.rs
@@ -1,0 +1,19 @@
+use super::assert_mir_golden;
+
+#[test]
+fn emit_json_mir_generic_behavior_association_schema_matches_golden() {
+    assert_mir_golden(
+        "tests/zen/behavior_json_generic_association.zen",
+        "tests/fixtures/ir_json/mir_generic_behavior_association.golden.json",
+        "generic behavior association input",
+    );
+}
+
+#[test]
+fn emit_json_mir_generic_behavior_bound_ufcs_schema_matches_golden() {
+    assert_mir_golden(
+        "tests/zen/behavior_json_generic_bound_ufcs.zen",
+        "tests/fixtures/ir_json/mir_generic_behavior_bound_ufcs.golden.json",
+        "generic behavior-bound UFCS input",
+    );
+}

--- a/tests/integration/cli_build/frontend_json/mir_golden/generic_enums.rs
+++ b/tests/integration/cli_build/frontend_json/mir_golden/generic_enums.rs
@@ -1,29 +1,4 @@
-use super::fixture;
-use std::process::Command;
-
-fn assert_mir_golden(source: &str, golden: &str, description: &str) {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "mir", fixture(source).to_str().unwrap()])
-        .output()
-        .unwrap_or_else(|err| panic!("run zen emit-json mir on {description}: {err}"));
-
-    assert!(
-        output.status.success(),
-        "zen emit-json mir should emit checked {description} MIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual = String::from_utf8(output.stdout)
-        .unwrap_or_else(|err| panic!("MIR {description} stdout is UTF-8: {err}"));
-    serde_json::from_str::<serde_json::Value>(&actual)
-        .unwrap_or_else(|err| panic!("MIR {description} stdout is JSON: {err}"));
-    let expected_path = fixture(golden);
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
+use super::assert_mir_golden;
 
 #[test]
 fn emit_json_mir_generic_result_schema_matches_golden() {

--- a/tests/integration/cli_build/frontend_json/mir_golden/generic_methods.rs
+++ b/tests/integration/cli_build/frontend_json/mir_golden/generic_methods.rs
@@ -1,0 +1,55 @@
+use super::assert_mir_golden;
+
+#[test]
+fn emit_json_mir_generic_method_schema_matches_golden() {
+    assert_mir_golden(
+        "tests/zen/generic_method.zen",
+        "tests/fixtures/ir_json/mir_generic_method.golden.json",
+        "generic method input",
+    );
+}
+
+#[test]
+fn emit_json_mir_generic_type_impl_methods_schema_matches_golden() {
+    assert_mir_golden(
+        "tests/zen/generic_type_impl_methods.zen",
+        "tests/fixtures/ir_json/mir_generic_type_impl_methods.golden.json",
+        "generic type impl methods input",
+    );
+}
+
+#[test]
+fn emit_json_mir_generic_self_method_schema_matches_golden() {
+    assert_mir_golden(
+        "tests/zen/generic_method_self.zen",
+        "tests/fixtures/ir_json/mir_generic_self_method.golden.json",
+        "generic Self method input",
+    );
+}
+
+#[test]
+fn emit_json_mir_generic_method_worklist_schema_matches_golden() {
+    assert_mir_golden(
+        "tests/zen/generic_method_worklist.zen",
+        "tests/fixtures/ir_json/mir_generic_method_worklist.golden.json",
+        "generic method worklist input",
+    );
+}
+
+#[test]
+fn emit_json_mir_generic_result_method_schema_matches_golden() {
+    assert_mir_golden(
+        "tests/zen/generic_result_enum_method.zen",
+        "tests/fixtures/ir_json/mir_generic_result_method.golden.json",
+        "generic Result method program input",
+    );
+}
+
+#[test]
+fn emit_json_mir_nested_generic_result_schema_matches_golden() {
+    assert_mir_golden(
+        "tests/zen/generic_nested_result_enum.zen",
+        "tests/fixtures/ir_json/mir_nested_generic_result.golden.json",
+        "nested generic Result program input",
+    );
+}

--- a/tests/integration/cli_build/frontend_json/mir_golden/generic_values.rs
+++ b/tests/integration/cli_build/frontend_json/mir_golden/generic_values.rs
@@ -1,0 +1,10 @@
+use super::assert_mir_golden;
+
+#[test]
+fn emit_json_mir_generic_vec_schema_matches_golden() {
+    assert_mir_golden(
+        "tests/zen/generic_vec.zen",
+        "tests/fixtures/ir_json/mir_generic_vec.golden.json",
+        "generic Vec input",
+    );
+}


### PR DESCRIPTION
## Summary
- split the MIR golden JSON suite into focused modules for basic programs, generic values, generic methods, behavior-bound cases, and generic enums
- keep the root MIR golden file as shared helpers plus module wiring
- remove the duplicate MIR golden assertion helper from the generic enum module

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test integration -- cli_build::frontend_json::mir_golden --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- push-event workflow check returned `[]`