### PR TITLE
Split stdlib path resolution

### DIFF
--- a/src/module_system/import_resolution.rs
+++ b/src/module_system/import_resolution.rs
@@ -8,8 +8,10 @@ use super::root_prefix::parse_module_root_prefix;
 use super::ModuleSystem;
 
 mod stdlib_gates;
+mod stdlib_paths;
 
 use stdlib_gates::GatedStdlibModule;
+pub(super) use stdlib_paths::find_stdlib_root;
 
 impl ModuleSystem {
     /// Walk Import declarations in `program` and load their dependencies.
@@ -253,47 +255,6 @@ impl ModuleSystem {
         })
     }
 
-    pub(super) fn resolve_stdlib_file_path(
-        &self,
-        sub_path: &[String],
-    ) -> Result<Option<PathBuf>, Vec<CompileError>> {
-        let root = match &self.stdlib_root {
-            Some(r) => r.clone(),
-            None => {
-                return Err(vec![CompileError::Resolution(
-                    "stdlib not found".into(),
-                    None,
-                )]);
-            }
-        };
-
-        if sub_path.is_empty() {
-            return Ok(None);
-        }
-
-        let mut dir = root;
-        for seg in sub_path {
-            dir.push(seg);
-        }
-
-        let file_path = dir.with_extension("zen");
-        if file_path.exists() {
-            return Ok(Some(file_path));
-        }
-
-        let mod_path = dir.join("mod.zen");
-        if mod_path.exists() {
-            return Ok(Some(mod_path));
-        }
-
-        let parent_file = dir.with_extension("zen");
-        if parent_file.exists() {
-            return Ok(Some(parent_file));
-        }
-
-        Ok(None)
-    }
-
     pub(super) fn reject_gated_stdlib_module(
         &self,
         sub_path: &[String],
@@ -307,32 +268,4 @@ impl ModuleSystem {
         }
         Ok(())
     }
-}
-
-/// Find the stdlib root by looking for a `stdlib/` directory.
-pub(super) fn find_stdlib_root() -> Option<PathBuf> {
-    if let Ok(exe) = std::env::current_exe() {
-        if let Some(dir) = exe.parent() {
-            let stdlib = dir.join("stdlib");
-            if stdlib.is_dir() {
-                return Some(stdlib);
-            }
-            if let Some(parent) = dir.parent() {
-                if let Some(grandparent) = parent.parent() {
-                    let stdlib = grandparent.join("stdlib");
-                    if stdlib.is_dir() {
-                        return Some(stdlib);
-                    }
-                }
-            }
-        }
-    }
-
-    let cwd = std::env::current_dir().ok()?;
-    let stdlib = cwd.join("stdlib");
-    if stdlib.is_dir() {
-        return Some(stdlib);
-    }
-
-    None
 }

--- a/src/module_system/import_resolution/stdlib_paths.rs
+++ b/src/module_system/import_resolution/stdlib_paths.rs
@@ -1,0 +1,72 @@
+use super::*;
+
+impl ModuleSystem {
+    pub(in crate::module_system) fn resolve_stdlib_file_path(
+        &self,
+        sub_path: &[String],
+    ) -> Result<Option<PathBuf>, Vec<CompileError>> {
+        let root = match &self.stdlib_root {
+            Some(r) => r.clone(),
+            None => {
+                return Err(vec![CompileError::Resolution(
+                    "stdlib not found".into(),
+                    None,
+                )]);
+            }
+        };
+
+        if sub_path.is_empty() {
+            return Ok(None);
+        }
+
+        let mut dir = root;
+        for seg in sub_path {
+            dir.push(seg);
+        }
+
+        let file_path = dir.with_extension("zen");
+        if file_path.exists() {
+            return Ok(Some(file_path));
+        }
+
+        let mod_path = dir.join("mod.zen");
+        if mod_path.exists() {
+            return Ok(Some(mod_path));
+        }
+
+        let parent_file = dir.with_extension("zen");
+        if parent_file.exists() {
+            return Ok(Some(parent_file));
+        }
+
+        Ok(None)
+    }
+}
+
+/// Find the stdlib root by looking for a `stdlib/` directory.
+pub(in crate::module_system) fn find_stdlib_root() -> Option<PathBuf> {
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            let stdlib = dir.join("stdlib");
+            if stdlib.is_dir() {
+                return Some(stdlib);
+            }
+            if let Some(parent) = dir.parent() {
+                if let Some(grandparent) = parent.parent() {
+                    let stdlib = grandparent.join("stdlib");
+                    if stdlib.is_dir() {
+                        return Some(stdlib);
+                    }
+                }
+            }
+        }
+    }
+
+    let cwd = std::env::current_dir().ok()?;
+    let stdlib = cwd.join("stdlib");
+    if stdlib.is_dir() {
+        return Some(stdlib);
+    }
+
+    None
+}

--- a/tests/docs_truth/repo_hygiene/module_system.rs
+++ b/tests/docs_truth/repo_hygiene/module_system.rs
@@ -65,3 +65,25 @@ fn stdlib_import_gates_live_in_focused_helper() {
         );
     }
 }
+
+#[test]
+fn stdlib_path_resolution_lives_in_focused_helper() {
+    let import_resolution = read("src/module_system/import_resolution.rs");
+    let stdlib_paths = read("src/module_system/import_resolution/stdlib_paths.rs");
+
+    for helper in ["resolve_stdlib_file_path", "find_stdlib_root"] {
+        assert!(
+            !import_resolution.contains(&format!("fn {helper}")),
+            "import routing dispatcher should not own stdlib path helper: {helper}"
+        );
+        assert!(
+            stdlib_paths.contains(&format!("fn {helper}")),
+            "stdlib path helper should live in focused helper: {helper}"
+        );
+    }
+
+    assert!(
+        import_resolution.contains("mod stdlib_paths;"),
+        "import routing should load focused stdlib path helper"
+    );
+}


### PR DESCRIPTION
## Summary
- Move stdlib file/root path helpers into `src/module_system/import_resolution/stdlib_paths.rs`.
- Re-export `find_stdlib_root` through the import-resolution module for the existing module-system constructor path.
- Add a docs-truth guard so stdlib path helpers stay out of the import routing dispatcher.

## Test-first note
- Added `stdlib_path_resolution_lives_in_focused_helper` first and confirmed it failed because `stdlib_paths.rs` did not exist.
- Moved the path helpers after the failing guard was in place.

## Verification
- `cargo test --test docs_truth stdlib_path_resolution_lives_in_focused_helper -- --nocapture`
- `cargo test --lib module_system`
- `cargo test --test docs_truth -- --nocapture`
- `cargo test --test integration multi_file_imports -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `gh run list --branch codex/split-stdlib-path-resolution --event push --limit 10 --json databaseId,status,conclusion,workflowName,headSha,createdAt,url` returned `[]`