### PR TITLE
Split target YAML tests

### DIFF
--- a/tests/integration/cli_build/frontend_json/target_yaml.rs
+++ b/tests/integration/cli_build/frontend_json/target_yaml.rs
@@ -1,146 +1,41 @@
 use std::process::Command;
 
-#[test]
-fn emit_json_target_yaml_validates_minimal_target_schema() {
+#[path = "target_yaml/invalid.rs"]
+mod invalid;
+#[path = "target_yaml/valid.rs"]
+mod valid;
+
+fn emit_target_yaml(yaml: &str, description: &str) -> std::process::Output {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let yaml_path = tmp.path().join("target.yaml");
-    std::fs::write(
-        &yaml_path,
-        r#"
-triple: x86_64-unknown-linux-gnu
-pointer_width: 64
-endianness: little
-abi: sysv
-"#,
-    )
-    .expect("write target yaml");
+    std::fs::write(&yaml_path, yaml)
+        .unwrap_or_else(|err| panic!("write {description} target yaml: {err}"));
 
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
+    Command::new(env!("CARGO_BIN_EXE_zen"))
         .args(["emit-json", "target-yaml", yaml_path.to_str().unwrap()])
         .output()
-        .expect("run zen emit-json target-yaml on YAML input");
+        .unwrap_or_else(|err| panic!("run zen emit-json target-yaml on {description}: {err}"))
+}
+
+fn assert_valid_target_yaml(yaml: &str, description: &str) -> serde_json::Value {
+    let output = emit_target_yaml(yaml, description);
 
     assert!(
         output.status.success(),
-        "zen emit-json target-yaml should validate target YAML: stdout={}, stderr={}",
+        "zen emit-json target-yaml should validate {description}: stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let json: serde_json::Value =
-        serde_json::from_slice(&output.stdout).expect("target-yaml stdout is json");
-    assert_eq!(json["format"], "zen.target.v0");
-    assert_eq!(json["schema_version"], 0);
-    assert_eq!(json["semantic_status"], "validated");
-    assert_eq!(json["target"]["triple"], "x86_64-unknown-linux-gnu");
-    assert_eq!(json["target"]["pointer_width"], 64);
-    assert_eq!(json["target"]["endianness"], "little");
-    assert_eq!(json["target"]["abi"], "sysv");
+    serde_json::from_slice(&output.stdout).expect("target-yaml stdout is json")
 }
 
-#[test]
-fn emit_json_target_yaml_validates_backend_schema() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let yaml_path = tmp.path().join("target.yaml");
-    std::fs::write(
-        &yaml_path,
-        r#"
-triple: x86_64-unknown-linux-gnu
-pointer_width: 64
-endianness: little
-abi: sysv
-backend:
-  codegen: c
-  c_compiler: cc
-"#,
-    )
-    .expect("write target yaml");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "target-yaml", yaml_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json target-yaml on YAML input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json target-yaml should validate backend YAML: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let json: serde_json::Value =
-        serde_json::from_slice(&output.stdout).expect("target-yaml stdout is json");
-    assert_eq!(json["format"], "zen.target.v0");
-    assert_eq!(json["semantic_status"], "validated");
-    assert_eq!(json["target"]["backend"]["codegen"], "c");
-    assert_eq!(json["target"]["backend"]["c_compiler"], "cc");
-}
-
-#[test]
-fn emit_json_target_yaml_validates_c_backend_flags() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let yaml_path = tmp.path().join("target.yaml");
-    std::fs::write(
-        &yaml_path,
-        r#"
-triple: x86_64-unknown-linux-gnu
-pointer_width: 64
-endianness: little
-abi: sysv
-backend:
-  codegen: c
-  c_compiler: cc
-  c_flags:
-    - -std=c11
-    - -Wall
-"#,
-    )
-    .expect("write target yaml");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "target-yaml", yaml_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json target-yaml on YAML input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json target-yaml should validate C backend flags: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let json: serde_json::Value =
-        serde_json::from_slice(&output.stdout).expect("target-yaml stdout is json");
-    assert_eq!(json["target"]["backend"]["codegen"], "c");
-    assert_eq!(json["target"]["backend"]["c_flags"][0], "-std=c11");
-    assert_eq!(json["target"]["backend"]["c_flags"][1], "-Wall");
-}
-
-#[test]
-fn emit_json_target_yaml_rejects_unsupported_backend_codegen() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let yaml_path = tmp.path().join("target.yaml");
-    std::fs::write(
-        &yaml_path,
-        r#"
-triple: x86_64-unknown-linux-gnu
-pointer_width: 64
-endianness: little
-abi: sysv
-backend:
-  codegen: llvm
-"#,
-    )
-    .expect("write target yaml");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "target-yaml", yaml_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json target-yaml on YAML input");
+fn assert_invalid_target_yaml(yaml: &str, description: &str, stderr_substring: &str) {
+    let output = emit_target_yaml(yaml, description);
 
     assert!(
         !output.status.success(),
-        "zen emit-json target-yaml should reject unsupported backend YAML: stdout={}, stderr={}",
+        "zen emit-json target-yaml should reject {description}: stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
@@ -152,92 +47,7 @@ backend:
         "invalid target-yaml should not emit target JSON, stdout={stdout}"
     );
     assert!(
-        stderr.contains("target YAML `backend.codegen` supports only `c`"),
-        "expected target YAML backend diagnostic, stderr={stderr}"
-    );
-}
-
-#[test]
-fn emit_json_target_yaml_rejects_empty_c_backend_flags() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let yaml_path = tmp.path().join("target.yaml");
-    std::fs::write(
-        &yaml_path,
-        r#"
-triple: x86_64-unknown-linux-gnu
-pointer_width: 64
-endianness: little
-abi: sysv
-backend:
-  codegen: c
-  c_flags:
-    - -std=c11
-    - ""
-"#,
-    )
-    .expect("write target yaml");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "target-yaml", yaml_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json target-yaml on YAML input");
-
-    assert!(
-        !output.status.success(),
-        "zen emit-json target-yaml should reject empty C backend flags: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stdout.trim().is_empty(),
-        "invalid target-yaml should not emit target JSON, stdout={stdout}"
-    );
-    assert!(
-        stderr.contains("target YAML `backend.c_flags` entries cannot be empty"),
-        "expected target YAML c_flags diagnostic, stderr={stderr}"
-    );
-}
-
-#[test]
-fn emit_json_target_yaml_rejects_layout_overrides() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let yaml_path = tmp.path().join("target.yaml");
-    std::fs::write(
-        &yaml_path,
-        r#"
-triple: x86_64-unknown-linux-gnu
-pointer_width: 64
-endianness: little
-abi: sysv
-overrides:
-  i32: i64
-"#,
-    )
-    .expect("write target yaml");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "target-yaml", yaml_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json target-yaml on YAML input");
-
-    assert!(
-        !output.status.success(),
-        "zen emit-json target-yaml should reject layout overrides: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stdout.trim().is_empty(),
-        "invalid target-yaml should not emit target JSON, stdout={stdout}"
-    );
-    assert!(
-        stderr.contains("target YAML cannot override compiler-owned type layouts"),
-        "expected target YAML layout override diagnostic, stderr={stderr}"
+        stderr.contains(stderr_substring),
+        "expected target YAML diagnostic `{stderr_substring}`, stderr={stderr}"
     );
 }

--- a/tests/integration/cli_build/frontend_json/target_yaml/invalid.rs
+++ b/tests/integration/cli_build/frontend_json/target_yaml/invalid.rs
@@ -1,0 +1,52 @@
+use super::assert_invalid_target_yaml;
+
+#[test]
+fn emit_json_target_yaml_rejects_unsupported_backend_codegen() {
+    assert_invalid_target_yaml(
+        r#"
+triple: x86_64-unknown-linux-gnu
+pointer_width: 64
+endianness: little
+abi: sysv
+backend:
+  codegen: llvm
+"#,
+        "unsupported backend YAML",
+        "target YAML `backend.codegen` supports only `c`",
+    );
+}
+
+#[test]
+fn emit_json_target_yaml_rejects_empty_c_backend_flags() {
+    assert_invalid_target_yaml(
+        r#"
+triple: x86_64-unknown-linux-gnu
+pointer_width: 64
+endianness: little
+abi: sysv
+backend:
+  codegen: c
+  c_flags:
+    - -std=c11
+    - ""
+"#,
+        "empty C backend flags",
+        "target YAML `backend.c_flags` entries cannot be empty",
+    );
+}
+
+#[test]
+fn emit_json_target_yaml_rejects_layout_overrides() {
+    assert_invalid_target_yaml(
+        r#"
+triple: x86_64-unknown-linux-gnu
+pointer_width: 64
+endianness: little
+abi: sysv
+overrides:
+  i32: i64
+"#,
+        "layout overrides",
+        "target YAML cannot override compiler-owned type layouts",
+    );
+}

--- a/tests/integration/cli_build/frontend_json/target_yaml/valid.rs
+++ b/tests/integration/cli_build/frontend_json/target_yaml/valid.rs
@@ -1,0 +1,66 @@
+use super::assert_valid_target_yaml;
+
+#[test]
+fn emit_json_target_yaml_validates_minimal_target_schema() {
+    let json = assert_valid_target_yaml(
+        r#"
+triple: x86_64-unknown-linux-gnu
+pointer_width: 64
+endianness: little
+abi: sysv
+"#,
+        "minimal target YAML",
+    );
+
+    assert_eq!(json["format"], "zen.target.v0");
+    assert_eq!(json["schema_version"], 0);
+    assert_eq!(json["semantic_status"], "validated");
+    assert_eq!(json["target"]["triple"], "x86_64-unknown-linux-gnu");
+    assert_eq!(json["target"]["pointer_width"], 64);
+    assert_eq!(json["target"]["endianness"], "little");
+    assert_eq!(json["target"]["abi"], "sysv");
+}
+
+#[test]
+fn emit_json_target_yaml_validates_backend_schema() {
+    let json = assert_valid_target_yaml(
+        r#"
+triple: x86_64-unknown-linux-gnu
+pointer_width: 64
+endianness: little
+abi: sysv
+backend:
+  codegen: c
+  c_compiler: cc
+"#,
+        "backend target YAML",
+    );
+
+    assert_eq!(json["format"], "zen.target.v0");
+    assert_eq!(json["semantic_status"], "validated");
+    assert_eq!(json["target"]["backend"]["codegen"], "c");
+    assert_eq!(json["target"]["backend"]["c_compiler"], "cc");
+}
+
+#[test]
+fn emit_json_target_yaml_validates_c_backend_flags() {
+    let json = assert_valid_target_yaml(
+        r#"
+triple: x86_64-unknown-linux-gnu
+pointer_width: 64
+endianness: little
+abi: sysv
+backend:
+  codegen: c
+  c_compiler: cc
+  c_flags:
+    - -std=c11
+    - -Wall
+"#,
+        "C backend flags target YAML",
+    );
+
+    assert_eq!(json["target"]["backend"]["codegen"], "c");
+    assert_eq!(json["target"]["backend"]["c_flags"][0], "-std=c11");
+    assert_eq!(json["target"]["backend"]["c_flags"][1], "-Wall");
+}


### PR DESCRIPTION
## Summary
- split target YAML JSON tests into valid and invalid target modules
- keep the root target YAML test file as shared command/assertion helpers plus module wiring
- preserve target YAML validation and rejection coverage

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test integration -- cli_build::frontend_json::target_yaml --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- push-event workflow check returned `[]`