### PR TITLE
Split HIR golden tests

### DIFF
--- a/tests/integration/cli_build/frontend_json/hir_golden.rs
+++ b/tests/integration/cli_build/frontend_json/hir_golden.rs
@@ -1,358 +1,68 @@
 use std::path::Path;
 use std::process::Command;
 
+#[path = "hir_golden/basic.rs"]
+mod basic;
+#[path = "hir_golden/behavior_bounds.rs"]
+mod behavior_bounds;
 #[path = "hir_golden/generic_enums.rs"]
 mod generic_enums;
+#[path = "hir_golden/generic_methods.rs"]
+mod generic_methods;
+#[path = "hir_golden/generic_values.rs"]
+mod generic_values;
 
 fn fixture(path: &str) -> std::path::PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(path)
 }
 
-#[test]
-fn emit_json_hir_declaration_schema_matches_golden() {
+fn assert_hir_golden(source: &str, golden: &str, description: &str) {
+    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "hir", fixture(source).to_str().unwrap()])
+        .output()
+        .unwrap_or_else(|err| panic!("run zen emit-json hir on {description}: {err}"));
+
+    assert!(
+        output.status.success(),
+        "zen emit-json hir should emit checked {description} HIR JSON: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let actual = String::from_utf8(output.stdout)
+        .unwrap_or_else(|err| panic!("HIR {description} stdout is UTF-8: {err}"));
+    serde_json::from_str::<serde_json::Value>(&actual)
+        .unwrap_or_else(|err| panic!("HIR {description} stdout is JSON: {err}"));
+    let expected_path = fixture(golden);
+    let expected = std::fs::read_to_string(&expected_path)
+        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
+
+    assert_eq!(actual.trim(), expected.trim());
+}
+
+fn assert_hir_source_golden(source: &str, filename: &str, golden: &str, description: &str) {
     let tmp = tempfile::tempdir().expect("create temp dir");
-    let zen_path = tmp.path().join("hir_declarations_subject.zen");
-    std::fs::write(
-        &zen_path,
-        r#"
-Pair: {
-    left: i32,
-    right: i32,
-}
-
-MaybePair:
-    None,
-    Some(Pair)
-
-threshold ::= 10
-
-choose = (candidate: Pair, enabled: bool) MaybePair {
-    enabled ?
-        | true { MaybePair.Some(candidate) }
-        | false { MaybePair.None }
-}
-
-main = () i32 { 0 }
-"#,
-    )
-    .expect("write HIR declarations subject");
+    let zen_path = tmp.path().join(filename);
+    std::fs::write(&zen_path, source)
+        .unwrap_or_else(|err| panic!("write HIR {description} subject: {err}"));
 
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
         .args(["emit-json", "hir", zen_path.to_str().unwrap()])
         .output()
-        .expect("run zen emit-json hir on declaration-rich program input");
+        .unwrap_or_else(|err| panic!("run zen emit-json hir on {description} input: {err}"));
 
     assert!(
         output.status.success(),
-        "zen emit-json hir should emit checked declaration-rich HIR JSON: stdout={}, stderr={}",
+        "zen emit-json hir should emit checked {description} HIR JSON: stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let actual = String::from_utf8(output.stdout).expect("HIR declarations stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual).expect("HIR declarations stdout is JSON");
-    let expected_path = fixture("tests/fixtures/ir_json/hir_declarations.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_hir_generic_vec_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "hir",
-            fixture("tests/zen/generic_vec.zen").to_str().unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json hir on generic Vec input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json hir should emit checked generic Vec HIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual = String::from_utf8(output.stdout).expect("HIR generic Vec stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual).expect("HIR generic Vec stdout is JSON");
-    let expected_path = fixture("tests/fixtures/ir_json/hir_generic_vec.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_hir_generic_method_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "hir",
-            fixture("tests/zen/generic_method.zen").to_str().unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json hir on generic method input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json hir should emit checked generic method HIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual = String::from_utf8(output.stdout).expect("HIR generic method stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual).expect("HIR generic method stdout is JSON");
-    let expected_path = fixture("tests/fixtures/ir_json/hir_generic_method.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_hir_generic_type_impl_methods_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "hir",
-            fixture("tests/zen/generic_type_impl_methods.zen")
-                .to_str()
-                .unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json hir on generic type impl methods input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json hir should emit checked generic type impl methods HIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual =
-        String::from_utf8(output.stdout).expect("HIR generic type impl methods stdout is UTF-8");
+    let actual = String::from_utf8(output.stdout)
+        .unwrap_or_else(|err| panic!("HIR {description} stdout is UTF-8: {err}"));
     serde_json::from_str::<serde_json::Value>(&actual)
-        .expect("HIR generic type impl methods stdout is JSON");
-    let expected_path = fixture("tests/fixtures/ir_json/hir_generic_type_impl_methods.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_hir_generic_self_method_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "hir",
-            fixture("tests/zen/generic_method_self.zen")
-                .to_str()
-                .unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json hir on generic Self method input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json hir should emit checked generic Self method HIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual = String::from_utf8(output.stdout).expect("HIR generic Self method stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual)
-        .expect("HIR generic Self method stdout is JSON");
-    let expected_path = fixture("tests/fixtures/ir_json/hir_generic_self_method.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_hir_generic_method_worklist_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "hir",
-            fixture("tests/zen/generic_method_worklist.zen")
-                .to_str()
-                .unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json hir on generic method worklist input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json hir should emit checked generic method worklist HIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual =
-        String::from_utf8(output.stdout).expect("HIR generic method worklist stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual)
-        .expect("HIR generic method worklist stdout is JSON");
-    let expected_path = fixture("tests/fixtures/ir_json/hir_generic_method_worklist.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_hir_generic_function_worklist_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "hir",
-            fixture("tests/zen/generic_worklist.zen").to_str().unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json hir on generic function worklist input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json hir should emit checked generic function worklist HIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual =
-        String::from_utf8(output.stdout).expect("HIR generic function worklist stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual)
-        .expect("HIR generic function worklist stdout is JSON");
-    let expected_path = fixture("tests/fixtures/ir_json/hir_generic_function_worklist.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_hir_generic_result_method_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "hir",
-            fixture("tests/zen/generic_result_enum_method.zen")
-                .to_str()
-                .unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json hir on generic Result method program input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json hir should emit checked generic Result method HIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual =
-        String::from_utf8(output.stdout).expect("HIR generic Result method stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual)
-        .expect("HIR generic Result method stdout is JSON");
-    let expected_path = fixture("tests/fixtures/ir_json/hir_generic_result_method.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_hir_nested_generic_result_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "hir",
-            fixture("tests/zen/generic_nested_result_enum.zen")
-                .to_str()
-                .unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json hir on nested generic Result program input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json hir should emit checked nested generic Result HIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual =
-        String::from_utf8(output.stdout).expect("HIR nested generic Result stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual)
-        .expect("HIR nested generic Result stdout is JSON");
-    let expected_path = fixture("tests/fixtures/ir_json/hir_nested_generic_result.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_hir_generic_behavior_association_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "hir",
-            fixture("tests/zen/behavior_json_generic_association.zen")
-                .to_str()
-                .unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json hir on generic behavior association input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json hir should emit checked generic behavior association HIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual =
-        String::from_utf8(output.stdout).expect("HIR generic behavior association stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual)
-        .expect("HIR generic behavior association stdout is JSON");
-    let expected_path =
-        fixture("tests/fixtures/ir_json/hir_generic_behavior_association.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_hir_generic_behavior_bound_ufcs_schema_matches_golden() {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args([
-            "emit-json",
-            "hir",
-            fixture("tests/zen/behavior_json_generic_bound_ufcs.zen")
-                .to_str()
-                .unwrap(),
-        ])
-        .output()
-        .expect("run zen emit-json hir on generic behavior-bound UFCS input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json hir should emit checked generic behavior-bound UFCS HIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual =
-        String::from_utf8(output.stdout).expect("HIR generic behavior-bound UFCS stdout is UTF-8");
-    serde_json::from_str::<serde_json::Value>(&actual)
-        .expect("HIR generic behavior-bound UFCS stdout is JSON");
-    let expected_path =
-        fixture("tests/fixtures/ir_json/hir_generic_behavior_bound_ufcs.golden.json");
+        .unwrap_or_else(|err| panic!("HIR {description} stdout is JSON: {err}"));
+    let expected_path = fixture(golden);
     let expected = std::fs::read_to_string(&expected_path)
         .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
 

--- a/tests/integration/cli_build/frontend_json/hir_golden/basic.rs
+++ b/tests/integration/cli_build/frontend_json/hir_golden/basic.rs
@@ -1,0 +1,30 @@
+use super::assert_hir_source_golden;
+
+#[test]
+fn emit_json_hir_declaration_schema_matches_golden() {
+    assert_hir_source_golden(
+        r#"
+Pair: {
+    left: i32,
+    right: i32,
+}
+
+MaybePair:
+    None,
+    Some(Pair)
+
+threshold ::= 10
+
+choose = (candidate: Pair, enabled: bool) MaybePair {
+    enabled ?
+        | true { MaybePair.Some(candidate) }
+        | false { MaybePair.None }
+}
+
+main = () i32 { 0 }
+"#,
+        "hir_declarations_subject.zen",
+        "tests/fixtures/ir_json/hir_declarations.golden.json",
+        "declaration-rich program",
+    );
+}

--- a/tests/integration/cli_build/frontend_json/hir_golden/behavior_bounds.rs
+++ b/tests/integration/cli_build/frontend_json/hir_golden/behavior_bounds.rs
@@ -1,0 +1,19 @@
+use super::assert_hir_golden;
+
+#[test]
+fn emit_json_hir_generic_behavior_association_schema_matches_golden() {
+    assert_hir_golden(
+        "tests/zen/behavior_json_generic_association.zen",
+        "tests/fixtures/ir_json/hir_generic_behavior_association.golden.json",
+        "generic behavior association input",
+    );
+}
+
+#[test]
+fn emit_json_hir_generic_behavior_bound_ufcs_schema_matches_golden() {
+    assert_hir_golden(
+        "tests/zen/behavior_json_generic_bound_ufcs.zen",
+        "tests/fixtures/ir_json/hir_generic_behavior_bound_ufcs.golden.json",
+        "generic behavior-bound UFCS input",
+    );
+}

--- a/tests/integration/cli_build/frontend_json/hir_golden/generic_enums.rs
+++ b/tests/integration/cli_build/frontend_json/hir_golden/generic_enums.rs
@@ -1,29 +1,4 @@
-use super::fixture;
-use std::process::Command;
-
-fn assert_hir_golden(source: &str, golden: &str, description: &str) {
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "hir", fixture(source).to_str().unwrap()])
-        .output()
-        .unwrap_or_else(|err| panic!("run zen emit-json hir on {description}: {err}"));
-
-    assert!(
-        output.status.success(),
-        "zen emit-json hir should emit checked {description} HIR JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual = String::from_utf8(output.stdout)
-        .unwrap_or_else(|err| panic!("HIR {description} stdout is UTF-8: {err}"));
-    serde_json::from_str::<serde_json::Value>(&actual)
-        .unwrap_or_else(|err| panic!("HIR {description} stdout is JSON: {err}"));
-    let expected_path = fixture(golden);
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(actual.trim(), expected.trim());
-}
+use super::assert_hir_golden;
 
 #[test]
 fn emit_json_hir_generic_result_schema_matches_golden() {

--- a/tests/integration/cli_build/frontend_json/hir_golden/generic_methods.rs
+++ b/tests/integration/cli_build/frontend_json/hir_golden/generic_methods.rs
@@ -1,0 +1,55 @@
+use super::assert_hir_golden;
+
+#[test]
+fn emit_json_hir_generic_method_schema_matches_golden() {
+    assert_hir_golden(
+        "tests/zen/generic_method.zen",
+        "tests/fixtures/ir_json/hir_generic_method.golden.json",
+        "generic method input",
+    );
+}
+
+#[test]
+fn emit_json_hir_generic_type_impl_methods_schema_matches_golden() {
+    assert_hir_golden(
+        "tests/zen/generic_type_impl_methods.zen",
+        "tests/fixtures/ir_json/hir_generic_type_impl_methods.golden.json",
+        "generic type impl methods input",
+    );
+}
+
+#[test]
+fn emit_json_hir_generic_self_method_schema_matches_golden() {
+    assert_hir_golden(
+        "tests/zen/generic_method_self.zen",
+        "tests/fixtures/ir_json/hir_generic_self_method.golden.json",
+        "generic Self method input",
+    );
+}
+
+#[test]
+fn emit_json_hir_generic_method_worklist_schema_matches_golden() {
+    assert_hir_golden(
+        "tests/zen/generic_method_worklist.zen",
+        "tests/fixtures/ir_json/hir_generic_method_worklist.golden.json",
+        "generic method worklist input",
+    );
+}
+
+#[test]
+fn emit_json_hir_generic_result_method_schema_matches_golden() {
+    assert_hir_golden(
+        "tests/zen/generic_result_enum_method.zen",
+        "tests/fixtures/ir_json/hir_generic_result_method.golden.json",
+        "generic Result method program input",
+    );
+}
+
+#[test]
+fn emit_json_hir_nested_generic_result_schema_matches_golden() {
+    assert_hir_golden(
+        "tests/zen/generic_nested_result_enum.zen",
+        "tests/fixtures/ir_json/hir_nested_generic_result.golden.json",
+        "nested generic Result program input",
+    );
+}

--- a/tests/integration/cli_build/frontend_json/hir_golden/generic_values.rs
+++ b/tests/integration/cli_build/frontend_json/hir_golden/generic_values.rs
@@ -1,0 +1,19 @@
+use super::assert_hir_golden;
+
+#[test]
+fn emit_json_hir_generic_vec_schema_matches_golden() {
+    assert_hir_golden(
+        "tests/zen/generic_vec.zen",
+        "tests/fixtures/ir_json/hir_generic_vec.golden.json",
+        "generic Vec input",
+    );
+}
+
+#[test]
+fn emit_json_hir_generic_function_worklist_schema_matches_golden() {
+    assert_hir_golden(
+        "tests/zen/generic_worklist.zen",
+        "tests/fixtures/ir_json/hir_generic_function_worklist.golden.json",
+        "generic function worklist input",
+    );
+}


### PR DESCRIPTION
## Summary
- split the HIR golden JSON suite into focused modules for declaration basics, generic values, generic methods, behavior-bound cases, and generic enums
- keep the root HIR golden file as shared helpers plus module wiring
- remove the duplicate HIR golden assertion helper from the generic enum module

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test integration -- cli_build::frontend_json::hir_golden --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- push-event workflow check returned `[]`