### PR TITLE
Split typechecker state

### DIFF
--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -66,77 +66,9 @@ pub(crate) use environment::{
 };
 
 include!("declaration_tasks.rs");
-// ── TypeChecker ───────────────────────────────────────────────────
-
-pub struct TypeChecker {
-    structs: HashMap<String, StructInfo>,
-    enums: HashMap<String, EnumInfo>,
-    functions: HashMap<String, FuncInfo>,
-    methods: HashMap<String, FuncInfo>, // key: "TypeName.method_name"
-    behaviors: HashMap<String, BehaviorInfo>,
-    behavior_extends: HashMap<String, Vec<BehaviorParentRef>>,
-    behavior_extends_spans: HashMap<String, Span>,
-    behavior_impls: HashSet<(String, String)>,
-    behavior_refs_by_key: HashMap<String, BehaviorParentRef>,
-    generic_functions: HashMap<String, GenericFunctionTemplate>,
-    generic_methods: HashMap<String, GenericFunctionTemplate>,
-    specialized_functions: Vec<TypedFunction>,
-    specializations_seen: HashSet<String>,
-    specialized_types: Vec<TypedTypeDef>,
-    specialized_types_seen: HashSet<String>,
-    type_substitutions: Vec<HashMap<String, Type>>,
-    imports: HashMap<String, Vec<String>>, // imported name -> source module path
-    scopes: Vec<Scope>,
-    diagnostics: Vec<Diagnostic>,
-    current_return_type: Option<Type>,
-    current_self_type: Option<Type>,
-    pending_defers: Vec<TypedExpression>,
-    resolver_backed_collection: bool,
-    resolver_behavior_impl_refs: HashMap<String, VecDeque<BehaviorRefMetadata>>,
-    resolver_behavior_required_refs: HashMap<String, VecDeque<BehaviorRefMetadata>>,
-    resolver_missing_behavior_impl_refs: HashSet<String>,
-    resolver_missing_behavior_required_refs: HashSet<String>,
-}
-
-impl Default for TypeChecker {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+include!("state.rs");
 
 impl TypeChecker {
-    pub fn new() -> Self {
-        Self {
-            structs: HashMap::new(),
-            enums: HashMap::new(),
-            functions: HashMap::new(),
-            methods: HashMap::new(),
-            behaviors: HashMap::new(),
-            behavior_extends: HashMap::new(),
-            behavior_extends_spans: HashMap::new(),
-            behavior_impls: HashSet::new(),
-            behavior_refs_by_key: HashMap::new(),
-            generic_functions: HashMap::new(),
-            generic_methods: HashMap::new(),
-            specialized_functions: Vec::new(),
-            specializations_seen: HashSet::new(),
-            specialized_types: Vec::new(),
-            specialized_types_seen: HashSet::new(),
-            type_substitutions: Vec::new(),
-            imports: HashMap::new(),
-            scopes: vec![Scope::new()], // global scope
-            diagnostics: Vec::new(),
-            current_return_type: None,
-            current_self_type: None,
-            pending_defers: Vec::new(),
-            resolver_backed_collection: false,
-            resolver_behavior_impl_refs: HashMap::new(),
-            resolver_behavior_required_refs: HashMap::new(),
-            resolver_missing_behavior_impl_refs: HashSet::new(),
-            resolver_missing_behavior_required_refs: HashSet::new(),
-        }
-    }
-
     fn collect_impl_method_signature(&mut self, type_name: &str, method: &Declaration) {
         let Declaration::Function {
             name,

--- a/src/typechecker/state.rs
+++ b/src/typechecker/state.rs
@@ -1,0 +1,69 @@
+pub struct TypeChecker {
+    structs: HashMap<String, StructInfo>,
+    enums: HashMap<String, EnumInfo>,
+    functions: HashMap<String, FuncInfo>,
+    methods: HashMap<String, FuncInfo>, // key: "TypeName.method_name"
+    behaviors: HashMap<String, BehaviorInfo>,
+    behavior_extends: HashMap<String, Vec<BehaviorParentRef>>,
+    behavior_extends_spans: HashMap<String, Span>,
+    behavior_impls: HashSet<(String, String)>,
+    behavior_refs_by_key: HashMap<String, BehaviorParentRef>,
+    generic_functions: HashMap<String, GenericFunctionTemplate>,
+    generic_methods: HashMap<String, GenericFunctionTemplate>,
+    specialized_functions: Vec<TypedFunction>,
+    specializations_seen: HashSet<String>,
+    specialized_types: Vec<TypedTypeDef>,
+    specialized_types_seen: HashSet<String>,
+    type_substitutions: Vec<HashMap<String, Type>>,
+    imports: HashMap<String, Vec<String>>, // imported name -> source module path
+    scopes: Vec<Scope>,
+    diagnostics: Vec<Diagnostic>,
+    current_return_type: Option<Type>,
+    current_self_type: Option<Type>,
+    pending_defers: Vec<TypedExpression>,
+    resolver_backed_collection: bool,
+    resolver_behavior_impl_refs: HashMap<String, VecDeque<BehaviorRefMetadata>>,
+    resolver_behavior_required_refs: HashMap<String, VecDeque<BehaviorRefMetadata>>,
+    resolver_missing_behavior_impl_refs: HashSet<String>,
+    resolver_missing_behavior_required_refs: HashSet<String>,
+}
+
+impl Default for TypeChecker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TypeChecker {
+    pub fn new() -> Self {
+        Self {
+            structs: HashMap::new(),
+            enums: HashMap::new(),
+            functions: HashMap::new(),
+            methods: HashMap::new(),
+            behaviors: HashMap::new(),
+            behavior_extends: HashMap::new(),
+            behavior_extends_spans: HashMap::new(),
+            behavior_impls: HashSet::new(),
+            behavior_refs_by_key: HashMap::new(),
+            generic_functions: HashMap::new(),
+            generic_methods: HashMap::new(),
+            specialized_functions: Vec::new(),
+            specializations_seen: HashSet::new(),
+            specialized_types: Vec::new(),
+            specialized_types_seen: HashSet::new(),
+            type_substitutions: Vec::new(),
+            imports: HashMap::new(),
+            scopes: vec![Scope::new()], // global scope
+            diagnostics: Vec::new(),
+            current_return_type: None,
+            current_self_type: None,
+            pending_defers: Vec::new(),
+            resolver_backed_collection: false,
+            resolver_behavior_impl_refs: HashMap::new(),
+            resolver_behavior_required_refs: HashMap::new(),
+            resolver_missing_behavior_impl_refs: HashSet::new(),
+            resolver_missing_behavior_required_refs: HashSet::new(),
+        }
+    }
+}

--- a/tests/docs_truth/repo_hygiene/mod.rs
+++ b/tests/docs_truth/repo_hygiene/mod.rs
@@ -24,3 +24,4 @@ mod typechecker_program_checking;
 mod typechecker_resolver_validation;
 mod typechecker_runtime;
 mod typechecker_semantic_validation;
+mod typechecker_state;

--- a/tests/docs_truth/repo_hygiene/typechecker_state.rs
+++ b/tests/docs_truth/repo_hygiene/typechecker_state.rs
@@ -1,0 +1,35 @@
+use super::*;
+
+#[test]
+fn typechecker_state_lives_in_focused_helper() {
+    let root = read("src/typechecker/mod.rs");
+    let state = read("src/typechecker/state.rs");
+
+    for helper in ["TypeChecker", "Default"] {
+        assert!(
+            !root.contains(&format!("impl {helper} for TypeChecker"))
+                && !root.contains(&format!("pub struct {helper}")),
+            "typechecker root should not own state helper: {helper}"
+        );
+    }
+    assert!(
+        !root.contains("pub fn new() -> Self"),
+        "typechecker root should not own TypeChecker::new"
+    );
+    assert!(
+        state.contains("pub struct TypeChecker"),
+        "TypeChecker state should live in focused helper"
+    );
+    assert!(
+        state.contains("impl Default for TypeChecker"),
+        "TypeChecker default impl should live in focused helper"
+    );
+    assert!(
+        state.contains("pub fn new() -> Self"),
+        "TypeChecker constructor should live in focused helper"
+    );
+    assert!(
+        root.contains("include!(\"state.rs\");"),
+        "typechecker root should include focused state helper"
+    );
+}


### PR DESCRIPTION
## Summary
- Move `TypeChecker` state, `Default`, and `new()` into `src/typechecker/state.rs`.
- Add a docs-truth repo-hygiene guard so state stays out of the typechecker root.
- Reduce `src/typechecker/mod.rs` from 343 to 275 lines.

## Test-first note
- Added `typechecker_state_lives_in_focused_helper` first and confirmed it failed because `src/typechecker/state.rs` did not exist.
- Moved the state and constructor after the failing guard was in place.

## Verification
- `cargo test --test docs_truth typechecker_state_lives_in_focused_helper -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- `cargo test --lib declaration_tasks`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `gh run list --branch codex/split-typechecker-state --event push --limit 10 --json databaseId,status,conclusion,workflowName,headSha,createdAt,url` returned `[]`