### PR TITLE
Split module graph program checking

### DIFF
--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -33,6 +33,7 @@ mod monomorphize_specialized_types;
 mod monomorphize_types;
 mod patterns;
 mod program_checking;
+mod program_module_graph;
 mod resolve;
 mod resolver_backed_collection;
 mod resolver_lookup;

--- a/src/typechecker/program_checking.rs
+++ b/src/typechecker/program_checking.rs
@@ -11,7 +11,7 @@ impl TypeChecker {
         self.check_program_after_collection(program)
     }
 
-    fn check_program_after_collection(
+    pub(super) fn check_program_after_collection(
         &mut self,
         program: &ast::Program,
     ) -> Result<TypedProgram, Vec<Diagnostic>> {
@@ -236,87 +236,6 @@ impl TypeChecker {
         self.collect_resolver_imports(symbols);
         self.collect_declarations_with_symbols(&program.declarations, symbols);
         self.check_program_after_collection(program)
-    }
-
-    pub fn check_module_graph_entry(
-        &mut self,
-        graph: &ResolvedModuleGraph,
-    ) -> Result<TypedProgram, Vec<Diagnostic>> {
-        let Some(entry) = graph.module(graph.entry) else {
-            self.diagnostics.push(Diagnostic::error(
-                "E0232",
-                format!("module graph missing entry module {:?}", graph.entry),
-                Span::dummy(),
-            ));
-            return Err(self
-                .diagnostics
-                .iter()
-                .filter(|diag| diag.is_error())
-                .cloned()
-                .collect());
-        };
-
-        let mut modules = graph.modules().values().collect::<Vec<_>>();
-        modules.sort_by_key(|module| module.info.id.0);
-
-        let mut dependency_programs = Vec::new();
-        for module in modules {
-            if module.info.id == graph.entry {
-                continue;
-            }
-
-            let mut checker = TypeChecker::new();
-            match checker.check_module_graph_module(graph, module) {
-                Ok(typed) => dependency_programs.push(typed),
-                Err(diags) => self.diagnostics.extend(diags),
-            }
-        }
-
-        if self.diagnostics.iter().any(|diag| diag.is_error()) {
-            return Err(self
-                .diagnostics
-                .iter()
-                .filter(|diag| diag.is_error())
-                .cloned()
-                .collect());
-        }
-
-        let mut typed = self.check_module_graph_module(graph, entry)?;
-        for mut dependency in dependency_programs {
-            typed.functions.append(&mut dependency.functions);
-            typed.types.append(&mut dependency.types);
-            typed.globals.append(&mut dependency.globals);
-        }
-        Ok(typed)
-    }
-
-    fn check_module_graph_module(
-        &mut self,
-        graph: &ResolvedModuleGraph,
-        module: &ResolvedModule,
-    ) -> Result<TypedProgram, Vec<Diagnostic>> {
-        self.validate_resolver_symbols(&module.program, &module.symbols);
-        if self.diagnostics.iter().any(|diag| diag.is_error()) {
-            return Err(self
-                .diagnostics
-                .iter()
-                .filter(|diag| diag.is_error())
-                .cloned()
-                .collect());
-        }
-
-        self.collect_module_graph_imports(graph, module);
-        if self.diagnostics.iter().any(|diag| diag.is_error()) {
-            return Err(self
-                .diagnostics
-                .iter()
-                .filter(|diag| diag.is_error())
-                .cloned()
-                .collect());
-        }
-
-        self.collect_declarations_with_symbols(&module.program.declarations, &module.symbols);
-        self.check_program_after_collection(&module.program)
     }
 
     /// Get all diagnostics (errors + warnings).

--- a/src/typechecker/program_module_graph.rs
+++ b/src/typechecker/program_module_graph.rs
@@ -1,0 +1,84 @@
+use super::*;
+
+impl TypeChecker {
+    pub fn check_module_graph_entry(
+        &mut self,
+        graph: &ResolvedModuleGraph,
+    ) -> Result<TypedProgram, Vec<Diagnostic>> {
+        let Some(entry) = graph.module(graph.entry) else {
+            self.diagnostics.push(Diagnostic::error(
+                "E0232",
+                format!("module graph missing entry module {:?}", graph.entry),
+                Span::dummy(),
+            ));
+            return Err(self
+                .diagnostics
+                .iter()
+                .filter(|diag| diag.is_error())
+                .cloned()
+                .collect());
+        };
+
+        let mut modules = graph.modules().values().collect::<Vec<_>>();
+        modules.sort_by_key(|module| module.info.id.0);
+
+        let mut dependency_programs = Vec::new();
+        for module in modules {
+            if module.info.id == graph.entry {
+                continue;
+            }
+
+            let mut checker = TypeChecker::new();
+            match checker.check_module_graph_module(graph, module) {
+                Ok(typed) => dependency_programs.push(typed),
+                Err(diags) => self.diagnostics.extend(diags),
+            }
+        }
+
+        if self.diagnostics.iter().any(|diag| diag.is_error()) {
+            return Err(self
+                .diagnostics
+                .iter()
+                .filter(|diag| diag.is_error())
+                .cloned()
+                .collect());
+        }
+
+        let mut typed = self.check_module_graph_module(graph, entry)?;
+        for mut dependency in dependency_programs {
+            typed.functions.append(&mut dependency.functions);
+            typed.types.append(&mut dependency.types);
+            typed.globals.append(&mut dependency.globals);
+        }
+        Ok(typed)
+    }
+
+    fn check_module_graph_module(
+        &mut self,
+        graph: &ResolvedModuleGraph,
+        module: &ResolvedModule,
+    ) -> Result<TypedProgram, Vec<Diagnostic>> {
+        self.validate_resolver_symbols(&module.program, &module.symbols);
+        if self.diagnostics.iter().any(|diag| diag.is_error()) {
+            return Err(self
+                .diagnostics
+                .iter()
+                .filter(|diag| diag.is_error())
+                .cloned()
+                .collect());
+        }
+
+        self.collect_module_graph_imports(graph, module);
+        if self.diagnostics.iter().any(|diag| diag.is_error()) {
+            return Err(self
+                .diagnostics
+                .iter()
+                .filter(|diag| diag.is_error())
+                .cloned()
+                .collect());
+        }
+
+        self.collect_declarations_with_symbols(&module.program.declarations, &module.symbols);
+        self.check_program_after_collection(&module.program)
+    }
+}

--- a/tests/docs_truth/repo_hygiene/mod.rs
+++ b/tests/docs_truth/repo_hygiene/mod.rs
@@ -18,6 +18,7 @@ mod resolver_validation;
 mod source_truth;
 mod typechecker_behavior_impls;
 mod typechecker_imports;
+mod typechecker_program_checking;
 mod typechecker_resolver_validation;
 mod typechecker_runtime;
 mod typechecker_semantic_validation;

--- a/tests/docs_truth/repo_hygiene/typechecker_program_checking.rs
+++ b/tests/docs_truth/repo_hygiene/typechecker_program_checking.rs
@@ -1,0 +1,24 @@
+use super::*;
+
+#[test]
+fn typechecker_module_graph_program_checking_lives_in_focused_helper() {
+    let root = read("src/typechecker/mod.rs");
+    let program_checking = read("src/typechecker/program_checking.rs");
+    let module_graph = read("src/typechecker/program_module_graph.rs");
+
+    for helper in ["check_module_graph_entry", "check_module_graph_module"] {
+        assert!(
+            !program_checking.contains(&format!("fn {helper}")),
+            "program_checking.rs should not own module graph checking helper: {helper}"
+        );
+        assert!(
+            module_graph.contains(&format!("fn {helper}")),
+            "module graph checking helper should live in focused helper: {helper}"
+        );
+    }
+
+    assert!(
+        root.contains("mod program_module_graph;"),
+        "typechecker root should include focused module graph checking module"
+    );
+}


### PR DESCRIPTION
## Summary
- Move module-graph program checking into `src/typechecker/program_module_graph.rs`
- Keep `program_checking.rs` focused on normal program checking and typed global handling
- Add a docs-truth guard for the module graph checking boundary

## Verification
- `cargo test --test docs_truth typechecker_module_graph_program_checking_lives_in_focused_helper -- --nocapture` failed before implementation
- `cargo test --test docs_truth typechecker_module_graph_program_checking_lives_in_focused_helper -- --nocapture`
- `cargo test --lib resolver_module_graph -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Push-event Actions check: `gh run list --branch codex/split-program-module-graph-checking --event push --limit 10 --json ...` returned `[]`.