### PR TITLE
[codex] Split resolver behavior association validation

### DIFF
--- a/src/resolver/declaration_validation.rs
+++ b/src/resolver/declaration_validation.rs
@@ -1,11 +1,13 @@
 use std::collections::HashSet;
 
 use crate::ast::Declaration;
-use crate::error::{Diagnostic, GATED_GENERATED_BEHAVIOR_DERIVE_MESSAGE};
+use crate::error::Diagnostic;
 
 use super::metadata_helpers::behavior_ref_display;
 use super::symbol_table::ScopeStack;
 use super::{BehaviorRefMetadata, Resolver, SymbolTable};
+
+mod behavior_associations;
 
 impl Resolver {
     pub(super) fn validate_declaration_types(
@@ -258,40 +260,14 @@ impl Resolver {
                 behavior_type_args,
                 span,
             } => {
-                if !self.is_known_type_name(table, &[], type_name) {
-                    diagnostics.push(Diagnostic::error(
-                        "E0201",
-                        format!("unknown type symbol '{type_name}'"),
-                        *span,
-                    ));
-                }
-                if !self.is_known_behavior_name(table, behavior) {
-                    diagnostics.push(Diagnostic::error(
-                        "E0202",
-                        format!("unknown behavior symbol '{behavior}'"),
-                        *span,
-                    ));
-                } else if self.is_known_type_name(table, &[], type_name) {
-                    let behavior_display = behavior_ref_display(behavior, behavior_type_args);
-                    if !table.record_behavior_required(
-                        type_name,
-                        BehaviorRefMetadata {
-                            name: behavior.clone(),
-                            type_args: behavior_type_args.clone(),
-                        },
-                    ) {
-                        diagnostics.push(Diagnostic::error(
-                            "E0216",
-                            format!(
-                                "duplicate required behavior `{behavior_display}` for `{type_name}`"
-                            ),
-                            *span,
-                        ));
-                    }
-                }
-                for type_arg in behavior_type_args {
-                    self.validate_type_ref(table, &[], type_arg, *span, false, diagnostics);
-                }
+                self.validate_requires_declaration(
+                    table,
+                    type_name,
+                    behavior,
+                    behavior_type_args,
+                    *span,
+                    diagnostics,
+                );
             }
             Declaration::Derive {
                 type_name,
@@ -299,26 +275,13 @@ impl Resolver {
                 behavior_type_args,
                 span,
             } => {
-                if !self.is_known_type_name(table, &[], type_name) {
-                    diagnostics.push(Diagnostic::error(
-                        "E0201",
-                        format!("unknown type symbol '{type_name}'"),
-                        *span,
-                    ));
-                }
-                if !self.is_known_behavior_name(table, behavior) {
-                    diagnostics.push(Diagnostic::error(
-                        "E0202",
-                        format!("unknown behavior symbol '{behavior}'"),
-                        *span,
-                    ));
-                }
-                for type_arg in behavior_type_args {
-                    self.validate_type_ref(table, &[], type_arg, *span, false, diagnostics);
-                }
-                diagnostics.push(
-                    Diagnostic::error("E2000", GATED_GENERATED_BEHAVIOR_DERIVE_MESSAGE, *span)
-                        .with_generated_behavior_derive_gate_context(),
+                self.validate_derive_declaration(
+                    table,
+                    type_name,
+                    behavior,
+                    behavior_type_args,
+                    *span,
+                    diagnostics,
                 );
             }
             Declaration::BehaviorExtends {
@@ -327,51 +290,14 @@ impl Resolver {
                 parent_type_args,
                 span,
             } => {
-                let behavior_known = self.is_known_behavior_name(table, behavior);
-                let parent_known = self.is_known_behavior_name(table, parent);
-                if !behavior_known {
-                    diagnostics.push(Diagnostic::error(
-                        "E0202",
-                        format!("unknown behavior symbol '{behavior}'"),
-                        *span,
-                    ));
-                }
-                if !parent_known {
-                    diagnostics.push(Diagnostic::error(
-                        "E0202",
-                        format!("unknown behavior symbol '{parent}'"),
-                        *span,
-                    ));
-                }
-                let behavior_type_params = self.behavior_type_params_for_ref(table, behavior);
-                for type_arg in parent_type_args {
-                    self.validate_type_ref(
-                        table,
-                        &behavior_type_params,
-                        type_arg,
-                        *span,
-                        false,
-                        diagnostics,
-                    );
-                }
-                if behavior_known && parent_known {
-                    let parent_display = behavior_ref_display(parent, parent_type_args);
-                    if !table.record_behavior_parent(
-                        behavior,
-                        BehaviorRefMetadata {
-                            name: parent.clone(),
-                            type_args: parent_type_args.clone(),
-                        },
-                    ) {
-                        diagnostics.push(Diagnostic::error(
-                            "E0215",
-                            format!(
-                                "duplicate behavior parent `{parent_display}` for `{behavior}`"
-                            ),
-                            *span,
-                        ));
-                    }
-                }
+                self.validate_behavior_extends_declaration(
+                    table,
+                    behavior,
+                    parent,
+                    parent_type_args,
+                    *span,
+                    diagnostics,
+                );
             }
             Declaration::TopLevelExpr { expr, .. } => {
                 let scope_id = table.new_scope();

--- a/src/resolver/declaration_validation/behavior_associations.rs
+++ b/src/resolver/declaration_validation/behavior_associations.rs
@@ -1,0 +1,136 @@
+use crate::ast::AstType;
+use crate::error::{Diagnostic, Span, GATED_GENERATED_BEHAVIOR_DERIVE_MESSAGE};
+
+use super::super::metadata_helpers::behavior_ref_display;
+use super::super::{BehaviorRefMetadata, Resolver, SymbolTable};
+
+impl Resolver {
+    pub(super) fn validate_requires_declaration(
+        &self,
+        table: &mut SymbolTable,
+        type_name: &str,
+        behavior: &str,
+        behavior_type_args: &[AstType],
+        span: Span,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        if !self.is_known_type_name(table, &[], type_name) {
+            diagnostics.push(Diagnostic::error(
+                "E0201",
+                format!("unknown type symbol '{type_name}'"),
+                span,
+            ));
+        }
+        if !self.is_known_behavior_name(table, behavior) {
+            diagnostics.push(Diagnostic::error(
+                "E0202",
+                format!("unknown behavior symbol '{behavior}'"),
+                span,
+            ));
+        } else if self.is_known_type_name(table, &[], type_name) {
+            let behavior_display = behavior_ref_display(behavior, behavior_type_args);
+            if !table.record_behavior_required(
+                type_name,
+                BehaviorRefMetadata {
+                    name: behavior.to_string(),
+                    type_args: behavior_type_args.to_vec(),
+                },
+            ) {
+                diagnostics.push(Diagnostic::error(
+                    "E0216",
+                    format!("duplicate required behavior `{behavior_display}` for `{type_name}`"),
+                    span,
+                ));
+            }
+        }
+        for type_arg in behavior_type_args {
+            self.validate_type_ref(table, &[], type_arg, span, false, diagnostics);
+        }
+    }
+
+    pub(super) fn validate_derive_declaration(
+        &self,
+        table: &mut SymbolTable,
+        type_name: &str,
+        behavior: &str,
+        behavior_type_args: &[AstType],
+        span: Span,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        if !self.is_known_type_name(table, &[], type_name) {
+            diagnostics.push(Diagnostic::error(
+                "E0201",
+                format!("unknown type symbol '{type_name}'"),
+                span,
+            ));
+        }
+        if !self.is_known_behavior_name(table, behavior) {
+            diagnostics.push(Diagnostic::error(
+                "E0202",
+                format!("unknown behavior symbol '{behavior}'"),
+                span,
+            ));
+        }
+        for type_arg in behavior_type_args {
+            self.validate_type_ref(table, &[], type_arg, span, false, diagnostics);
+        }
+        diagnostics.push(
+            Diagnostic::error("E2000", GATED_GENERATED_BEHAVIOR_DERIVE_MESSAGE, span)
+                .with_generated_behavior_derive_gate_context(),
+        );
+    }
+
+    pub(super) fn validate_behavior_extends_declaration(
+        &self,
+        table: &mut SymbolTable,
+        behavior: &str,
+        parent: &str,
+        parent_type_args: &[AstType],
+        span: Span,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        let behavior_known = self.is_known_behavior_name(table, behavior);
+        let parent_known = self.is_known_behavior_name(table, parent);
+        if !behavior_known {
+            diagnostics.push(Diagnostic::error(
+                "E0202",
+                format!("unknown behavior symbol '{behavior}'"),
+                span,
+            ));
+        }
+        if !parent_known {
+            diagnostics.push(Diagnostic::error(
+                "E0202",
+                format!("unknown behavior symbol '{parent}'"),
+                span,
+            ));
+        }
+        let behavior_type_params = self.behavior_type_params_for_ref(table, behavior);
+        for type_arg in parent_type_args {
+            self.validate_type_ref(
+                table,
+                &behavior_type_params,
+                type_arg,
+                span,
+                false,
+                diagnostics,
+            );
+        }
+        if behavior_known && parent_known {
+            let parent_display = behavior_ref_display(parent, parent_type_args);
+            if !table.record_behavior_parent(
+                behavior,
+                BehaviorRefMetadata {
+                    name: parent.to_string(),
+                    type_args: parent_type_args.to_vec(),
+                },
+            ) {
+                diagnostics.push(Diagnostic::error(
+                    "E0215",
+                    format!("duplicate behavior parent `{parent_display}` for `{behavior}`"),
+                    span,
+                ));
+            }
+        }
+    }
+}

--- a/tests/docs_truth/repo_hygiene/mod.rs
+++ b/tests/docs_truth/repo_hygiene/mod.rs
@@ -9,6 +9,7 @@ mod module_system;
 mod parser_enums;
 mod parser_keywords;
 mod removed_syntax;
+mod resolver_validation;
 mod source_truth;
 mod typechecker_imports;
 mod typechecker_runtime;

--- a/tests/docs_truth/repo_hygiene/resolver_validation.rs
+++ b/tests/docs_truth/repo_hygiene/resolver_validation.rs
@@ -1,0 +1,34 @@
+use super::*;
+
+#[test]
+fn resolver_behavior_association_validation_lives_in_focused_helper() {
+    let declaration_validation = read("src/resolver/declaration_validation.rs");
+    let behavior_associations =
+        read("src/resolver/declaration_validation/behavior_associations.rs");
+
+    for validation_helper in [
+        "validate_requires_declaration",
+        "validate_derive_declaration",
+        "validate_behavior_extends_declaration",
+    ] {
+        assert!(
+            !declaration_validation.contains(&format!("fn {validation_helper}")),
+            "main resolver declaration validation should not own behavior-association helper: {validation_helper}"
+        );
+        assert!(
+            behavior_associations.contains(&format!("fn {validation_helper}")),
+            "behavior association declaration validation should live in the focused helper: {validation_helper}"
+        );
+    }
+
+    for dispatch_call in [
+        "self.validate_requires_declaration",
+        "self.validate_derive_declaration",
+        "self.validate_behavior_extends_declaration",
+    ] {
+        assert!(
+            declaration_validation.contains(dispatch_call),
+            "main resolver declaration validation should dispatch behavior-association validation through helper: {dispatch_call}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Move resolver validation for `requires`, `derive`, and `Behavior.extends` declarations into `src/resolver/declaration_validation/behavior_associations.rs`.
- Keep `src/resolver/declaration_validation.rs` as the dispatcher for declaration validation.
- Add docs-truth coverage that keeps behavior-association validation in the focused helper.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth repo_hygiene::resolver_validation::resolver_behavior_association_validation_lives_in_focused_helper -- --nocapture`
- `cargo test --test docs_truth repo_hygiene::resolver_validation -- --nocapture`
- `cargo test --test resolver_phase2 generic_behavior_associations -- --nocapture`
- `cargo test --test integration frontend_diagnostics::generic_behavior_imports -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Push-event Actions check for `codex/split-resolver-behavior-association-validation` returned `[]`.