### PR TITLE
Split MIR JSON tests

### DIFF
--- a/tests/integration/cli_build/frontend_json/mir_json.rs
+++ b/tests/integration/cli_build/frontend_json/mir_json.rs
@@ -1,189 +1,35 @@
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
-#[test]
-fn emit_json_mir_outputs_checked_minimal_function_graph() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let zen_path = tmp.path().join("mir_subject.zen");
-    std::fs::write(
-        &zen_path,
-        r#"
-main = () i32 {
-    value = 40 + 2
-    value
-}
-"#,
-    )
-    .expect("write MIR subject");
+#[path = "mir_json/boundary.rs"]
+mod boundary;
+#[path = "mir_json/match_schema.rs"]
+mod match_schema;
+#[path = "mir_json/minimal.rs"]
+mod minimal;
 
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "mir", zen_path.to_str().unwrap()])
+fn write_subject(tmp: &tempfile::TempDir, file_name: &str, source: &str) -> PathBuf {
+    let zen_path = tmp.path().join(file_name);
+    std::fs::write(&zen_path, source).unwrap_or_else(|err| panic!("write {file_name}: {err}"));
+    zen_path
+}
+
+fn emit_mir(path: &Path, description: &str) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_zen"))
+        .args(["emit-json", "mir", path.to_str().unwrap()])
         .output()
-        .expect("run zen emit-json mir on program input");
+        .unwrap_or_else(|err| panic!("run zen emit-json mir on {description}: {err}"))
+}
+
+fn checked_mir_json(path: &Path, description: &str) -> serde_json::Value {
+    let output = emit_mir(path, description);
 
     assert!(
         output.status.success(),
-        "zen emit-json mir should emit checked minimal MIR JSON: stdout={}, stderr={}",
+        "zen emit-json mir should emit checked MIR JSON for {description}: stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let json: serde_json::Value =
-        serde_json::from_slice(&output.stdout).expect("MIR stdout is json");
-    assert_eq!(json["format"], "zen.mir.v0");
-    assert_eq!(json["schema_version"], 0);
-    assert_eq!(json["semantic_status"], "checked");
-    assert_eq!(json["lowering_status"], "minimal");
-
-    let functions = json["functions"].as_array().expect("MIR functions array");
-    let main = functions
-        .iter()
-        .find(|function| function["name"] == "main")
-        .expect("main function in MIR");
-    assert_eq!(main["return_type"], "i32");
-
-    let entry = &main["blocks"][0];
-    assert_eq!(entry["label"], "entry");
-    assert_eq!(entry["statements"][0]["kind"], "let");
-    assert_eq!(entry["statements"][0]["name"], "value");
-    assert_eq!(entry["statements"][0]["type"], "i32");
-    assert_eq!(entry["statements"][0]["value"]["kind"], "binary");
-    assert_eq!(entry["statements"][0]["value"]["op"], "+");
-    assert_eq!(entry["terminator"]["kind"], "return");
-    assert_eq!(entry["terminator"]["value"]["kind"], "local");
-    assert_eq!(entry["terminator"]["value"]["name"], "value");
-    assert_eq!(entry["terminator"]["value"]["type"], "i32");
-}
-
-#[test]
-fn emit_json_mir_outputs_match_arm_schema() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let zen_path = tmp.path().join("mir_match_subject.zen");
-    std::fs::write(
-        &zen_path,
-        r#"
-Choice:
-    Empty,
-    Value(i32)
-
-score = (choice: Choice) i32 {
-    choice ?
-        | Empty { 0 }
-        | Value(n) { n }
-}
-
-main = () i32 {
-    score(Choice.Value(42))
-}
-"#,
-    )
-    .expect("write MIR match subject");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "mir", zen_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json mir on match program input");
-
-    assert!(
-        output.status.success(),
-        "zen emit-json mir should emit checked MIR match JSON: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let json: serde_json::Value =
-        serde_json::from_slice(&output.stdout).expect("MIR match stdout is json");
-    assert_eq!(json["format"], "zen.mir.v0");
-    assert_eq!(json["schema_version"], 0);
-    assert_eq!(json["semantic_status"], "checked");
-
-    let functions = json["functions"].as_array().expect("MIR functions array");
-    let score = functions
-        .iter()
-        .find(|function| function["name"] == "score")
-        .expect("score function in MIR");
-    let entry = &score["blocks"][0];
-    let terminator_value = &entry["terminator"]["value"];
-    assert_eq!(terminator_value["kind"], "match");
-    assert_eq!(terminator_value["match_kind"], "enum");
-    assert_eq!(terminator_value["target"]["kind"], "local");
-    assert_eq!(terminator_value["target"]["name"], "choice");
-
-    let arms = terminator_value["arms"].as_array().expect("MIR match arms");
-    assert_eq!(arms[0]["pattern"]["kind"], "enum_variant");
-    assert_eq!(arms[0]["pattern"]["name"], "Choice.Empty");
-    assert!(arms[0]["pattern"]["bindings"]
-        .as_array()
-        .expect("Empty bindings")
-        .is_empty());
-    assert_eq!(arms[0]["body"]["terminator"]["value"]["kind"], "block");
-    assert_eq!(
-        arms[0]["body"]["terminator"]["value"]["value"]["result"]["kind"],
-        "int"
-    );
-    assert_eq!(
-        arms[0]["body"]["terminator"]["value"]["value"]["result"]["value"],
-        0
-    );
-
-    assert_eq!(arms[1]["pattern"]["kind"], "enum_variant");
-    assert_eq!(arms[1]["pattern"]["name"], "Choice.Value");
-    assert_eq!(arms[1]["pattern"]["bindings"][0]["name"], "n");
-    assert_eq!(arms[1]["pattern"]["bindings"][0]["type"], "i32");
-    assert_eq!(arms[1]["body"]["terminator"]["value"]["kind"], "block");
-    assert_eq!(
-        arms[1]["body"]["terminator"]["value"]["value"]["result"]["kind"],
-        "local"
-    );
-    assert_eq!(
-        arms[1]["body"]["terminator"]["value"]["value"]["result"]["name"],
-        "n"
-    );
-}
-
-#[test]
-fn emit_json_mir_rejects_hand_authored_json_before_ir_override() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let json_path = tmp.path().join("forged_mir.json");
-    std::fs::write(
-        &json_path,
-        r#"
-{
-  "format": "zen.mir.v0",
-  "semantic_status": "checked",
-  "program": {
-    "types": {
-      "i32": { "layout": "forged-i64" }
-    }
-  }
-}
-"#,
-    )
-    .expect("write forged MIR JSON");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_zen"))
-        .args(["emit-json", "mir", json_path.to_str().unwrap()])
-        .output()
-        .expect("run zen emit-json mir on hand-authored JSON input");
-
-    assert!(
-        !output.status.success(),
-        "zen emit-json mir should gate hand-authored IR before override: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stdout.trim().is_empty(),
-        "gated MIR should not emit or accept hand-authored JSON IR, stdout={stdout}"
-    );
-    assert!(
-        stderr.contains("compiler-owned IR schemas"),
-        "MIR gate should name the compiler-owned IR schema boundary, stderr={stderr}"
-    );
-    assert!(
-        !stderr.contains("unknown command") && !stderr.contains("No such file"),
-        "MIR should reject through the IR-boundary gate, not command/path handling, stderr={stderr}"
-    );
+    serde_json::from_slice(&output.stdout).expect("MIR stdout is json")
 }

--- a/tests/integration/cli_build/frontend_json/mir_json/boundary.rs
+++ b/tests/integration/cli_build/frontend_json/mir_json/boundary.rs
@@ -1,0 +1,46 @@
+use super::emit_mir;
+use super::write_subject;
+
+#[test]
+fn emit_json_mir_rejects_hand_authored_json_before_ir_override() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let json_path = write_subject(
+        &tmp,
+        "forged_mir.json",
+        r#"
+{
+  "format": "zen.mir.v0",
+  "semantic_status": "checked",
+  "program": {
+    "types": {
+      "i32": { "layout": "forged-i64" }
+    }
+  }
+}
+"#,
+    );
+
+    let output = emit_mir(&json_path, "hand-authored JSON input");
+
+    assert!(
+        !output.status.success(),
+        "zen emit-json mir should gate hand-authored IR before override: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.trim().is_empty(),
+        "gated MIR should not emit or accept hand-authored JSON IR, stdout={stdout}"
+    );
+    assert!(
+        stderr.contains("compiler-owned IR schemas"),
+        "MIR gate should name the compiler-owned IR schema boundary, stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("unknown command") && !stderr.contains("No such file"),
+        "MIR should reject through the IR-boundary gate, not command/path handling, stderr={stderr}"
+    );
+}

--- a/tests/integration/cli_build/frontend_json/mir_json/match_schema.rs
+++ b/tests/integration/cli_build/frontend_json/mir_json/match_schema.rs
@@ -1,0 +1,74 @@
+use super::checked_mir_json;
+use super::write_subject;
+
+#[test]
+fn emit_json_mir_outputs_match_arm_schema() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let zen_path = write_subject(
+        &tmp,
+        "mir_match_subject.zen",
+        r#"
+Choice:
+    Empty,
+    Value(i32)
+
+score = (choice: Choice) i32 {
+    choice ?
+        | Empty { 0 }
+        | Value(n) { n }
+}
+
+main = () i32 {
+    score(Choice.Value(42))
+}
+"#,
+    );
+
+    let json = checked_mir_json(&zen_path, "match program input");
+    assert_eq!(json["format"], "zen.mir.v0");
+    assert_eq!(json["schema_version"], 0);
+    assert_eq!(json["semantic_status"], "checked");
+
+    let functions = json["functions"].as_array().expect("MIR functions array");
+    let score = functions
+        .iter()
+        .find(|function| function["name"] == "score")
+        .expect("score function in MIR");
+    let entry = &score["blocks"][0];
+    let terminator_value = &entry["terminator"]["value"];
+    assert_eq!(terminator_value["kind"], "match");
+    assert_eq!(terminator_value["match_kind"], "enum");
+    assert_eq!(terminator_value["target"]["kind"], "local");
+    assert_eq!(terminator_value["target"]["name"], "choice");
+
+    let arms = terminator_value["arms"].as_array().expect("MIR match arms");
+    assert_eq!(arms[0]["pattern"]["kind"], "enum_variant");
+    assert_eq!(arms[0]["pattern"]["name"], "Choice.Empty");
+    assert!(arms[0]["pattern"]["bindings"]
+        .as_array()
+        .expect("Empty bindings")
+        .is_empty());
+    assert_eq!(arms[0]["body"]["terminator"]["value"]["kind"], "block");
+    assert_eq!(
+        arms[0]["body"]["terminator"]["value"]["value"]["result"]["kind"],
+        "int"
+    );
+    assert_eq!(
+        arms[0]["body"]["terminator"]["value"]["value"]["result"]["value"],
+        0
+    );
+
+    assert_eq!(arms[1]["pattern"]["kind"], "enum_variant");
+    assert_eq!(arms[1]["pattern"]["name"], "Choice.Value");
+    assert_eq!(arms[1]["pattern"]["bindings"][0]["name"], "n");
+    assert_eq!(arms[1]["pattern"]["bindings"][0]["type"], "i32");
+    assert_eq!(arms[1]["body"]["terminator"]["value"]["kind"], "block");
+    assert_eq!(
+        arms[1]["body"]["terminator"]["value"]["value"]["result"]["kind"],
+        "local"
+    );
+    assert_eq!(
+        arms[1]["body"]["terminator"]["value"]["value"]["result"]["name"],
+        "n"
+    );
+}

--- a/tests/integration/cli_build/frontend_json/mir_json/minimal.rs
+++ b/tests/integration/cli_build/frontend_json/mir_json/minimal.rs
@@ -1,0 +1,42 @@
+use super::checked_mir_json;
+use super::write_subject;
+
+#[test]
+fn emit_json_mir_outputs_checked_minimal_function_graph() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let zen_path = write_subject(
+        &tmp,
+        "mir_subject.zen",
+        r#"
+main = () i32 {
+    value = 40 + 2
+    value
+}
+"#,
+    );
+
+    let json = checked_mir_json(&zen_path, "program input");
+    assert_eq!(json["format"], "zen.mir.v0");
+    assert_eq!(json["schema_version"], 0);
+    assert_eq!(json["semantic_status"], "checked");
+    assert_eq!(json["lowering_status"], "minimal");
+
+    let functions = json["functions"].as_array().expect("MIR functions array");
+    let main = functions
+        .iter()
+        .find(|function| function["name"] == "main")
+        .expect("main function in MIR");
+    assert_eq!(main["return_type"], "i32");
+
+    let entry = &main["blocks"][0];
+    assert_eq!(entry["label"], "entry");
+    assert_eq!(entry["statements"][0]["kind"], "let");
+    assert_eq!(entry["statements"][0]["name"], "value");
+    assert_eq!(entry["statements"][0]["type"], "i32");
+    assert_eq!(entry["statements"][0]["value"]["kind"], "binary");
+    assert_eq!(entry["statements"][0]["value"]["op"], "+");
+    assert_eq!(entry["terminator"]["kind"], "return");
+    assert_eq!(entry["terminator"]["value"]["kind"], "local");
+    assert_eq!(entry["terminator"]["value"]["name"], "value");
+    assert_eq!(entry["terminator"]["value"]["type"], "i32");
+}


### PR DESCRIPTION
## Summary
- Split MIR JSON frontend tests into minimal, match-schema, and IR-boundary submodules
- Share temporary subject writing, MIR command execution, and checked JSON parsing helpers
- Reduce the root `mir_json.rs` harness to module wiring and helpers

## Local verification
- cargo fmt --check
- git diff --check
- cargo test --test integration -- cli_build::frontend_json::mir_json --nocapture
- cargo clippy -- -D warnings
- cargo test --lib
- cargo test --tests

## Workflow check
- Verified no push-event runs for this branch: `gh run list --branch codex/split-mir-json-tests --event push ...` returned `[]`.