### PR TITLE
Split AST expression operators

### DIFF
--- a/src/ast/expressions.rs
+++ b/src/ast/expressions.rs
@@ -3,120 +3,9 @@ use crate::ast::statements::Statement;
 use crate::ast::types::{AstType, Param};
 use crate::error::Span;
 use serde::Serialize;
-use std::fmt;
-use std::str::FromStr;
 
-/// Binary operators.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-pub enum BinaryOp {
-    // Arithmetic
-    Add,
-    Sub,
-    Mul,
-    Div,
-    Mod,
-
-    // Comparison
-    Eq,
-    NotEq,
-    Lt,
-    Gt,
-    LtEq,
-    GtEq,
-
-    // Logical
-    And,
-    Or,
-
-    // Bitwise
-    BitAnd,
-    BitOr,
-    BitXor,
-    ShiftLeft,
-    ShiftRight,
-}
-
-impl BinaryOp {
-    /// Returns the operator symbol for display/error messages.
-    pub fn symbol(&self) -> &'static str {
-        match self {
-            BinaryOp::Add => "+",
-            BinaryOp::Sub => "-",
-            BinaryOp::Mul => "*",
-            BinaryOp::Div => "/",
-            BinaryOp::Mod => "%",
-            BinaryOp::Eq => "==",
-            BinaryOp::NotEq => "!=",
-            BinaryOp::Lt => "<",
-            BinaryOp::Gt => ">",
-            BinaryOp::LtEq => "<=",
-            BinaryOp::GtEq => ">=",
-            BinaryOp::And => "&&",
-            BinaryOp::Or => "||",
-            BinaryOp::BitAnd => "&",
-            BinaryOp::BitOr => "|",
-            BinaryOp::BitXor => "^",
-            BinaryOp::ShiftLeft => "<<",
-            BinaryOp::ShiftRight => ">>",
-        }
-    }
-}
-
-/// Unary operators.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-pub enum UnaryOp {
-    Neg,    // -x
-    Not,    // !x
-    BitNot, // ~x
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-pub enum LoopControlAction {
-    Done,
-    Next,
-}
-
-impl LoopControlAction {
-    pub const DONE: &'static str = "done";
-    pub const NEXT: &'static str = "next";
-
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::Done => Self::DONE,
-            Self::Next => Self::NEXT,
-        }
-    }
-}
-
-impl fmt::Display for LoopControlAction {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-impl FromStr for LoopControlAction {
-    type Err = ();
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        if value == Self::Done.as_str() {
-            Ok(Self::Done)
-        } else if value == Self::Next.as_str() {
-            Ok(Self::Next)
-        } else {
-            Err(())
-        }
-    }
-}
-
-impl UnaryOp {
-    pub fn symbol(&self) -> &'static str {
-        match self {
-            UnaryOp::Neg => "-",
-            UnaryOp::Not => "!",
-            UnaryOp::BitNot => "~",
-        }
-    }
-}
+mod operators;
+pub use operators::{BinaryOp, LoopControlAction, UnaryOp};
 
 /// Parts of a string interpolation: `"Hello, ${name}!"` becomes
 /// `[Literal("Hello, "), Expr(<name>), Literal("!")]`.
@@ -355,27 +244,5 @@ impl Expression {
             | Expression::Defer { span, .. }
             | Expression::Error { span, .. } => *span,
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn loop_control_action_owns_text_spelling() {
-        assert_eq!(LoopControlAction::Done.as_str(), "done");
-        assert_eq!(LoopControlAction::Next.as_str(), "next");
-        assert_eq!(
-            "done".parse::<LoopControlAction>(),
-            Ok(LoopControlAction::Done)
-        );
-        assert_eq!(
-            "next".parse::<LoopControlAction>(),
-            Ok(LoopControlAction::Next)
-        );
-        assert!("stop".parse::<LoopControlAction>().is_err());
-        assert_eq!(LoopControlAction::Done.to_string(), "done");
-        assert_eq!(LoopControlAction::Next.to_string(), "next");
     }
 }

--- a/src/ast/expressions/operators.rs
+++ b/src/ast/expressions/operators.rs
@@ -1,0 +1,137 @@
+use serde::Serialize;
+use std::fmt;
+use std::str::FromStr;
+
+/// Binary operators.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum BinaryOp {
+    // Arithmetic
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Mod,
+
+    // Comparison
+    Eq,
+    NotEq,
+    Lt,
+    Gt,
+    LtEq,
+    GtEq,
+
+    // Logical
+    And,
+    Or,
+
+    // Bitwise
+    BitAnd,
+    BitOr,
+    BitXor,
+    ShiftLeft,
+    ShiftRight,
+}
+
+impl BinaryOp {
+    /// Returns the operator symbol for display/error messages.
+    pub fn symbol(&self) -> &'static str {
+        match self {
+            BinaryOp::Add => "+",
+            BinaryOp::Sub => "-",
+            BinaryOp::Mul => "*",
+            BinaryOp::Div => "/",
+            BinaryOp::Mod => "%",
+            BinaryOp::Eq => "==",
+            BinaryOp::NotEq => "!=",
+            BinaryOp::Lt => "<",
+            BinaryOp::Gt => ">",
+            BinaryOp::LtEq => "<=",
+            BinaryOp::GtEq => ">=",
+            BinaryOp::And => "&&",
+            BinaryOp::Or => "||",
+            BinaryOp::BitAnd => "&",
+            BinaryOp::BitOr => "|",
+            BinaryOp::BitXor => "^",
+            BinaryOp::ShiftLeft => "<<",
+            BinaryOp::ShiftRight => ">>",
+        }
+    }
+}
+
+/// Unary operators.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum UnaryOp {
+    Neg,    // -x
+    Not,    // !x
+    BitNot, // ~x
+}
+
+impl UnaryOp {
+    pub fn symbol(&self) -> &'static str {
+        match self {
+            UnaryOp::Neg => "-",
+            UnaryOp::Not => "!",
+            UnaryOp::BitNot => "~",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum LoopControlAction {
+    Done,
+    Next,
+}
+
+impl LoopControlAction {
+    pub const DONE: &'static str = "done";
+    pub const NEXT: &'static str = "next";
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Done => Self::DONE,
+            Self::Next => Self::NEXT,
+        }
+    }
+}
+
+impl fmt::Display for LoopControlAction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for LoopControlAction {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value == Self::Done.as_str() {
+            Ok(Self::Done)
+        } else if value == Self::Next.as_str() {
+            Ok(Self::Next)
+        } else {
+            Err(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loop_control_action_owns_text_spelling() {
+        assert_eq!(LoopControlAction::Done.as_str(), "done");
+        assert_eq!(LoopControlAction::Next.as_str(), "next");
+        assert_eq!(
+            "done".parse::<LoopControlAction>(),
+            Ok(LoopControlAction::Done)
+        );
+        assert_eq!(
+            "next".parse::<LoopControlAction>(),
+            Ok(LoopControlAction::Next)
+        );
+        assert!("stop".parse::<LoopControlAction>().is_err());
+        assert_eq!(LoopControlAction::Done.to_string(), "done");
+        assert_eq!(LoopControlAction::Next.to_string(), "next");
+    }
+}

--- a/tests/docs_truth/repo_hygiene/ast_expression_operators.rs
+++ b/tests/docs_truth/repo_hygiene/ast_expression_operators.rs
@@ -1,0 +1,28 @@
+use super::*;
+
+#[test]
+fn ast_expression_operator_spelling_lives_in_focused_helper() {
+    let expressions = read("src/ast/expressions.rs");
+    let operators = read("src/ast/expressions/operators.rs");
+
+    for helper in ["BinaryOp", "UnaryOp", "LoopControlAction"] {
+        assert!(
+            !expressions.contains(&format!("pub enum {helper}")),
+            "expression AST root should not own operator/control spelling enum: {helper}"
+        );
+        assert!(
+            operators.contains(&format!("pub enum {helper}")),
+            "operator/control spelling enum should live in focused helper: {helper}"
+        );
+    }
+
+    for required in [
+        "mod operators;",
+        "pub use operators::{BinaryOp, LoopControlAction, UnaryOp};",
+    ] {
+        assert!(
+            expressions.contains(required),
+            "expression AST root should re-export focused operator helper: {required}"
+        );
+    }
+}

--- a/tests/docs_truth/repo_hygiene/mod.rs
+++ b/tests/docs_truth/repo_hygiene/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+mod ast_expression_operators;
 mod build_graph_dsl;
 mod builtin_type_spelling;
 mod ci_configs;


### PR DESCRIPTION
## Summary
- Move `BinaryOp`, `UnaryOp`, and `LoopControlAction` into `src/ast/expressions/operators.rs`
- Re-export the operator/control types from `src/ast/expressions.rs` to keep existing import paths stable
- Add docs-truth coverage so expression shape and operator spelling stay separated

## Verification
- `cargo test --test docs_truth repo_hygiene::ast_expression_operators::ast_expression_operator_spelling_lives_in_focused_helper -- --nocapture`
- `cargo test --lib ast::expressions::operators::tests::loop_control_action_owns_text_spelling -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Push-event Actions check for `codex/split-ast-expression-operators`: `[]`.