### PR TITLE
[codex] Compact Learn Zen guide

### DIFF
--- a/docs/learn_zen_in_y_minutes.md
+++ b/docs/learn_zen_in_y_minutes.md
@@ -12,26 +12,8 @@ actors, and comptime type matching.
 
 ## The Shape
 
-```zen
-{ io } = std
-
-Point: {
-    x: i32,
-    y: i32,
-}
-
-Point.sum = (self: Point) i32 {
-    self.x + self.y
-}
-
-main = () i32 {
-    point = Point { x: 20, y: 22 }
-    io.println("sum: ${point.sum()}")
-    0
-}
-```
-
-The name being introduced or changed comes first:
+Declarations are prefix-first. The name being introduced or changed comes
+first:
 
 | Need | Spell it like this |
 | --- | --- |
@@ -100,41 +82,13 @@ image.
 
 ## Dynamic String Preview
 
-`String<A>` is preview syntax for owned runtime text. It is different from
-`StaticString` because it has memory that can grow or be released, so the owner
-must carry allocator state.
-
-```zen
-String<A>: {
-    ptr: RawPtr<u8>,
-    len: usize,
-    capacity: usize,
-    allocator: A,
-}
-```
+`String<A>` is preview syntax for owned runtime text. It has memory that can
+grow or be released, so the owner must carry allocator state.
 
 A literal such as `"Zen"` never silently becomes `String<A>`. Runtime text
 construction belongs on an allocator-aware API.
 
 ## Calls, Structs, And Data
-
-```zen
-Point: {
-    x: i32,
-    y: i32,
-}
-
-Point.sum = (self: Point) i32 {
-    self.x + self.y
-}
-
-main = () i32 {
-    point = Point { x: 20, y: 22 }
-    dot = point.sum()
-    ufc = sum(point)
-    dot + ufc
-}
-```
 
 `value.method(args)` and `method(value, args)` are call-site spellings for the
 same attached function. They are not alternate declaration forms. Struct
@@ -279,27 +233,9 @@ the loop and are read after `done`.
 
 ## Defer
 
-```zen
-{ io } = std
-
-main = () i32 {
-    @this.defer(io.println("leaving main"))
-    io.println("inside main")
-    0
-}
-```
-
 `defer` runs cleanup expressions before leaving the current scope.
 
 ## Imports And Modules
-
-```zen
-{ clamp, factorial } = math_utils
-
-main = () i32 {
-    clamp(factorial(4), 0, 100)
-}
-```
 
 Imports use destructuring-style binding from a module path. Local files import
 by module name, and dotted paths resolve through subdirectories.
@@ -378,14 +314,9 @@ Buffer<T, A: Allocator<T, Sync>>: {
 
 make_buffer<T, A: Allocator<T, Sync>> = (allocator: A, len: usize) Result<Buffer<T, A>, AllocError> {
     allocator.alloc(len) ?
-        | Ok(ptr) {
-            Result<Buffer<T, A>, AllocError>.Ok(Buffer<T, A> {
-                ptr: ptr,
-                len: len,
-                capacity: len,
-                allocator: allocator,
-            })
-        }
+        | Ok(ptr) { Result<Buffer<T, A>, AllocError>.Ok(Buffer<T, A> {
+            ptr: ptr, len: len, capacity: len, allocator: allocator,
+        }) }
         | Err(error) {
             Result<Buffer<T, A>, AllocError>.Err(error)
         }
@@ -397,16 +328,6 @@ Raw allocation intrinsics such as `@builtin.raw_allocate`,
 preview names. Stable source should not call them directly.
 
 ## Pointer, Slice, Array, Actor, And Comptime Preview
-
-```zen
-PointerViews: {
-    raw: RawPtr<i32>,
-    pointer: Ptr<i32>,
-    mutable_pointer: MutPtr<i32>,
-    slice: Slice<i32>,
-    fixed: [i32; 4],
-}
-```
 
 `RawPtr<T>` is the explicit raw-memory spelling used in allocator previews.
 `Ptr<T>`, `MutPtr<T>`, `Slice<T>`, and `[T; N]` name pointer, mutable pointer,
@@ -450,9 +371,7 @@ Point.sum = (self: Point) i32 {
 }
 
 Point.implements(Display) {
-    display = (self: Point) StaticString {
-        "Point"
-    }
+    display = (self: Point) StaticString { "Point" }
 }
 
 sum_to = (limit: i32) i32 {
@@ -478,9 +397,7 @@ show<T: Display> = (value: T) StaticString {
 
 main = () i32 {
     point = Point { x: 20, y: 22 }
-    name: StaticString = show(point)
-
-    io.println("${name}: ${point.sum()}")
+    io.println("${show(point)}: ${point.sum()}")
     sum_to(10)
 }
 ```

--- a/tests/docs_truth/public_docs/learn_zen.rs
+++ b/tests/docs_truth/public_docs/learn_zen.rs
@@ -109,7 +109,7 @@ fn learn_zen_guide_covers_core_tour_and_gated_previews() {
     }
 
     assert!(
-        guide.lines().count() <= 500,
+        guide.lines().count() <= 430,
         "Learn guide should stay compact; move detailed status or evidence to phase docs and tests"
     );
 }


### PR DESCRIPTION
## What changed

- Compacted `docs/learn_zen_in_y_minutes.md` from 498 lines to 415 lines.
- Removed repeated tutorial snippets while keeping the canonical examples for final expressions, `StaticString`, loop handles, behaviors, sync/async allocator previews, and gated memory/runtime surfaces.
- Tightened the public-docs compactness guard from 500 lines to 430 lines so the guide cannot drift back to the edge of the old limit.

## Validation

- `cargo test --test docs_truth learn_zen_guide_covers_core_tour_and_gated_previews -- --nocapture` failed first with the tightened guard.
- `cargo test --test docs_truth -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

## Workflow check

- `gh run list --branch codex/compact-learn-zen-guide --event push --limit 10 --json databaseId,status,conclusion,workflowName,headSha,createdAt,url` returned `[]`, so the branch push did not trigger push-event Actions.