### PR TITLE
Split build graph dependency ordering

### DIFF
--- a/src/build_graph.rs
+++ b/src/build_graph.rs
@@ -1,7 +1,9 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::fmt;
 
 use serde::Serialize;
+
+mod dependency_order;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BuildGraphInput {
@@ -156,29 +158,6 @@ impl BuildGraph {
         &self.targets
     }
 
-    pub fn targets_in_dependency_order(&self) -> Result<Vec<&BuildTarget>, BuildGraphError> {
-        let targets_by_name: BTreeMap<&str, &BuildTarget> = self
-            .targets
-            .iter()
-            .map(|target| (target.name.as_str(), target))
-            .collect();
-        let mut visiting = BTreeSet::new();
-        let mut visited = BTreeSet::new();
-        let mut ordered = Vec::with_capacity(self.targets.len());
-
-        for target in &self.targets {
-            visit_target(
-                target.name.as_str(),
-                &targets_by_name,
-                &mut visiting,
-                &mut visited,
-                &mut ordered,
-            )?;
-        }
-
-        Ok(ordered)
-    }
-
     pub fn canonical_json(&self) -> Result<String, serde_json::Error> {
         serde_json::to_string(&BuildGraphJson {
             format: "zen.build_graph.v0",
@@ -256,49 +235,6 @@ impl fmt::Display for BuildGraphError {
 }
 
 impl std::error::Error for BuildGraphError {}
-
-fn visit_target<'a>(
-    name: &'a str,
-    targets_by_name: &BTreeMap<&'a str, &'a BuildTarget>,
-    visiting: &mut BTreeSet<&'a str>,
-    visited: &mut BTreeSet<&'a str>,
-    ordered: &mut Vec<&'a BuildTarget>,
-) -> Result<(), BuildGraphError> {
-    if visited.contains(name) {
-        return Ok(());
-    }
-    if !visiting.insert(name) {
-        return Err(BuildGraphError::CyclicTargetDependency(name.to_string()));
-    }
-
-    let target =
-        targets_by_name
-            .get(name)
-            .ok_or_else(|| BuildGraphError::UnknownTargetDependency {
-                target: name.to_string(),
-                dependency: name.to_string(),
-            })?;
-    for dependency in target.dependencies() {
-        if !targets_by_name.contains_key(dependency.as_str()) {
-            return Err(BuildGraphError::UnknownTargetDependency {
-                target: target.name().to_string(),
-                dependency: dependency.clone(),
-            });
-        }
-        visit_target(
-            dependency.as_str(),
-            targets_by_name,
-            visiting,
-            visited,
-            ordered,
-        )?;
-    }
-
-    visiting.remove(name);
-    visited.insert(name);
-    ordered.push(*target);
-    Ok(())
-}
 
 fn sorted_unique<T>(values: Vec<T>) -> Vec<T>
 where

--- a/src/build_graph/dependency_order.rs
+++ b/src/build_graph/dependency_order.rs
@@ -1,0 +1,71 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::{BuildGraph, BuildGraphError, BuildTarget};
+
+impl BuildGraph {
+    pub fn targets_in_dependency_order(&self) -> Result<Vec<&BuildTarget>, BuildGraphError> {
+        let targets_by_name: BTreeMap<&str, &BuildTarget> = self
+            .targets
+            .iter()
+            .map(|target| (target.name.as_str(), target))
+            .collect();
+        let mut visiting = BTreeSet::new();
+        let mut visited = BTreeSet::new();
+        let mut ordered = Vec::with_capacity(self.targets.len());
+
+        for target in &self.targets {
+            visit_target(
+                target.name.as_str(),
+                &targets_by_name,
+                &mut visiting,
+                &mut visited,
+                &mut ordered,
+            )?;
+        }
+
+        Ok(ordered)
+    }
+}
+
+fn visit_target<'a>(
+    name: &'a str,
+    targets_by_name: &BTreeMap<&'a str, &'a BuildTarget>,
+    visiting: &mut BTreeSet<&'a str>,
+    visited: &mut BTreeSet<&'a str>,
+    ordered: &mut Vec<&'a BuildTarget>,
+) -> Result<(), BuildGraphError> {
+    if visited.contains(name) {
+        return Ok(());
+    }
+    if !visiting.insert(name) {
+        return Err(BuildGraphError::CyclicTargetDependency(name.to_string()));
+    }
+
+    let target =
+        targets_by_name
+            .get(name)
+            .ok_or_else(|| BuildGraphError::UnknownTargetDependency {
+                target: name.to_string(),
+                dependency: name.to_string(),
+            })?;
+    for dependency in target.dependencies() {
+        if !targets_by_name.contains_key(dependency.as_str()) {
+            return Err(BuildGraphError::UnknownTargetDependency {
+                target: target.name().to_string(),
+                dependency: dependency.clone(),
+            });
+        }
+        visit_target(
+            dependency.as_str(),
+            targets_by_name,
+            visiting,
+            visited,
+            ordered,
+        )?;
+    }
+
+    visiting.remove(name);
+    visited.insert(name);
+    ordered.push(*target);
+    Ok(())
+}

--- a/tests/docs_truth/repo_hygiene/build_graph_dsl.rs
+++ b/tests/docs_truth/repo_hygiene/build_graph_dsl.rs
@@ -33,3 +33,25 @@ fn build_graph_dsl_parsing_uses_enum_static_tables() {
         );
     }
 }
+
+#[test]
+fn build_graph_dependency_order_lives_in_focused_helper() {
+    let root = read("src/build_graph.rs");
+    let dependency_order = read("src/build_graph/dependency_order.rs");
+
+    for helper in ["targets_in_dependency_order", "visit_target"] {
+        assert!(
+            !root.contains(&format!("fn {helper}")),
+            "build graph root should not own dependency ordering helper: {helper}"
+        );
+        assert!(
+            dependency_order.contains(&format!("fn {helper}")),
+            "dependency ordering should live in focused build graph helper: {helper}"
+        );
+    }
+
+    assert!(
+        root.contains("mod dependency_order;"),
+        "build graph root should include focused dependency ordering module"
+    );
+}


### PR DESCRIPTION
## Summary
- Move build graph dependency-order traversal into `src/build_graph/dependency_order.rs`.
- Keep `src/build_graph.rs` focused on graph data, validation, JSON, and public target/effect types.
- Add a docs-truth guard so dependency ordering stays in the focused helper.

## TDD
- First added `build_graph_dependency_order_lives_in_focused_helper` and confirmed it failed because the focused helper file did not exist.

## Validation
- `cargo test --test docs_truth build_graph_dependency_order_lives_in_focused_helper -- --nocapture`
- `cargo test --lib build_graph -- --nocapture`
- `cargo test --test build_graph -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --test docs_truth -- --nocapture`
- `cargo test --lib`
- `cargo test --tests`
- Push-triggered Actions check: `[]`