### PR TITLE
Share behavior reference parsing

### DIFF
--- a/src/parser/behavior_declarations.rs
+++ b/src/parser/behavior_declarations.rs
@@ -3,6 +3,7 @@ use crate::ast::BehaviorMethod;
 use crate::parser::keywords::ParserBehaviorKeyword;
 
 type BehaviorMethodSignature = (Vec<Param>, Option<AstType>, Option<Expression>);
+type ParenthesizedBehaviorRef = (String, Span, Vec<AstType>, Span);
 
 impl Parser {
     pub(super) fn parse_behavior_def(
@@ -205,17 +206,7 @@ impl Parser {
         type_name: String,
         name_span: Span,
     ) -> Result<Declaration, CompileError> {
-        self.skip_newlines();
-        self.expect(&Token::LParen)?;
-        self.skip_newlines();
-        let (behavior, _) = self.expect_identifier()?;
-        let behavior_type_args = if matches!(self.peek(), Token::Lt) {
-            self.parse_type_arg_list()?
-        } else {
-            Vec::new()
-        };
-        self.skip_newlines();
-        self.expect(&Token::RParen)?;
+        let (behavior, _, behavior_type_args, _) = self.parse_parenthesized_behavior_ref()?;
         self.skip_newlines();
         self.expect(&Token::LBrace)?;
 
@@ -239,11 +230,9 @@ impl Parser {
         })
     }
 
-    pub(super) fn parse_behavior_requires(
+    fn parse_parenthesized_behavior_ref(
         &mut self,
-        type_name: String,
-        name_span: Span,
-    ) -> Result<Declaration, CompileError> {
+    ) -> Result<ParenthesizedBehaviorRef, CompileError> {
         self.skip_newlines();
         self.expect(&Token::LParen)?;
         self.skip_newlines();
@@ -255,6 +244,17 @@ impl Parser {
         };
         self.skip_newlines();
         let end = self.expect(&Token::RParen)?;
+
+        Ok((behavior, behavior_span, behavior_type_args, end))
+    }
+
+    pub(super) fn parse_behavior_requires(
+        &mut self,
+        type_name: String,
+        name_span: Span,
+    ) -> Result<Declaration, CompileError> {
+        let (behavior, behavior_span, behavior_type_args, end) =
+            self.parse_parenthesized_behavior_ref()?;
         Ok(Declaration::Requires {
             type_name,
             behavior,
@@ -268,17 +268,8 @@ impl Parser {
         type_name: String,
         name_span: Span,
     ) -> Result<Declaration, CompileError> {
-        self.skip_newlines();
-        self.expect(&Token::LParen)?;
-        self.skip_newlines();
-        let (behavior, behavior_span) = self.expect_identifier()?;
-        let behavior_type_args = if matches!(self.peek(), Token::Lt) {
-            self.parse_type_arg_list()?
-        } else {
-            Vec::new()
-        };
-        self.skip_newlines();
-        let end = self.expect(&Token::RParen)?;
+        let (behavior, behavior_span, behavior_type_args, end) =
+            self.parse_parenthesized_behavior_ref()?;
         Ok(Declaration::Derive {
             type_name,
             behavior,
@@ -292,17 +283,8 @@ impl Parser {
         behavior: String,
         name_span: Span,
     ) -> Result<Declaration, CompileError> {
-        self.skip_newlines();
-        self.expect(&Token::LParen)?;
-        self.skip_newlines();
-        let (parent, parent_span) = self.expect_identifier()?;
-        let parent_type_args = if matches!(self.peek(), Token::Lt) {
-            self.parse_type_arg_list()?
-        } else {
-            Vec::new()
-        };
-        self.skip_newlines();
-        let end = self.expect(&Token::RParen)?;
+        let (parent, parent_span, parent_type_args, end) =
+            self.parse_parenthesized_behavior_ref()?;
         Ok(Declaration::BehaviorExtends {
             behavior,
             parent,

--- a/tests/docs_truth/repo_hygiene/mod.rs
+++ b/tests/docs_truth/repo_hygiene/mod.rs
@@ -9,6 +9,7 @@ mod error_diagnostics;
 mod file_size;
 mod ir_json;
 mod module_system;
+mod parser_behavior_declarations;
 mod parser_core;
 mod parser_enums;
 mod parser_function_forms;

--- a/tests/docs_truth/repo_hygiene/parser_behavior_declarations.rs
+++ b/tests/docs_truth/repo_hygiene/parser_behavior_declarations.rs
@@ -1,0 +1,33 @@
+use super::*;
+
+#[test]
+fn parser_behavior_relationships_share_parenthesized_ref_parser() {
+    let source = read("src/parser/behavior_declarations.rs");
+
+    assert!(
+        source.contains("fn parse_parenthesized_behavior_ref"),
+        "behavior relationship parsing should share a helper for `(Behavior<T>)` references"
+    );
+
+    for parser in [
+        "parse_behavior_impl_block",
+        "parse_behavior_requires",
+        "parse_behavior_derive",
+        "parse_behavior_extends",
+    ] {
+        let start = source
+            .find(&format!("fn {parser}"))
+            .unwrap_or_else(|| panic!("missing parser helper: {parser}"));
+        let body = &source[start..];
+        let next_fn = body[1..]
+            .find("\n    fn ")
+            .or_else(|| body[1..].find("\n    pub(super) fn "))
+            .map(|offset| offset + 1)
+            .unwrap_or(body.len());
+        let body = &body[..next_fn];
+        assert!(
+            body.contains("self.parse_parenthesized_behavior_ref()?"),
+            "{parser} should use the shared parenthesized behavior reference parser"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add a shared parser helper for parenthesized behavior references such as `(Json<T>)`.
- Use it from behavior impl, requires, derive, and extends parsing paths.
- Add a docs-truth guard to prevent the repeated parser blocks from creeping back in.

## TDD
- First added `parser_behavior_relationships_share_parenthesized_ref_parser` and confirmed it failed because the shared helper did not exist.

## Validation
- `cargo test --test docs_truth parser_behavior_relationships_share_parenthesized_ref_parser -- --nocapture`
- `cargo test --lib parse_behavior -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --test docs_truth -- --nocapture`
- `cargo test --lib`
- `cargo test --tests`
- Push-triggered Actions check: `[]`