### PR TITLE
Split struct literal default tests

### DIFF
--- a/src/typechecker/tests/core_semantics.rs
+++ b/src/typechecker/tests/core_semantics.rs
@@ -6,5 +6,6 @@ mod enum_assignment_and_modules;
 mod feature_gates;
 mod intrinsic_gates;
 mod match_semantics;
+mod struct_literal_defaults;
 mod struct_literals;
 mod type_helpers;

--- a/src/typechecker/tests/core_semantics/struct_literal_defaults.rs
+++ b/src/typechecker/tests/core_semantics/struct_literal_defaults.rs
@@ -1,8 +1,9 @@
 use super::*;
 
 #[test]
-fn struct_literal_missing_field_is_error() {
+fn struct_literal_uses_default_for_omitted_field() {
     use crate::ast::declarations::StructField;
+    use crate::ast::typed::{TypedExprKind, TypedStatementKind};
     use crate::ast::{Expression, Program, Statement};
     let mut tc = TypeChecker::new();
     let program = Program {
@@ -21,7 +22,10 @@ fn struct_literal_missing_field_is_error() {
                     StructField {
                         name: "y".into(),
                         ty: AstType::I32,
-                        default: None,
+                        default: Some(Expression::IntLiteral {
+                            value: 2,
+                            span: Span::dummy(),
+                        }),
                         mutable: false,
                         span: Span::dummy(),
                     },
@@ -64,31 +68,58 @@ fn struct_literal_missing_field_is_error() {
         file_id: 0,
     };
 
-    let errors = tc
+    let typed = tc
         .check_program(&program)
-        .expect_err("missing struct field should fail");
-    assert!(
-        errors
-            .iter()
-            .any(|d| d.message.contains("missing field `y` for struct `Point`")),
-        "expected missing field diagnostic, got {errors:?}"
-    );
+        .expect("defaulted struct field may be omitted");
+    let TypedStatementKind::VarDecl { value, .. } = &typed.functions[0].body.statements[0].kind
+    else {
+        panic!("expected var decl");
+    };
+    let TypedExprKind::StructLiteral { fields, .. } = &value.kind else {
+        panic!("expected struct literal");
+    };
+    assert_eq!(fields.len(), 2);
+    assert_eq!(fields[1].0, "y");
+    assert!(matches!(fields[1].1.kind, TypedExprKind::IntLiteral(2)));
 }
 
 #[test]
-fn struct_literal_field_type_mismatch_is_error() {
-    use crate::ast::declarations::StructField;
+fn generic_struct_literal_uses_substituted_default_for_omitted_field() {
+    use crate::ast::declarations::{StructField, TypeParam};
+    use crate::ast::typed::{TypedExprKind, TypedStatementKind};
     use crate::ast::{Expression, Program, Statement};
     let mut tc = TypeChecker::new();
     let program = Program {
         declarations: vec![
             Declaration::Struct {
-                name: "Point".into(),
-                type_params: Vec::new(),
+                name: "Box".into(),
+                type_params: vec![TypeParam {
+                    name: "T".into(),
+                    constraint: None,
+                    constraint_type_args: Vec::new(),
+                    span: Span::dummy(),
+                }],
                 fields: vec![StructField {
-                    name: "x".into(),
-                    ty: AstType::I32,
-                    default: None,
+                    name: "value".into(),
+                    ty: AstType::Named("T".into()),
+                    default: Some(Expression::Block {
+                        statements: vec![Statement::VarDecl {
+                            name: "same".into(),
+                            ty: Some(AstType::Named("T".into())),
+                            value: Expression::StringLiteral {
+                                value: "fallback".into(),
+                                span: Span::dummy(),
+                            },
+                            mutable: false,
+                            constant: false,
+                            span: Span::dummy(),
+                        }],
+                        expr: Some(Box::new(Expression::Identifier {
+                            name: "same".into(),
+                            span: Span::dummy(),
+                        })),
+                        span: Span::dummy(),
+                    }),
                     mutable: false,
                     span: Span::dummy(),
                 }],
@@ -102,18 +133,12 @@ fn struct_literal_field_type_mismatch_is_error() {
                 return_type: Some(AstType::Void),
                 body: Expression::Block {
                     statements: vec![Statement::VarDecl {
-                        name: "p".into(),
+                        name: "box".into(),
                         ty: None,
                         value: Expression::StructLiteral {
-                            name: "Point".into(),
-                            type_args: Vec::new(),
-                            fields: vec![(
-                                "x".into(),
-                                Expression::StringLiteral {
-                                    value: "bad".into(),
-                                    span: Span::dummy(),
-                                },
-                            )],
+                            name: "Box".into(),
+                            type_args: vec![AstType::Str],
+                            fields: Vec::new(),
                             span: Span::dummy(),
                         },
                         mutable: false,
@@ -130,13 +155,17 @@ fn struct_literal_field_type_mismatch_is_error() {
         file_id: 0,
     };
 
-    let errors = tc
+    let typed = tc
         .check_program(&program)
-        .expect_err("struct field type mismatch should fail");
-    assert!(
-        errors.iter().any(|d| d
-            .message
-            .contains("field `x` for struct `Point` expects `i32`, found `StaticString`")),
-        "expected field type diagnostic, got {errors:?}"
-    );
+        .expect("generic defaulted struct field may be omitted");
+    let TypedStatementKind::VarDecl { value, .. } = &typed.functions[0].body.statements[0].kind
+    else {
+        panic!("expected var decl");
+    };
+    let TypedExprKind::StructLiteral { fields, .. } = &value.kind else {
+        panic!("expected struct literal");
+    };
+    assert_eq!(fields.len(), 1);
+    assert_eq!(fields[0].0, "value");
+    assert_eq!(fields[0].1.ty, Type::Str);
 }

--- a/tests/docs_truth/repo_hygiene/file_size.rs
+++ b/tests/docs_truth/repo_hygiene/file_size.rs
@@ -117,3 +117,31 @@ fn declaration_validation_precollection_tasks_live_in_focused_helper() {
         "declaration_validation.rs should include the focused precollection_tasks module"
     );
 }
+
+#[test]
+fn struct_literal_default_tests_live_in_focused_helper() {
+    let struct_literals = read("src/typechecker/tests/core_semantics/struct_literals.rs");
+    let defaults = read("src/typechecker/tests/core_semantics/struct_literal_defaults.rs");
+    let module = read("src/typechecker/tests/core_semantics.rs");
+
+    assert!(
+        struct_literals.lines().count() < 180,
+        "struct_literals.rs should stay focused on struct literal error cases"
+    );
+    assert!(
+        !struct_literals.contains("struct_literal_uses_default_for_omitted_field"),
+        "struct literal default tests should live in struct_literal_defaults.rs"
+    );
+    assert!(
+        defaults.contains("struct_literal_uses_default_for_omitted_field"),
+        "struct_literal_defaults.rs should cover defaulted field omission"
+    );
+    assert!(
+        defaults.contains("generic_struct_literal_uses_substituted_default_for_omitted_field"),
+        "struct_literal_defaults.rs should cover generic default substitution"
+    );
+    assert!(
+        module.contains("mod struct_literal_defaults;"),
+        "core_semantics.rs should include the focused struct_literal_defaults module"
+    );
+}


### PR DESCRIPTION
## Summary
- Move struct literal default-field tests into `struct_literal_defaults.rs`.
- Keep `struct_literals.rs` focused on missing-field and field-type error cases.
- Add a docs-truth guard that preserves the focused test split.

## TDD
- First added `struct_literal_default_tests_live_in_focused_helper` and confirmed it failed because `struct_literal_defaults.rs` did not exist.

## Validation
- `cargo test --test docs_truth struct_literal_default_tests_live_in_focused_helper -- --nocapture`
- `cargo test --lib core_semantics::struct_literal -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Push-triggered Actions check: `[]`