### PR TITLE
Compact status markdown docs

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -14,7 +14,7 @@ not assume completion without evidence.
 |---|---|---|
 | Verify repo state | Check `git status --short --branch`. | required each slice |
 | Verify tests before pushing | Run `cargo fmt --check`, `git diff --check`, focused tests, `cargo clippy -- -D warnings`, `cargo test --lib`, and `cargo test --tests`. | required each slice |
-| Keep CI quiet on normal branch pushes | Normal branch pushes should not fan out GitHub Actions; PR checks are the ready-review path. | active |
+| Keep CI quiet on normal branch pushes | normal branch pushes should not fan out GitHub Actions; PR checks are the ready-review path. | active |
 | Recover from `183d140c` | `docs/PHASE_PLAN.md` records the recovery point. | satisfied |
 | Reconstruct missing plan | `docs/PHASE_PLAN.md` records design decisions, compressed evidence, current phase, and next slice. | satisfied |
 | Continue TDD-first | New language/compiler behavior starts with a failing or tightened test. | ongoing |
@@ -29,10 +29,10 @@ first; AST/HIR traversal remains tooling/metaprogramming; type matching and
 behavior association remain separate; JSON is compiler-owned IR output; YAML is
 human-authored config/spec input; `build.zen` is deterministic comptime build
 graph construction; `StaticString` is baked program data; allocator-backed `String`
-is dynamic memory; `Type.implements(Behavior)` covers non-generic explicit behavior associations;
-Dev UX and Agent UX target MoonBit-style toolchain integration with a VS Code extension,
-language server, agent-readable diagnostics, project graph output, and
-structured fix suggestions.
+is dynamic memory; `Type.implements(Behavior)` covers non-generic explicit behavior associations.
+Dev UX and Agent UX target MoonBit-style toolchain integration with a VS Code extension, language server,
+agent-readable diagnostics, project graph output, and structured fix
+suggestions.
 
 ## Compressed Evidence Summary
 
@@ -88,13 +88,7 @@ Do not mark the objective complete while these gaps remain.
 
 ## Evidence Pointers
 
-- `docs/PHASE_PLAN.md`: recovery point, design decisions, evidence map, phase,
-  and next slice.
-- `docs/V1_SPEC.md`: current language/spec surface.
-- `docs/DIAGNOSTICS.md`: stable diagnostics catalog.
-- `docs/learn_zen_in_y_minutes.md`: concise public language tour.
-- `tests/docs_truth`: documentation, repo hygiene, and status truth gates.
-- `tests/integration`: CLI, JSON, diagnostics, build graph, and generated-C.
-- `tests/resolver_phase2.rs`: resolver Phase 2 semantic evidence.
-- `tests/zen`: executable language fixtures.
-- Git history: implementation detail that should stay out of compact Markdown.
+Use `docs/PHASE_PLAN.md`, `docs/V1_SPEC.md`, `docs/DIAGNOSTICS.md`,
+`docs/learn_zen_in_y_minutes.md`, `tests/docs_truth`, `tests/integration`,
+`tests/resolver_phase2.rs`, `tests/zen`, and git history. Keep implementation
+detail in tests, fixtures, and commits instead of expanding compact Markdown.

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -33,15 +33,12 @@ and machine-readable outputs should feel coherent rather than bolted together.
 Required Dev UX includes VS Code syntax, semantic diagnostics,
 go-to-definition, hover, completion, formatting, run/test code lenses, target
 selection, language server restart, compiler version display, local toolchain
-validation, and `zen lsp` backed by the CLI parser, resolver, typechecker,
-build graph, and diagnostics.
-
-Required Agent UX includes agent-readable diagnostics with stable codes, spans,
-related locations, suggested_fixes, feature_gate metadata, CLI/editor-aligned
-JSON, Machine-readable project graph and symbol graph output, deterministic
-quiet commands, formatting, future fix-application workflows,
-retrieval-friendly canonical docs, structured fix suggestions, and quiet
-branch-push CI.
+validation, and `zen lsp` backed by the CLI parser, resolver, typechecker, build
+graph, and diagnostics. Required Agent UX includes agent-readable diagnostics
+with stable codes, spans, related locations, suggested_fixes, feature_gate
+metadata, CLI/editor-aligned JSON, Machine-readable project graph and symbol
+graph output, deterministic quiet commands, formatting, structured fix suggestions,
+retrieval-friendly canonical docs, quiet branch-push CI, and quiet normal branch pushes.
 
 ## Compressed Evidence Map
 
@@ -113,26 +110,20 @@ advanced comptime type matching, and broad package/link build-driver behavior.
 
 ## Next Small Slice
 
-1. Pick one oversized Rust file that still crosses the cleanup threshold.
-2. Add or tighten a focused repo-hygiene/test guard.
-3. Move one coherent responsibility into a focused module.
-4. Run local gates: `cargo fmt --check`, `git diff --check`, focused tests,
-   `cargo clippy -- -D warnings`, `cargo test --lib`, and `cargo test --tests`.
-5. Confirm GitHub Actions stay quiet on normal branch pushes before opening a
-   ready PR.
+Pick one oversized Rust file that still crosses the cleanup threshold, add or
+tighten a focused repo-hygiene/test guard, move one coherent responsibility into
+a focused module, run local gates (`cargo fmt --check`, `git diff --check`,
+focused tests, `cargo clippy -- -D warnings`, `cargo test --lib`,
+`cargo test --tests`), and confirm GitHub Actions stay quiet on normal branch
+pushes before opening a ready PR.
 
 Do not mark the broader objective complete until the completion audit confirms
 all required language, docs, CI, Dev UX, Agent UX, and build-driver evidence.
 
 ## Detailed Evidence References
 
-- `docs/V1_SPEC.md`: current language/spec surface.
-- `docs/DIAGNOSTICS.md`: stable diagnostic codes and JSON expectations.
-- `docs/learn_zen_in_y_minutes.md`: concise public language tour.
-- `docs/COMPLETION_AUDIT.md`: checklist, compressed evidence, and gaps.
-- `tests/docs_truth`: documentation and repo-shape truth gates.
-- `tests/integration`: CLI, JSON, build graph, diagnostics, and generated-C.
-- `tests/resolver_phase2.rs`: resolver Phase 2 semantic evidence.
-- `tests/zen`: executable language fixtures.
-- Git history: per-slice implementation detail that should not be copied into
-  status Markdown.
+Use `docs/V1_SPEC.md`, `docs/DIAGNOSTICS.md`,
+`docs/learn_zen_in_y_minutes.md`, `docs/COMPLETION_AUDIT.md`,
+`tests/docs_truth`, `tests/integration`, `tests/resolver_phase2.rs`,
+`tests/zen`, and git history. Keep per-slice implementation detail in tests,
+fixtures, and commits instead of expanding status Markdown.

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -30,17 +30,15 @@ execution beyond the constrained deterministic graph surface.
 Developer UX and Agent UX are product requirements, not polish. The v1 language
 surface should grow toward MoonBit-style toolchain integration, but the compiler
 must not advertise unsupported language-server binaries or editor features as
-implemented. The current contract: VS Code extension remains a constrained editor wrapper until language server tests exist; `zen lsp` remains gated until
-it is backed by the same parser, resolver, typechecker, build graph, and
-diagnostics as the CLI; Agent-readable diagnostics keep stable codes, spans,
-related locations, suggested fixes, feature_gate metadata, and JSON output
-aligned with CLI and editor behavior; the machine-readable project graph and
-symbol graph remain compiler-owned outputs for modules, imports, visibility,
-targets, dependencies, generated symbols, examples, and stdlib gates; structured fix suggestions are planned for missing match arms, generic arity mistakes,
-removed syntax such as `return`, gated features, missing imports, and common type
-mismatches; quiet deterministic commands such as `zen check`, `zen test`, and
-`zen emit-json` are required for agents and editors before automated fix or
-package workflows can be promoted.
+implemented. The current contract: VS Code extension remains a constrained editor wrapper until
+language-server tests exist; `zen lsp` remains gated until it uses the same
+parser, resolver, typechecker, build graph, and diagnostics as the CLI;
+Agent-readable diagnostics keep stable codes, spans, related locations,
+structured fix suggestions, feature_gate metadata, and JSON aligned with
+CLI/editor behavior; machine-readable project graph and symbol graph JSON remain
+compiler-owned; quiet deterministic commands such as `zen check`, `zen test`,
+and `zen emit-json` are required before automated fix or package workflows can
+be promoted.
 
 ## Accepted Syntax Forms
 
@@ -170,8 +168,7 @@ Representative golden anchors:
   `unwrap_or<T, E>`, `Result.unwrap_or<T, E>`, `self: Self`,
   `Json<StaticString>`, `Json<Point>`, and `Point.encode__Json_Point`.
 - diagnostics JSON: `docs/DIAGNOSTICS.md` catalogs JSON-stable public diagnostic codes
-  only after golden fixtures pin the code and shape; broader diagnostic-code coverage is still required. Important anchors include
-  `context.kind = "feature_gate"`,
+  only after golden fixtures pin the code and shape; broader diagnostic-code coverage is still required. Anchors include `context.kind = "feature_gate"`,
   `emit_json_diagnostics_removed_return_schema_matches_golden`,
   `emit_json_diagnostics_behavior_derive_gate_schema_matches_golden`,
   `emit_json_diagnostics_generic_association_gate_schema_matches_golden`,

--- a/tests/docs_truth/phase_audit/completion_audit.rs
+++ b/tests/docs_truth/phase_audit/completion_audit.rs
@@ -68,7 +68,7 @@ fn completion_audit_records_recovery_objective_evidence_and_gaps() {
     }
 
     assert!(
-        audit.lines().count() <= 120,
+        audit.lines().count() <= 105,
         "docs/COMPLETION_AUDIT.md should stay compact; move granular evidence to tests or git history"
     );
 

--- a/tests/docs_truth/phase_audit/phase_plan.rs
+++ b/tests/docs_truth/phase_audit/phase_plan.rs
@@ -76,7 +76,7 @@ fn phase_plan_records_recovered_progress_and_next_slice() {
     }
 
     assert!(
-        plan.lines().count() <= 155,
+        plan.lines().count() <= 140,
         "docs/PHASE_PLAN.md should stay compact; move granular evidence to tests or git history"
     );
 

--- a/tests/docs_truth/v1_spec/implementation_evidence.rs
+++ b/tests/docs_truth/v1_spec/implementation_evidence.rs
@@ -64,7 +64,7 @@ fn v1_spec_records_resolver_generic_and_behavior_evidence() {
     }
 
     assert!(
-        spec.lines().count() <= 270,
+        spec.lines().count() <= 260,
         "docs/V1_SPEC.md should stay compact; move exhaustive evidence to tests, golden fixtures, or git history"
     );
 }


### PR DESCRIPTION
## Summary
- Compact duplicated status/spec prose in `PHASE_PLAN`, `COMPLETION_AUDIT`, and `V1_SPEC`.
- Keep Learn Zen unchanged as the tutorial surface.
- Tighten docs-truth line caps for the compacted files so status Markdown cannot drift back upward as easily.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Push-triggered Actions check: `[]`