### PR TITLE
Make VS Code extension docs truthful

### DIFF
--- a/tests/docs_truth/repo_hygiene/ci_configs.rs
+++ b/tests/docs_truth/repo_hygiene/ci_configs.rs
@@ -84,6 +84,43 @@ fn ci_and_release_only_advertise_existing_targets() {
 }
 
 #[test]
+fn vscode_extension_docs_advertise_only_shipped_editor_features() {
+    let readme = read("vscode-extension/README.md");
+    let package = read("vscode-extension/package.json");
+    let source = read("vscode-extension/src/extension.ts");
+
+    assert!(
+        readme.contains("Syntax highlighting"),
+        "VS Code README should advertise shipped syntax highlighting"
+    );
+    assert!(
+        readme.contains("command palette"),
+        "VS Code README should describe shipped command-palette commands"
+    );
+    assert!(
+        package.contains("\"zen.run\"") && source.contains("registerCommand('zen.run'"),
+        "VS Code run command should be contributed and registered"
+    );
+    assert!(
+        package.contains("\"zen.build\"") && source.contains("registerCommand('zen.build'"),
+        "VS Code build command should be contributed and registered"
+    );
+
+    for unsupported in [
+        "CodeLens",
+        "Run button",
+        "Build button",
+        "CODELENS_FEATURE.md",
+        "language-server features",
+    ] {
+        assert!(
+            !readme.contains(unsupported),
+            "VS Code README should not advertise unshipped editor feature: {unsupported}"
+        );
+    }
+}
+
+#[test]
 fn checked_in_configs_do_not_contain_secret_literals() {
     let config_paths = [
         ".github/copilot-mcp.json",

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -4,16 +4,16 @@ This extension provides language support for the Zen programming language in Vis
 
 ## Features
 
-- **Syntax Highlighting**: Full syntax highlighting for Zen code
-- **CodeLens Actions**: Inline buttons to run and build functions
-  - Run button for all functions
-  - Build button for main and build entry points
-  - Automatic detection of `main` and `build` functions
-  - Click to execute directly from your editor
-- **Code Snippets**: Common Zen code patterns
+- **Syntax highlighting**: TextMate grammar support for `.zen` files.
+- **Command palette actions**: `Zen: Run Zen Function` and
+  `Zen: Build Zen Function` call the local `zen` compiler for the active file.
+- **Language configuration**: comments, brackets, indentation, and word
+  patterns for editor basics.
 
-Language-server features are not part of the rewrite baseline. They are gated
-until a tested server binary is added to the package.
+Language server, semantic diagnostics, hover, completion, formatting, and inline
+editor actions are not shipped in this rewrite package. They stay gated until a
+tested `zen lsp` binary is backed by the CLI parser, resolver, typechecker,
+build graph, and diagnostics.
 
 ## Requirements
 
@@ -44,17 +44,13 @@ This extension contributes the following settings:
 
 1. Open any `.zen` file in VS Code
 2. You'll see syntax highlighting immediately
-3. CodeLens commands can call the local `zen` compiler where supported
+3. Use the command palette to run `Zen: Run Zen Function` or
+   `Zen: Build Zen Function`
 
-### Using CodeLens Actions
+### Using Command Palette Actions
 
-1. The extension automatically detects functions in your code
-2. Look for Run and Build buttons above function definitions
-3. Click Run to execute a function
-4. Click Build to compile a function (available for `main` and `build` functions)
-5. Output appears in the "Zen Run" or "Zen Build" output channel at the bottom
-
-See [CODELENS_FEATURE.md](./CODELENS_FEATURE.md) for detailed information about the CodeLens feature.
+The commands use the active `.zen` file and write output to "Zen Run" or
+"Zen Build" output channels.
 
 ## Development
 
@@ -67,7 +63,7 @@ To work on this extension:
 
 ## Known Issues
 
-- Language-server features are gated and not shipped in this rewrite package
+- Language server features are gated and not shipped in this rewrite package
 - Performance may vary with large files
 
 ## Release Notes
@@ -76,4 +72,4 @@ To work on this extension:
 
 Initial release with basic language support:
 - Syntax highlighting
-- CodeLens command integration
+- Command palette integration


### PR DESCRIPTION
## Summary
- Update the VS Code extension README to advertise only shipped editor features.
- Remove stale CodeLens/button claims and the missing `CODELENS_FEATURE.md` link.
- Add a docs-truth guard tying README claims to contributed/registered extension commands.

## TDD
- First added `vscode_extension_docs_advertise_only_shipped_editor_features` and confirmed it failed because the README still advertised unshipped CodeLens features and did not describe command-palette commands.

## Validation
- `cargo test --test docs_truth vscode_extension_docs_advertise_only_shipped_editor_features -- --nocapture`
- `cargo test --test docs_truth ci_and_release_only_advertise_existing_targets -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --test docs_truth -- --nocapture`
- `cargo test --lib`
- `cargo test --tests`
- Push-triggered Actions check: `[]`