### PR TITLE
Split resolver expression dispatch

### DIFF
--- a/src/resolver/expression_validation.rs
+++ b/src/resolver/expression_validation.rs
@@ -1,16 +1,13 @@
 use crate::ast::{Expression, TypeParam};
 use crate::error::Diagnostic;
 
-use super::expression_validation_constructs::{
-    BlockRef, ClosureRef, EnumVariantRef, StructLiteralRef,
-};
 use super::symbol_table::ScopeStack;
 use super::{Resolver, SymbolTable};
 
 mod calls;
+mod construct_dispatch;
+mod dispatch;
 mod traversal;
-use calls::{FunctionCallRef, MethodCallRef};
-use traversal::{BinaryExprRef, IfOrWhileExprRef, IndexExprRef, RangeExprRef};
 
 impl Resolver {
     pub(super) fn validate_expr_refs(
@@ -23,281 +20,47 @@ impl Resolver {
         diagnostics: &mut Vec<Diagnostic>,
     ) {
         match expr {
-            Expression::FunctionCall {
-                name,
-                module,
-                type_args,
-                args,
-                span,
-            } => {
-                self.validate_function_call_expr_refs(
-                    table,
-                    type_params,
-                    FunctionCallRef {
-                        name,
-                        module: module.as_deref(),
-                        type_args,
-                        args,
-                        span: *span,
-                    },
-                    locals,
-                    allow_self_type,
-                    diagnostics,
-                );
-            }
-            Expression::Identifier { name, span } => {
-                self.validate_identifier_expr_refs(table, name, *span, locals, diagnostics);
-            }
-            Expression::MethodCall {
-                receiver,
-                type_args,
-                args,
-                span,
-                ..
-            } => {
-                self.validate_method_call_expr_refs(
-                    table,
-                    type_params,
-                    MethodCallRef {
-                        receiver,
-                        type_args,
-                        args,
-                        span: *span,
-                    },
-                    locals,
-                    allow_self_type,
-                    diagnostics,
-                );
-            }
-            Expression::BinaryOp { left, right, .. } => {
-                self.validate_binary_expr_refs(
-                    table,
-                    type_params,
-                    BinaryExprRef { left, right },
-                    locals,
-                    allow_self_type,
-                    diagnostics,
-                );
-            }
-            Expression::UnaryOp { operand, .. }
-            | Expression::MemberAccess {
-                object: operand, ..
-            } => {
-                self.validate_unary_expr_refs(
-                    table,
-                    type_params,
-                    operand,
-                    locals,
-                    allow_self_type,
-                    diagnostics,
-                );
-            }
-            Expression::IndexAccess { object, index, .. } => {
-                self.validate_index_expr_refs(
-                    table,
-                    type_params,
-                    IndexExprRef { object, index },
-                    locals,
-                    allow_self_type,
-                    diagnostics,
-                );
-            }
-            Expression::StructLiteral {
-                name,
-                type_args,
-                fields,
-                span,
-            } => {
-                self.validate_struct_literal_refs(
-                    table,
-                    type_params,
-                    StructLiteralRef {
-                        name,
-                        type_args,
-                        fields,
-                        span: *span,
-                    },
-                    locals,
-                    allow_self_type,
-                    diagnostics,
-                );
-            }
-            Expression::EnumVariant {
-                enum_name,
-                type_args,
-                variant,
-                payload,
-                span,
-            } => {
-                self.validate_enum_variant_refs(
-                    table,
-                    type_params,
-                    EnumVariantRef {
-                        enum_name,
-                        type_args,
-                        variant,
-                        payload: payload.as_deref(),
-                        span: *span,
-                    },
-                    locals,
-                    allow_self_type,
-                    diagnostics,
-                );
-            }
-            Expression::ArrayLiteral { elements, .. } => {
-                self.validate_expr_arg_refs(
-                    table,
-                    type_params,
-                    elements,
-                    locals,
-                    allow_self_type,
-                    diagnostics,
-                );
-            }
-            Expression::Match {
-                scrutinee, arms, ..
-            } => {
-                self.validate_expr_refs(
-                    table,
-                    type_params,
-                    scrutinee,
-                    locals,
-                    allow_self_type,
-                    diagnostics,
-                );
-                for arm in arms {
-                    self.validate_match_arm_refs(
-                        table,
-                        type_params,
-                        arm,
-                        locals,
-                        allow_self_type,
-                        diagnostics,
-                    );
-                }
-            }
-            Expression::WhileLoop {
-                condition, body, ..
-            }
-            | Expression::If {
-                condition,
-                then_body: body,
-                ..
-            } => {
-                let else_body = match expr {
-                    Expression::If { else_body, .. } => else_body.as_deref(),
-                    _ => None,
-                };
-                self.validate_if_or_while_expr_refs(
-                    table,
-                    type_params,
-                    IfOrWhileExprRef {
-                        condition,
-                        body,
-                        else_body,
-                    },
-                    locals,
-                    allow_self_type,
-                    diagnostics,
-                );
-            }
-            Expression::Loop { body, .. } => {
-                self.validate_child_scope_expr_refs(
-                    table,
-                    type_params,
-                    body,
-                    locals,
-                    allow_self_type,
-                    diagnostics,
-                );
-            }
-            Expression::Block {
-                statements, expr, ..
-            } => {
-                self.validate_block_refs(
-                    table,
-                    type_params,
-                    BlockRef {
-                        statements,
-                        expr: expr.as_deref(),
-                    },
-                    locals,
-                    allow_self_type,
-                    diagnostics,
-                );
-            }
-            Expression::Closure {
-                params,
-                return_type,
-                body,
-                span,
-            } => {
-                self.validate_closure_refs(
-                    table,
-                    type_params,
-                    ClosureRef {
-                        params,
-                        return_type: return_type.as_ref(),
-                        body,
-                        span: *span,
-                    },
-                    locals,
-                    allow_self_type,
-                    diagnostics,
-                );
-            }
-            Expression::Cast {
+            Expression::FunctionCall { .. }
+            | Expression::Identifier { .. }
+            | Expression::MethodCall { .. } => self.validate_call_expr_refs(
+                table,
+                type_params,
                 expr,
-                target_type,
-                span,
-            } => {
-                self.validate_expr_refs(
-                    table,
-                    type_params,
-                    expr,
-                    locals,
-                    allow_self_type,
-                    diagnostics,
-                );
-                self.validate_type_ref(
-                    table,
-                    type_params,
-                    target_type,
-                    *span,
-                    allow_self_type,
-                    diagnostics,
-                );
-            }
-            Expression::StringInterpolation { parts, .. } => {
-                self.validate_string_interpolation_refs(
-                    table,
-                    type_params,
-                    parts,
-                    locals,
-                    allow_self_type,
-                    diagnostics,
-                );
-            }
-            Expression::Range { start, end, .. } => {
-                self.validate_range_expr_refs(
-                    table,
-                    type_params,
-                    RangeExprRef { start, end },
-                    locals,
-                    allow_self_type,
-                    diagnostics,
-                );
-            }
-            Expression::Defer { expr, .. } => {
-                self.validate_defer_expr_refs(
-                    table,
-                    type_params,
-                    expr,
-                    locals,
-                    allow_self_type,
-                    diagnostics,
-                );
-            }
+                locals,
+                allow_self_type,
+                diagnostics,
+            ),
+            Expression::BinaryOp { .. }
+            | Expression::UnaryOp { .. }
+            | Expression::MemberAccess { .. }
+            | Expression::IndexAccess { .. }
+            | Expression::WhileLoop { .. }
+            | Expression::If { .. }
+            | Expression::Cast { .. }
+            | Expression::StringInterpolation { .. }
+            | Expression::Range { .. }
+            | Expression::Defer { .. } => self.validate_traversal_expr_refs(
+                table,
+                type_params,
+                expr,
+                locals,
+                allow_self_type,
+                diagnostics,
+            ),
+            Expression::StructLiteral { .. }
+            | Expression::EnumVariant { .. }
+            | Expression::ArrayLiteral { .. }
+            | Expression::Match { .. }
+            | Expression::Loop { .. }
+            | Expression::Block { .. }
+            | Expression::Closure { .. } => self.validate_construct_expr_refs(
+                table,
+                type_params,
+                expr,
+                locals,
+                allow_self_type,
+                diagnostics,
+            ),
             Expression::IntLiteral { .. }
             | Expression::FloatLiteral { .. }
             | Expression::StringLiteral { .. }

--- a/src/resolver/expression_validation/construct_dispatch.rs
+++ b/src/resolver/expression_validation/construct_dispatch.rs
@@ -1,0 +1,131 @@
+use crate::ast::{Expression, TypeParam};
+use crate::error::Diagnostic;
+
+use super::super::expression_validation_constructs::{
+    BlockRef, ClosureRef, EnumVariantRef, StructLiteralRef,
+};
+use super::super::symbol_table::ScopeStack;
+use super::super::{Resolver, SymbolTable};
+
+impl Resolver {
+    pub(super) fn validate_construct_expr_refs(
+        &self,
+        table: &mut SymbolTable,
+        type_params: &[TypeParam],
+        expr: &Expression,
+        locals: &mut ScopeStack,
+        allow_self_type: bool,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        match expr {
+            Expression::StructLiteral {
+                name,
+                type_args,
+                fields,
+                span,
+            } => self.validate_struct_literal_refs(
+                table,
+                type_params,
+                StructLiteralRef {
+                    name,
+                    type_args,
+                    fields,
+                    span: *span,
+                },
+                locals,
+                allow_self_type,
+                diagnostics,
+            ),
+            Expression::EnumVariant {
+                enum_name,
+                type_args,
+                variant,
+                payload,
+                span,
+            } => self.validate_enum_variant_refs(
+                table,
+                type_params,
+                EnumVariantRef {
+                    enum_name,
+                    type_args,
+                    variant,
+                    payload: payload.as_deref(),
+                    span: *span,
+                },
+                locals,
+                allow_self_type,
+                diagnostics,
+            ),
+            Expression::ArrayLiteral { elements, .. } => self.validate_expr_arg_refs(
+                table,
+                type_params,
+                elements,
+                locals,
+                allow_self_type,
+                diagnostics,
+            ),
+            Expression::Match {
+                scrutinee, arms, ..
+            } => {
+                self.validate_expr_refs(
+                    table,
+                    type_params,
+                    scrutinee,
+                    locals,
+                    allow_self_type,
+                    diagnostics,
+                );
+                for arm in arms {
+                    self.validate_match_arm_refs(
+                        table,
+                        type_params,
+                        arm,
+                        locals,
+                        allow_self_type,
+                        diagnostics,
+                    );
+                }
+            }
+            Expression::Loop { body, .. } => self.validate_child_scope_expr_refs(
+                table,
+                type_params,
+                body,
+                locals,
+                allow_self_type,
+                diagnostics,
+            ),
+            Expression::Block {
+                statements, expr, ..
+            } => self.validate_block_refs(
+                table,
+                type_params,
+                BlockRef {
+                    statements,
+                    expr: expr.as_deref(),
+                },
+                locals,
+                allow_self_type,
+                diagnostics,
+            ),
+            Expression::Closure {
+                params,
+                return_type,
+                body,
+                span,
+            } => self.validate_closure_refs(
+                table,
+                type_params,
+                ClosureRef {
+                    params,
+                    return_type: return_type.as_ref(),
+                    body,
+                    span: *span,
+                },
+                locals,
+                allow_self_type,
+                diagnostics,
+            ),
+            _ => unreachable!("construct dispatch received non-construct expression"),
+        }
+    }
+}

--- a/src/resolver/expression_validation/dispatch.rs
+++ b/src/resolver/expression_validation/dispatch.rs
@@ -1,0 +1,178 @@
+use crate::ast::{Expression, TypeParam};
+use crate::error::Diagnostic;
+
+use super::super::symbol_table::ScopeStack;
+use super::super::{Resolver, SymbolTable};
+use super::calls::{FunctionCallRef, MethodCallRef};
+use super::traversal::{BinaryExprRef, IfOrWhileExprRef, IndexExprRef, RangeExprRef};
+
+impl Resolver {
+    pub(super) fn validate_call_expr_refs(
+        &self,
+        table: &mut SymbolTable,
+        type_params: &[TypeParam],
+        expr: &Expression,
+        locals: &mut ScopeStack,
+        allow_self_type: bool,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        match expr {
+            Expression::FunctionCall {
+                name,
+                module,
+                type_args,
+                args,
+                span,
+            } => self.validate_function_call_expr_refs(
+                table,
+                type_params,
+                FunctionCallRef {
+                    name,
+                    module: module.as_deref(),
+                    type_args,
+                    args,
+                    span: *span,
+                },
+                locals,
+                allow_self_type,
+                diagnostics,
+            ),
+            Expression::Identifier { name, span } => {
+                self.validate_identifier_expr_refs(table, name, *span, locals, diagnostics);
+            }
+            Expression::MethodCall {
+                receiver,
+                type_args,
+                args,
+                span,
+                ..
+            } => self.validate_method_call_expr_refs(
+                table,
+                type_params,
+                MethodCallRef {
+                    receiver,
+                    type_args,
+                    args,
+                    span: *span,
+                },
+                locals,
+                allow_self_type,
+                diagnostics,
+            ),
+            _ => unreachable!("call expression dispatch received non-call expression"),
+        }
+    }
+
+    pub(super) fn validate_traversal_expr_refs(
+        &self,
+        table: &mut SymbolTable,
+        type_params: &[TypeParam],
+        expr: &Expression,
+        locals: &mut ScopeStack,
+        allow_self_type: bool,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        match expr {
+            Expression::BinaryOp { left, right, .. } => self.validate_binary_expr_refs(
+                table,
+                type_params,
+                BinaryExprRef { left, right },
+                locals,
+                allow_self_type,
+                diagnostics,
+            ),
+            Expression::UnaryOp { operand, .. }
+            | Expression::MemberAccess {
+                object: operand, ..
+            } => self.validate_unary_expr_refs(
+                table,
+                type_params,
+                operand,
+                locals,
+                allow_self_type,
+                diagnostics,
+            ),
+            Expression::IndexAccess { object, index, .. } => self.validate_index_expr_refs(
+                table,
+                type_params,
+                IndexExprRef { object, index },
+                locals,
+                allow_self_type,
+                diagnostics,
+            ),
+            Expression::WhileLoop {
+                condition, body, ..
+            }
+            | Expression::If {
+                condition,
+                then_body: body,
+                ..
+            } => {
+                let else_body = match expr {
+                    Expression::If { else_body, .. } => else_body.as_deref(),
+                    _ => None,
+                };
+                self.validate_if_or_while_expr_refs(
+                    table,
+                    type_params,
+                    IfOrWhileExprRef {
+                        condition,
+                        body,
+                        else_body,
+                    },
+                    locals,
+                    allow_self_type,
+                    diagnostics,
+                );
+            }
+            Expression::Cast {
+                expr,
+                target_type,
+                span,
+            } => {
+                self.validate_expr_refs(
+                    table,
+                    type_params,
+                    expr,
+                    locals,
+                    allow_self_type,
+                    diagnostics,
+                );
+                self.validate_type_ref(
+                    table,
+                    type_params,
+                    target_type,
+                    *span,
+                    allow_self_type,
+                    diagnostics,
+                );
+            }
+            Expression::StringInterpolation { parts, .. } => self
+                .validate_string_interpolation_refs(
+                    table,
+                    type_params,
+                    parts,
+                    locals,
+                    allow_self_type,
+                    diagnostics,
+                ),
+            Expression::Range { start, end, .. } => self.validate_range_expr_refs(
+                table,
+                type_params,
+                RangeExprRef { start, end },
+                locals,
+                allow_self_type,
+                diagnostics,
+            ),
+            Expression::Defer { expr, .. } => self.validate_defer_expr_refs(
+                table,
+                type_params,
+                expr,
+                locals,
+                allow_self_type,
+                diagnostics,
+            ),
+            _ => unreachable!("traversal dispatch received non-traversal expression"),
+        }
+    }
+}

--- a/tests/docs_truth/repo_hygiene/resolver_expression_validation.rs
+++ b/tests/docs_truth/repo_hygiene/resolver_expression_validation.rs
@@ -84,3 +84,52 @@ fn resolver_expression_traversal_lives_in_focused_helper() {
         "resolver expression validation should load focused traversal validation"
     );
 }
+
+#[test]
+fn resolver_expression_dispatch_stays_as_category_router() {
+    let validation = read("src/resolver/expression_validation.rs");
+    let dispatch = read("src/resolver/expression_validation/dispatch.rs");
+    let construct_dispatch = read("src/resolver/expression_validation/construct_dispatch.rs");
+    let calls = read("src/resolver/expression_validation/calls.rs");
+    let traversal = read("src/resolver/expression_validation/traversal.rs");
+    let constructs = read("src/resolver/expression_validation_constructs.rs");
+
+    assert!(
+        validation.lines().count() < 180,
+        "resolver expression validation should stay a compact dispatch router"
+    );
+    assert!(
+        validation.contains("mod dispatch;"),
+        "resolver expression validation should load focused expression dispatch"
+    );
+    assert!(
+        validation.contains("mod construct_dispatch;"),
+        "resolver expression validation should load focused construct dispatch"
+    );
+    assert!(
+        dispatch.lines().count() < 220,
+        "resolver expression category dispatch should stay compact"
+    );
+    assert!(
+        construct_dispatch.lines().count() < 140,
+        "resolver construct expression dispatch should stay compact"
+    );
+    assert!(
+        dispatch.contains("fn validate_call_expr_refs"),
+        "dispatch.rs should route call-like expressions through calls.rs"
+    );
+    assert!(
+        dispatch.contains("fn validate_traversal_expr_refs"),
+        "dispatch.rs should route traversal expressions through traversal.rs"
+    );
+    assert!(
+        construct_dispatch.contains("fn validate_construct_expr_refs"),
+        "construct_dispatch.rs should route construct/scoped expressions through expression_validation_constructs.rs"
+    );
+    assert!(
+        !calls.contains("fn validate_call_expr_refs")
+            && !traversal.contains("fn validate_traversal_expr_refs")
+            && !constructs.contains("fn validate_construct_expr_refs"),
+        "category dispatch should stay out of leaf validation helpers"
+    );
+}


### PR DESCRIPTION
## Summary
- Keep `src/resolver/expression_validation.rs` as a compact category router instead of a 300+ line match body.
- Move call/traversal routing into `expression_validation/dispatch.rs` and construct/scoped routing into `expression_validation/construct_dispatch.rs`.
- Add a docs-truth guard that keeps category dispatch compact and out of leaf validation helpers.

## TDD
- First added `resolver_expression_dispatch_stays_as_category_router` and confirmed it failed because the root dispatcher was still too large and the dispatch helpers did not exist.

## Validation
- `cargo test --test docs_truth resolver_expression_dispatch_stays_as_category_router -- --nocapture`
- `cargo test --lib resolver -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Push-triggered Actions check: `[]`