### PR TITLE
Compact phase audit docs

### DIFF
--- a/docs/COMPLETION_AUDIT.md
+++ b/docs/COMPLETION_AUDIT.md
@@ -3,55 +3,43 @@
 ## Objective Restatement
 
 Continue from recovered branch `codex/phase0-1-truth-gates` at recovery commit
-`183d140c` from 2026-05-12 08:18:35 UTC. Treat unpushed `/tmp` work after that
-commit as lost, reconstruct the durable plan from checked-in docs/tests/commits,
-continue TDD-first in small tested commits, preserve design decisions, and do
-not assume completion without evidence.
+`183d140c` from 2026-05-12 08:18:35 UTC. Reconstruct durable work from checked-in
+docs/tests/commits, keep slices TDD-first, and do not assume completion without
+evidence. `docs/PHASE_PLAN.md` is the operating plan.
 
 ## Prompt-To-Artifact Checklist
 
 | Requirement | Evidence | Status |
 |---|---|---|
-| Verify repo state | Check `git status --short --branch`. | required each slice |
-| Verify tests before pushing | Run `cargo fmt --check`, `git diff --check`, focused tests, `cargo clippy -- -D warnings`, `cargo test --lib`, and `cargo test --tests`. | required each slice |
-| Keep CI quiet on normal branch pushes | normal branch pushes should not fan out GitHub Actions; PR checks are the ready-review path. | active |
-| Recover from `183d140c` | `docs/PHASE_PLAN.md` records the recovery point. | satisfied |
-| Reconstruct missing plan | `docs/PHASE_PLAN.md` records design decisions, compressed evidence, current phase, and next slice. | satisfied |
-| Continue TDD-first | New language/compiler behavior starts with a failing or tightened test. | ongoing |
-| Work in small tested commits | Recent history is split into focused docs, schema, diagnostic, parser, resolver, and cleanup commits. | ongoing |
-| Preserve design decisions | See below and `docs/PHASE_PLAN.md`. | satisfied |
-| Avoid completion assumption | Unresolved gaps remain. | active |
+| Verify repo state | `git status --short --branch`. | required each slice |
+| Verify tests before pushing | `cargo fmt --check`, `git diff --check`, focused tests, `cargo clippy -- -D warnings`, `cargo test --lib`, `cargo test --tests`. | required each slice |
+| Keep CI quiet on normal branch pushes | Branch push Actions should be quiet; PR checks are the ready-review path. | active |
+| Recover/reconstruct plan | `docs/PHASE_PLAN.md` records recovery, decisions, evidence, phase, and next slice. | satisfied |
+| Preserve decisions and avoid completion assumption | See preserved decisions and unresolved gaps below. | active |
 
 ## Design Decisions Preserved
 
-Sync/Async are real effects; typed allocators remain central; actors live in std
-first; AST/HIR traversal remains tooling/metaprogramming; type matching and
-behavior association remain separate; JSON is compiler-owned IR output; YAML is
-human-authored config/spec input; `build.zen` is deterministic comptime build
-graph construction; `StaticString` is baked program data; allocator-backed `String`
-is dynamic memory; `Type.implements(Behavior)` covers non-generic explicit behavior associations.
-Dev UX and Agent UX target MoonBit-style toolchain integration with a VS Code extension, language server,
-agent-readable diagnostics, project graph output, and structured fix
+Sync/Async are real effects; typed allocators are central; actors live in std first;
+AST/HIR traversal is tooling/metaprogramming; type matching and behavior association
+are separate; JSON is compiler-owned IR output; YAML is human-authored config/spec
+input; `build.zen` is deterministic comptime build graph construction; `StaticString`
+is baked program data; allocator-backed `String` is dynamic memory;
+`Type.implements(Behavior)` covers non-generic explicit behavior associations. Dev
+UX and Agent UX target MoonBit-style toolchain integration with a VS Code extension,
+language server, agent-readable diagnostics, project graph output, and structured fix
 suggestions.
 
 ## Compressed Evidence Summary
 
-- Public docs are split by job: `README.md` pitches the language,
-  `docs/learn_zen_in_y_minutes.md` teaches it, and status lives here plus
-  `docs/PHASE_PLAN.md`.
-- Phase 0 truth gates and repo shape are guarded by `tests/docs_truth`,
-  including `production_rust_files_stay_below_cleanup_threshold`,
-  `zen_source_files_stay_below_cleanup_threshold`, and every tracked Rust source file
-  threshold.
-- Phase 1 frontend/C-backend behavior is guarded by `docs/V1_SPEC.md`,
-  `tests/zen`, generated-C checks, and integration tests.
-- Generic specialization covers executable fixtures, JSON golden tests,
-  imported templates, nested `Result<Option<T>, StaticString>`, and
-  generated-C definition/call scans.
-- Resolver/typechecker handoff uses resolver-owned metadata with coverage for
-  declaration replay, `generic_struct_constructor_without_type_args_is_error`,
-  stale AST avoidance, and behavior impl passes.
-- Diagnostics have stable JSON surfaces through
+- Public docs are split by job: `README.md` pitches, `docs/learn_zen_in_y_minutes.md` teaches, and status lives here plus `docs/PHASE_PLAN.md`.
+- Phase 0 and repo shape are guarded by `tests/docs_truth`, including
+  `production_rust_files_stay_below_cleanup_threshold`,
+  `zen_source_files_stay_below_cleanup_threshold`, and every tracked Rust source file.
+- Frontend/C-backend behavior is guarded by `docs/V1_SPEC.md`, `tests/zen`,
+  generated-C checks, and integration tests.
+- Generic specialization covers executable fixtures, JSON golden tests, imports, nested `Result<Option<T>, StaticString>`, generated-C scans, and `generic_struct_constructor_without_type_args_is_error`.
+- Resolver/typechecker handoff uses resolver-owned metadata with declaration replay, stale AST avoidance, and behavior impl passes.
+- Diagnostics have stable JSON through
   `emit_json_diagnostics_command_outputs_machine_readable_errors`,
   `emit_json_diagnostics_includes_structured_return_keyword_fix`,
   `emit_json_diagnostics_includes_structured_missing_bool_match_arm_fix`,
@@ -69,14 +57,11 @@ suggestions.
   `dynamic_string_type_is_rejected_as_allocator_backed_gate`,
   `raw_memory_intrinsics_are_rejected_as_allocator_gates`, and
   `syscall_intrinsics_are_rejected_as_host_effect_gates`.
-- Standard library sketches remain visible but guarded, including
-  `stdlib/io/mux/uring.zen`, `stdlib/io/net/unix_socket.zen`,
-  `stdlib/io/net/socket.zen`, `stdlib/io/files/file.zen`, and
-  `stdlib/sys/process/prctl.zen`.
+- Standard library sketches remain visible but guarded: `stdlib/io/mux/uring.zen`, `stdlib/io/net/unix_socket.zen`, `stdlib/io/net/socket.zen`, `stdlib/io/files/file.zen`, and `stdlib/sys/process/prctl.zen`.
 
 ## Unresolved Gaps
 
-- The constrained build-driver is not a full package manager or open-ended link
+- The constrained build-driver is not a package manager or open-ended link
   system; broader build graph semantics remain gated behind deterministic graph tests.
 - Dev UX and Agent UX are planned requirements, not finished product surfaces.
 - Async lowering, allocator-backed dynamic strings, raw memory, byte memory,

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -3,10 +3,8 @@
 ## Recovery Point
 
 Recovered branch: `codex/phase0-1-truth-gates`.
-
 Recovery commit: `183d140c` from 2026-05-12 08:18:35 UTC.
-
-Treat unpushed `/tmp` work after that commit as lost. Continue from checked-in
+Treat unpushed `/tmp` work after that commit as lost; continue from checked-in
 docs, tests, and commits only.
 
 ## Design Decisions To Preserve
@@ -28,102 +26,88 @@ docs, tests, and commits only.
 
 MoonBit-style toolchain integration is the benchmark: compiler, build graph,
 package surface, language server, VS Code extension, web/editor entry point,
-and machine-readable outputs should feel coherent rather than bolted together.
+and machine-readable outputs should feel coherent.
 
-Required Dev UX includes VS Code syntax, semantic diagnostics,
-go-to-definition, hover, completion, formatting, run/test code lenses, target
-selection, language server restart, compiler version display, local toolchain
-validation, and `zen lsp` backed by the CLI parser, resolver, typechecker, build
-graph, and diagnostics. Required Agent UX includes agent-readable diagnostics
-with stable codes, spans, related locations, suggested_fixes, feature_gate
-metadata, CLI/editor-aligned JSON, Machine-readable project graph and symbol
-graph output, deterministic quiet commands, formatting, structured fix suggestions,
-retrieval-friendly canonical docs, quiet branch-push CI, and quiet normal branch pushes.
+Required Dev UX: syntax, semantic diagnostics, go-to-definition, hover,
+completion, formatting, run/test code lenses, target selection, language server
+restart, compiler version display, local toolchain validation, and `zen lsp`.
+
+Required Agent UX: agent-readable diagnostics with stable codes, spans, related
+locations, suggested_fixes, feature_gate metadata, CLI/editor-aligned JSON,
+Machine-readable project graph and symbol graph output, deterministic quiet commands,
+structured fix suggestions, retrieval-friendly docs, and quiet normal branch pushes.
 
 ## Compressed Evidence Map
 
-This is a capability index, not a changelog. Granular evidence belongs in
-tests, golden fixtures, and git history.
+This is a capability index, not a changelog. Granular evidence belongs in tests,
+golden fixtures, and git history.
 
-- Phase 0 truth gates: README, contributor, stdlib, CI, release, old-spec
+- Phase 0 truth gates: README, contributor docs, stdlib, CI, release, old-spec
   quarantine, and docs shape are guarded by `tests/docs_truth`.
-- Phase 1 frontend and C-backend baseline: supported syntax and C execution are
-  documented in `docs/V1_SPEC.md` and covered by `tests/zen` plus integration
-  tests.
-- generic specialization: generic functions, structs, enums, methods,
-  recursive worklists, imported templates, nested `Result<Option<T>,
-  StaticString>`, and generated-C consistency are covered by executable and
-  JSON-golden integration tests.
+- Phase 1 frontend and C-backend baseline: syntax and C execution are covered by
+  `docs/V1_SPEC.md`, `tests/zen`, integration tests, and generated-C checks.
+- generic specialization: functions, structs, enums, methods, recursive
+  worklists, imports, nested `Result<Option<T>, StaticString>`, and generated-C
+  consistency are covered by executable and JSON-golden integration tests.
 - resolver/typechecker replay: resolver-owned metadata, callable signatures,
-  behavior impl passes, stale AST protection, `generic_struct_constructor_without_type_args_is_error`,
-  and generic arity diagnostics are covered by `tests/resolver_phase2.rs`,
-  typechecker unit tests, and integration diagnostics.
+  behavior impl passes, stale AST protection,
+  `generic_struct_constructor_without_type_args_is_error`, and generic arity
+  diagnostics are covered by `tests/resolver_phase2.rs`, typechecker unit tests,
+  and integration diagnostics.
 - diagnostics JSON: `emit_json_diagnostics_command_outputs_machine_readable_errors`,
   `emit_json_diagnostics_includes_structured_return_keyword_fix`, and
   `emit_json_diagnostics_includes_structured_missing_bool_match_arm_fix` pin
   stable diagnostics with suggested_fixes and feature_gate data.
 - Typed/HIR/MIR JSON: `emit_json_ast_marks_semantically_unchecked_sources_that_typed_json_rejects`
-  and `emit_json_typed_command_outputs_checked_program` guard checked program
-  output with schema golden tests.
+  and `emit_json_typed_command_outputs_checked_program` guard checked output.
 - build graph: deterministic build.zen graph behavior is guarded by parser,
-  lowering, JSON, and CLI tests such as
-  `deterministic_build_graph_creates_one_executable_target`.
-- Gated effects and intrinsics:
-  `async_scheduler_intrinsics_are_rejected_as_gated_not_unknown`,
+  lowering, JSON, CLI tests, and `deterministic_build_graph_creates_one_executable_target`.
+- Gated effects/intrinsics: `async_scheduler_intrinsics_are_rejected_as_gated_not_unknown`,
   `atomic_intrinsics_are_rejected_as_effect_gates`,
   `comptime_type_match_intrinsic_is_rejected_as_gated_not_unknown`,
   `dynamic_string_type_is_rejected_as_allocator_backed_gate`,
   `raw_memory_intrinsics_are_rejected_as_allocator_gates`, and
   `syscall_intrinsics_are_rejected_as_host_effect_gates`.
-- repo hygiene: `production_rust_files_stay_below_cleanup_threshold`,
-  `zen_source_files_stay_below_cleanup_threshold`, owned spelling enums, and
-  old-node cleanup tests keep files and syntax tables from regressing.
+- repo hygiene: file-size tests, owned spelling enums, syntax cleanup tests, and
+  docs-truth caps prevent large-file and status-doc regressions.
 
 ## Current Phase
 
-Phase 5 is in evidence-hardening and cleanup. The main generic specialization
-surfaces are implemented; continue by closing proof gaps, keeping generated C
+Phase 5 is in evidence-hardening and cleanup. The generic specialization
+surfaces are implemented; continue closing proof gaps, keeping generated C
 consistent, and preventing large-file/slop regressions.
 
 ## Phase 5 Acceptance Evidence
 
-- generic enum specialization: `Option<T>`, `Result<T, E>`, nested
-  `Result<Option<T>, StaticString>`, duplicate variants, and multi-file enum
-  dependencies are covered by executable fixtures, typed/HIR/MIR golden tests,
-  and generated-C tests.
+- generic enum specialization: `Option<T>`, `Result<T, E>`, nested results,
+  duplicate variants, multi-file dependencies, executable fixtures, typed/HIR/MIR
+  golden tests, and generated-C tests.
 - generic method specialization: generic, `Self`, type impl, enum, imported
-  dependency, and nested result method cases are covered by executable
-  fixtures, JSON golden tests, and method worklist generated-C tests.
-- worklist monomorphization: recursive functions, methods, imported transitive
-  dependencies, and deduped instantiations are covered by `generic_worklist*`,
-  `generic_method_worklist`, `multi_file_generic_imported_*`, and generated-C
-  definition-count checks.
+  dependency, nested result cases, JSON golden tests, and method worklist
+  generated-C checks.
+- worklist monomorphization: recursive functions/methods, imported transitive
+  dependencies, deduped instantiations, and generated-C definition-count checks.
 - generated-C call/definition consistency:
   `compile_to_c_with_generated_call_check`, `undefined_generated_c_calls`, and
-  duplicate-definition checks scan specialization fixtures.
+  duplicate-definition scans.
 - generic arity, inference, and bound diagnostics: E5000, E5001, E5002, and
-  E6004 are pinned across unit, CLI, and JSON golden tests.
+  E6004 across unit, CLI, and JSON golden tests.
 
-Current non-Phase-5 gaps remain Dev UX, Agent UX, full LSP/editor workflows,
+Non-Phase-5 gaps remain Dev UX, Agent UX, full LSP/editor workflows,
 allocator-backed dynamic strings, Sync/Async lowering, raw memory semantics,
 advanced comptime type matching, and broad package/link build-driver behavior.
 
 ## Next Small Slice
 
-Pick one oversized Rust file that still crosses the cleanup threshold, add or
-tighten a focused repo-hygiene/test guard, move one coherent responsibility into
-a focused module, run local gates (`cargo fmt --check`, `git diff --check`,
-focused tests, `cargo clippy -- -D warnings`, `cargo test --lib`,
-`cargo test --tests`), and confirm GitHub Actions stay quiet on normal branch
-pushes before opening a ready PR.
-
-Do not mark the broader objective complete until the completion audit confirms
-all required language, docs, CI, Dev UX, Agent UX, and build-driver evidence.
+Pick one oversized Rust file, add or tighten a focused repo-hygiene/test guard,
+move one coherent responsibility into a focused module, run local gates, confirm
+normal branch-push Actions stay quiet, open a ready PR, and merge only when PR
+checks pass.
 
 ## Detailed Evidence References
 
 Use `docs/V1_SPEC.md`, `docs/DIAGNOSTICS.md`,
 `docs/learn_zen_in_y_minutes.md`, `docs/COMPLETION_AUDIT.md`,
 `tests/docs_truth`, `tests/integration`, `tests/resolver_phase2.rs`,
-`tests/zen`, and git history. Keep per-slice implementation detail in tests,
-fixtures, and commits instead of expanding status Markdown.
+`tests/zen`, and git history. Keep implementation detail in tests, fixtures,
+and commits instead of expanding status Markdown.

--- a/tests/docs_truth/phase_audit/completion_audit.rs
+++ b/tests/docs_truth/phase_audit/completion_audit.rs
@@ -68,7 +68,7 @@ fn completion_audit_records_recovery_objective_evidence_and_gaps() {
     }
 
     assert!(
-        audit.lines().count() <= 105,
+        audit.lines().count() <= 80,
         "docs/COMPLETION_AUDIT.md should stay compact; move granular evidence to tests or git history"
     );
 

--- a/tests/docs_truth/phase_audit/phase_plan.rs
+++ b/tests/docs_truth/phase_audit/phase_plan.rs
@@ -76,7 +76,7 @@ fn phase_plan_records_recovered_progress_and_next_slice() {
     }
 
     assert!(
-        plan.lines().count() <= 140,
+        plan.lines().count() <= 115,
         "docs/PHASE_PLAN.md should stay compact; move granular evidence to tests or git history"
     );
 


### PR DESCRIPTION
## Summary
- Compress `docs/PHASE_PLAN.md` and `docs/COMPLETION_AUDIT.md` by removing repeated status narrative while preserving durable evidence pointers.
- Tighten docs-truth line caps so phase-plan/audit docs stay compact going forward.
- Leave `docs/learn_zen_in_y_minutes.md` intact because it is language tutorial content, not status noise.

## TDD
- First tightened the phase audit compactness caps and confirmed `cargo test --test docs_truth phase_audit -- --nocapture` failed on the current docs.

## Validation
- `cargo test --test docs_truth phase_audit -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Push-triggered Actions check: `[]`