### PR TITLE
Split behavior association diagnostics goldens

### DIFF
--- a/tests/integration/cli_build/frontend_json/diagnostics_behavior_association_golden.rs
+++ b/tests/integration/cli_build/frontend_json/diagnostics_behavior_association_golden.rs
@@ -1,40 +1,34 @@
 use std::path::Path;
 use std::process::Command;
 
+#[path = "diagnostics_behavior_association_golden/relationship_arity.rs"]
+mod relationship_arity;
+#[path = "diagnostics_behavior_association_golden/requires.rs"]
+mod requires;
+
 fn fixture(path: &str) -> std::path::PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(path)
 }
 
-#[test]
-fn emit_json_diagnostics_generic_requires_missing_impl_schema_matches_golden() {
+fn assert_behavior_association_diagnostics_golden(
+    source: &str,
+    filename: &str,
+    golden: &str,
+    description: &str,
+) {
     let tmp = tempfile::tempdir().expect("create temp dir");
-    let zen_path = tmp.path().join("generic_requires_missing_impl.zen");
-    std::fs::write(
-        &zen_path,
-        r#"
-Point: { x: i32 }
-
-Json<T>: behavior {
-    encode: (Self) T
-}
-
-Point.requires(Json<StaticString>)
-
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write generic requires missing impl source");
+    let zen_path = tmp.path().join(filename);
+    std::fs::write(&zen_path, source)
+        .unwrap_or_else(|err| panic!("write {description} source: {err}"));
 
     let output = Command::new(env!("CARGO_BIN_EXE_zen"))
         .args(["emit-json", "diagnostics", zen_path.to_str().unwrap()])
         .output()
-        .expect("run zen emit-json diagnostics");
+        .unwrap_or_else(|err| panic!("run zen emit-json diagnostics for {description}: {err}"));
 
     assert!(
         !output.status.success(),
-        "zen emit-json diagnostics should fail on missing generic behavior requires impl: stdout={}, stderr={}",
+        "zen emit-json diagnostics should fail on {description}: stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
@@ -48,302 +42,11 @@ main = () i32 {
             .expect("diagnostics array")
             .len(),
         1,
-        "missing generic behavior requires impl should emit one diagnostic: {json}"
+        "{description} should emit one diagnostic: {json}"
     );
 
     let normalized = actual.replace(tmp.path().to_str().expect("tmp path is UTF-8"), "$TMP");
-    let expected_path =
-        fixture("tests/fixtures/ir_json/diagnostics_generic_requires_missing_impl.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(normalized.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_diagnostics_duplicate_generic_requires_schema_matches_golden() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let zen_path = tmp.path().join("duplicate_generic_requires.zen");
-    std::fs::write(
-        &zen_path,
-        r#"
-Point: { x: i32 }
-
-Json<T>: behavior {
-    encode: (Self) T
-}
-
-Point.implements(Json<StaticString>) {
-    encode = (value: Point) StaticString { "point" }
-}
-
-Point.requires(Json<StaticString>)
-Point.requires(Json<StaticString>)
-
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write duplicate generic requires source");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "diagnostics", zen_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json diagnostics");
-
-    assert!(
-        !output.status.success(),
-        "zen emit-json diagnostics should fail on duplicate generic behavior requires: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual = String::from_utf8(output.stdout).expect("diagnostics stdout is UTF-8");
-    let json: serde_json::Value =
-        serde_json::from_str(&actual).expect("diagnostics stdout is JSON");
-    assert_eq!(
-        json["diagnostics"]
-            .as_array()
-            .expect("diagnostics array")
-            .len(),
-        1,
-        "duplicate generic behavior requires should emit one diagnostic: {json}"
-    );
-
-    let normalized = actual.replace(tmp.path().to_str().expect("tmp path is UTF-8"), "$TMP");
-    let expected_path =
-        fixture("tests/fixtures/ir_json/diagnostics_duplicate_generic_requires.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(normalized.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_diagnostics_generic_requires_arity_schema_matches_golden() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let zen_path = tmp.path().join("generic_requires_arity.zen");
-    std::fs::write(
-        &zen_path,
-        r#"
-Point: { x: i32 }
-
-Json<T>: behavior {
-    encode: (Self) T
-}
-
-Point.requires(Json<i32, StaticString>)
-
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write generic requires arity source");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "diagnostics", zen_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json diagnostics");
-
-    assert!(
-        !output.status.success(),
-        "zen emit-json diagnostics should fail on generic behavior requires arity: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual = String::from_utf8(output.stdout).expect("diagnostics stdout is UTF-8");
-    let json: serde_json::Value =
-        serde_json::from_str(&actual).expect("diagnostics stdout is JSON");
-    assert_eq!(
-        json["diagnostics"]
-            .as_array()
-            .expect("diagnostics array")
-            .len(),
-        1,
-        "generic behavior requires arity should emit one diagnostic: {json}"
-    );
-
-    let normalized = actual.replace(tmp.path().to_str().expect("tmp path is UTF-8"), "$TMP");
-    let expected_path =
-        fixture("tests/fixtures/ir_json/diagnostics_generic_requires_arity.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(normalized.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_diagnostics_generic_impl_arity_schema_matches_golden() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let zen_path = tmp.path().join("generic_impl_arity.zen");
-    std::fs::write(
-        &zen_path,
-        r#"
-Point: { x: i32 }
-
-Json<T>: behavior {
-    encode: (Self) T
-}
-
-Point.implements(Json) {
-    encode = (value: Point) StaticString { "point" }
-}
-
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write generic impl arity source");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "diagnostics", zen_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json diagnostics");
-
-    assert!(
-        !output.status.success(),
-        "zen emit-json diagnostics should fail on generic behavior impl arity: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual = String::from_utf8(output.stdout).expect("diagnostics stdout is UTF-8");
-    let json: serde_json::Value =
-        serde_json::from_str(&actual).expect("diagnostics stdout is JSON");
-    assert_eq!(
-        json["diagnostics"]
-            .as_array()
-            .expect("diagnostics array")
-            .len(),
-        1,
-        "generic behavior impl arity should emit one diagnostic: {json}"
-    );
-
-    let normalized = actual.replace(tmp.path().to_str().expect("tmp path is UTF-8"), "$TMP");
-    let expected_path =
-        fixture("tests/fixtures/ir_json/diagnostics_generic_impl_arity.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(normalized.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_diagnostics_generic_extends_arity_schema_matches_golden() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let zen_path = tmp.path().join("generic_extends_arity.zen");
-    std::fs::write(
-        &zen_path,
-        r#"
-Json<T>: behavior {
-    encode: (Self) T
-}
-
-PrettyJson: behavior {
-    pretty: (Self) StaticString
-}
-
-PrettyJson.extends(Json)
-
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write generic extends arity source");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "diagnostics", zen_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json diagnostics");
-
-    assert!(
-        !output.status.success(),
-        "zen emit-json diagnostics should fail on generic behavior extends arity: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual = String::from_utf8(output.stdout).expect("diagnostics stdout is UTF-8");
-    let json: serde_json::Value =
-        serde_json::from_str(&actual).expect("diagnostics stdout is JSON");
-    assert_eq!(
-        json["diagnostics"]
-            .as_array()
-            .expect("diagnostics array")
-            .len(),
-        1,
-        "generic behavior extends arity should emit one diagnostic: {json}"
-    );
-
-    let normalized = actual.replace(tmp.path().to_str().expect("tmp path is UTF-8"), "$TMP");
-    let expected_path =
-        fixture("tests/fixtures/ir_json/diagnostics_generic_extends_arity.golden.json");
-    let expected = std::fs::read_to_string(&expected_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
-
-    assert_eq!(normalized.trim(), expected.trim());
-}
-
-#[test]
-fn emit_json_diagnostics_duplicate_generic_impl_schema_matches_golden() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let zen_path = tmp.path().join("duplicate_generic_impl.zen");
-    std::fs::write(
-        &zen_path,
-        r#"
-Point: { x: i32 }
-
-Json<T>: behavior {
-    encode: (Self) T
-}
-
-Point.implements(Json<StaticString>) {
-    encode = (value: Point) StaticString { "point" }
-}
-
-Point.implements(Json<StaticString>) {
-    encode = (value: Point) StaticString { "point-again" }
-}
-
-main = () i32 {
-    0
-}
-"#,
-    )
-    .expect("write duplicate generic impl source");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "diagnostics", zen_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json diagnostics");
-
-    assert!(
-        !output.status.success(),
-        "zen emit-json diagnostics should fail on duplicate generic behavior impl: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let actual = String::from_utf8(output.stdout).expect("diagnostics stdout is UTF-8");
-    let json: serde_json::Value =
-        serde_json::from_str(&actual).expect("diagnostics stdout is JSON");
-    assert_eq!(
-        json["diagnostics"]
-            .as_array()
-            .expect("diagnostics array")
-            .len(),
-        1,
-        "duplicate generic behavior impl should emit one diagnostic: {json}"
-    );
-
-    let normalized = actual.replace(tmp.path().to_str().expect("tmp path is UTF-8"), "$TMP");
-    let expected_path =
-        fixture("tests/fixtures/ir_json/diagnostics_duplicate_generic_impl.golden.json");
+    let expected_path = fixture(golden);
     let expected = std::fs::read_to_string(&expected_path)
         .unwrap_or_else(|err| panic!("read {}: {err}", expected_path.display()));
 

--- a/tests/integration/cli_build/frontend_json/diagnostics_behavior_association_golden/relationship_arity.rs
+++ b/tests/integration/cli_build/frontend_json/diagnostics_behavior_association_golden/relationship_arity.rs
@@ -1,0 +1,77 @@
+use super::assert_behavior_association_diagnostics_golden;
+
+#[test]
+fn emit_json_diagnostics_generic_impl_arity_schema_matches_golden() {
+    assert_behavior_association_diagnostics_golden(
+        r#"
+Point: { x: i32 }
+
+Json<T>: behavior {
+    encode: (Self) T
+}
+
+Point.implements(Json) {
+    encode = (value: Point) StaticString { "point" }
+}
+
+main = () i32 {
+    0
+}
+"#,
+        "generic_impl_arity.zen",
+        "tests/fixtures/ir_json/diagnostics_generic_impl_arity.golden.json",
+        "generic behavior impl arity",
+    );
+}
+
+#[test]
+fn emit_json_diagnostics_generic_extends_arity_schema_matches_golden() {
+    assert_behavior_association_diagnostics_golden(
+        r#"
+Json<T>: behavior {
+    encode: (Self) T
+}
+
+PrettyJson: behavior {
+    pretty: (Self) StaticString
+}
+
+PrettyJson.extends(Json)
+
+main = () i32 {
+    0
+}
+"#,
+        "generic_extends_arity.zen",
+        "tests/fixtures/ir_json/diagnostics_generic_extends_arity.golden.json",
+        "generic behavior extends arity",
+    );
+}
+
+#[test]
+fn emit_json_diagnostics_duplicate_generic_impl_schema_matches_golden() {
+    assert_behavior_association_diagnostics_golden(
+        r#"
+Point: { x: i32 }
+
+Json<T>: behavior {
+    encode: (Self) T
+}
+
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
+}
+
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point-again" }
+}
+
+main = () i32 {
+    0
+}
+"#,
+        "duplicate_generic_impl.zen",
+        "tests/fixtures/ir_json/diagnostics_duplicate_generic_impl.golden.json",
+        "duplicate generic behavior impl",
+    );
+}

--- a/tests/integration/cli_build/frontend_json/diagnostics_behavior_association_golden/requires.rs
+++ b/tests/integration/cli_build/frontend_json/diagnostics_behavior_association_golden/requires.rs
@@ -1,0 +1,72 @@
+use super::assert_behavior_association_diagnostics_golden;
+
+#[test]
+fn emit_json_diagnostics_generic_requires_missing_impl_schema_matches_golden() {
+    assert_behavior_association_diagnostics_golden(
+        r#"
+Point: { x: i32 }
+
+Json<T>: behavior {
+    encode: (Self) T
+}
+
+Point.requires(Json<StaticString>)
+
+main = () i32 {
+    0
+}
+"#,
+        "generic_requires_missing_impl.zen",
+        "tests/fixtures/ir_json/diagnostics_generic_requires_missing_impl.golden.json",
+        "missing generic behavior requires impl",
+    );
+}
+
+#[test]
+fn emit_json_diagnostics_duplicate_generic_requires_schema_matches_golden() {
+    assert_behavior_association_diagnostics_golden(
+        r#"
+Point: { x: i32 }
+
+Json<T>: behavior {
+    encode: (Self) T
+}
+
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
+}
+
+Point.requires(Json<StaticString>)
+Point.requires(Json<StaticString>)
+
+main = () i32 {
+    0
+}
+"#,
+        "duplicate_generic_requires.zen",
+        "tests/fixtures/ir_json/diagnostics_duplicate_generic_requires.golden.json",
+        "duplicate generic behavior requires",
+    );
+}
+
+#[test]
+fn emit_json_diagnostics_generic_requires_arity_schema_matches_golden() {
+    assert_behavior_association_diagnostics_golden(
+        r#"
+Point: { x: i32 }
+
+Json<T>: behavior {
+    encode: (Self) T
+}
+
+Point.requires(Json<i32, StaticString>)
+
+main = () i32 {
+    0
+}
+"#,
+        "generic_requires_arity.zen",
+        "tests/fixtures/ir_json/diagnostics_generic_requires_arity.golden.json",
+        "generic behavior requires arity",
+    );
+}


### PR DESCRIPTION
## Summary
- split behavior-association diagnostics golden tests into requires and relationship arity modules
- keep the root file as shared fixture/assertion helper plus module wiring
- preserve all six diagnostics JSON golden checks and one-diagnostic assertions

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test integration -- cli_build::frontend_json::diagnostics_behavior_association_golden --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- push-event workflow check returned `[]`