### PR TITLE
Split binary op checking

### DIFF
--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -36,6 +36,7 @@ mod patterns;
 mod program_checking;
 mod program_module_graph;
 mod resolve;
+mod resolve_binary_ops;
 mod resolver_backed_collection;
 mod resolver_lookup;
 mod resolver_metadata_collection;

--- a/src/typechecker/resolve.rs
+++ b/src/typechecker/resolve.rs
@@ -1,10 +1,8 @@
-//! Type resolution — AstType → Type, field lookups, binary op checking.
+//! Type resolution — AstType → Type, field lookups, and compatibility checks.
 #![allow(clippy::result_large_err)]
 
-use crate::ast::expressions::BinaryOp;
 use crate::ast::typed::Type;
 use crate::ast::{is_builtin_type_name, AstType};
-use crate::error::{Diagnostic, Span};
 
 use super::TypeChecker;
 
@@ -185,117 +183,5 @@ impl TypeChecker {
         // Numeric width/sign conversions require explicit casts. Literal
         // coercion is handled before this check at declaration sites.
         false
-    }
-
-    pub(crate) fn check_binary_op(
-        &self,
-        op: BinaryOp,
-        left: &Type,
-        right: &Type,
-        span: &Span,
-    ) -> Result<Type, Diagnostic> {
-        match op {
-            BinaryOp::Add | BinaryOp::Sub | BinaryOp::Mul | BinaryOp::Div | BinaryOp::Mod => {
-                // Arithmetic — both sides must be numeric (allow Unknown for error recovery)
-                if *left == Type::Unknown || *right == Type::Unknown {
-                    let known = if *left != Type::Unknown {
-                        left
-                    } else {
-                        right
-                    };
-                    return Ok(known.clone());
-                }
-                if !left.is_numeric() {
-                    return Err(Diagnostic::error(
-                        "E3010",
-                        format!("arithmetic on non-numeric type `{}`", left.display_name()),
-                        *span,
-                    ));
-                }
-                if !right.is_numeric() {
-                    return Err(Diagnostic::error(
-                        "E3010",
-                        format!("arithmetic on non-numeric type `{}`", right.display_name()),
-                        *span,
-                    ));
-                }
-                if left != right {
-                    return Err(Diagnostic::error(
-                        "E3013",
-                        format!(
-                            "arithmetic operands must have the same type, found `{}` and `{}`",
-                            left.display_name(),
-                            right.display_name()
-                        ),
-                        *span,
-                    ));
-                }
-                Ok(left.clone())
-            }
-            BinaryOp::Eq
-            | BinaryOp::NotEq
-            | BinaryOp::Lt
-            | BinaryOp::Gt
-            | BinaryOp::LtEq
-            | BinaryOp::GtEq => Ok(Type::Bool),
-            BinaryOp::And | BinaryOp::Or => {
-                if *left != Type::Bool && *left != Type::Unknown {
-                    return Err(Diagnostic::error(
-                        "E3011",
-                        format!(
-                            "logical operator requires `bool`, found `{}`",
-                            left.display_name()
-                        ),
-                        *span,
-                    ));
-                }
-                if *right != Type::Bool && *right != Type::Unknown {
-                    return Err(Diagnostic::error(
-                        "E3011",
-                        format!(
-                            "logical operator requires `bool`, found `{}`",
-                            right.display_name()
-                        ),
-                        *span,
-                    ));
-                }
-                Ok(Type::Bool)
-            }
-            BinaryOp::BitAnd
-            | BinaryOp::BitOr
-            | BinaryOp::BitXor
-            | BinaryOp::ShiftLeft
-            | BinaryOp::ShiftRight => {
-                if *left == Type::Unknown || *right == Type::Unknown {
-                    let known = if *left != Type::Unknown {
-                        left
-                    } else {
-                        right
-                    };
-                    return Ok(known.clone());
-                }
-                if !left.is_integer() {
-                    return Err(Diagnostic::error(
-                        "E3012",
-                        format!(
-                            "bitwise operator requires integer type, found `{}`",
-                            left.display_name()
-                        ),
-                        *span,
-                    ));
-                }
-                if !right.is_integer() {
-                    return Err(Diagnostic::error(
-                        "E3012",
-                        format!(
-                            "bitwise operator requires integer type, found `{}`",
-                            right.display_name()
-                        ),
-                        *span,
-                    ));
-                }
-                Ok(left.clone())
-            }
-        }
     }
 }

--- a/src/typechecker/resolve_binary_ops.rs
+++ b/src/typechecker/resolve_binary_ops.rs
@@ -1,0 +1,143 @@
+#![allow(clippy::result_large_err)]
+
+use crate::ast::expressions::BinaryOp;
+use crate::ast::typed::Type;
+use crate::error::{Diagnostic, Span};
+
+use super::TypeChecker;
+
+impl TypeChecker {
+    pub(crate) fn check_binary_op(
+        &self,
+        op: BinaryOp,
+        left: &Type,
+        right: &Type,
+        span: &Span,
+    ) -> Result<Type, Diagnostic> {
+        match op {
+            BinaryOp::Add | BinaryOp::Sub | BinaryOp::Mul | BinaryOp::Div | BinaryOp::Mod => {
+                self.check_arithmetic_binary_op(left, right, span)
+            }
+            BinaryOp::Eq
+            | BinaryOp::NotEq
+            | BinaryOp::Lt
+            | BinaryOp::Gt
+            | BinaryOp::LtEq
+            | BinaryOp::GtEq => Ok(Type::Bool),
+            BinaryOp::And | BinaryOp::Or => self.check_logical_binary_op(left, right, span),
+            BinaryOp::BitAnd
+            | BinaryOp::BitOr
+            | BinaryOp::BitXor
+            | BinaryOp::ShiftLeft
+            | BinaryOp::ShiftRight => self.check_bitwise_binary_op(left, right, span),
+        }
+    }
+
+    fn check_arithmetic_binary_op(
+        &self,
+        left: &Type,
+        right: &Type,
+        span: &Span,
+    ) -> Result<Type, Diagnostic> {
+        if *left == Type::Unknown || *right == Type::Unknown {
+            let known = if *left != Type::Unknown {
+                left
+            } else {
+                right
+            };
+            return Ok(known.clone());
+        }
+        if !left.is_numeric() {
+            return Err(Diagnostic::error(
+                "E3010",
+                format!("arithmetic on non-numeric type `{}`", left.display_name()),
+                *span,
+            ));
+        }
+        if !right.is_numeric() {
+            return Err(Diagnostic::error(
+                "E3010",
+                format!("arithmetic on non-numeric type `{}`", right.display_name()),
+                *span,
+            ));
+        }
+        if left != right {
+            return Err(Diagnostic::error(
+                "E3013",
+                format!(
+                    "arithmetic operands must have the same type, found `{}` and `{}`",
+                    left.display_name(),
+                    right.display_name()
+                ),
+                *span,
+            ));
+        }
+        Ok(left.clone())
+    }
+
+    fn check_logical_binary_op(
+        &self,
+        left: &Type,
+        right: &Type,
+        span: &Span,
+    ) -> Result<Type, Diagnostic> {
+        if *left != Type::Bool && *left != Type::Unknown {
+            return Err(Diagnostic::error(
+                "E3011",
+                format!(
+                    "logical operator requires `bool`, found `{}`",
+                    left.display_name()
+                ),
+                *span,
+            ));
+        }
+        if *right != Type::Bool && *right != Type::Unknown {
+            return Err(Diagnostic::error(
+                "E3011",
+                format!(
+                    "logical operator requires `bool`, found `{}`",
+                    right.display_name()
+                ),
+                *span,
+            ));
+        }
+        Ok(Type::Bool)
+    }
+
+    fn check_bitwise_binary_op(
+        &self,
+        left: &Type,
+        right: &Type,
+        span: &Span,
+    ) -> Result<Type, Diagnostic> {
+        if *left == Type::Unknown || *right == Type::Unknown {
+            let known = if *left != Type::Unknown {
+                left
+            } else {
+                right
+            };
+            return Ok(known.clone());
+        }
+        if !left.is_integer() {
+            return Err(Diagnostic::error(
+                "E3012",
+                format!(
+                    "bitwise operator requires integer type, found `{}`",
+                    left.display_name()
+                ),
+                *span,
+            ));
+        }
+        if !right.is_integer() {
+            return Err(Diagnostic::error(
+                "E3012",
+                format!(
+                    "bitwise operator requires integer type, found `{}`",
+                    right.display_name()
+                ),
+                *span,
+            ));
+        }
+        Ok(left.clone())
+    }
+}

--- a/tests/docs_truth/repo_hygiene/mod.rs
+++ b/tests/docs_truth/repo_hygiene/mod.rs
@@ -25,6 +25,7 @@ mod typechecker_declaration_collection;
 mod typechecker_imports;
 mod typechecker_patterns;
 mod typechecker_program_checking;
+mod typechecker_resolve;
 mod typechecker_resolver_validation;
 mod typechecker_runtime;
 mod typechecker_semantic_validation;

--- a/tests/docs_truth/repo_hygiene/typechecker_resolve.rs
+++ b/tests/docs_truth/repo_hygiene/typechecker_resolve.rs
@@ -1,0 +1,29 @@
+use super::*;
+
+#[test]
+fn typechecker_binary_op_checking_lives_in_focused_helper() {
+    let root = read("src/typechecker/resolve.rs");
+    let binary_ops = read("src/typechecker/resolve_binary_ops.rs");
+    let module = read("src/typechecker/mod.rs");
+
+    for helper in [
+        "check_binary_op",
+        "check_arithmetic_binary_op",
+        "check_logical_binary_op",
+        "check_bitwise_binary_op",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {helper}")),
+            "type resolution root should not own binary operator helper: {helper}"
+        );
+        assert!(
+            binary_ops.contains(&format!("fn {helper}")),
+            "binary operator checking should live in focused helper: {helper}"
+        );
+    }
+
+    assert!(
+        module.contains("mod resolve_binary_ops;"),
+        "typechecker root should include focused binary operator checking module"
+    );
+}


### PR DESCRIPTION
## Summary
- Move binary operator type checking and diagnostics into `src/typechecker/resolve_binary_ops.rs`.
- Keep `resolve.rs` focused on type resolution, field lookup, and compatibility.
- Add a docs-truth guard to keep binary operator checking split out.

## TDD
- First added `typechecker_binary_op_checking_lives_in_focused_helper` and confirmed it failed because the focused helper file did not exist.

## Validation
- `cargo test --test docs_truth typechecker_binary_op_checking_lives_in_focused_helper -- --nocapture`
- `cargo test --lib binary_ops -- --nocapture`
- `cargo test --lib core_semantics::binary_ops -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --test docs_truth -- --nocapture`
- `cargo test --lib`
- `cargo test --tests`
- Push-triggered Actions check: `[]`