### PR TITLE
[codex] Split MIR JSON schema helpers

### DIFF
--- a/src/ir_json/mir.rs
+++ b/src/ir_json/mir.rs
@@ -1,111 +1,14 @@
-use serde::Serialize;
-
 use crate::ast::typed::{
     MatchKind, TypedBlock, TypedExprKind, TypedExpression, TypedFunction, TypedMatchArm,
     TypedParam, TypedPattern, TypedProgram, TypedStatement, TypedStatementKind,
 };
 
-#[derive(Serialize)]
-struct MirJsonProgram {
-    format: &'static str,
-    schema_version: u32,
-    semantic_status: &'static str,
-    lowering_status: &'static str,
-    functions: Vec<MirFunction>,
-}
+mod schema;
 
-#[derive(Serialize)]
-struct MirFunction {
-    name: String,
-    params: Vec<MirParam>,
-    return_type: String,
-    blocks: Vec<MirBlock>,
-}
-
-#[derive(Serialize)]
-struct MirParam {
-    name: String,
-    r#type: String,
-}
-
-#[derive(Serialize)]
-struct MirBlock {
-    label: &'static str,
-    statements: Vec<MirStatement>,
-    terminator: MirTerminator,
-}
-
-#[derive(Serialize)]
-struct MirStatement {
-    kind: &'static str,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<String>,
-    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
-    ty: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    mutable: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    value: Option<MirExpression>,
-}
-
-#[derive(Serialize)]
-struct MirTerminator {
-    kind: &'static str,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    value: Option<MirExpression>,
-}
-
-#[derive(Serialize)]
-struct MirExpression {
-    kind: &'static str,
-    #[serde(rename = "type")]
-    ty: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    value: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    op: Option<&'static str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    left: Option<Box<MirExpression>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    right: Option<Box<MirExpression>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    target: Option<Box<MirExpression>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    field: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    function: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    match_kind: Option<&'static str>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    args: Vec<MirExpression>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    arms: Vec<MirMatchArm>,
-}
-
-#[derive(Serialize)]
-struct MirMatchArm {
-    pattern: MirPattern,
-    body: MirBlock,
-}
-
-#[derive(Serialize)]
-struct MirPattern {
-    kind: &'static str,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    value: Option<serde_json::Value>,
-    bindings: Vec<MirPatternBinding>,
-}
-
-#[derive(Serialize)]
-struct MirPatternBinding {
-    name: String,
-    #[serde(rename = "type")]
-    ty: String,
-}
+use schema::{
+    MirBlock, MirExpression, MirFunction, MirJsonProgram, MirMatchArm, MirParam, MirPattern,
+    MirPatternBinding, MirStatement, MirTerminator,
+};
 
 pub(super) fn program_to_json(program: &TypedProgram) -> serde_json::Result<String> {
     let graph = MirJsonProgram {

--- a/src/ir_json/mir/schema.rs
+++ b/src/ir_json/mir/schema.rs
@@ -1,0 +1,103 @@
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub(super) struct MirJsonProgram {
+    pub(super) format: &'static str,
+    pub(super) schema_version: u32,
+    pub(super) semantic_status: &'static str,
+    pub(super) lowering_status: &'static str,
+    pub(super) functions: Vec<MirFunction>,
+}
+
+#[derive(Serialize)]
+pub(super) struct MirFunction {
+    pub(super) name: String,
+    pub(super) params: Vec<MirParam>,
+    pub(super) return_type: String,
+    pub(super) blocks: Vec<MirBlock>,
+}
+
+#[derive(Serialize)]
+pub(super) struct MirParam {
+    pub(super) name: String,
+    pub(super) r#type: String,
+}
+
+#[derive(Serialize)]
+pub(super) struct MirBlock {
+    pub(super) label: &'static str,
+    pub(super) statements: Vec<MirStatement>,
+    pub(super) terminator: MirTerminator,
+}
+
+#[derive(Serialize)]
+pub(super) struct MirStatement {
+    pub(super) kind: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) name: Option<String>,
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub(super) ty: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) mutable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) value: Option<MirExpression>,
+}
+
+#[derive(Serialize)]
+pub(super) struct MirTerminator {
+    pub(super) kind: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) value: Option<MirExpression>,
+}
+
+#[derive(Serialize)]
+pub(super) struct MirExpression {
+    pub(super) kind: &'static str,
+    #[serde(rename = "type")]
+    pub(super) ty: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) value: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) op: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) left: Option<Box<MirExpression>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) right: Option<Box<MirExpression>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) target: Option<Box<MirExpression>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) field: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) function: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) match_kind: Option<&'static str>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(super) args: Vec<MirExpression>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(super) arms: Vec<MirMatchArm>,
+}
+
+#[derive(Serialize)]
+pub(super) struct MirMatchArm {
+    pub(super) pattern: MirPattern,
+    pub(super) body: MirBlock,
+}
+
+#[derive(Serialize)]
+pub(super) struct MirPattern {
+    pub(super) kind: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) value: Option<serde_json::Value>,
+    pub(super) bindings: Vec<MirPatternBinding>,
+}
+
+#[derive(Serialize)]
+pub(super) struct MirPatternBinding {
+    pub(super) name: String,
+    #[serde(rename = "type")]
+    pub(super) ty: String,
+}

--- a/tests/docs_truth/repo_hygiene/ir_json.rs
+++ b/tests/docs_truth/repo_hygiene/ir_json.rs
@@ -1,0 +1,28 @@
+use super::*;
+
+#[test]
+fn mir_json_schema_types_live_in_focused_helper() {
+    let mir_lowering = read("src/ir_json/mir.rs");
+    let mir_schema = read("src/ir_json/mir/schema.rs");
+
+    for moved_schema_type in [
+        "struct MirJsonProgram",
+        "struct MirFunction",
+        "struct MirExpression",
+        "struct MirPattern",
+    ] {
+        assert!(
+            !mir_lowering.contains(moved_schema_type),
+            "MIR JSON lowering should not own schema data type definitions: {moved_schema_type}"
+        );
+        assert!(
+            mir_schema.contains(moved_schema_type),
+            "MIR JSON schema type definitions should live in the focused schema helper: {moved_schema_type}"
+        );
+    }
+
+    assert!(
+        mir_schema.contains("use serde::Serialize"),
+        "MIR JSON schema helper should own serialization derives"
+    );
+}

--- a/tests/docs_truth/repo_hygiene/mod.rs
+++ b/tests/docs_truth/repo_hygiene/mod.rs
@@ -4,6 +4,7 @@ mod build_graph_dsl;
 mod builtin_type_spelling;
 mod ci_configs;
 mod file_size;
+mod ir_json;
 mod module_system;
 mod parser_enums;
 mod parser_keywords;


### PR DESCRIPTION
## Summary

- Moved MIR JSON serializable schema structs into `src/ir_json/mir/schema.rs`.
- Kept MIR JSON lowering logic in `src/ir_json/mir.rs`.
- Reduced `src/ir_json/mir.rs` from 399 lines to 302 lines while preserving behavior.
- Added a docs-truth hygiene guard proving MIR JSON schema types stay in the focused helper.

## Validation

- TDD: `cargo test --test docs_truth repo_hygiene::ir_json::mir_json_schema_types_live_in_focused_helper -- --nocapture` failed before `schema.rs` existed and passed after the split.
- `cargo fmt --check`
- `git diff --check master...HEAD`
- `cargo test --test docs_truth repo_hygiene::ir_json -- --nocapture`
- `cargo test --test integration cli_build::frontend_json::mir_json -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Push-event Actions check for `codex/split-mir-json-schema`: `[]`