### PR TITLE
Split resolver call expression validation

### DIFF
--- a/src/resolver/expression_validation.rs
+++ b/src/resolver/expression_validation.rs
@@ -7,6 +7,9 @@ use super::expression_validation_constructs::{
 use super::symbol_table::ScopeStack;
 use super::{Resolver, SymbolTable};
 
+mod calls;
+use calls::{FunctionCallRef, MethodCallRef};
+
 impl Resolver {
     pub(super) fn validate_expr_refs(
         &self,
@@ -25,38 +28,23 @@ impl Resolver {
                 args,
                 span,
             } => {
-                self.validate_type_arg_refs(
+                self.validate_function_call_expr_refs(
                     table,
                     type_params,
-                    type_args,
-                    *span,
-                    allow_self_type,
-                    diagnostics,
-                );
-                if module.is_none() && !self.is_known_value_name(table, locals, name) {
-                    diagnostics.push(Diagnostic::error(
-                        "E0203",
-                        format!("unknown value symbol '{name}'"),
-                        *span,
-                    ));
-                }
-                self.validate_expr_arg_refs(
-                    table,
-                    type_params,
-                    args,
+                    FunctionCallRef {
+                        name,
+                        module: module.as_deref(),
+                        type_args,
+                        args,
+                        span: *span,
+                    },
                     locals,
                     allow_self_type,
                     diagnostics,
                 );
             }
             Expression::Identifier { name, span } => {
-                if !self.is_known_value_name(table, locals, name) {
-                    diagnostics.push(Diagnostic::error(
-                        "E0203",
-                        format!("unknown value symbol '{name}'"),
-                        *span,
-                    ));
-                }
+                self.validate_identifier_expr_refs(table, name, *span, locals, diagnostics);
             }
             Expression::MethodCall {
                 receiver,
@@ -65,26 +53,15 @@ impl Resolver {
                 span,
                 ..
             } => {
-                self.validate_expr_refs(
+                self.validate_method_call_expr_refs(
                     table,
                     type_params,
-                    receiver,
-                    locals,
-                    allow_self_type,
-                    diagnostics,
-                );
-                self.validate_type_arg_refs(
-                    table,
-                    type_params,
-                    type_args,
-                    *span,
-                    allow_self_type,
-                    diagnostics,
-                );
-                self.validate_expr_arg_refs(
-                    table,
-                    type_params,
-                    args,
+                    MethodCallRef {
+                        receiver,
+                        type_args,
+                        args,
+                        span: *span,
+                    },
                     locals,
                     allow_self_type,
                     diagnostics,

--- a/src/resolver/expression_validation/calls.rs
+++ b/src/resolver/expression_validation/calls.rs
@@ -1,0 +1,123 @@
+use crate::ast::{AstType, Expression, TypeParam};
+use crate::error::{Diagnostic, Span};
+
+use super::super::symbol_table::ScopeStack;
+use super::super::{Resolver, SymbolTable};
+
+pub(in crate::resolver) struct FunctionCallRef<'a> {
+    pub name: &'a str,
+    pub module: Option<&'a str>,
+    pub type_args: &'a [AstType],
+    pub args: &'a [Expression],
+    pub span: Span,
+}
+
+pub(in crate::resolver) struct MethodCallRef<'a> {
+    pub receiver: &'a Expression,
+    pub type_args: &'a [AstType],
+    pub args: &'a [Expression],
+    pub span: Span,
+}
+
+impl Resolver {
+    pub(in crate::resolver) fn validate_function_call_expr_refs(
+        &self,
+        table: &mut SymbolTable,
+        type_params: &[TypeParam],
+        call: FunctionCallRef<'_>,
+        locals: &mut ScopeStack,
+        allow_self_type: bool,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        let FunctionCallRef {
+            name,
+            module,
+            type_args,
+            args,
+            span,
+        } = call;
+
+        self.validate_type_arg_refs(
+            table,
+            type_params,
+            type_args,
+            span,
+            allow_self_type,
+            diagnostics,
+        );
+        if module.is_none() && !self.is_known_value_name(table, locals, name) {
+            diagnostics.push(Diagnostic::error(
+                "E0203",
+                format!("unknown value symbol '{name}'"),
+                span,
+            ));
+        }
+        self.validate_expr_arg_refs(
+            table,
+            type_params,
+            args,
+            locals,
+            allow_self_type,
+            diagnostics,
+        );
+    }
+
+    pub(in crate::resolver) fn validate_identifier_expr_refs(
+        &self,
+        table: &SymbolTable,
+        name: &str,
+        span: Span,
+        locals: &ScopeStack,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        if !self.is_known_value_name(table, locals, name) {
+            diagnostics.push(Diagnostic::error(
+                "E0203",
+                format!("unknown value symbol '{name}'"),
+                span,
+            ));
+        }
+    }
+
+    pub(in crate::resolver) fn validate_method_call_expr_refs(
+        &self,
+        table: &mut SymbolTable,
+        type_params: &[TypeParam],
+        call: MethodCallRef<'_>,
+        locals: &mut ScopeStack,
+        allow_self_type: bool,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        let MethodCallRef {
+            receiver,
+            type_args,
+            args,
+            span,
+        } = call;
+
+        self.validate_expr_refs(
+            table,
+            type_params,
+            receiver,
+            locals,
+            allow_self_type,
+            diagnostics,
+        );
+        self.validate_type_arg_refs(
+            table,
+            type_params,
+            type_args,
+            span,
+            allow_self_type,
+            diagnostics,
+        );
+        self.validate_expr_arg_refs(
+            table,
+            type_params,
+            args,
+            locals,
+            allow_self_type,
+            diagnostics,
+        );
+    }
+}

--- a/tests/docs_truth/repo_hygiene/resolver_expression_validation.rs
+++ b/tests/docs_truth/repo_hygiene/resolver_expression_validation.rs
@@ -28,3 +28,29 @@ fn resolver_aggregate_expression_validation_lives_in_focused_helper() {
         "resolver expression construct helpers should load aggregate literal validation"
     );
 }
+
+#[test]
+fn resolver_call_expression_validation_lives_in_focused_helper() {
+    let validation = read("src/resolver/expression_validation.rs");
+    let calls = read("src/resolver/expression_validation/calls.rs");
+
+    for helper in [
+        "validate_function_call_expr_refs",
+        "validate_identifier_expr_refs",
+        "validate_method_call_expr_refs",
+    ] {
+        assert!(
+            !validation.contains(&format!("fn {helper}")),
+            "resolver expression dispatch should not own call helper: {helper}"
+        );
+        assert!(
+            calls.contains(&format!("fn {helper}")),
+            "resolver call expression validation should live in focused helper: {helper}"
+        );
+    }
+
+    assert!(
+        validation.contains("mod calls;"),
+        "resolver expression validation should load focused call validation"
+    );
+}


### PR DESCRIPTION
## Summary
- Move resolver validation for function calls, identifiers, and method calls into `src/resolver/expression_validation/calls.rs`.
- Keep `expression_validation.rs` focused on expression traversal and dispatch.
- Add a docs-truth guard so call validation helpers stay in the focused module.

## Verification
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --test docs_truth repo_hygiene::resolver_expression_validation::resolver_call_expression_validation_lives_in_focused_helper -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- `cargo test --lib`
- `cargo test --tests`
- Push-event Actions check: `[]`