### PR TITLE
Split resolver aggregate expression validation

### DIFF
--- a/src/resolver/expression_validation_constructs.rs
+++ b/src/resolver/expression_validation_constructs.rs
@@ -1,25 +1,11 @@
-use std::collections::HashSet;
-
 use crate::ast::{AstType, Expression, MatchArm, Param, Statement, TypeParam};
 use crate::error::{Diagnostic, Span};
 
 use super::symbol_table::ScopeStack;
-use super::{Namespace, Resolver, SymbolTable};
+use super::{Resolver, SymbolTable};
 
-pub(super) struct StructLiteralRef<'a> {
-    pub name: &'a str,
-    pub type_args: &'a [AstType],
-    pub fields: &'a [(String, Expression)],
-    pub span: Span,
-}
-
-pub(super) struct EnumVariantRef<'a> {
-    pub enum_name: &'a str,
-    pub type_args: &'a [AstType],
-    pub variant: &'a str,
-    pub payload: Option<&'a Expression>,
-    pub span: Span,
-}
+mod aggregate_literals;
+pub(super) use aggregate_literals::{EnumVariantRef, StructLiteralRef};
 
 pub(super) struct BlockRef<'a> {
     pub statements: &'a [Statement],
@@ -69,155 +55,6 @@ impl Resolver {
                 table,
                 type_params,
                 arg,
-                locals,
-                allow_self_type,
-                diagnostics,
-            );
-        }
-    }
-
-    pub(super) fn validate_struct_literal_refs(
-        &self,
-        table: &mut SymbolTable,
-        type_params: &[TypeParam],
-        literal: StructLiteralRef<'_>,
-        locals: &mut ScopeStack,
-        allow_self_type: bool,
-        diagnostics: &mut Vec<Diagnostic>,
-    ) {
-        let StructLiteralRef {
-            name,
-            type_args,
-            fields,
-            span,
-        } = literal;
-
-        if let Some(symbol) = table.lookup(Namespace::Type, name) {
-            if let Some(field_type_names) = symbol.field_type_names.as_ref() {
-                let expected_fields: HashSet<&str> = field_type_names
-                    .iter()
-                    .map(|(field_name, _)| field_name.as_str())
-                    .collect();
-                let mut provided_fields = HashSet::new();
-
-                for (field_name, _) in fields {
-                    if !provided_fields.insert(field_name.as_str()) {
-                        diagnostics.push(Diagnostic::error(
-                            "E0208",
-                            format!("duplicate field `{field_name}` for struct `{name}`"),
-                            span,
-                        ));
-                    }
-                    if !expected_fields.contains(field_name.as_str()) {
-                        diagnostics.push(Diagnostic::error(
-                            "E0209",
-                            format!("unknown field `{field_name}` for struct `{name}`"),
-                            span,
-                        ));
-                    }
-                }
-
-                for expected_field in expected_fields {
-                    if !provided_fields.contains(expected_field) {
-                        diagnostics.push(Diagnostic::error(
-                            "E0210",
-                            format!("missing field `{expected_field}` for struct `{name}`"),
-                            span,
-                        ));
-                    }
-                }
-            }
-        } else if !self.is_known_type_name(table, type_params, name) {
-            diagnostics.push(Diagnostic::error(
-                "E0201",
-                format!("unknown type symbol '{name}'"),
-                span,
-            ));
-        }
-
-        self.validate_type_arg_refs(
-            table,
-            type_params,
-            type_args,
-            span,
-            allow_self_type,
-            diagnostics,
-        );
-        for (_, value) in fields {
-            self.validate_expr_refs(
-                table,
-                type_params,
-                value,
-                locals,
-                allow_self_type,
-                diagnostics,
-            );
-        }
-    }
-
-    pub(super) fn validate_enum_variant_refs(
-        &self,
-        table: &mut SymbolTable,
-        type_params: &[TypeParam],
-        variant_ref: EnumVariantRef<'_>,
-        locals: &mut ScopeStack,
-        allow_self_type: bool,
-        diagnostics: &mut Vec<Diagnostic>,
-    ) {
-        let EnumVariantRef {
-            enum_name,
-            type_args,
-            variant,
-            payload,
-            span,
-        } = variant_ref;
-
-        if table.lookup(Namespace::Type, enum_name).is_some() {
-            if let Some(variant_symbol) = table.lookup_variant(enum_name, variant) {
-                match (
-                    variant_symbol.variant_payload_count.unwrap_or(0),
-                    payload.is_some(),
-                ) {
-                    (1, false) => diagnostics.push(Diagnostic::error(
-                        "E0206",
-                        format!("enum variant `{enum_name}.{variant}` requires a payload"),
-                        span,
-                    )),
-                    (0, true) => diagnostics.push(Diagnostic::error(
-                        "E0207",
-                        format!("enum variant `{enum_name}.{variant}` does not accept a payload"),
-                        span,
-                    )),
-                    _ => {}
-                }
-            } else {
-                diagnostics.push(Diagnostic::error(
-                    "E0205",
-                    format!("enum `{enum_name}` has no variant `{variant}`"),
-                    span,
-                ));
-            }
-        } else if !self.is_known_type_name(table, type_params, enum_name) {
-            diagnostics.push(Diagnostic::error(
-                "E0201",
-                format!("unknown type symbol '{enum_name}'"),
-                span,
-            ));
-        }
-
-        self.validate_type_arg_refs(
-            table,
-            type_params,
-            type_args,
-            span,
-            allow_self_type,
-            diagnostics,
-        );
-        if let Some(payload) = payload {
-            self.validate_expr_refs(
-                table,
-                type_params,
-                payload,
                 locals,
                 allow_self_type,
                 diagnostics,

--- a/src/resolver/expression_validation_constructs/aggregate_literals.rs
+++ b/src/resolver/expression_validation_constructs/aggregate_literals.rs
@@ -1,0 +1,173 @@
+use std::collections::HashSet;
+
+use crate::ast::{AstType, Expression, TypeParam};
+use crate::error::{Diagnostic, Span};
+
+use super::super::symbol_table::ScopeStack;
+use super::super::{Namespace, Resolver, SymbolTable};
+
+pub(in crate::resolver) struct StructLiteralRef<'a> {
+    pub name: &'a str,
+    pub type_args: &'a [AstType],
+    pub fields: &'a [(String, Expression)],
+    pub span: Span,
+}
+
+pub(in crate::resolver) struct EnumVariantRef<'a> {
+    pub enum_name: &'a str,
+    pub type_args: &'a [AstType],
+    pub variant: &'a str,
+    pub payload: Option<&'a Expression>,
+    pub span: Span,
+}
+
+impl Resolver {
+    pub(in crate::resolver) fn validate_struct_literal_refs(
+        &self,
+        table: &mut SymbolTable,
+        type_params: &[TypeParam],
+        literal: StructLiteralRef<'_>,
+        locals: &mut ScopeStack,
+        allow_self_type: bool,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        let StructLiteralRef {
+            name,
+            type_args,
+            fields,
+            span,
+        } = literal;
+
+        if let Some(symbol) = table.lookup(Namespace::Type, name) {
+            if let Some(field_type_names) = symbol.field_type_names.as_ref() {
+                let expected_fields: HashSet<&str> = field_type_names
+                    .iter()
+                    .map(|(field_name, _)| field_name.as_str())
+                    .collect();
+                let mut provided_fields = HashSet::new();
+
+                for (field_name, _) in fields {
+                    if !provided_fields.insert(field_name.as_str()) {
+                        diagnostics.push(Diagnostic::error(
+                            "E0208",
+                            format!("duplicate field `{field_name}` for struct `{name}`"),
+                            span,
+                        ));
+                    }
+                    if !expected_fields.contains(field_name.as_str()) {
+                        diagnostics.push(Diagnostic::error(
+                            "E0209",
+                            format!("unknown field `{field_name}` for struct `{name}`"),
+                            span,
+                        ));
+                    }
+                }
+
+                for expected_field in expected_fields {
+                    if !provided_fields.contains(expected_field) {
+                        diagnostics.push(Diagnostic::error(
+                            "E0210",
+                            format!("missing field `{expected_field}` for struct `{name}`"),
+                            span,
+                        ));
+                    }
+                }
+            }
+        } else if !self.is_known_type_name(table, type_params, name) {
+            diagnostics.push(Diagnostic::error(
+                "E0201",
+                format!("unknown type symbol '{name}'"),
+                span,
+            ));
+        }
+
+        self.validate_type_arg_refs(
+            table,
+            type_params,
+            type_args,
+            span,
+            allow_self_type,
+            diagnostics,
+        );
+        for (_, value) in fields {
+            self.validate_expr_refs(
+                table,
+                type_params,
+                value,
+                locals,
+                allow_self_type,
+                diagnostics,
+            );
+        }
+    }
+
+    pub(in crate::resolver) fn validate_enum_variant_refs(
+        &self,
+        table: &mut SymbolTable,
+        type_params: &[TypeParam],
+        variant_ref: EnumVariantRef<'_>,
+        locals: &mut ScopeStack,
+        allow_self_type: bool,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        let EnumVariantRef {
+            enum_name,
+            type_args,
+            variant,
+            payload,
+            span,
+        } = variant_ref;
+
+        if table.lookup(Namespace::Type, enum_name).is_some() {
+            if let Some(variant_symbol) = table.lookup_variant(enum_name, variant) {
+                match (
+                    variant_symbol.variant_payload_count.unwrap_or(0),
+                    payload.is_some(),
+                ) {
+                    (1, false) => diagnostics.push(Diagnostic::error(
+                        "E0206",
+                        format!("enum variant `{enum_name}.{variant}` requires a payload"),
+                        span,
+                    )),
+                    (0, true) => diagnostics.push(Diagnostic::error(
+                        "E0207",
+                        format!("enum variant `{enum_name}.{variant}` does not accept a payload"),
+                        span,
+                    )),
+                    _ => {}
+                }
+            } else {
+                diagnostics.push(Diagnostic::error(
+                    "E0205",
+                    format!("enum `{enum_name}` has no variant `{variant}`"),
+                    span,
+                ));
+            }
+        } else if !self.is_known_type_name(table, type_params, enum_name) {
+            diagnostics.push(Diagnostic::error(
+                "E0201",
+                format!("unknown type symbol '{enum_name}'"),
+                span,
+            ));
+        }
+
+        self.validate_type_arg_refs(
+            table,
+            type_params,
+            type_args,
+            span,
+            allow_self_type,
+            diagnostics,
+        );
+        if let Some(payload) = payload {
+            self.validate_expr_refs(
+                table,
+                type_params,
+                payload,
+                locals,
+                allow_self_type,
+                diagnostics,
+            );
+        }
+    }
+}

--- a/tests/docs_truth/repo_hygiene/mod.rs
+++ b/tests/docs_truth/repo_hygiene/mod.rs
@@ -11,6 +11,7 @@ mod parser_enums;
 mod parser_function_forms;
 mod parser_keywords;
 mod removed_syntax;
+mod resolver_expression_validation;
 mod resolver_validation;
 mod source_truth;
 mod typechecker_behavior_impls;

--- a/tests/docs_truth/repo_hygiene/resolver_expression_validation.rs
+++ b/tests/docs_truth/repo_hygiene/resolver_expression_validation.rs
@@ -1,0 +1,30 @@
+use super::*;
+
+#[test]
+fn resolver_aggregate_expression_validation_lives_in_focused_helper() {
+    let constructs = read("src/resolver/expression_validation_constructs.rs");
+    let aggregates = read("src/resolver/expression_validation_constructs/aggregate_literals.rs");
+
+    for helper in [
+        "StructLiteralRef",
+        "EnumVariantRef",
+        "validate_struct_literal_refs",
+        "validate_enum_variant_refs",
+    ] {
+        assert!(
+            !constructs.contains(&format!("struct {helper}"))
+                && !constructs.contains(&format!("fn {helper}")),
+            "general resolver expression constructs should not own aggregate helper: {helper}"
+        );
+        assert!(
+            aggregates.contains(&format!("struct {helper}"))
+                || aggregates.contains(&format!("fn {helper}")),
+            "aggregate expression validation should live in focused helper: {helper}"
+        );
+    }
+
+    assert!(
+        constructs.contains("mod aggregate_literals;"),
+        "resolver expression construct helpers should load aggregate literal validation"
+    );
+}


### PR DESCRIPTION
## Summary
- Move resolver struct/enum aggregate expression validation into `src/resolver/expression_validation_constructs/aggregate_literals.rs`
- Keep `expression_validation_constructs.rs` focused on shared type/arg traversal and scoped expression constructs
- Add docs-truth coverage so aggregate expression validation stays in the focused helper

## Verification
- `cargo test --test docs_truth repo_hygiene::resolver_expression_validation::resolver_aggregate_expression_validation_lives_in_focused_helper -- --nocapture`
- `cargo test --lib resolver -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Push-event Actions check for `codex/split-resolver-aggregate-validation`: `[]`.