### PR TITLE
[codex] Split stdlib import gate helpers

### DIFF
--- a/src/module_system/import_resolution.rs
+++ b/src/module_system/import_resolution.rs
@@ -7,79 +7,9 @@ use crate::error::{CompileError, FileTable, Span};
 use super::root_prefix::parse_module_root_prefix;
 use super::ModuleSystem;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum GatedStdlibModule {
-    ActorFramework,
-    AllocatorFramework,
-    AsyncRuntime,
-    SyncRuntime,
-}
+mod stdlib_gates;
 
-impl GatedStdlibModule {
-    const CONCURRENCY_SEGMENT: &'static str = "concurrency";
-    const ACTOR_SEGMENT: &'static str = "actor";
-    const ASYNC_SEGMENT: &'static str = "async";
-    const SYNC_SEGMENT: &'static str = "sync";
-    const MEMORY_SEGMENT: &'static str = "memory";
-    const ALLOCATOR_SEGMENT: &'static str = "allocator";
-
-    fn from_sub_path(sub_path: &[String]) -> Option<Self> {
-        if sub_path
-            .first()
-            .is_some_and(|segment| segment == Self::CONCURRENCY_SEGMENT)
-            && sub_path
-                .get(1)
-                .is_some_and(|segment| segment == Self::ACTOR_SEGMENT)
-        {
-            return Some(Self::ActorFramework);
-        }
-        if sub_path
-            .first()
-            .is_some_and(|segment| segment == Self::CONCURRENCY_SEGMENT)
-            && sub_path
-                .get(1)
-                .is_some_and(|segment| segment == Self::ASYNC_SEGMENT)
-        {
-            return Some(Self::AsyncRuntime);
-        }
-        if sub_path
-            .first()
-            .is_some_and(|segment| segment == Self::CONCURRENCY_SEGMENT)
-            && sub_path
-                .get(1)
-                .is_some_and(|segment| segment == Self::SYNC_SEGMENT)
-        {
-            return Some(Self::SyncRuntime);
-        }
-        if sub_path
-            .first()
-            .is_some_and(|segment| segment == Self::MEMORY_SEGMENT)
-            && sub_path
-                .get(1)
-                .is_some_and(|segment| segment == Self::ALLOCATOR_SEGMENT)
-        {
-            return Some(Self::AllocatorFramework);
-        }
-        None
-    }
-
-    fn gate_message(self) -> &'static str {
-        match self {
-            Self::ActorFramework => {
-                "std actor framework modules are gated until mailbox, scheduling, supervisor, and allocator semantics are implemented"
-            }
-            Self::AllocatorFramework => {
-                "std allocator modules are gated until allocator ownership and effect semantics are implemented"
-            }
-            Self::AsyncRuntime => {
-                "std async runtime modules are gated until Sync/Async effect checking and task lowering are implemented"
-            }
-            Self::SyncRuntime => {
-                "std sync runtime modules are gated until channel, mailbox, and blocking semantics are implemented"
-            }
-        }
-    }
-}
+use stdlib_gates::GatedStdlibModule;
 
 impl ModuleSystem {
     /// Walk Import declarations in `program` and load their dependencies.

--- a/src/module_system/import_resolution/stdlib_gates.rs
+++ b/src/module_system/import_resolution/stdlib_gates.rs
@@ -1,0 +1,73 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum GatedStdlibModule {
+    ActorFramework,
+    AllocatorFramework,
+    AsyncRuntime,
+    SyncRuntime,
+}
+
+impl GatedStdlibModule {
+    const CONCURRENCY_SEGMENT: &'static str = "concurrency";
+    const ACTOR_SEGMENT: &'static str = "actor";
+    const ASYNC_SEGMENT: &'static str = "async";
+    const SYNC_SEGMENT: &'static str = "sync";
+    const MEMORY_SEGMENT: &'static str = "memory";
+    const ALLOCATOR_SEGMENT: &'static str = "allocator";
+
+    pub(super) fn from_sub_path(sub_path: &[String]) -> Option<Self> {
+        if sub_path
+            .first()
+            .is_some_and(|segment| segment == Self::CONCURRENCY_SEGMENT)
+            && sub_path
+                .get(1)
+                .is_some_and(|segment| segment == Self::ACTOR_SEGMENT)
+        {
+            return Some(Self::ActorFramework);
+        }
+        if sub_path
+            .first()
+            .is_some_and(|segment| segment == Self::CONCURRENCY_SEGMENT)
+            && sub_path
+                .get(1)
+                .is_some_and(|segment| segment == Self::ASYNC_SEGMENT)
+        {
+            return Some(Self::AsyncRuntime);
+        }
+        if sub_path
+            .first()
+            .is_some_and(|segment| segment == Self::CONCURRENCY_SEGMENT)
+            && sub_path
+                .get(1)
+                .is_some_and(|segment| segment == Self::SYNC_SEGMENT)
+        {
+            return Some(Self::SyncRuntime);
+        }
+        if sub_path
+            .first()
+            .is_some_and(|segment| segment == Self::MEMORY_SEGMENT)
+            && sub_path
+                .get(1)
+                .is_some_and(|segment| segment == Self::ALLOCATOR_SEGMENT)
+        {
+            return Some(Self::AllocatorFramework);
+        }
+        None
+    }
+
+    pub(super) fn gate_message(self) -> &'static str {
+        match self {
+            Self::ActorFramework => {
+                "std actor framework modules are gated until mailbox, scheduling, supervisor, and allocator semantics are implemented"
+            }
+            Self::AllocatorFramework => {
+                "std allocator modules are gated until allocator ownership and effect semantics are implemented"
+            }
+            Self::AsyncRuntime => {
+                "std async runtime modules are gated until Sync/Async effect checking and task lowering are implemented"
+            }
+            Self::SyncRuntime => {
+                "std sync runtime modules are gated until channel, mailbox, and blocking semantics are implemented"
+            }
+        }
+    }
+}

--- a/tests/docs_truth/repo_hygiene/module_system.rs
+++ b/tests/docs_truth/repo_hygiene/module_system.rs
@@ -39,3 +39,29 @@ fn module_system_roots_use_owned_prefix_enum() {
         );
     }
 }
+
+#[test]
+fn stdlib_import_gates_live_in_focused_helper() {
+    let import_resolution = read("src/module_system/import_resolution.rs");
+    let stdlib_gates = read("src/module_system/import_resolution/stdlib_gates.rs");
+
+    assert!(
+        !import_resolution.contains("enum GatedStdlibModule"),
+        "gated stdlib module table should not live in the import routing dispatcher"
+    );
+
+    for required in [
+        "pub(super) enum GatedStdlibModule",
+        "ActorFramework",
+        "AllocatorFramework",
+        "AsyncRuntime",
+        "SyncRuntime",
+        "pub(super) fn from_sub_path",
+        "pub(super) fn gate_message",
+    ] {
+        assert!(
+            stdlib_gates.contains(required),
+            "stdlib import gate spelling should live in the focused helper: {required}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Moves the gated stdlib module table and diagnostics from `src/module_system/import_resolution.rs` into `src/module_system/import_resolution/stdlib_gates.rs`.
- Leaves import routing in `import_resolution.rs` and reduces it from 408 lines to 338 lines.
- Adds docs-truth hygiene coverage so the stdlib gate table stays in the focused helper.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth repo_hygiene::module_system::stdlib_import_gates_live_in_focused_helper -- --nocapture` (failed before implementation, passed after)
- `cargo test --test docs_truth repo_hygiene::module_system -- --nocapture`
- `cargo test --lib module_system -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Push-event Actions check for `codex/split-stdlib-import-gates` returned `[]`.