### PR TITLE
Split diagnostic core

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,11 +2,15 @@ use std::fmt;
 
 use serde::Serialize;
 
+mod diagnostic;
 mod diagnostic_enrichment;
 mod file_table;
 #[cfg(test)]
 mod tests;
 
+pub use diagnostic::{
+    ContextFrame, ContextKind, Diagnostic, Label, Severity, SuggestedFix, TextEdit,
+};
 pub use file_table::{FileId, FileTable};
 
 // ── Span ───────────────────────────────────────────────────────────
@@ -56,81 +60,6 @@ impl Span {
     }
 }
 
-// ── Severity ───────────────────────────────────────────────────────
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Severity {
-    Error,
-    Warning,
-    Hint,
-    Info,
-}
-
-impl fmt::Display for Severity {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Severity::Error => write!(f, "error"),
-            Severity::Warning => write!(f, "warning"),
-            Severity::Hint => write!(f, "hint"),
-            Severity::Info => write!(f, "info"),
-        }
-    }
-}
-
-// ── Label ──────────────────────────────────────────────────────────
-
-/// A secondary annotation pointing at a span with a message.
-#[derive(Debug, Clone)]
-pub struct Label {
-    pub span: Span,
-    pub message: String,
-}
-
-impl Label {
-    pub fn new(span: Span, message: impl Into<String>) -> Self {
-        Self {
-            span,
-            message: message.into(),
-        }
-    }
-}
-
-// ── Context Frames ────────────────────────────────────────────────
-
-/// What kind of context led to this diagnostic.
-#[derive(Debug, Clone, PartialEq)]
-pub enum ContextKind {
-    FeatureGate,
-    InFunction,
-    InModule,
-    InGenericInstantiation,
-    InTraitImpl,
-    InImport,
-    InMacroExpansion,
-}
-
-impl ContextKind {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::FeatureGate => "feature_gate",
-            Self::InFunction => "in_function",
-            Self::InModule => "in_module",
-            Self::InGenericInstantiation => "in_generic_instantiation",
-            Self::InTraitImpl => "in_trait_impl",
-            Self::InImport => "in_import",
-            Self::InMacroExpansion => "in_macro_expansion",
-        }
-    }
-}
-
-/// A frame in the context stack showing how we reached the error.
-#[derive(Debug, Clone, PartialEq)]
-pub struct ContextFrame {
-    pub span: Span,
-    pub kind: ContextKind,
-    pub message: String,
-}
-
 pub const REMOVED_RETURN_KEYWORD_MESSAGE: &str =
     "return keyword has been removed; use the final expression in the block";
 pub const REMOVED_RETURN_FIX_KIND: &str = "replace_removed_return_with_final_expression";
@@ -158,120 +87,6 @@ pub const GATED_GENERIC_ASSOCIATION_TARGET_CONTEXT: &str =
     "reserved generic behavior association target";
 pub const MISSING_BOOL_MATCH_ARM_FIX_KIND: &str = "add_missing_bool_match_arm";
 pub const MISSING_BOOL_MATCH_ARM_FIX_TITLE: &str = "Add missing bool match arm";
-
-#[derive(Debug, Clone)]
-pub struct TextEdit {
-    pub span: Span,
-    pub replacement: String,
-}
-
-impl TextEdit {
-    pub fn new(span: Span, replacement: impl Into<String>) -> Self {
-        Self {
-            span,
-            replacement: replacement.into(),
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct SuggestedFix {
-    pub kind: String,
-    pub title: String,
-    pub edits: Vec<TextEdit>,
-}
-
-impl SuggestedFix {
-    pub fn new(kind: impl Into<String>, title: impl Into<String>, edits: Vec<TextEdit>) -> Self {
-        Self {
-            kind: kind.into(),
-            title: title.into(),
-            edits,
-        }
-    }
-}
-
-// ── Diagnostic ─────────────────────────────────────────────────────
-
-/// A single compiler diagnostic — shared across all phases.
-#[derive(Debug, Clone)]
-pub struct Diagnostic {
-    pub severity: Severity,
-    pub code: String,
-    pub message: String,
-    pub span: Option<Span>,
-    pub labels: Vec<Label>,
-    pub notes: Vec<String>,
-    pub context: Vec<ContextFrame>,
-    pub suggested_fixes: Vec<SuggestedFix>,
-}
-
-impl Diagnostic {
-    /// Create an error diagnostic.
-    pub fn error(code: impl Into<String>, message: impl Into<String>, span: Span) -> Self {
-        Self {
-            severity: Severity::Error,
-            code: code.into(),
-            message: message.into(),
-            span: Some(span),
-            labels: Vec::new(),
-            notes: Vec::new(),
-            context: Vec::new(),
-            suggested_fixes: Vec::new(),
-        }
-    }
-
-    /// Create a warning diagnostic.
-    pub fn warning(code: impl Into<String>, message: impl Into<String>, span: Span) -> Self {
-        Self {
-            severity: Severity::Warning,
-            code: code.into(),
-            message: message.into(),
-            span: Some(span),
-            labels: Vec::new(),
-            notes: Vec::new(),
-            context: Vec::new(),
-            suggested_fixes: Vec::new(),
-        }
-    }
-
-    /// Add a secondary label.
-    pub fn with_label(mut self, span: Span, message: impl Into<String>) -> Self {
-        self.labels.push(Label::new(span, message));
-        self
-    }
-
-    /// Add a help/note string.
-    pub fn with_note(mut self, note: impl Into<String>) -> Self {
-        self.notes.push(note.into());
-        self
-    }
-
-    /// Add a context frame showing how we reached this diagnostic.
-    pub fn with_context(mut self, frame: ContextFrame) -> Self {
-        self.context.push(frame);
-        self
-    }
-
-    pub fn with_suggested_fix(mut self, fix: SuggestedFix) -> Self {
-        self.suggested_fixes.push(fix);
-        self
-    }
-
-    pub fn is_error(&self) -> bool {
-        self.severity == Severity::Error
-    }
-}
-
-impl fmt::Display for Diagnostic {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}[{}]: {}", self.severity, self.code, self.message)?;
-        for frame in &self.context {
-            write!(f, "\n   = {}", frame.message)?;
-        }
-        Ok(())
-    }
-}
 
 // ── CompileError ───────────────────────────────────────────────────
 

--- a/src/error/diagnostic.rs
+++ b/src/error/diagnostic.rs
@@ -1,0 +1,184 @@
+use std::fmt;
+
+use super::Span;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    Error,
+    Warning,
+    Hint,
+    Info,
+}
+
+impl fmt::Display for Severity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Severity::Error => write!(f, "error"),
+            Severity::Warning => write!(f, "warning"),
+            Severity::Hint => write!(f, "hint"),
+            Severity::Info => write!(f, "info"),
+        }
+    }
+}
+
+/// A secondary annotation pointing at a span with a message.
+#[derive(Debug, Clone)]
+pub struct Label {
+    pub span: Span,
+    pub message: String,
+}
+
+impl Label {
+    pub fn new(span: Span, message: impl Into<String>) -> Self {
+        Self {
+            span,
+            message: message.into(),
+        }
+    }
+}
+
+/// What kind of context led to this diagnostic.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ContextKind {
+    FeatureGate,
+    InFunction,
+    InModule,
+    InGenericInstantiation,
+    InTraitImpl,
+    InImport,
+    InMacroExpansion,
+}
+
+impl ContextKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::FeatureGate => "feature_gate",
+            Self::InFunction => "in_function",
+            Self::InModule => "in_module",
+            Self::InGenericInstantiation => "in_generic_instantiation",
+            Self::InTraitImpl => "in_trait_impl",
+            Self::InImport => "in_import",
+            Self::InMacroExpansion => "in_macro_expansion",
+        }
+    }
+}
+
+/// A frame in the context stack showing how we reached the error.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ContextFrame {
+    pub span: Span,
+    pub kind: ContextKind,
+    pub message: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct TextEdit {
+    pub span: Span,
+    pub replacement: String,
+}
+
+impl TextEdit {
+    pub fn new(span: Span, replacement: impl Into<String>) -> Self {
+        Self {
+            span,
+            replacement: replacement.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SuggestedFix {
+    pub kind: String,
+    pub title: String,
+    pub edits: Vec<TextEdit>,
+}
+
+impl SuggestedFix {
+    pub fn new(kind: impl Into<String>, title: impl Into<String>, edits: Vec<TextEdit>) -> Self {
+        Self {
+            kind: kind.into(),
+            title: title.into(),
+            edits,
+        }
+    }
+}
+
+/// A single compiler diagnostic shared across all phases.
+#[derive(Debug, Clone)]
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: String,
+    pub message: String,
+    pub span: Option<Span>,
+    pub labels: Vec<Label>,
+    pub notes: Vec<String>,
+    pub context: Vec<ContextFrame>,
+    pub suggested_fixes: Vec<SuggestedFix>,
+}
+
+impl Diagnostic {
+    /// Create an error diagnostic.
+    pub fn error(code: impl Into<String>, message: impl Into<String>, span: Span) -> Self {
+        Self {
+            severity: Severity::Error,
+            code: code.into(),
+            message: message.into(),
+            span: Some(span),
+            labels: Vec::new(),
+            notes: Vec::new(),
+            context: Vec::new(),
+            suggested_fixes: Vec::new(),
+        }
+    }
+
+    /// Create a warning diagnostic.
+    pub fn warning(code: impl Into<String>, message: impl Into<String>, span: Span) -> Self {
+        Self {
+            severity: Severity::Warning,
+            code: code.into(),
+            message: message.into(),
+            span: Some(span),
+            labels: Vec::new(),
+            notes: Vec::new(),
+            context: Vec::new(),
+            suggested_fixes: Vec::new(),
+        }
+    }
+
+    /// Add a secondary label.
+    pub fn with_label(mut self, span: Span, message: impl Into<String>) -> Self {
+        self.labels.push(Label::new(span, message));
+        self
+    }
+
+    /// Add a help/note string.
+    pub fn with_note(mut self, note: impl Into<String>) -> Self {
+        self.notes.push(note.into());
+        self
+    }
+
+    /// Add a context frame showing how we reached this diagnostic.
+    pub fn with_context(mut self, frame: ContextFrame) -> Self {
+        self.context.push(frame);
+        self
+    }
+
+    pub fn with_suggested_fix(mut self, fix: SuggestedFix) -> Self {
+        self.suggested_fixes.push(fix);
+        self
+    }
+
+    pub fn is_error(&self) -> bool {
+        self.severity == Severity::Error
+    }
+}
+
+impl fmt::Display for Diagnostic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}[{}]: {}", self.severity, self.code, self.message)?;
+        for frame in &self.context {
+            write!(f, "\n   = {}", frame.message)?;
+        }
+        Ok(())
+    }
+}

--- a/tests/docs_truth/repo_hygiene/error_diagnostics.rs
+++ b/tests/docs_truth/repo_hygiene/error_diagnostics.rs
@@ -1,0 +1,32 @@
+use super::*;
+
+#[test]
+fn diagnostic_core_lives_in_focused_helper() {
+    let root = read("src/error.rs");
+    let diagnostic = read("src/error/diagnostic.rs");
+
+    for item in [
+        "pub enum Severity",
+        "pub struct Label",
+        "pub enum ContextKind",
+        "pub struct ContextFrame",
+        "pub struct TextEdit",
+        "pub struct SuggestedFix",
+        "pub struct Diagnostic",
+        "impl Diagnostic",
+    ] {
+        assert!(
+            !root.contains(item),
+            "error module root should not own diagnostic core item: {item}"
+        );
+        assert!(
+            diagnostic.contains(item),
+            "diagnostic core item should live in focused helper: {item}"
+        );
+    }
+
+    assert!(
+        root.contains("mod diagnostic;"),
+        "error module should load focused diagnostic core"
+    );
+}

--- a/tests/docs_truth/repo_hygiene/mod.rs
+++ b/tests/docs_truth/repo_hygiene/mod.rs
@@ -4,6 +4,7 @@ mod ast_expression_operators;
 mod build_graph_dsl;
 mod builtin_type_spelling;
 mod ci_configs;
+mod error_diagnostics;
 mod file_size;
 mod ir_json;
 mod module_system;


### PR DESCRIPTION
## Summary
- Move diagnostic core types and constructors into `src/error/diagnostic.rs`.
- Keep `src/error.rs` focused on the error module root, spans, constants, and `CompileError` conversion.
- Add a docs-truth guard for the diagnostic core module boundary.

## Verification
- `cargo test --test docs_truth repo_hygiene::error_diagnostics::diagnostic_core_lives_in_focused_helper -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Push-event Actions check: `[]`