### PR TITLE
Compact status docs

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -5,83 +5,70 @@
 Continue from recovered branch `codex/phase0-1-truth-gates` at recovery commit
 `183d140c` from 2026-05-12 08:18:35 UTC. Treat unpushed `/tmp` work after that
 commit as lost, reconstruct the durable plan from checked-in docs/tests/commits,
-continue TDD-first in small tested commits, preserve the stated design decisions,
-and do not assume the broader objective is complete without evidence.
+continue TDD-first in small tested commits, preserve design decisions, and do
+not assume completion without evidence.
 
 ## Prompt-To-Artifact Checklist
 
 | Requirement | Evidence | Status |
 |---|---|---|
-| Verify repo state | Work continues from git-tracked history; current state is checked with `git status --short --branch`. | satisfied |
-| Verify tests before pushing | Required local gates are `cargo fmt --check`, `git diff --check`, focused tests, `cargo clippy -- -D warnings`, `cargo test --lib`, and `cargo test --tests`. | required each slice |
-| Keep CI quiet on normal branch pushes | GitHub Actions should stay quiet on normal branch pushes; use PR ready-for-review checks or manual dispatch. | active |
-| Recover from `183d140c` | `docs/PHASE_PLAN.md` records the recovery point and current history is built on top of it. | satisfied |
+| Verify repo state | Check `git status --short --branch`. | required each slice |
+| Verify tests before pushing | Run `cargo fmt --check`, `git diff --check`, focused tests, `cargo clippy -- -D warnings`, `cargo test --lib`, and `cargo test --tests`. | required each slice |
+| Keep CI quiet on normal branch pushes | Normal branch pushes should not fan out GitHub Actions; PR checks are the ready-review path. | active |
+| Recover from `183d140c` | `docs/PHASE_PLAN.md` records the recovery point. | satisfied |
 | Reconstruct missing plan | `docs/PHASE_PLAN.md` records design decisions, compressed evidence, current phase, and next slice. | satisfied |
-| Identify completed phases | The phase plan and tests summarize Phase 0 truth gates, Phase 1 frontend/C backend, resolver/typechecker work, diagnostics JSON, build graph constraints, stdlib gates, and repo hygiene. | satisfied |
-| Continue TDD-first | New behavior slices should add or tighten failing tests before implementation. | ongoing |
+| Continue TDD-first | New language/compiler behavior starts with a failing or tightened test. | ongoing |
 | Work in small tested commits | Recent history is split into focused docs, schema, diagnostic, parser, resolver, and cleanup commits. | ongoing |
-| Preserve design decisions | See Design Decisions Preserved below and `docs/PHASE_PLAN.md`. | satisfied |
-| Avoid completion assumption | Unresolved gaps remain; do not mark the objective complete. | active |
+| Preserve design decisions | See below and `docs/PHASE_PLAN.md`. | satisfied |
+| Avoid completion assumption | Unresolved gaps remain. | active |
 
 ## Design Decisions Preserved
 
-- Sync/Async are real effects, not marker-only types.
-- typed allocators remain central to allocation and effect decisions.
-- actors live in std first; no actor syntax has been promoted.
-- AST/HIR traversal remains tooling/metaprogramming, not core semantics.
-- type matching and behavior association remain separate.
-- JSON is compiler-owned IR output.
-- YAML is human-authored config/spec input.
-- `build.zen` is deterministic comptime build graph construction, currently
-  constrained by tests rather than open-ended package/link execution.
-- `StaticString` is baked program data; allocator-backed `String` is dynamic
-  memory and remains allocator-gated.
-- Dev UX and Agent UX are explicit roadmap requirements. Zen should grow toward
-  MoonBit-style toolchain integration with shared CLI/editor/LSP diagnostics,
-  VS Code extension support, language-server target/test discovery,
-  agent-readable diagnostics, machine-readable project graph output, and
-  structured fix suggestions.
+Sync/Async are real effects; typed allocators remain central; actors live in std
+first; AST/HIR traversal remains tooling/metaprogramming; type matching and
+behavior association remain separate; JSON is compiler-owned IR output; YAML is
+human-authored config/spec input; `build.zen` is deterministic comptime build
+graph construction; `StaticString` is baked program data; allocator-backed `String`
+is dynamic memory; `Type.implements(Behavior)` covers non-generic explicit behavior associations;
+Dev UX and Agent UX target MoonBit-style toolchain integration with a VS Code extension,
+language server, agent-readable diagnostics, project graph output, and
+structured fix suggestions.
 
 ## Compressed Evidence Summary
 
-- Public language docs are separated from status docs. `README.md` is a language
-  pitch, `docs/learn_zen_in_y_minutes.md` is a concise tour, and detailed status
-  lives here plus `docs/PHASE_PLAN.md`.
-- Phase 0 truth gates are guarded by `tests/docs_truth`, including old-spec
-  quarantine and public docs consistency.
-- Phase 1 frontend and C-backend behavior are guarded by `docs/V1_SPEC.md`,
-  `tests/zen`, and integration tests.
-- Generic specialization is covered across executable fixtures, JSON golden
-  tests, generated-C call/definition scans, imported templates, nested
-  `Result<Option<T>, StaticString>`, and multi-specialization cases.
-- Resolver/typechecker handoff uses resolver-owned metadata and has focused
-  coverage for declaration replay, `generic_struct_constructor_without_type_args_is_error`,
-  stale AST avoidance, behavior impl tasks, and bundled semantic passes.
-- Diagnostics have stable JSON surfaces with
+- Public docs are split by job: `README.md` pitches the language,
+  `docs/learn_zen_in_y_minutes.md` teaches it, and status lives here plus
+  `docs/PHASE_PLAN.md`.
+- Phase 0 truth gates and repo shape are guarded by `tests/docs_truth`,
+  including `production_rust_files_stay_below_cleanup_threshold`,
+  `zen_source_files_stay_below_cleanup_threshold`, and every tracked Rust source file
+  threshold.
+- Phase 1 frontend/C-backend behavior is guarded by `docs/V1_SPEC.md`,
+  `tests/zen`, generated-C checks, and integration tests.
+- Generic specialization covers executable fixtures, JSON golden tests,
+  imported templates, nested `Result<Option<T>, StaticString>`, and
+  generated-C definition/call scans.
+- Resolver/typechecker handoff uses resolver-owned metadata with coverage for
+  declaration replay, `generic_struct_constructor_without_type_args_is_error`,
+  stale AST avoidance, and behavior impl passes.
+- Diagnostics have stable JSON surfaces through
   `emit_json_diagnostics_command_outputs_machine_readable_errors`,
-  `suggested_fixes`, `feature_gate` metadata, removed-`return` fixes, and
-  missing bool match arm fixes through
-  `emit_json_diagnostics_includes_structured_return_keyword_fix` and
-  `emit_json_diagnostics_includes_structured_missing_bool_match_arm_fix`.
+  `emit_json_diagnostics_includes_structured_return_keyword_fix`,
+  `emit_json_diagnostics_includes_structured_missing_bool_match_arm_fix`,
+  suggested_fixes, and feature_gate metadata.
 - Checked JSON output is pinned by
   `emit_json_ast_marks_semantically_unchecked_sources_that_typed_json_rejects`
   and `emit_json_typed_command_outputs_checked_program`.
 - Build graph support is constrained and tested through deterministic build.zen
-  parsing, target lowering, dependency ordering, declared host effects,
-  library/test/executable target validation, JSON output, and
+  parsing, target lowering, declared host effects, JSON output, and
   `BuildGraphExecutionContext`.
-- Repo hygiene is active: `production_rust_files_stay_below_cleanup_threshold`,
-  `zen_source_files_stay_below_cleanup_threshold`, owned spelling enum checks,
-  old AST node cleanup, and every tracked Rust source file threshold guard keep
-  slop from silently returning.
-- Gated surfaces are explicit: `Type.implements(Behavior)` covers
-  non-generic explicit behavior associations; async scheduler intrinsics are rejected as
-  gated not unknown by `async_scheduler_intrinsics_are_rejected_as_gated_not_unknown`;
+- Gated surfaces are explicit:
+  `async_scheduler_intrinsics_are_rejected_as_gated_not_unknown`,
   `atomic_intrinsics_are_rejected_as_effect_gates`,
   `comptime_type_match_intrinsic_is_rejected_as_gated_not_unknown`,
   `dynamic_string_type_is_rejected_as_allocator_backed_gate`,
-  `raw_memory_intrinsics_are_rejected_as_allocator_gates`,
-  and `syscall_intrinsics_are_rejected_as_host_effect_gates`.
+  `raw_memory_intrinsics_are_rejected_as_allocator_gates`, and
+  `syscall_intrinsics_are_rejected_as_host_effect_gates`.
 - Standard library sketches remain visible but guarded, including
   `stdlib/io/mux/uring.zen`, `stdlib/io/net/unix_socket.zen`,
   `stdlib/io/net/socket.zen`, `stdlib/io/files/file.zen`, and
@@ -92,28 +79,22 @@ and do not assume the broader objective is complete without evidence.
 - The constrained build-driver is not a full package manager or open-ended link
   system; broader build graph semantics remain gated behind deterministic graph tests.
 - Dev UX and Agent UX are planned requirements, not finished product surfaces.
-  The VS Code extension, language server, project graph commands, and agent fix
-  workflows need dedicated implementation slices.
 - Async lowering, allocator-backed dynamic strings, raw memory, byte memory,
   raw pointers, syscalls, and advanced comptime type matching remain gated.
 - Generic behavior association and generated association fallback syntax remain
-  gated until the behavior solver can model those semantics safely.
-- The audit should not be treated as complete until local gates and CI are green
-  for the final merged state.
+  gated until solver semantics exist.
 
 Do not mark the objective complete while these gaps remain.
 
 ## Evidence Pointers
 
-- `docs/PHASE_PLAN.md`: current recovery point, design decisions, compressed
-  evidence map, current phase, and next slice.
+- `docs/PHASE_PLAN.md`: recovery point, design decisions, evidence map, phase,
+  and next slice.
 - `docs/V1_SPEC.md`: current language/spec surface.
 - `docs/DIAGNOSTICS.md`: stable diagnostics catalog.
 - `docs/learn_zen_in_y_minutes.md`: concise public language tour.
 - `tests/docs_truth`: documentation, repo hygiene, and status truth gates.
-- `tests/integration`: CLI, JSON, diagnostics, build graph, and generated-C
-  integration behavior.
+- `tests/integration`: CLI, JSON, diagnostics, build graph, and generated-C.
 - `tests/resolver_phase2.rs`: resolver Phase 2 semantic evidence.
 - `tests/zen`: executable language fixtures.
-- Git history: detailed implementation evidence that should stay out of compact
-  Markdown status docs.
+- Git history: implementation detail that should stay out of compact Markdown.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -6,8 +6,8 @@ Recovered branch: `codex/phase0-1-truth-gates`.
 
 Recovery commit: `183d140c` from 2026-05-12 08:18:35 UTC.
 
-Any unpushed `/tmp` work after that commit is treated as lost. Continue from
-checked-in docs, tests, and commits only.
+Treat unpushed `/tmp` work after that commit as lost. Continue from checked-in
+docs, tests, and commits only.
 
 ## Design Decisions To Preserve
 
@@ -19,74 +19,58 @@ checked-in docs, tests, and commits only.
 - JSON is compiler-owned IR output.
 - YAML is human-authored config/spec input.
 - build.zen is deterministic comptime build graph construction.
-- `StaticString` is baked program data; allocator-backed `String` remains a
-  separate dynamic type and must not be blurred in docs or diagnostics.
-- `Type.implements(Behavior)` stays as the explicit non-generic behavior
-  association spelling until a solver can handle more advanced forms.
+- `StaticString` is baked program data; allocator-backed `String` is dynamic.
+- `Type.implements(Behavior)` covers non-generic explicit behavior associations
+  until the solver supports advanced forms.
 - Dev UX and Agent UX are product requirements, not polish.
 
 ## Dev UX And Agent UX Track
 
-MoonBit-style toolchain integration is the benchmark: one coherent compiler,
-build system, package graph, language server, VS Code extension, web/editor
-entry point, and machine-readable surface area rather than disconnected tools.
+MoonBit-style toolchain integration is the benchmark: compiler, build graph,
+package surface, language server, VS Code extension, web/editor entry point,
+and machine-readable outputs should feel coherent rather than bolted together.
 
-Dev UX requirements: VS Code syntax, semantic diagnostics, go-to-definition,
-hover, completion, formatting, run/test code lenses, target selection, language
-server restart, compiler version display, local toolchain validation, and
-`zen lsp` backed by the CLI parser, resolver, typechecker, build graph, and
-diagnostics. Editor build graph integration must cover target/test discovery,
-dependency inspection, run/test/build, declared host effects, deterministic
-errors, and structured fix suggestions for missing match arms, generic arity
-mistakes, removed syntax such as `return`, gated features, missing imports, and
-common type mismatches.
+Required Dev UX includes VS Code syntax, semantic diagnostics,
+go-to-definition, hover, completion, formatting, run/test code lenses, target
+selection, language server restart, compiler version display, local toolchain
+validation, and `zen lsp` backed by the CLI parser, resolver, typechecker,
+build graph, and diagnostics.
 
-Agent UX requirements: agent-readable diagnostics with stable codes, spans,
+Required Agent UX includes agent-readable diagnostics with stable codes, spans,
 related locations, suggested_fixes, feature_gate metadata, CLI/editor-aligned
-JSON. Machine-readable project graph and symbol graph output, deterministic
-quiet commands for `zen check`, `zen test`, `zen emit-json`, build graph
-inspection, formatting, future fix-application workflows, retrieval-friendly
-canonical docs, and quiet branch-push CI.
+JSON, Machine-readable project graph and symbol graph output, deterministic
+quiet commands, formatting, future fix-application workflows,
+retrieval-friendly canonical docs, structured fix suggestions, and quiet
+branch-push CI.
 
 ## Compressed Evidence Map
 
-This section records current capability groups, not every historical test name.
-Granular evidence belongs in tests, golden fixtures, and git history.
+This is a capability index, not a changelog. Granular evidence belongs in
+tests, golden fixtures, and git history.
 
 - Phase 0 truth gates: README, contributor, stdlib, CI, release, old-spec
   quarantine, and docs shape are guarded by `tests/docs_truth`.
-- Phase 1 frontend and C-backend baseline: supported syntax and C execution
-  behavior are documented in `docs/V1_SPEC.md` and covered by `tests/zen` plus
-  integration tests.
+- Phase 1 frontend and C-backend baseline: supported syntax and C execution are
+  documented in `docs/V1_SPEC.md` and covered by `tests/zen` plus integration
+  tests.
 - generic specialization: generic functions, structs, enums, methods,
-  recursive worklists, imported generic templates, nested `Result<Option<T>,
-  StaticString>` cases, and generated-C call/definition consistency are covered
-  by executable and JSON-golden integration tests.
-- resolver/typechecker replay: resolver-owned declaration metadata, callable
-  signatures, behavior impl passes, stale AST protection, and generic arity
-  diagnostics are covered by `tests/resolver_phase2.rs`, typechecker unit
-  tests, and integration diagnostics. Representative tests include
-  `generic_struct_constructor_without_type_args_is_error` and the
-  non-generic explicit behavior associations around `Type.implements(Behavior)`.
-- Behavior and type matching boundaries: type matching remains separate from
-  behavior association; generic association targets and generated association
-  syntax remain gated until solver semantics exist.
+  recursive worklists, imported templates, nested `Result<Option<T>,
+  StaticString>`, and generated-C consistency are covered by executable and
+  JSON-golden integration tests.
+- resolver/typechecker replay: resolver-owned metadata, callable signatures,
+  behavior impl passes, stale AST protection, `generic_struct_constructor_without_type_args_is_error`,
+  and generic arity diagnostics are covered by `tests/resolver_phase2.rs`,
+  typechecker unit tests, and integration diagnostics.
 - diagnostics JSON: `emit_json_diagnostics_command_outputs_machine_readable_errors`,
   `emit_json_diagnostics_includes_structured_return_keyword_fix`, and
   `emit_json_diagnostics_includes_structured_missing_bool_match_arm_fix` pin
-  stable machine-readable diagnostics with suggested_fixes and feature_gate data.
+  stable diagnostics with suggested_fixes and feature_gate data.
 - Typed/HIR/MIR JSON: `emit_json_ast_marks_semantically_unchecked_sources_that_typed_json_rejects`
   and `emit_json_typed_command_outputs_checked_program` guard checked program
-  output, with HIR/MIR schema golden tests covering monomorphized structures.
-- Build graph: deterministic build.zen graph behavior is guarded by parser,
-  lowering, JSON, and CLI tests. Representative anchors include
-  `deterministic_build_graph_creates_one_executable_target`,
-  `build_graph_rejects_undeclared_host_effects`, library/test/executable
-  targets, target dependencies, declared env/file reads, unsupported package
-  and link gates, and `BuildGraphExecutionContext` execution routing.
-- Target YAML: target schema validation covers minimal target shape, backend
-  settings, C backend flags, empty flag rejection, layout override gates, and
-  unsupported backend codegen gates.
+  output with schema golden tests.
+- build graph: deterministic build.zen graph behavior is guarded by parser,
+  lowering, JSON, and CLI tests such as
+  `deterministic_build_graph_creates_one_executable_target`.
 - Gated effects and intrinsics:
   `async_scheduler_intrinsics_are_rejected_as_gated_not_unknown`,
   `atomic_intrinsics_are_rejected_as_effect_gates`,
@@ -94,15 +78,9 @@ Granular evidence belongs in tests, golden fixtures, and git history.
   `dynamic_string_type_is_rejected_as_allocator_backed_gate`,
   `raw_memory_intrinsics_are_rejected_as_allocator_gates`, and
   `syscall_intrinsics_are_rejected_as_host_effect_gates`.
-- Standard library gates: promoted stdlib modules avoid removed or gated
-  syntax while gated sketches such as `stdlib/io/mux/uring.zen`,
-  `stdlib/io/net/unix_socket.zen`, `stdlib/io/net/socket.zen`,
-  `stdlib/io/files/file.zen`, and `stdlib/sys/process/prctl.zen` remain visible
-  as future surfaces.
 - repo hygiene: `production_rust_files_stay_below_cleanup_threshold`,
   `zen_source_files_stay_below_cleanup_threshold`, owned spelling enums, and
-  old-node cleanup tests keep files and syntax tables from regressing. Every
-  tracked Rust source file should stay below the cleanup threshold or get split.
+  old-node cleanup tests keep files and syntax tables from regressing.
 
 ## Current Phase
 
@@ -117,21 +95,17 @@ consistent, and preventing large-file/slop regressions.
   dependencies are covered by executable fixtures, typed/HIR/MIR golden tests,
   and generated-C tests.
 - generic method specialization: generic, `Self`, type impl, enum, imported
-  dependency, and nested result method cases are covered by executable fixtures,
-  JSON golden tests, and method worklist generated-C tests.
+  dependency, and nested result method cases are covered by executable
+  fixtures, JSON golden tests, and method worklist generated-C tests.
 - worklist monomorphization: recursive functions, methods, imported transitive
   dependencies, and deduped instantiations are covered by `generic_worklist*`,
   `generic_method_worklist`, `multi_file_generic_imported_*`, and generated-C
   definition-count checks.
-- generated-C call/definition consistency: `compile_to_c_with_generated_call_check`
-  plus `undefined_generated_c_calls` scan specialization fixtures, while
-  `generic_specializations_emit_each_generated_c_definition_once` guards
-  duplicate definitions.
+- generated-C call/definition consistency:
+  `compile_to_c_with_generated_call_check`, `undefined_generated_c_calls`, and
+  duplicate-definition checks scan specialization fixtures.
 - generic arity, inference, and bound diagnostics: E5000, E5001, E5002, and
   E6004 are pinned across unit, CLI, and JSON golden tests.
-- magic-string and fixture-hardcoding risk remains an active hygiene concern:
-  owned spelling enums and docs-truth repo-hygiene checks should keep replacing
-  ad hoc semantic string checks when they appear.
 
 Current non-Phase-5 gaps remain Dev UX, Agent UX, full LSP/editor workflows,
 allocator-backed dynamic strings, Sync/Async lowering, raw memory semantics,
@@ -139,15 +113,11 @@ advanced comptime type matching, and broad package/link build-driver behavior.
 
 ## Next Small Slice
 
-Recommended next slice:
-
 1. Pick one oversized Rust file that still crosses the cleanup threshold.
-2. Add or tighten a focused repo-hygiene/test guard for the boundary being
-   extracted.
+2. Add or tighten a focused repo-hygiene/test guard.
 3. Move one coherent responsibility into a focused module.
-4. Run local gates before pushing: `cargo fmt --check`, `git diff --check`,
-   focused tests, `cargo clippy -- -D warnings`, `cargo test --lib`, and
-   `cargo test --tests`.
+4. Run local gates: `cargo fmt --check`, `git diff --check`, focused tests,
+   `cargo clippy -- -D warnings`, `cargo test --lib`, and `cargo test --tests`.
 5. Confirm GitHub Actions stay quiet on normal branch pushes before opening a
    ready PR.
 
@@ -159,11 +129,10 @@ all required language, docs, CI, Dev UX, Agent UX, and build-driver evidence.
 - `docs/V1_SPEC.md`: current language/spec surface.
 - `docs/DIAGNOSTICS.md`: stable diagnostic codes and JSON expectations.
 - `docs/learn_zen_in_y_minutes.md`: concise public language tour.
-- `docs/COMPLETION_AUDIT.md`: objective checklist, evidence summary, and gaps.
+- `docs/COMPLETION_AUDIT.md`: checklist, compressed evidence, and gaps.
 - `tests/docs_truth`: documentation and repo-shape truth gates.
-- `tests/integration`: CLI, JSON, build graph, diagnostics, and generated-C
-  behavior.
+- `tests/integration`: CLI, JSON, build graph, diagnostics, and generated-C.
 - `tests/resolver_phase2.rs`: resolver Phase 2 semantic evidence.
 - `tests/zen`: executable language fixtures.
-- Git history: detailed per-slice implementation evidence that should not be
-  copied wholesale into status Markdown.
+- Git history: per-slice implementation detail that should not be copied into
+  status Markdown.

--- a/tests/docs_truth/phase_audit/completion_audit.rs
+++ b/tests/docs_truth/phase_audit/completion_audit.rs
@@ -68,7 +68,7 @@ fn completion_audit_records_recovery_objective_evidence_and_gaps() {
     }
 
     assert!(
-        audit.lines().count() <= 220,
+        audit.lines().count() <= 120,
         "docs/COMPLETION_AUDIT.md should stay compact; move granular evidence to tests or git history"
     );
 

--- a/tests/docs_truth/phase_audit/phase_plan.rs
+++ b/tests/docs_truth/phase_audit/phase_plan.rs
@@ -76,7 +76,7 @@ fn phase_plan_records_recovered_progress_and_next_slice() {
     }
 
     assert!(
-        plan.lines().count() <= 180,
+        plan.lines().count() <= 155,
         "docs/PHASE_PLAN.md should stay compact; move granular evidence to tests or git history"
     );
 


### PR DESCRIPTION
## Summary
- Compact `docs/PHASE_PLAN.md` and `docs/COMPLETION_AUDIT.md` into shorter status/reference docs.
- Preserve durable design decisions, evidence anchors, unresolved gaps, and docs pointers.
- Tighten docs-truth line-count guards so status docs do not expand again.

## Validation
- `cargo test --test docs_truth -- --nocapture`
- `git diff --check`
- Push-triggered Actions check: `[]`