### PR TITLE
Split resolver expression traversal

### DIFF
--- a/src/resolver/expression_validation.rs
+++ b/src/resolver/expression_validation.rs
@@ -1,4 +1,4 @@
-use crate::ast::{Expression, StringPart, TypeParam};
+use crate::ast::{Expression, TypeParam};
 use crate::error::Diagnostic;
 
 use super::expression_validation_constructs::{
@@ -8,7 +8,9 @@ use super::symbol_table::ScopeStack;
 use super::{Resolver, SymbolTable};
 
 mod calls;
+mod traversal;
 use calls::{FunctionCallRef, MethodCallRef};
+use traversal::{BinaryExprRef, IfOrWhileExprRef, IndexExprRef, RangeExprRef};
 
 impl Resolver {
     pub(super) fn validate_expr_refs(
@@ -68,18 +70,10 @@ impl Resolver {
                 );
             }
             Expression::BinaryOp { left, right, .. } => {
-                self.validate_expr_refs(
+                self.validate_binary_expr_refs(
                     table,
                     type_params,
-                    left,
-                    locals,
-                    allow_self_type,
-                    diagnostics,
-                );
-                self.validate_expr_refs(
-                    table,
-                    type_params,
-                    right,
+                    BinaryExprRef { left, right },
                     locals,
                     allow_self_type,
                     diagnostics,
@@ -89,7 +83,7 @@ impl Resolver {
             | Expression::MemberAccess {
                 object: operand, ..
             } => {
-                self.validate_expr_refs(
+                self.validate_unary_expr_refs(
                     table,
                     type_params,
                     operand,
@@ -99,18 +93,10 @@ impl Resolver {
                 );
             }
             Expression::IndexAccess { object, index, .. } => {
-                self.validate_expr_refs(
+                self.validate_index_expr_refs(
                     table,
                     type_params,
-                    object,
-                    locals,
-                    allow_self_type,
-                    diagnostics,
-                );
-                self.validate_expr_refs(
-                    table,
-                    type_params,
-                    index,
+                    IndexExprRef { object, index },
                     locals,
                     allow_self_type,
                     diagnostics,
@@ -198,36 +184,22 @@ impl Resolver {
                 then_body: body,
                 ..
             } => {
-                self.validate_expr_refs(
+                let else_body = match expr {
+                    Expression::If { else_body, .. } => else_body.as_deref(),
+                    _ => None,
+                };
+                self.validate_if_or_while_expr_refs(
                     table,
                     type_params,
-                    condition,
-                    locals,
-                    allow_self_type,
-                    diagnostics,
-                );
-                self.validate_child_scope_expr_refs(
-                    table,
-                    type_params,
-                    body,
-                    locals,
-                    allow_self_type,
-                    diagnostics,
-                );
-                if let Expression::If {
-                    else_body: Some(else_body),
-                    ..
-                } = expr
-                {
-                    self.validate_child_scope_expr_refs(
-                        table,
-                        type_params,
+                    IfOrWhileExprRef {
+                        condition,
+                        body,
                         else_body,
-                        locals,
-                        allow_self_type,
-                        diagnostics,
-                    );
-                }
+                    },
+                    locals,
+                    allow_self_type,
+                    diagnostics,
+                );
             }
             Expression::Loop { body, .. } => {
                 self.validate_child_scope_expr_refs(
@@ -297,39 +269,27 @@ impl Resolver {
                 );
             }
             Expression::StringInterpolation { parts, .. } => {
-                for part in parts {
-                    if let StringPart::Expr(expr) = part {
-                        self.validate_expr_refs(
-                            table,
-                            type_params,
-                            expr,
-                            locals,
-                            allow_self_type,
-                            diagnostics,
-                        );
-                    }
-                }
-            }
-            Expression::Range { start, end, .. } => {
-                self.validate_expr_refs(
+                self.validate_string_interpolation_refs(
                     table,
                     type_params,
-                    start,
+                    parts,
                     locals,
                     allow_self_type,
                     diagnostics,
                 );
-                self.validate_expr_refs(
+            }
+            Expression::Range { start, end, .. } => {
+                self.validate_range_expr_refs(
                     table,
                     type_params,
-                    end,
+                    RangeExprRef { start, end },
                     locals,
                     allow_self_type,
                     diagnostics,
                 );
             }
             Expression::Defer { expr, .. } => {
-                self.validate_expr_refs(
+                self.validate_defer_expr_refs(
                     table,
                     type_params,
                     expr,

--- a/src/resolver/expression_validation/traversal.rs
+++ b/src/resolver/expression_validation/traversal.rs
@@ -1,0 +1,206 @@
+use crate::ast::{Expression, StringPart, TypeParam};
+use crate::error::Diagnostic;
+
+use super::*;
+
+pub(super) struct BinaryExprRef<'a> {
+    pub(super) left: &'a Expression,
+    pub(super) right: &'a Expression,
+}
+
+pub(super) struct IndexExprRef<'a> {
+    pub(super) object: &'a Expression,
+    pub(super) index: &'a Expression,
+}
+
+pub(super) struct IfOrWhileExprRef<'a> {
+    pub(super) condition: &'a Expression,
+    pub(super) body: &'a Expression,
+    pub(super) else_body: Option<&'a Expression>,
+}
+
+pub(super) struct RangeExprRef<'a> {
+    pub(super) start: &'a Expression,
+    pub(super) end: &'a Expression,
+}
+
+impl Resolver {
+    pub(super) fn validate_binary_expr_refs(
+        &self,
+        table: &mut SymbolTable,
+        type_params: &[TypeParam],
+        expr: BinaryExprRef<'_>,
+        locals: &mut ScopeStack,
+        allow_self_type: bool,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        self.validate_expr_refs(
+            table,
+            type_params,
+            expr.left,
+            locals,
+            allow_self_type,
+            diagnostics,
+        );
+        self.validate_expr_refs(
+            table,
+            type_params,
+            expr.right,
+            locals,
+            allow_self_type,
+            diagnostics,
+        );
+    }
+
+    pub(super) fn validate_unary_expr_refs(
+        &self,
+        table: &mut SymbolTable,
+        type_params: &[TypeParam],
+        operand: &Expression,
+        locals: &mut ScopeStack,
+        allow_self_type: bool,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        self.validate_expr_refs(
+            table,
+            type_params,
+            operand,
+            locals,
+            allow_self_type,
+            diagnostics,
+        );
+    }
+
+    pub(super) fn validate_index_expr_refs(
+        &self,
+        table: &mut SymbolTable,
+        type_params: &[TypeParam],
+        expr: IndexExprRef<'_>,
+        locals: &mut ScopeStack,
+        allow_self_type: bool,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        self.validate_expr_refs(
+            table,
+            type_params,
+            expr.object,
+            locals,
+            allow_self_type,
+            diagnostics,
+        );
+        self.validate_expr_refs(
+            table,
+            type_params,
+            expr.index,
+            locals,
+            allow_self_type,
+            diagnostics,
+        );
+    }
+
+    pub(super) fn validate_if_or_while_expr_refs(
+        &self,
+        table: &mut SymbolTable,
+        type_params: &[TypeParam],
+        expr: IfOrWhileExprRef<'_>,
+        locals: &mut ScopeStack,
+        allow_self_type: bool,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        self.validate_expr_refs(
+            table,
+            type_params,
+            expr.condition,
+            locals,
+            allow_self_type,
+            diagnostics,
+        );
+        self.validate_child_scope_expr_refs(
+            table,
+            type_params,
+            expr.body,
+            locals,
+            allow_self_type,
+            diagnostics,
+        );
+        if let Some(else_body) = expr.else_body {
+            self.validate_child_scope_expr_refs(
+                table,
+                type_params,
+                else_body,
+                locals,
+                allow_self_type,
+                diagnostics,
+            );
+        }
+    }
+
+    pub(super) fn validate_string_interpolation_refs(
+        &self,
+        table: &mut SymbolTable,
+        type_params: &[TypeParam],
+        parts: &[StringPart],
+        locals: &mut ScopeStack,
+        allow_self_type: bool,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        for part in parts {
+            if let StringPart::Expr(expr) = part {
+                self.validate_expr_refs(
+                    table,
+                    type_params,
+                    expr,
+                    locals,
+                    allow_self_type,
+                    diagnostics,
+                );
+            }
+        }
+    }
+
+    pub(super) fn validate_range_expr_refs(
+        &self,
+        table: &mut SymbolTable,
+        type_params: &[TypeParam],
+        expr: RangeExprRef<'_>,
+        locals: &mut ScopeStack,
+        allow_self_type: bool,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        self.validate_expr_refs(
+            table,
+            type_params,
+            expr.start,
+            locals,
+            allow_self_type,
+            diagnostics,
+        );
+        self.validate_expr_refs(
+            table,
+            type_params,
+            expr.end,
+            locals,
+            allow_self_type,
+            diagnostics,
+        );
+    }
+
+    pub(super) fn validate_defer_expr_refs(
+        &self,
+        table: &mut SymbolTable,
+        type_params: &[TypeParam],
+        expr: &Expression,
+        locals: &mut ScopeStack,
+        allow_self_type: bool,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        self.validate_expr_refs(
+            table,
+            type_params,
+            expr,
+            locals,
+            allow_self_type,
+            diagnostics,
+        );
+    }
+}

--- a/tests/docs_truth/repo_hygiene/resolver_expression_validation.rs
+++ b/tests/docs_truth/repo_hygiene/resolver_expression_validation.rs
@@ -54,3 +54,33 @@ fn resolver_call_expression_validation_lives_in_focused_helper() {
         "resolver expression validation should load focused call validation"
     );
 }
+
+#[test]
+fn resolver_expression_traversal_lives_in_focused_helper() {
+    let validation = read("src/resolver/expression_validation.rs");
+    let traversal = read("src/resolver/expression_validation/traversal.rs");
+
+    for helper in [
+        "validate_binary_expr_refs",
+        "validate_unary_expr_refs",
+        "validate_index_expr_refs",
+        "validate_if_or_while_expr_refs",
+        "validate_string_interpolation_refs",
+        "validate_range_expr_refs",
+        "validate_defer_expr_refs",
+    ] {
+        assert!(
+            !validation.contains(&format!("fn {helper}")),
+            "resolver expression dispatch should not own traversal helper: {helper}"
+        );
+        assert!(
+            traversal.contains(&format!("fn {helper}")),
+            "resolver expression traversal should live in focused helper: {helper}"
+        );
+    }
+
+    assert!(
+        validation.contains("mod traversal;"),
+        "resolver expression validation should load focused traversal validation"
+    );
+}


### PR DESCRIPTION
## Summary
- Move repeated resolver expression traversal helpers into `src/resolver/expression_validation/traversal.rs`.
- Keep `expression_validation.rs` focused on dispatch and specialized validation paths.
- Add a docs-truth repo hygiene guard so traversal helpers stay in the focused module.

## TDD
- First ran `cargo test --test docs_truth resolver_expression_traversal_lives_in_focused_helper -- --nocapture`; it failed because `src/resolver/expression_validation/traversal.rs` did not exist yet.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --test docs_truth -- --nocapture`
- `cargo test --tests`
- Push-triggered Actions check: `gh run list --branch codex/split-resolver-expression-traversal --event push --limit 10 --json databaseId,status,conclusion,workflowName,headSha,createdAt,url` returned `[]`.