### PR TITLE
Split resolver type declaration validation

### DIFF
--- a/src/resolver/declaration_validation.rs
+++ b/src/resolver/declaration_validation.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use crate::ast::Declaration;
 use crate::error::Diagnostic;
 
@@ -8,6 +6,7 @@ use super::symbol_table::ScopeStack;
 use super::{BehaviorRefMetadata, Resolver, SymbolTable};
 
 mod behavior_associations;
+mod type_declarations;
 
 impl Resolver {
     pub(super) fn validate_declaration_types(
@@ -79,56 +78,14 @@ impl Resolver {
                 fields,
                 ..
             } => {
-                self.validate_type_param_constraints(table, type_params, false, diagnostics);
-                let mut seen_fields = HashSet::new();
-                for field in fields {
-                    if !seen_fields.insert(field.name.as_str()) {
-                        diagnostics.push(Diagnostic::error(
-                            "E0211",
-                            format!("duplicate field `{}` for struct `{name}`", field.name),
-                            field.span,
-                        ));
-                    }
-                    self.validate_type_ref(
-                        table,
-                        type_params,
-                        &field.ty,
-                        field.span,
-                        false,
-                        diagnostics,
-                    );
-                    if let Some(default) = &field.default {
-                        let scope_id = table.new_scope();
-                        let mut locals = ScopeStack::new(scope_id);
-                        self.validate_expr_refs(
-                            table,
-                            type_params,
-                            default,
-                            &mut locals,
-                            false,
-                            diagnostics,
-                        );
-                    }
-                }
+                self.validate_struct_declaration(table, name, type_params, fields, diagnostics);
             }
             Declaration::Enum {
                 type_params,
                 variants,
                 ..
             } => {
-                self.validate_type_param_constraints(table, type_params, false, diagnostics);
-                for variant in variants {
-                    if let Some(payload) = &variant.payload {
-                        self.validate_type_ref(
-                            table,
-                            type_params,
-                            payload,
-                            variant.span,
-                            false,
-                            diagnostics,
-                        );
-                    }
-                }
+                self.validate_enum_declaration(table, type_params, variants, diagnostics);
             }
             Declaration::Behavior {
                 name,
@@ -136,41 +93,7 @@ impl Resolver {
                 methods,
                 ..
             } => {
-                self.validate_type_param_constraints(table, type_params, true, diagnostics);
-                let mut seen_methods = HashSet::new();
-                for method in methods {
-                    if !seen_methods.insert(method.name.as_str()) {
-                        diagnostics.push(Diagnostic::error(
-                            "E0212",
-                            format!("duplicate behavior method `{}` in `{name}`", method.name),
-                            method.span,
-                        ));
-                    }
-                    self.validate_params(table, type_params, &method.params, true, diagnostics);
-                    if let Some(return_type) = &method.return_type {
-                        self.validate_type_ref(
-                            table,
-                            type_params,
-                            return_type,
-                            method.span,
-                            true,
-                            diagnostics,
-                        );
-                    }
-                    if let Some(default_body) = &method.default_body {
-                        let scope_id = table.new_scope();
-                        let mut locals =
-                            self.param_locals(table, &method.params, scope_id, diagnostics);
-                        self.validate_expr_refs(
-                            table,
-                            type_params,
-                            default_body,
-                            &mut locals,
-                            true,
-                            diagnostics,
-                        );
-                    }
-                }
+                self.validate_behavior_declaration(table, name, type_params, methods, diagnostics);
             }
             Declaration::ImplBlock {
                 type_name,

--- a/src/resolver/declaration_validation/type_declarations.rs
+++ b/src/resolver/declaration_validation/type_declarations.rs
@@ -1,0 +1,116 @@
+use std::collections::HashSet;
+
+use crate::ast::{BehaviorMethod, EnumVariant, StructField, TypeParam};
+use crate::error::Diagnostic;
+
+use super::super::symbol_table::ScopeStack;
+use super::super::{Resolver, SymbolTable};
+
+impl Resolver {
+    pub(super) fn validate_struct_declaration(
+        &self,
+        table: &mut SymbolTable,
+        name: &str,
+        type_params: &[TypeParam],
+        fields: &[StructField],
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        self.validate_type_param_constraints(table, type_params, false, diagnostics);
+        let mut seen_fields = HashSet::new();
+        for field in fields {
+            if !seen_fields.insert(field.name.as_str()) {
+                diagnostics.push(Diagnostic::error(
+                    "E0211",
+                    format!("duplicate field `{}` for struct `{name}`", field.name),
+                    field.span,
+                ));
+            }
+            self.validate_type_ref(
+                table,
+                type_params,
+                &field.ty,
+                field.span,
+                false,
+                diagnostics,
+            );
+            if let Some(default) = &field.default {
+                let scope_id = table.new_scope();
+                let mut locals = ScopeStack::new(scope_id);
+                self.validate_expr_refs(
+                    table,
+                    type_params,
+                    default,
+                    &mut locals,
+                    false,
+                    diagnostics,
+                );
+            }
+        }
+    }
+
+    pub(super) fn validate_enum_declaration(
+        &self,
+        table: &mut SymbolTable,
+        type_params: &[TypeParam],
+        variants: &[EnumVariant],
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        self.validate_type_param_constraints(table, type_params, false, diagnostics);
+        for variant in variants {
+            if let Some(payload) = &variant.payload {
+                self.validate_type_ref(
+                    table,
+                    type_params,
+                    payload,
+                    variant.span,
+                    false,
+                    diagnostics,
+                );
+            }
+        }
+    }
+
+    pub(super) fn validate_behavior_declaration(
+        &self,
+        table: &mut SymbolTable,
+        name: &str,
+        type_params: &[TypeParam],
+        methods: &[BehaviorMethod],
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        self.validate_type_param_constraints(table, type_params, true, diagnostics);
+        let mut seen_methods = HashSet::new();
+        for method in methods {
+            if !seen_methods.insert(method.name.as_str()) {
+                diagnostics.push(Diagnostic::error(
+                    "E0212",
+                    format!("duplicate behavior method `{}` in `{name}`", method.name),
+                    method.span,
+                ));
+            }
+            self.validate_params(table, type_params, &method.params, true, diagnostics);
+            if let Some(return_type) = &method.return_type {
+                self.validate_type_ref(
+                    table,
+                    type_params,
+                    return_type,
+                    method.span,
+                    true,
+                    diagnostics,
+                );
+            }
+            if let Some(default_body) = &method.default_body {
+                let scope_id = table.new_scope();
+                let mut locals = self.param_locals(table, &method.params, scope_id, diagnostics);
+                self.validate_expr_refs(
+                    table,
+                    type_params,
+                    default_body,
+                    &mut locals,
+                    true,
+                    diagnostics,
+                );
+            }
+        }
+    }
+}

--- a/tests/docs_truth/repo_hygiene/resolver_validation.rs
+++ b/tests/docs_truth/repo_hygiene/resolver_validation.rs
@@ -32,3 +32,40 @@ fn resolver_behavior_association_validation_lives_in_focused_helper() {
         );
     }
 }
+
+#[test]
+fn resolver_type_declaration_validation_lives_in_focused_helper() {
+    let declaration_validation = read("src/resolver/declaration_validation.rs");
+    let type_declarations = read("src/resolver/declaration_validation/type_declarations.rs");
+
+    for validation_helper in [
+        "validate_struct_declaration",
+        "validate_enum_declaration",
+        "validate_behavior_declaration",
+    ] {
+        assert!(
+            !declaration_validation.contains(&format!("fn {validation_helper}")),
+            "main resolver declaration validation should not own type declaration helper: {validation_helper}"
+        );
+        assert!(
+            type_declarations.contains(&format!("fn {validation_helper}")),
+            "type declaration validation should live in focused helper: {validation_helper}"
+        );
+    }
+
+    assert!(
+        declaration_validation.lines().count() < 250,
+        "declaration_validation.rs should stay a dispatcher plus small declaration-specific checks"
+    );
+
+    for dispatch_call in [
+        "self.validate_struct_declaration",
+        "self.validate_enum_declaration",
+        "self.validate_behavior_declaration",
+    ] {
+        assert!(
+            declaration_validation.contains(dispatch_call),
+            "main resolver declaration validation should dispatch type declaration validation through helper: {dispatch_call}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Move struct, enum, and behavior declaration validation helpers into `declaration_validation/type_declarations.rs`.
- Keep `declaration_validation.rs` as the dispatcher plus smaller declaration-specific paths.
- Add a docs-truth guard enforcing the focused helper split.

## TDD
- First added `resolver_type_declaration_validation_lives_in_focused_helper` and confirmed it failed because `type_declarations.rs` did not exist.

## Validation
- `cargo test --test docs_truth resolver_type_declaration_validation_lives_in_focused_helper -- --nocapture`
- `cargo test --lib resolver -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Push-triggered Actions check: `[]`