### PR TITLE
[codex] Split C syscall intrinsic lowering

### DIFF
--- a/src/codegen/c/intrinsics.rs
+++ b/src/codegen/c/intrinsics.rs
@@ -2,6 +2,7 @@ use super::*;
 use names::CIntrinsic;
 
 mod names;
+mod syscalls;
 
 impl CEmitter {
     // ── Intrinsics ────────────────────────────────────────────
@@ -18,6 +19,8 @@ impl CEmitter {
         };
 
         match intrinsic {
+            _ if intrinsic.is_syscall() => intrinsic.emit_syscall(self, args),
+
             // -- Memory allocation ----------------------------------------
             CIntrinsic::RawAllocate => {
                 let size = self.emit_expr_inline(&args[0]);
@@ -170,60 +173,6 @@ impl CEmitter {
             }
             CIntrinsic::Fence => "(__atomic_thread_fence(__ATOMIC_SEQ_CST), (void)0)".into(),
 
-            // -- Syscalls -------------------------------------------------
-            CIntrinsic::Syscall0 => {
-                let num = self.emit_expr_inline(&args[0]);
-                format!("syscall({})", num)
-            }
-            CIntrinsic::Syscall1 => {
-                let num = self.emit_expr_inline(&args[0]);
-                let a0 = self.emit_expr_inline(&args[1]);
-                format!("syscall({}, {})", num, a0)
-            }
-            CIntrinsic::Syscall2 => {
-                let num = self.emit_expr_inline(&args[0]);
-                let a0 = self.emit_expr_inline(&args[1]);
-                let a1 = self.emit_expr_inline(&args[2]);
-                format!("syscall({}, {}, {})", num, a0, a1)
-            }
-            CIntrinsic::Syscall3 => {
-                let num = self.emit_expr_inline(&args[0]);
-                let a0 = self.emit_expr_inline(&args[1]);
-                let a1 = self.emit_expr_inline(&args[2]);
-                let a2 = self.emit_expr_inline(&args[3]);
-                format!("syscall({}, {}, {}, {})", num, a0, a1, a2)
-            }
-            CIntrinsic::Syscall4 => {
-                let num = self.emit_expr_inline(&args[0]);
-                let a0 = self.emit_expr_inline(&args[1]);
-                let a1 = self.emit_expr_inline(&args[2]);
-                let a2 = self.emit_expr_inline(&args[3]);
-                let a3 = self.emit_expr_inline(&args[4]);
-                format!("syscall({}, {}, {}, {}, {})", num, a0, a1, a2, a3)
-            }
-            CIntrinsic::Syscall5 => {
-                let num = self.emit_expr_inline(&args[0]);
-                let a0 = self.emit_expr_inline(&args[1]);
-                let a1 = self.emit_expr_inline(&args[2]);
-                let a2 = self.emit_expr_inline(&args[3]);
-                let a3 = self.emit_expr_inline(&args[4]);
-                let a4 = self.emit_expr_inline(&args[5]);
-                format!("syscall({}, {}, {}, {}, {}, {})", num, a0, a1, a2, a3, a4)
-            }
-            CIntrinsic::Syscall6 => {
-                let num = self.emit_expr_inline(&args[0]);
-                let a0 = self.emit_expr_inline(&args[1]);
-                let a1 = self.emit_expr_inline(&args[2]);
-                let a2 = self.emit_expr_inline(&args[3]);
-                let a3 = self.emit_expr_inline(&args[4]);
-                let a4 = self.emit_expr_inline(&args[5]);
-                let a5 = self.emit_expr_inline(&args[6]);
-                format!(
-                    "syscall({}, {}, {}, {}, {}, {}, {})",
-                    num, a0, a1, a2, a3, a4, a5
-                )
-            }
-
             // -- Debug / trap / panic -------------------------------------
             CIntrinsic::Trap => "(__builtin_trap(), (void)0)".into(),
             CIntrinsic::Debugtrap => "(__builtin_debugtrap(), (void)0)".into(),
@@ -366,6 +315,7 @@ impl CEmitter {
                     ptr, payload
                 )
             }
+            _ => unreachable!("syscall intrinsic should be handled before category lowering"),
         }
     }
 

--- a/src/codegen/c/intrinsics/syscalls.rs
+++ b/src/codegen/c/intrinsics/syscalls.rs
@@ -1,0 +1,73 @@
+use super::*;
+
+impl CIntrinsic {
+    pub(super) const fn is_syscall(self) -> bool {
+        matches!(
+            self,
+            CIntrinsic::Syscall0
+                | CIntrinsic::Syscall1
+                | CIntrinsic::Syscall2
+                | CIntrinsic::Syscall3
+                | CIntrinsic::Syscall4
+                | CIntrinsic::Syscall5
+                | CIntrinsic::Syscall6
+        )
+    }
+
+    pub(super) fn emit_syscall(self, emitter: &mut CEmitter, args: &[TypedExpression]) -> String {
+        let emitted_args: Vec<_> = args
+            .iter()
+            .map(|arg| emitter.emit_expr_inline(arg))
+            .collect();
+        match self {
+            CIntrinsic::Syscall0 => format!("syscall({})", emitted_args[0]),
+            CIntrinsic::Syscall1 => format!("syscall({}, {})", emitted_args[0], emitted_args[1]),
+            CIntrinsic::Syscall2 => {
+                format!(
+                    "syscall({}, {}, {})",
+                    emitted_args[0], emitted_args[1], emitted_args[2]
+                )
+            }
+            CIntrinsic::Syscall3 => {
+                format!(
+                    "syscall({}, {}, {}, {})",
+                    emitted_args[0], emitted_args[1], emitted_args[2], emitted_args[3]
+                )
+            }
+            CIntrinsic::Syscall4 => {
+                format!(
+                    "syscall({}, {}, {}, {}, {})",
+                    emitted_args[0],
+                    emitted_args[1],
+                    emitted_args[2],
+                    emitted_args[3],
+                    emitted_args[4]
+                )
+            }
+            CIntrinsic::Syscall5 => {
+                format!(
+                    "syscall({}, {}, {}, {}, {}, {})",
+                    emitted_args[0],
+                    emitted_args[1],
+                    emitted_args[2],
+                    emitted_args[3],
+                    emitted_args[4],
+                    emitted_args[5]
+                )
+            }
+            CIntrinsic::Syscall6 => {
+                format!(
+                    "syscall({}, {}, {}, {}, {}, {}, {})",
+                    emitted_args[0],
+                    emitted_args[1],
+                    emitted_args[2],
+                    emitted_args[3],
+                    emitted_args[4],
+                    emitted_args[5],
+                    emitted_args[6]
+                )
+            }
+            _ => unreachable!("non-syscall intrinsic routed to syscall lowering"),
+        }
+    }
+}

--- a/tests/docs_truth/repo_hygiene/parser_enums/codegen_and_tools.rs
+++ b/tests/docs_truth/repo_hygiene/parser_enums/codegen_and_tools.rs
@@ -53,6 +53,40 @@ fn codegen_c_intrinsics_use_owned_name_enum() {
 }
 
 #[test]
+fn codegen_c_syscall_intrinsics_live_in_focused_helper() {
+    let lowering = read("src/codegen/c/intrinsics.rs");
+    let syscalls = read("src/codegen/c/intrinsics/syscalls.rs");
+
+    for syscall_variant in [
+        "CIntrinsic::Syscall0",
+        "CIntrinsic::Syscall1",
+        "CIntrinsic::Syscall2",
+        "CIntrinsic::Syscall3",
+        "CIntrinsic::Syscall4",
+        "CIntrinsic::Syscall5",
+        "CIntrinsic::Syscall6",
+    ] {
+        assert!(
+            !lowering.contains(syscall_variant),
+            "main C intrinsic dispatcher should route syscall lowering to a focused helper: {syscall_variant}"
+        );
+        assert!(
+            syscalls.contains(syscall_variant),
+            "C syscall intrinsic lowering should live in the focused syscall helper: {syscall_variant}"
+        );
+    }
+
+    assert!(
+        lowering.contains("intrinsic.emit_syscall(self, args)"),
+        "main C intrinsic dispatcher should delegate syscall lowering through CIntrinsic"
+    );
+    assert!(
+        syscalls.contains("pub(super) fn emit_syscall"),
+        "syscall helper should own the C syscall lowering entry point"
+    );
+}
+
+#[test]
 fn build_graph_host_effect_methods_parse_dsl_ident_enum() {
     let lowering = read("src/build_graph/lowering.rs");
     let dsl = read("src/build_graph/lowering/dsl.rs");


### PR DESCRIPTION
## Summary

- Move syscall intrinsic C lowering from the main intrinsic dispatcher into `src/codegen/c/intrinsics/syscalls.rs`.
- Keep the main intrinsic dispatcher routing through the enum-owned intrinsic category instead of embedding each syscall case.
- Add docs-truth coverage that keeps syscall lowering in the focused helper.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth repo_hygiene::parser_enums::codegen_and_tools::codegen_c_syscall_intrinsics_live_in_focused_helper -- --nocapture`
- `cargo test --test docs_truth repo_hygiene::parser_enums::codegen_and_tools -- --nocapture`
- `cargo test --lib codegen::c::tests -- --nocapture`
- `cargo test --test integration generated_c_assertions -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Push-event Actions check for `codex/split-c-syscall-intrinsics` returned `[]`.