### PR TITLE
Split resolver expected formatting

### DIFF
--- a/src/typechecker/resolver_validation_support.rs
+++ b/src/typechecker/resolver_validation_support.rs
@@ -14,4 +14,5 @@ include!("resolver_validation_support/behavior_type_helpers.rs");
 include!("resolver_validation_support/behavior_refs.rs");
 include!("resolver_validation_support/expected_locals.rs");
 include!("resolver_validation_support/expected_local_traversal.rs");
+include!("resolver_validation_support/expected_formatting.rs");
 include!("resolver_validation_support/expected_helpers.rs");

--- a/src/typechecker/resolver_validation_support/expected_formatting.rs
+++ b/src/typechecker/resolver_validation_support/expected_formatting.rs
@@ -1,0 +1,182 @@
+fn visibility_name(is_public: bool) -> &'static str {
+    if is_public {
+        "public"
+    } else {
+        "private"
+    }
+}
+
+fn mutability_name(is_mutable: Option<bool>) -> &'static str {
+    match is_mutable {
+        Some(true) => "mutable",
+        Some(false) => "immutable",
+        None => "unknown",
+    }
+}
+
+fn resolver_count_display(count: Option<usize>) -> String {
+    count
+        .map(|count| count.to_string())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn resolver_metadata_display(value: Option<&str>) -> &str {
+    value.unwrap_or("unknown")
+}
+
+fn resolver_ast_type_metadata_display(value: Option<&AstType>) -> String {
+    optional_ast_type_display(value, "unknown")
+}
+
+fn optional_ast_type_display(value: Option<&AstType>, missing: &str) -> String {
+    value
+        .map(AstType::display_name)
+        .unwrap_or_else(|| missing.to_string())
+}
+
+fn format_type_parameter_names(names: Option<&[String]>) -> String {
+    format_resolver_string_list(names)
+}
+
+fn format_type_parameter_bounds(bounds: Option<&[TypeParameterBoundMetadata]>) -> String {
+    format_resolver_display_list(bounds, |(name, behavior)| format!("{name}: {behavior}"))
+}
+
+fn format_type_parameter_bound_refs(bounds: Option<&[TypeParameterBoundRefMetadata]>) -> String {
+    format_resolver_display_list(bounds, |bound| {
+        format!(
+            "{}: {}",
+            bound.type_parameter,
+            behavior_ref_display(&bound.behavior, &bound.type_args)
+        )
+    })
+}
+
+fn format_parameter_type_names(names: Option<&[String]>) -> String {
+    format_resolver_string_list(names)
+}
+
+fn format_ast_type_list(types: Option<&[AstType]>) -> String {
+    format_resolver_display_list(types, AstType::display_name)
+}
+
+fn format_parameter_names(names: Option<&[String]>) -> String {
+    format_resolver_string_list(names)
+}
+
+fn format_field_types(fields: Option<&[(String, AstType)]>) -> String {
+    format_resolver_named_list(fields, AstType::display_name)
+}
+
+fn format_field_type_names(fields: Option<&[(String, String)]>) -> String {
+    format_resolver_named_list(fields, String::clone)
+}
+
+fn format_variant_names(variants: Option<&[String]>) -> String {
+    format_resolver_string_list(variants)
+}
+
+fn format_resolver_string_list(values: Option<&[String]>) -> String {
+    format_resolver_display_list(values, String::clone)
+}
+
+fn format_resolver_display_list<T>(
+    values: Option<&[T]>,
+    display_value: impl Fn(&T) -> String,
+) -> String {
+    values
+        .map(|values| format!("({})", join_resolver_display_values(values, display_value)))
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn join_resolver_strings(values: &[String]) -> String {
+    values.join(", ")
+}
+
+fn join_resolver_display_values<T>(values: &[T], display_value: impl Fn(&T) -> String) -> String {
+    let entries = values.iter().map(display_value).collect::<Vec<_>>();
+    join_resolver_strings(&entries)
+}
+
+fn format_resolver_named_list<T>(
+    values: Option<&[(String, T)]>,
+    display_value: impl Fn(&T) -> String,
+) -> String {
+    values
+        .map(|values| {
+            let entries = values
+                .iter()
+                .map(|(name, value)| format!("{name}: {}", display_value(value)))
+                .collect::<Vec<_>>();
+            format!("({})", join_resolver_strings(&entries))
+        })
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn format_behavior_method_signatures(methods: Option<&[MethodSignatureMetadata]>) -> String {
+    format_resolver_display_list(methods, |(name, params, return_type)| {
+        format!("{name}({}) {return_type}", params.join(", "))
+    })
+}
+
+fn format_behavior_method_types(methods: Option<&[BehaviorMethodTypeMetadata]>) -> String {
+    format_resolver_display_list(methods, |method| {
+        let params = method
+            .parameter_types
+            .iter()
+            .enumerate()
+            .map(|(index, ty)| {
+                let name = method
+                    .parameter_names
+                    .get(index)
+                    .map(String::as_str)
+                    .unwrap_or("_");
+                format!("{name}: {}", ty.display_name())
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(
+            "{}({}) {}",
+            method.name,
+            params,
+            method.return_type.display_name()
+        )
+    })
+}
+
+fn format_behavior_ref_names(parents: Option<&[String]>) -> String {
+    format_resolver_nonempty_joined_list(parents, String::clone)
+}
+
+fn format_behavior_refs(refs: Option<&[BehaviorRefMetadata]>) -> String {
+    format_resolver_nonempty_joined_list(refs, |behavior| {
+        behavior_ref_display(&behavior.name, &behavior.type_args)
+    })
+}
+
+fn format_resolver_nonempty_joined_list<T>(
+    values: Option<&[T]>,
+    display_value: impl Fn(&T) -> String,
+) -> String {
+    match values {
+        Some(values) if !values.is_empty() => join_resolver_display_values(values, display_value),
+        _ => "none".to_string(),
+    }
+}
+
+fn behavior_ref_names_match(actual: Option<&[String]>, expected: &[String]) -> bool {
+    match actual {
+        Some(actual) => actual == expected,
+        None => expected.is_empty(),
+    }
+}
+
+fn behavior_refs_match(
+    actual: Option<&[BehaviorRefMetadata]>,
+    expected: &[BehaviorRefMetadata],
+) -> bool {
+    match actual {
+        Some(actual) => actual == expected,
+        None => expected.is_empty(),
+    }
+}

--- a/src/typechecker/resolver_validation_support/expected_helpers.rs
+++ b/src/typechecker/resolver_validation_support/expected_helpers.rs
@@ -2,42 +2,6 @@ fn expected_return_metadata(return_type: &Option<AstType>) -> ExpectedReturnMeta
     ExpectedReturnMetadata::new(return_type)
 }
 
-fn visibility_name(is_public: bool) -> &'static str {
-    if is_public {
-        "public"
-    } else {
-        "private"
-    }
-}
-
-fn mutability_name(is_mutable: Option<bool>) -> &'static str {
-    match is_mutable {
-        Some(true) => "mutable",
-        Some(false) => "immutable",
-        None => "unknown",
-    }
-}
-
-fn resolver_count_display(count: Option<usize>) -> String {
-    count
-        .map(|count| count.to_string())
-        .unwrap_or_else(|| "unknown".to_string())
-}
-
-fn resolver_metadata_display(value: Option<&str>) -> &str {
-    value.unwrap_or("unknown")
-}
-
-fn resolver_ast_type_metadata_display(value: Option<&AstType>) -> String {
-    optional_ast_type_display(value, "unknown")
-}
-
-fn optional_ast_type_display(value: Option<&AstType>, missing: &str) -> String {
-    value
-        .map(AstType::display_name)
-        .unwrap_or_else(|| missing.to_string())
-}
-
 fn expected_parameter_metadata(params: &[Param]) -> Vec<ExpectedParameter> {
     let mut expected = Vec::new();
     for param in params {
@@ -115,36 +79,6 @@ fn expected_local_symbol(is_mutable: bool, scope_id: u32) -> ExpectedLocalSymbol
     ExpectedLocalSymbol::new(is_mutable, scope_id)
 }
 
-fn format_type_parameter_names(names: Option<&[String]>) -> String {
-    format_resolver_string_list(names)
-}
-
-fn format_type_parameter_bounds(bounds: Option<&[TypeParameterBoundMetadata]>) -> String {
-    format_resolver_display_list(bounds, |(name, behavior)| format!("{name}: {behavior}"))
-}
-
-fn format_type_parameter_bound_refs(bounds: Option<&[TypeParameterBoundRefMetadata]>) -> String {
-    format_resolver_display_list(bounds, |bound| {
-        format!(
-            "{}: {}",
-            bound.type_parameter,
-            behavior_ref_display(&bound.behavior, &bound.type_args)
-        )
-    })
-}
-
-fn format_parameter_type_names(names: Option<&[String]>) -> String {
-    format_resolver_string_list(names)
-}
-
-fn format_ast_type_list(types: Option<&[AstType]>) -> String {
-    format_resolver_display_list(types, AstType::display_name)
-}
-
-fn format_parameter_names(names: Option<&[String]>) -> String {
-    format_resolver_string_list(names)
-}
-
 fn expected_field_metadata(fields: &[StructField]) -> Vec<ExpectedField> {
     let mut expected = Vec::new();
     for field in fields {
@@ -153,60 +87,11 @@ fn expected_field_metadata(fields: &[StructField]) -> Vec<ExpectedField> {
     expected
 }
 
-fn format_field_types(fields: Option<&[(String, AstType)]>) -> String {
-    format_resolver_named_list(fields, AstType::display_name)
-}
-
-fn format_field_type_names(fields: Option<&[(String, String)]>) -> String {
-    format_resolver_named_list(fields, String::clone)
-}
-
 fn expected_variant_name_metadata(variants: &[EnumVariant]) -> Vec<String> {
     variants
         .iter()
         .map(|variant| variant.name.clone())
         .collect()
-}
-
-fn format_variant_names(variants: Option<&[String]>) -> String {
-    format_resolver_string_list(variants)
-}
-
-fn format_resolver_string_list(values: Option<&[String]>) -> String {
-    format_resolver_display_list(values, String::clone)
-}
-
-fn format_resolver_display_list<T>(
-    values: Option<&[T]>,
-    display_value: impl Fn(&T) -> String,
-) -> String {
-    values
-        .map(|values| format!("({})", join_resolver_display_values(values, display_value)))
-        .unwrap_or_else(|| "unknown".to_string())
-}
-
-fn join_resolver_strings(values: &[String]) -> String {
-    values.join(", ")
-}
-
-fn join_resolver_display_values<T>(values: &[T], display_value: impl Fn(&T) -> String) -> String {
-    let entries = values.iter().map(display_value).collect::<Vec<_>>();
-    join_resolver_strings(&entries)
-}
-
-fn format_resolver_named_list<T>(
-    values: Option<&[(String, T)]>,
-    display_value: impl Fn(&T) -> String,
-) -> String {
-    values
-        .map(|values| {
-            let entries = values
-                .iter()
-                .map(|(name, value)| format!("{name}: {}", display_value(value)))
-                .collect::<Vec<_>>();
-            format!("({})", join_resolver_strings(&entries))
-        })
-        .unwrap_or_else(|| "unknown".to_string())
 }
 
 fn expected_behavior_method_metadata(
@@ -250,72 +135,4 @@ fn push_expected_behavior_parent_edge(
     parent_type_args: &[AstType],
 ) {
     expected.push(behavior, parent, parent_type_args);
-}
-
-fn format_behavior_method_signatures(methods: Option<&[MethodSignatureMetadata]>) -> String {
-    format_resolver_display_list(methods, |(name, params, return_type)| {
-        format!("{name}({}) {return_type}", params.join(", "))
-    })
-}
-
-fn format_behavior_method_types(methods: Option<&[BehaviorMethodTypeMetadata]>) -> String {
-    format_resolver_display_list(methods, |method| {
-        let params = method
-            .parameter_types
-            .iter()
-            .enumerate()
-            .map(|(index, ty)| {
-                let name = method
-                    .parameter_names
-                    .get(index)
-                    .map(String::as_str)
-                    .unwrap_or("_");
-                format!("{name}: {}", ty.display_name())
-            })
-            .collect::<Vec<_>>()
-            .join(", ");
-        format!(
-            "{}({}) {}",
-            method.name,
-            params,
-            method.return_type.display_name()
-        )
-    })
-}
-
-fn format_behavior_ref_names(parents: Option<&[String]>) -> String {
-    format_resolver_nonempty_joined_list(parents, String::clone)
-}
-
-fn format_behavior_refs(refs: Option<&[BehaviorRefMetadata]>) -> String {
-    format_resolver_nonempty_joined_list(refs, |behavior| {
-        behavior_ref_display(&behavior.name, &behavior.type_args)
-    })
-}
-
-fn format_resolver_nonempty_joined_list<T>(
-    values: Option<&[T]>,
-    display_value: impl Fn(&T) -> String,
-) -> String {
-    match values {
-        Some(values) if !values.is_empty() => join_resolver_display_values(values, display_value),
-        _ => "none".to_string(),
-    }
-}
-
-fn behavior_ref_names_match(actual: Option<&[String]>, expected: &[String]) -> bool {
-    match actual {
-        Some(actual) => actual == expected,
-        None => expected.is_empty(),
-    }
-}
-
-fn behavior_refs_match(
-    actual: Option<&[BehaviorRefMetadata]>,
-    expected: &[BehaviorRefMetadata],
-) -> bool {
-    match actual {
-        Some(actual) => actual == expected,
-        None => expected.is_empty(),
-    }
 }

--- a/tests/docs_truth/repo_hygiene/typechecker_resolver_validation.rs
+++ b/tests/docs_truth/repo_hygiene/typechecker_resolver_validation.rs
@@ -58,6 +58,57 @@ fn typechecker_resolver_expected_value_symbols_live_in_focused_helper() {
 }
 
 #[test]
+fn typechecker_resolver_expected_formatting_lives_in_focused_helper() {
+    let root = read("src/typechecker/resolver_validation_support.rs");
+    let helpers = read("src/typechecker/resolver_validation_support/expected_helpers.rs");
+    let formatting = read("src/typechecker/resolver_validation_support/expected_formatting.rs");
+
+    for helper in [
+        "visibility_name",
+        "mutability_name",
+        "resolver_count_display",
+        "resolver_metadata_display",
+        "resolver_ast_type_metadata_display",
+        "optional_ast_type_display",
+        "format_type_parameter_names",
+        "format_type_parameter_bounds",
+        "format_type_parameter_bound_refs",
+        "format_parameter_type_names",
+        "format_ast_type_list",
+        "format_parameter_names",
+        "format_field_types",
+        "format_field_type_names",
+        "format_variant_names",
+        "format_resolver_string_list",
+        "format_resolver_display_list",
+        "join_resolver_strings",
+        "join_resolver_display_values",
+        "format_resolver_named_list",
+        "format_behavior_method_signatures",
+        "format_behavior_method_types",
+        "format_behavior_ref_names",
+        "format_behavior_refs",
+        "format_resolver_nonempty_joined_list",
+        "behavior_ref_names_match",
+        "behavior_refs_match",
+    ] {
+        assert!(
+            !helpers.contains(&format!("fn {helper}")),
+            "expected_helpers.rs should not own resolver formatting helper: {helper}"
+        );
+        assert!(
+            formatting.contains(&format!("fn {helper}")),
+            "resolver expected formatting should live in focused helper: {helper}"
+        );
+    }
+
+    assert!(
+        root.contains("include!(\"resolver_validation_support/expected_formatting.rs\");"),
+        "resolver validation support should include focused expected formatting helper"
+    );
+}
+
+#[test]
 fn typechecker_resolver_pattern_local_traversal_lives_in_focused_helper() {
     let traversal = read("src/typechecker/resolver_validation/local_traversal.rs");
     let patterns = read("src/typechecker/resolver_validation/pattern_locals.rs");


### PR DESCRIPTION
## Summary
- Move resolver expected formatting/display helpers into `src/typechecker/resolver_validation_support/expected_formatting.rs`.
- Keep `expected_helpers.rs` focused on expected-symbol constructor helpers.
- Add a docs-truth guard to keep formatting helpers split out.

## TDD
- First added `typechecker_resolver_expected_formatting_lives_in_focused_helper` and confirmed it failed because the focused helper file did not exist.

## Validation
- `cargo test --test docs_truth typechecker_resolver_expected_formatting_lives_in_focused_helper -- --nocapture`
- `cargo test --lib resolver_metadata::formatting_and_behavior_refs -- --nocapture`
- `cargo test --lib resolver_metadata::validation_descriptors -- --nocapture`
- `cargo test --lib resolver_validation::behavior_refs -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- `cargo fmt --check`
- `git diff --check`
- Push-triggered Actions check: `[]`