### PR TITLE
Compact learn guide

### DIFF
--- a/docs/learn_zen_in_y_minutes.md
+++ b/docs/learn_zen_in_y_minutes.md
@@ -167,16 +167,7 @@ PrettyDisplay.extends(Display)
 
 ## Loops
 
-Zen has one loop entry form:
-
-```zen
-loop((label) {
-    condition ?
-        | true { label.done() }
-        | false { label.next() }
-})
-```
-
+Zen has one loop entry form.
 The loop handle is compiler-owned. `done` and `next` are closed loop-control
 verbs for that handle, not arbitrary user methods and not stringly names.
 
@@ -260,17 +251,13 @@ alone is just an address.
 `Sync` and `Async` are effect modes in type surfaces. They are not source
 keywords and there is no `async fn` spelling.
 
-Sync work returns checked data now:
+Sync work returns checked data now; Async work returns task-shaped data.
 
 ```zen
 read_now = (source: Source, allocator: Allocator<u8, Sync>) Result<Bytes<u8>, IoError> {
     source.read_all(allocator)
 }
-```
 
-Async work returns task-shaped data:
-
-```zen
 read_later = (source: Source, allocator: Allocator<u8, Async>) Task<Result<Bytes<u8>, IoError>> {
     source.read_all_async(allocator)
 }

--- a/tests/docs_truth/public_docs/learn_zen.rs
+++ b/tests/docs_truth/public_docs/learn_zen.rs
@@ -109,7 +109,7 @@ fn learn_zen_guide_covers_core_tour_and_gated_previews() {
     }
 
     assert!(
-        guide.lines().count() <= 430,
+        guide.lines().count() <= 400,
         "Learn guide should stay compact; move detailed status or evidence to phase docs and tests"
     );
 }


### PR DESCRIPTION
## Summary
- Trim repeated examples/prose from `docs/learn_zen_in_y_minutes.md` while preserving the language tour coverage.
- Tighten the Learn guide docs-truth line cap from 430 to 400 so it stays compact.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth learn_zen_guide_covers_core_tour_and_gated_previews -- --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- Push-triggered Actions check: `[]`