### PR TITLE
Split C memory intrinsic lowering

### DIFF
--- a/src/codegen/c/intrinsics.rs
+++ b/src/codegen/c/intrinsics.rs
@@ -1,6 +1,7 @@
 use super::*;
 use names::CIntrinsic;
 
+mod memory;
 mod names;
 mod syscalls;
 
@@ -18,85 +19,14 @@ impl CEmitter {
             return "(void)0".into();
         };
 
+        if intrinsic.is_syscall() {
+            return intrinsic.emit_syscall(self, args);
+        }
+        if let Some(emitted) = intrinsic.emit_memory(self, args, result_ty) {
+            return emitted;
+        }
+
         match intrinsic {
-            _ if intrinsic.is_syscall() => intrinsic.emit_syscall(self, args),
-
-            // -- Memory allocation ----------------------------------------
-            CIntrinsic::RawAllocate => {
-                let size = self.emit_expr_inline(&args[0]);
-                format!("malloc({})", size)
-            }
-            CIntrinsic::RawDeallocate => {
-                let ptr = self.emit_expr_inline(&args[0]);
-                format!("free({})", ptr)
-            }
-            CIntrinsic::RawReallocate => {
-                let ptr = self.emit_expr_inline(&args[0]);
-                let new_size = self.emit_expr_inline(&args[2]);
-                format!("realloc({}, {})", ptr, new_size)
-            }
-
-            // -- Memory operations ----------------------------------------
-            CIntrinsic::Memcpy => {
-                let dest = self.emit_expr_inline(&args[0]);
-                let src = self.emit_expr_inline(&args[1]);
-                let n = self.emit_expr_inline(&args[2]);
-                format!("memcpy({}, {}, {})", dest, src, n)
-            }
-            CIntrinsic::Memmove => {
-                let dest = self.emit_expr_inline(&args[0]);
-                let src = self.emit_expr_inline(&args[1]);
-                let n = self.emit_expr_inline(&args[2]);
-                format!("memmove({}, {}, {})", dest, src, n)
-            }
-            CIntrinsic::Memset => {
-                let dest = self.emit_expr_inline(&args[0]);
-                let val = self.emit_expr_inline(&args[1]);
-                let n = self.emit_expr_inline(&args[2]);
-                format!("memset({}, {}, {})", dest, val, n)
-            }
-            CIntrinsic::Memcmp => {
-                let a = self.emit_expr_inline(&args[0]);
-                let b = self.emit_expr_inline(&args[1]);
-                let n = self.emit_expr_inline(&args[2]);
-                format!("memcmp({}, {}, {})", a, b, n)
-            }
-
-            // -- Load / Store ---------------------------------------------
-            CIntrinsic::Load => {
-                let ptr = self.emit_expr_inline(&args[0]);
-                let ty = self.c_type(result_ty);
-                format!("(*(({}*)({})))", ty, ptr)
-            }
-            CIntrinsic::Store => {
-                let ptr = self.emit_expr_inline(&args[0]);
-                let val = self.emit_expr_inline(&args[1]);
-                let ty = self.c_type(&args[1].ty);
-                format!("(*(({}*)({})) = ({}))", ty, ptr, val)
-            }
-
-            // -- Type introspection ---------------------------------------
-            CIntrinsic::Sizeof => {
-                if !args.is_empty() {
-                    let ty = self.c_type(&args[0].ty);
-                    format!("sizeof({})", ty)
-                } else {
-                    // sizeof<T>() with no runtime args — typechecker should
-                    // have resolved this to a constant before reaching codegen.
-                    self.line("#error \"sizeof intrinsic reached codegen without type arg\"");
-                    "0".into()
-                }
-            }
-            CIntrinsic::Alignof => {
-                if !args.is_empty() {
-                    let ty = self.c_type(&args[0].ty);
-                    format!("_Alignof({})", ty)
-                } else {
-                    self.line("#error \"alignof intrinsic reached codegen without type arg\"");
-                    "0".into()
-                }
-            }
-
             // -- Pointer operations ---------------------------------------
             CIntrinsic::IntToPtr => {
                 let val = self.emit_expr_inline(&args[0]);

--- a/src/codegen/c/intrinsics/memory.rs
+++ b/src/codegen/c/intrinsics/memory.rs
@@ -1,0 +1,80 @@
+use super::*;
+
+impl CIntrinsic {
+    pub(super) fn emit_memory(
+        self,
+        emitter: &mut CEmitter,
+        args: &[TypedExpression],
+        result_ty: &Type,
+    ) -> Option<String> {
+        match self {
+            CIntrinsic::RawAllocate => {
+                let size = emitter.emit_expr_inline(&args[0]);
+                Some(format!("malloc({})", size))
+            }
+            CIntrinsic::RawDeallocate => {
+                let ptr = emitter.emit_expr_inline(&args[0]);
+                Some(format!("free({})", ptr))
+            }
+            CIntrinsic::RawReallocate => {
+                let ptr = emitter.emit_expr_inline(&args[0]);
+                let new_size = emitter.emit_expr_inline(&args[2]);
+                Some(format!("realloc({}, {})", ptr, new_size))
+            }
+            CIntrinsic::Memcpy => {
+                let dest = emitter.emit_expr_inline(&args[0]);
+                let src = emitter.emit_expr_inline(&args[1]);
+                let n = emitter.emit_expr_inline(&args[2]);
+                Some(format!("memcpy({}, {}, {})", dest, src, n))
+            }
+            CIntrinsic::Memmove => {
+                let dest = emitter.emit_expr_inline(&args[0]);
+                let src = emitter.emit_expr_inline(&args[1]);
+                let n = emitter.emit_expr_inline(&args[2]);
+                Some(format!("memmove({}, {}, {})", dest, src, n))
+            }
+            CIntrinsic::Memset => {
+                let dest = emitter.emit_expr_inline(&args[0]);
+                let val = emitter.emit_expr_inline(&args[1]);
+                let n = emitter.emit_expr_inline(&args[2]);
+                Some(format!("memset({}, {}, {})", dest, val, n))
+            }
+            CIntrinsic::Memcmp => {
+                let a = emitter.emit_expr_inline(&args[0]);
+                let b = emitter.emit_expr_inline(&args[1]);
+                let n = emitter.emit_expr_inline(&args[2]);
+                Some(format!("memcmp({}, {}, {})", a, b, n))
+            }
+            CIntrinsic::Load => {
+                let ptr = emitter.emit_expr_inline(&args[0]);
+                let ty = emitter.c_type(result_ty);
+                Some(format!("(*(({}*)({})))", ty, ptr))
+            }
+            CIntrinsic::Store => {
+                let ptr = emitter.emit_expr_inline(&args[0]);
+                let val = emitter.emit_expr_inline(&args[1]);
+                let ty = emitter.c_type(&args[1].ty);
+                Some(format!("(*(({}*)({})) = ({}))", ty, ptr, val))
+            }
+            CIntrinsic::Sizeof => {
+                if !args.is_empty() {
+                    let ty = emitter.c_type(&args[0].ty);
+                    Some(format!("sizeof({})", ty))
+                } else {
+                    emitter.line("#error \"sizeof intrinsic reached codegen without type arg\"");
+                    Some("0".into())
+                }
+            }
+            CIntrinsic::Alignof => {
+                if !args.is_empty() {
+                    let ty = emitter.c_type(&args[0].ty);
+                    Some(format!("_Alignof({})", ty))
+                } else {
+                    emitter.line("#error \"alignof intrinsic reached codegen without type arg\"");
+                    Some("0".into())
+                }
+            }
+            _ => None,
+        }
+    }
+}

--- a/tests/docs_truth/repo_hygiene/parser_enums/codegen_and_tools.rs
+++ b/tests/docs_truth/repo_hygiene/parser_enums/codegen_and_tools.rs
@@ -87,6 +87,44 @@ fn codegen_c_syscall_intrinsics_live_in_focused_helper() {
 }
 
 #[test]
+fn codegen_c_memory_intrinsics_live_in_focused_helper() {
+    let lowering = read("src/codegen/c/intrinsics.rs");
+    let memory = read("src/codegen/c/intrinsics/memory.rs");
+
+    for memory_variant in [
+        "CIntrinsic::RawAllocate =>",
+        "CIntrinsic::RawDeallocate =>",
+        "CIntrinsic::RawReallocate =>",
+        "CIntrinsic::Memcpy =>",
+        "CIntrinsic::Memmove =>",
+        "CIntrinsic::Memset =>",
+        "CIntrinsic::Memcmp =>",
+        "CIntrinsic::Load =>",
+        "CIntrinsic::Store =>",
+        "CIntrinsic::Sizeof =>",
+        "CIntrinsic::Alignof =>",
+    ] {
+        assert!(
+            !lowering.contains(memory_variant),
+            "main C intrinsic dispatcher should route memory lowering to a focused helper: {memory_variant}"
+        );
+        assert!(
+            memory.contains(memory_variant),
+            "C memory intrinsic lowering should live in the focused memory helper: {memory_variant}"
+        );
+    }
+
+    assert!(
+        lowering.contains("intrinsic.emit_memory(self, args, result_ty)"),
+        "main C intrinsic dispatcher should delegate memory lowering through CIntrinsic"
+    );
+    assert!(
+        memory.contains("pub(super) fn emit_memory"),
+        "memory helper should own the C memory lowering entry point"
+    );
+}
+
+#[test]
 fn build_graph_host_effect_methods_parse_dsl_ident_enum() {
     let lowering = read("src/build_graph/lowering.rs");
     let dsl = read("src/build_graph/lowering/dsl.rs");


### PR DESCRIPTION
## What changed

- Moved allocation, byte-memory, load/store, and sizeof/alignof C intrinsic lowering into `src/codegen/c/intrinsics/memory.rs`.
- Left the main C intrinsic dispatcher to route syscall and memory categories before handling the remaining intrinsic families.
- Added a docs-truth repo-hygiene guard so memory-related C intrinsic match arms stay out of the main dispatcher.

## Validation

TDD first:

- `cargo test --test docs_truth codegen_c_memory_intrinsics_live_in_focused_helper -- --nocapture` failed before implementation because `src/codegen/c/intrinsics/memory.rs` did not exist.

After implementation:

- `cargo test --test docs_truth codegen_c_memory_intrinsics_live_in_focused_helper -- --nocapture`
- `cargo test --test docs_truth codegen_c_intrinsics -- --nocapture`
- `cargo test --lib codegen::c -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

## Workflow check

- `gh run list --branch codex/split-codegen-c-memory-intrinsics --event push --limit 10 --json databaseId,status,conclusion,workflowName,headSha,createdAt,url` returned `[]`, so the branch push did not trigger push-event Actions.