### PR TITLE
Split behavior association task types

### DIFF
--- a/src/typechecker/declaration_tasks.rs
+++ b/src/typechecker/declaration_tasks.rs
@@ -221,12 +221,7 @@ struct ResolverBehaviorDeclarationMetadataTask<'a> {
     span: Span,
 }
 
-#[derive(Default)]
-struct BehaviorAssociationValidationTasks<'a> {
-    extends: Vec<BehaviorExtendsValidationTask<'a>>,
-    impls: Vec<ResolverBehaviorImplBlockDeclarationTask<'a>>,
-    requires: Vec<BehaviorRequiresValidationTask<'a>>,
-}
+include!("declaration_tasks_behavior_associations.rs");
 
 #[derive(Default)]
 struct AstDeclarationValidationTasks<'a> {
@@ -239,16 +234,6 @@ struct AstDeclarationValidationTasks<'a> {
 struct AstPrecollectionValidationTasks<'a> {
     self_type_contexts: Vec<SelfTypeContextValidationTask<'a>>,
     behavior_associations: BehaviorAssociationValidationTasks<'a>,
-}
-
-trait BehaviorAssociationValidationTaskSource<'a> {
-    fn behavior_association_tasks(&self) -> &BehaviorAssociationValidationTasks<'a>;
-}
-
-impl<'a> BehaviorAssociationValidationTaskSource<'a> for BehaviorAssociationValidationTasks<'a> {
-    fn behavior_association_tasks(&self) -> &BehaviorAssociationValidationTasks<'a> {
-        self
-    }
 }
 
 impl<'a> BehaviorAssociationValidationTaskSource<'a> for AstDeclarationValidationTasks<'a> {
@@ -285,48 +270,6 @@ impl<'a> BehaviorAssociationValidationTaskSource<'a>
     fn behavior_association_tasks(&self) -> &BehaviorAssociationValidationTasks<'a> {
         &self.behavior_associations
     }
-}
-
-struct ResolverBehaviorImplBlockDeclarationTask<'a> {
-    ast_type_name: &'a str,
-    behavior: &'a str,
-    behavior_type_args: &'a [AstType],
-    methods: &'a [Declaration],
-    span: Span,
-}
-
-struct ResolverBehaviorImplBlockTask<'a> {
-    ast_type_name: &'a str,
-    restored_type_name: String,
-    behavior: &'a str,
-    behavior_type_args: &'a [AstType],
-    methods: &'a [Declaration],
-}
-
-struct ImplBlockDeclarationTask<'a> {
-    type_name: &'a str,
-    behavior: Option<&'a str>,
-    behavior_type_args: &'a [AstType],
-    methods: &'a [Declaration],
-}
-
-struct BehaviorRequiresValidationTask<'a> {
-    type_name: &'a str,
-    behavior: &'a str,
-    behavior_type_args: &'a [AstType],
-    span: Span,
-}
-
-struct EffectiveBehaviorImplMethod<'a> {
-    declaration: &'a Declaration,
-    method_name: String,
-}
-
-struct BehaviorExtendsValidationTask<'a> {
-    behavior: &'a str,
-    parent: &'a str,
-    parent_type_args: &'a [AstType],
-    span: Span,
 }
 
 struct ResolverTypeBehaviorRefreshTask {

--- a/src/typechecker/declaration_tasks_behavior_associations.rs
+++ b/src/typechecker/declaration_tasks_behavior_associations.rs
@@ -1,0 +1,58 @@
+#[derive(Default)]
+struct BehaviorAssociationValidationTasks<'a> {
+    extends: Vec<BehaviorExtendsValidationTask<'a>>,
+    impls: Vec<ResolverBehaviorImplBlockDeclarationTask<'a>>,
+    requires: Vec<BehaviorRequiresValidationTask<'a>>,
+}
+
+trait BehaviorAssociationValidationTaskSource<'a> {
+    fn behavior_association_tasks(&self) -> &BehaviorAssociationValidationTasks<'a>;
+}
+
+impl<'a> BehaviorAssociationValidationTaskSource<'a> for BehaviorAssociationValidationTasks<'a> {
+    fn behavior_association_tasks(&self) -> &BehaviorAssociationValidationTasks<'a> {
+        self
+    }
+}
+
+struct ResolverBehaviorImplBlockDeclarationTask<'a> {
+    ast_type_name: &'a str,
+    behavior: &'a str,
+    behavior_type_args: &'a [AstType],
+    methods: &'a [Declaration],
+    span: Span,
+}
+
+struct ResolverBehaviorImplBlockTask<'a> {
+    ast_type_name: &'a str,
+    restored_type_name: String,
+    behavior: &'a str,
+    behavior_type_args: &'a [AstType],
+    methods: &'a [Declaration],
+}
+
+struct ImplBlockDeclarationTask<'a> {
+    type_name: &'a str,
+    behavior: Option<&'a str>,
+    behavior_type_args: &'a [AstType],
+    methods: &'a [Declaration],
+}
+
+struct BehaviorRequiresValidationTask<'a> {
+    type_name: &'a str,
+    behavior: &'a str,
+    behavior_type_args: &'a [AstType],
+    span: Span,
+}
+
+struct EffectiveBehaviorImplMethod<'a> {
+    declaration: &'a Declaration,
+    method_name: String,
+}
+
+struct BehaviorExtendsValidationTask<'a> {
+    behavior: &'a str,
+    parent: &'a str,
+    parent_type_args: &'a [AstType],
+    span: Span,
+}

--- a/tests/docs_truth/repo_hygiene/typechecker_behavior_impls.rs
+++ b/tests/docs_truth/repo_hygiene/typechecker_behavior_impls.rs
@@ -27,3 +27,38 @@ fn behavior_default_method_synthesis_lives_in_focused_helper() {
         "behavior impl support should load the focused default-method helper"
     );
 }
+
+#[test]
+fn behavior_association_declaration_tasks_live_in_focused_helper() {
+    let root = read("src/typechecker/declaration_tasks.rs");
+    let focused = read("src/typechecker/declaration_tasks_behavior_associations.rs");
+
+    for helper in [
+        "BehaviorAssociationValidationTasks",
+        "BehaviorAssociationValidationTaskSource",
+        "ResolverBehaviorImplBlockDeclarationTask",
+        "ResolverBehaviorImplBlockTask",
+        "ImplBlockDeclarationTask",
+        "BehaviorRequiresValidationTask",
+        "EffectiveBehaviorImplMethod",
+        "BehaviorExtendsValidationTask",
+    ] {
+        assert!(
+            !root.contains(&format!("struct {helper}"))
+                && !root.contains(&format!("enum {helper}"))
+                && !root.contains(&format!("trait {helper}")),
+            "declaration_tasks.rs should not own behavior association task: {helper}"
+        );
+        assert!(
+            focused.contains(&format!("struct {helper}"))
+                || focused.contains(&format!("enum {helper}"))
+                || focused.contains(&format!("trait {helper}")),
+            "behavior association task should live in focused helper: {helper}"
+        );
+    }
+
+    assert!(
+        root.contains("include!(\"declaration_tasks_behavior_associations.rs\");"),
+        "declaration tasks should include focused behavior association tasks"
+    );
+}


### PR DESCRIPTION
## Summary
- Move behavior-association declaration task types out of `declaration_tasks.rs` into `declaration_tasks_behavior_associations.rs`.
- Add a docs-truth repo-hygiene guard so those task types stay in the focused helper.
- Reduce `declaration_tasks.rs` from 344 to 287 lines.

## Test-first note
- Added `behavior_association_declaration_tasks_live_in_focused_helper` first and confirmed it failed because the focused helper file did not exist.
- Moved the task type cluster after the failing guard was in place.

## Verification
- `cargo test --test docs_truth behavior_association_declaration_tasks_live_in_focused_helper -- --nocapture`
- `cargo test --lib declaration_tasks`
- `cargo test --test docs_truth -- --nocapture`
- `cargo test --test resolver_phase2 behavior_relations -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `gh run list --branch codex/split-behavior-association-tasks --event push --limit 10 --json databaseId,status,conclusion,workflowName,headSha,createdAt,url` returned `[]`