### PR TITLE
Split bool match validation

### DIFF
--- a/src/typechecker/patterns.rs
+++ b/src/typechecker/patterns.rs
@@ -6,6 +6,7 @@ use crate::ast::Pattern;
 use super::TypeChecker;
 
 mod match_validation;
+mod match_validation_bool;
 
 impl TypeChecker {
     /// Look up the payload type for a specific enum variant.

--- a/src/typechecker/patterns/match_validation.rs
+++ b/src/typechecker/patterns/match_validation.rs
@@ -3,10 +3,7 @@ use std::collections::{HashMap, HashSet};
 use crate::ast::expressions::MatchArm;
 use crate::ast::typed::*;
 use crate::ast::Pattern;
-use crate::error::{
-    Diagnostic, Span, SuggestedFix, TextEdit, MISSING_BOOL_MATCH_ARM_FIX_KIND,
-    MISSING_BOOL_MATCH_ARM_FIX_TITLE,
-};
+use crate::error::{Diagnostic, Span};
 
 use super::TypeChecker;
 
@@ -149,84 +146,6 @@ impl TypeChecker {
                 )),
                 _ => {}
             }
-        }
-    }
-
-    pub(crate) fn check_bool_match_patterns(
-        &mut self,
-        arms: &[MatchArm],
-        require_exhaustive: bool,
-        span: Span,
-    ) {
-        let mut true_seen = false;
-        let mut false_seen = false;
-        let mut wildcard_seen = false;
-
-        for arm in arms {
-            match &arm.pattern {
-                Pattern::BoolTrue { span } => {
-                    if true_seen || wildcard_seen {
-                        self.diagnostics.push(Diagnostic::error(
-                            "E4005",
-                            "duplicate match arm for `true`",
-                            *span,
-                        ));
-                    }
-                    true_seen = true;
-                }
-                Pattern::BoolFalse { span } => {
-                    if false_seen || wildcard_seen {
-                        self.diagnostics.push(Diagnostic::error(
-                            "E4005",
-                            "duplicate match arm for `false`",
-                            *span,
-                        ));
-                    }
-                    false_seen = true;
-                }
-                Pattern::Wildcard { span } => {
-                    if wildcard_seen || (true_seen && false_seen) {
-                        self.diagnostics.push(Diagnostic::error(
-                            "E4005",
-                            "redundant wildcard match arm",
-                            *span,
-                        ));
-                    }
-                    wildcard_seen = true;
-                }
-                _ => {}
-            }
-        }
-
-        if require_exhaustive && !wildcard_seen && !(true_seen && false_seen) {
-            let missing_values: Vec<&str> = match (true_seen, false_seen) {
-                (true, false) => vec!["false"],
-                (false, true) => vec!["true"],
-                _ => vec!["true", "false"],
-            };
-            let missing = missing_values
-                .iter()
-                .map(|value| format!("`{value}`"))
-                .collect::<Vec<_>>()
-                .join(", ");
-            let replacement = missing_values
-                .iter()
-                .map(|value| format!("        | {value} {{ <expression> }}"))
-                .collect::<Vec<_>>()
-                .join("\n");
-            let insertion = Span::new(span.file_id, span.end, span.end);
-            self.diagnostics.push(
-                Diagnostic::error(
-                    "E4006",
-                    format!("non-exhaustive bool match: missing {missing}"),
-                    span,
-                )
-                .with_suggested_fix(SuggestedFix::new(
-                    MISSING_BOOL_MATCH_ARM_FIX_KIND,
-                    MISSING_BOOL_MATCH_ARM_FIX_TITLE,
-                    vec![TextEdit::new(insertion, format!("\n{replacement}"))],
-                )),
-            );
         }
     }
 

--- a/src/typechecker/patterns/match_validation_bool.rs
+++ b/src/typechecker/patterns/match_validation_bool.rs
@@ -1,0 +1,96 @@
+use crate::ast::expressions::MatchArm;
+use crate::ast::Pattern;
+use crate::error::{
+    Diagnostic, Span, SuggestedFix, TextEdit, MISSING_BOOL_MATCH_ARM_FIX_KIND,
+    MISSING_BOOL_MATCH_ARM_FIX_TITLE,
+};
+
+use super::TypeChecker;
+
+impl TypeChecker {
+    pub(crate) fn check_bool_match_patterns(
+        &mut self,
+        arms: &[MatchArm],
+        require_exhaustive: bool,
+        span: Span,
+    ) {
+        let mut true_seen = false;
+        let mut false_seen = false;
+        let mut wildcard_seen = false;
+
+        for arm in arms {
+            match &arm.pattern {
+                Pattern::BoolTrue { span } => {
+                    if true_seen || wildcard_seen {
+                        self.diagnostics.push(Diagnostic::error(
+                            "E4005",
+                            "duplicate match arm for `true`",
+                            *span,
+                        ));
+                    }
+                    true_seen = true;
+                }
+                Pattern::BoolFalse { span } => {
+                    if false_seen || wildcard_seen {
+                        self.diagnostics.push(Diagnostic::error(
+                            "E4005",
+                            "duplicate match arm for `false`",
+                            *span,
+                        ));
+                    }
+                    false_seen = true;
+                }
+                Pattern::Wildcard { span } => {
+                    if wildcard_seen || (true_seen && false_seen) {
+                        self.diagnostics.push(Diagnostic::error(
+                            "E4005",
+                            "redundant wildcard match arm",
+                            *span,
+                        ));
+                    }
+                    wildcard_seen = true;
+                }
+                _ => {}
+            }
+        }
+
+        if require_exhaustive && !wildcard_seen && !(true_seen && false_seen) {
+            let missing_values = Self::missing_bool_match_values(true_seen, false_seen);
+            let missing = missing_values
+                .iter()
+                .map(|value| format!("`{value}`"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let replacement = Self::missing_bool_match_fix_replacement(&missing_values);
+            let insertion = Span::new(span.file_id, span.end, span.end);
+            self.diagnostics.push(
+                Diagnostic::error(
+                    "E4006",
+                    format!("non-exhaustive bool match: missing {missing}"),
+                    span,
+                )
+                .with_suggested_fix(SuggestedFix::new(
+                    MISSING_BOOL_MATCH_ARM_FIX_KIND,
+                    MISSING_BOOL_MATCH_ARM_FIX_TITLE,
+                    vec![TextEdit::new(insertion, format!("\n{replacement}"))],
+                )),
+            );
+        }
+    }
+
+    fn missing_bool_match_values(true_seen: bool, false_seen: bool) -> Vec<&'static str> {
+        match (true_seen, false_seen) {
+            (true, false) => vec!["false"],
+            (false, true) => vec!["true"],
+            _ => vec!["true", "false"],
+        }
+    }
+
+    fn missing_bool_match_fix_replacement(missing_values: &[&str]) -> String {
+        missing_values
+            .iter()
+            .map(|value| format!("        | {value} {{ <expression> }}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}

--- a/tests/docs_truth/repo_hygiene/mod.rs
+++ b/tests/docs_truth/repo_hygiene/mod.rs
@@ -23,6 +23,7 @@ mod typechecker_behavior_impls;
 mod typechecker_call_validation;
 mod typechecker_declaration_collection;
 mod typechecker_imports;
+mod typechecker_patterns;
 mod typechecker_program_checking;
 mod typechecker_resolver_validation;
 mod typechecker_runtime;

--- a/tests/docs_truth/repo_hygiene/typechecker_patterns.rs
+++ b/tests/docs_truth/repo_hygiene/typechecker_patterns.rs
@@ -1,0 +1,28 @@
+use super::*;
+
+#[test]
+fn bool_match_validation_lives_in_focused_helper() {
+    let root = read("src/typechecker/patterns/match_validation.rs");
+    let bools = read("src/typechecker/patterns/match_validation_bool.rs");
+    let patterns = read("src/typechecker/patterns.rs");
+
+    for helper in [
+        "check_bool_match_patterns",
+        "missing_bool_match_values",
+        "missing_bool_match_fix_replacement",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {helper}")),
+            "match validation root should not own bool-specific helper: {helper}"
+        );
+        assert!(
+            bools.contains(&format!("fn {helper}")),
+            "bool match validation should live in focused helper: {helper}"
+        );
+    }
+
+    assert!(
+        patterns.contains("mod match_validation_bool;"),
+        "pattern helpers should load focused bool match validation"
+    );
+}


### PR DESCRIPTION
## Summary
- Move bool-specific match validation and missing-arm fix construction into `src/typechecker/patterns/match_validation_bool.rs`.
- Keep `match_validation.rs` focused on match kind and enum match validation.
- Add a docs-truth guard to keep bool match validation split out.

## TDD
- First added `bool_match_validation_lives_in_focused_helper` and confirmed it failed because the focused helper file did not exist.

## Validation
- `cargo test --test docs_truth bool_match_validation_lives_in_focused_helper -- --nocapture`
- `cargo test --lib match_semantics -- --nocapture`
- `cargo test --test integration diagnostics_json -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Push-triggered Actions check: `[]`