### PR TITLE
Split resolver pattern local traversal

### DIFF
--- a/src/typechecker/resolver_validation.rs
+++ b/src/typechecker/resolver_validation.rs
@@ -13,6 +13,7 @@ include!("resolver_validation/imports_behavior_dependencies.rs");
 include!("resolver_validation/imports_source_dependencies.rs");
 include!("resolver_validation/symbols_locals.rs");
 include!("resolver_validation/local_traversal.rs");
+include!("resolver_validation/pattern_locals.rs");
 include!("resolver_validation/metadata_core.rs");
 include!("resolver_validation/metadata_diagnostics.rs");
 include!("resolver_validation/metadata_types.rs");

--- a/src/typechecker/resolver_validation/local_traversal.rs
+++ b/src/typechecker/resolver_validation/local_traversal.rs
@@ -27,19 +27,6 @@ impl TypeChecker {
         self.require_resolver_expr_locals(symbols, expr, scope_cursor, &mut child_locals);
     }
 
-    fn require_resolver_pattern_expr_locals(
-        &mut self,
-        symbols: &SymbolTable,
-        pattern: &ast::Pattern,
-        expr: &Expression,
-        scope_cursor: &mut ResolverScopeCursor,
-        locals: &ResolverLocalScope,
-    ) {
-        let mut pattern_locals = scope_cursor.child_scope(locals);
-        self.require_resolver_pattern_locals(symbols, pattern, scope_cursor, &mut pattern_locals);
-        self.require_resolver_expr_locals(symbols, expr, scope_cursor, &mut pattern_locals);
-    }
-
     fn require_resolver_block_locals(
         &mut self,
         symbols: &SymbolTable,
@@ -263,64 +250,4 @@ impl TypeChecker {
         locals.insert(name.to_string(), mutable);
     }
 
-    fn require_resolver_pattern_locals(
-        &mut self,
-        symbols: &SymbolTable,
-        pattern: &ast::Pattern,
-        scope_cursor: &mut ResolverScopeCursor,
-        locals: &mut ResolverLocalScope,
-    ) {
-        match pattern {
-            ast::Pattern::Identifier { name, span } => {
-                self.require_resolver_pattern_binding(symbols, name, *span, locals);
-            }
-            ast::Pattern::Struct { fields, span, .. } => {
-                for (name, nested) in fields {
-                    if let Some(nested) = nested {
-                        self.require_resolver_pattern_locals(symbols, nested, scope_cursor, locals);
-                    } else {
-                        self.require_resolver_pattern_binding(symbols, name, *span, locals);
-                    }
-                }
-            }
-            ast::Pattern::Enum {
-                payload: Some(payload),
-                ..
-            } => {
-                self.require_resolver_pattern_locals(symbols, payload, scope_cursor, locals);
-            }
-            ast::Pattern::Or { patterns, .. } => {
-                for pattern in patterns {
-                    self.require_resolver_pattern_locals(symbols, pattern, scope_cursor, locals);
-                }
-            }
-            ast::Pattern::Literal { value, .. } => {
-                self.require_resolver_expr_locals(symbols, value, scope_cursor, locals);
-            }
-            ast::Pattern::Range { start, end, .. } => {
-                self.require_resolver_expr_locals(symbols, start, scope_cursor, locals);
-                self.require_resolver_expr_locals(symbols, end, scope_cursor, locals);
-            }
-            ast::Pattern::Wildcard { .. }
-            | ast::Pattern::Enum { payload: None, .. }
-            | ast::Pattern::BoolTrue { .. }
-            | ast::Pattern::BoolFalse { .. } => {}
-        }
-    }
-
-    fn require_resolver_pattern_binding(
-        &mut self,
-        symbols: &SymbolTable,
-        name: &str,
-        span: Span,
-        locals: &mut ResolverLocalScope,
-    ) {
-        self.require_resolver_local_symbol(
-            symbols,
-            name,
-            expected_local_symbol(false, locals.current_scope_id),
-            span,
-        );
-        locals.insert(name.to_string(), false);
-    }
 }

--- a/src/typechecker/resolver_validation/pattern_locals.rs
+++ b/src/typechecker/resolver_validation/pattern_locals.rs
@@ -1,0 +1,75 @@
+impl TypeChecker {
+    fn require_resolver_pattern_expr_locals(
+        &mut self,
+        symbols: &SymbolTable,
+        pattern: &ast::Pattern,
+        expr: &Expression,
+        scope_cursor: &mut ResolverScopeCursor,
+        locals: &ResolverLocalScope,
+    ) {
+        let mut pattern_locals = scope_cursor.child_scope(locals);
+        self.require_resolver_pattern_locals(symbols, pattern, scope_cursor, &mut pattern_locals);
+        self.require_resolver_expr_locals(symbols, expr, scope_cursor, &mut pattern_locals);
+    }
+
+    fn require_resolver_pattern_locals(
+        &mut self,
+        symbols: &SymbolTable,
+        pattern: &ast::Pattern,
+        scope_cursor: &mut ResolverScopeCursor,
+        locals: &mut ResolverLocalScope,
+    ) {
+        match pattern {
+            ast::Pattern::Identifier { name, span } => {
+                self.require_resolver_pattern_binding(symbols, name, *span, locals);
+            }
+            ast::Pattern::Struct { fields, span, .. } => {
+                for (name, nested) in fields {
+                    if let Some(nested) = nested {
+                        self.require_resolver_pattern_locals(symbols, nested, scope_cursor, locals);
+                    } else {
+                        self.require_resolver_pattern_binding(symbols, name, *span, locals);
+                    }
+                }
+            }
+            ast::Pattern::Enum {
+                payload: Some(payload),
+                ..
+            } => {
+                self.require_resolver_pattern_locals(symbols, payload, scope_cursor, locals);
+            }
+            ast::Pattern::Or { patterns, .. } => {
+                for pattern in patterns {
+                    self.require_resolver_pattern_locals(symbols, pattern, scope_cursor, locals);
+                }
+            }
+            ast::Pattern::Literal { value, .. } => {
+                self.require_resolver_expr_locals(symbols, value, scope_cursor, locals);
+            }
+            ast::Pattern::Range { start, end, .. } => {
+                self.require_resolver_expr_locals(symbols, start, scope_cursor, locals);
+                self.require_resolver_expr_locals(symbols, end, scope_cursor, locals);
+            }
+            ast::Pattern::Wildcard { .. }
+            | ast::Pattern::Enum { payload: None, .. }
+            | ast::Pattern::BoolTrue { .. }
+            | ast::Pattern::BoolFalse { .. } => {}
+        }
+    }
+
+    fn require_resolver_pattern_binding(
+        &mut self,
+        symbols: &SymbolTable,
+        name: &str,
+        span: Span,
+        locals: &mut ResolverLocalScope,
+    ) {
+        self.require_resolver_local_symbol(
+            symbols,
+            name,
+            expected_local_symbol(false, locals.current_scope_id),
+            span,
+        );
+        locals.insert(name.to_string(), false);
+    }
+}

--- a/tests/docs_truth/repo_hygiene/typechecker_resolver_validation.rs
+++ b/tests/docs_truth/repo_hygiene/typechecker_resolver_validation.rs
@@ -56,3 +56,30 @@ fn typechecker_resolver_expected_value_symbols_live_in_focused_helper() {
         "resolver validation support should include focused expected value-symbol helpers"
     );
 }
+
+#[test]
+fn typechecker_resolver_pattern_local_traversal_lives_in_focused_helper() {
+    let traversal = read("src/typechecker/resolver_validation/local_traversal.rs");
+    let patterns = read("src/typechecker/resolver_validation/pattern_locals.rs");
+
+    for helper in [
+        "require_resolver_pattern_expr_locals",
+        "require_resolver_pattern_locals",
+        "require_resolver_pattern_binding",
+    ] {
+        assert!(
+            !traversal.contains(&format!("fn {helper}")),
+            "resolver local traversal should not own pattern-local helper: {helper}"
+        );
+        assert!(
+            patterns.contains(&format!("fn {helper}")),
+            "resolver pattern-local traversal should live in focused helper: {helper}"
+        );
+    }
+
+    let root = read("src/typechecker/resolver_validation.rs");
+    assert!(
+        root.contains("include!(\"resolver_validation/pattern_locals.rs\");"),
+        "resolver validation should include focused pattern-local traversal"
+    );
+}


### PR DESCRIPTION
## Summary
- Move resolver pattern-local traversal helpers into `src/typechecker/resolver_validation/pattern_locals.rs`.
- Keep `local_traversal.rs` focused on expression, statement, block, and closure local traversal; it drops from 326 to 253 lines.
- Add a docs-truth guard for the new pattern-local traversal boundary.

## TDD
- First added `typechecker_resolver_pattern_local_traversal_lives_in_focused_helper` and ran `cargo test --test docs_truth typechecker_resolver_pattern_local_traversal_lives_in_focused_helper -- --nocapture`; it failed because `src/typechecker/resolver_validation/pattern_locals.rs` did not exist yet.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --test docs_truth -- --nocapture`
- `cargo test --tests`
- Push-triggered Actions check: `gh run list --branch codex/split-resolver-pattern-locals --event push --limit 10 --json databaseId,status,conclusion,workflowName,headSha,createdAt,url` returned `[]`.