### PR TITLE
Split build target field extraction

### DIFF
--- a/src/build_graph/lowering.rs
+++ b/src/build_graph/lowering.rs
@@ -2,6 +2,8 @@ use crate::ast::{Declaration, Expression, MatchArm, Program, Statement};
 
 #[path = "lowering/dsl.rs"]
 mod dsl;
+#[path = "lowering/target_fields.rs"]
+mod target_fields;
 #[path = "lowering/targets.rs"]
 mod targets;
 

--- a/src/build_graph/lowering/target_fields.rs
+++ b/src/build_graph/lowering/target_fields.rs
@@ -1,0 +1,104 @@
+use crate::ast::Expression;
+
+use super::dsl::{BuildTargetDslKind, BuildTargetField};
+use super::BuildGraphError;
+
+pub(super) fn required_string_field(
+    kind: BuildTargetDslKind,
+    fields: &[(String, Expression)],
+    field: BuildTargetField,
+) -> Result<String, BuildGraphError> {
+    optional_string_field(kind, fields, field)?.ok_or_else(|| {
+        BuildGraphError::UnsupportedBuildScript(format!(
+            "missing required field `{field}` in `{kind}` build target"
+        ))
+    })
+}
+
+pub(super) fn required_one_of_string_fields(
+    kind: BuildTargetDslKind,
+    fields: &[(String, Expression)],
+    options: &[BuildTargetField],
+) -> Result<String, BuildGraphError> {
+    for field in options {
+        if let Some(value) = optional_string_field(kind, fields, *field)? {
+            return Ok(value);
+        }
+    }
+    let names = options
+        .iter()
+        .map(|field| format!("`{field}`"))
+        .collect::<Vec<_>>();
+    let Some((last, rest)) = names.split_last() else {
+        return Err(BuildGraphError::UnsupportedBuildScript(format!(
+            "missing required source field in `{kind}` build target"
+        )));
+    };
+    let display = if rest.is_empty() {
+        last.clone()
+    } else {
+        format!("{} or {last}", rest.join(", "))
+    };
+    Err(BuildGraphError::UnsupportedBuildScript(format!(
+        "missing required field {display} in `{kind}` build target"
+    )))
+}
+
+pub(super) fn optional_string_field(
+    kind: BuildTargetDslKind,
+    fields: &[(String, Expression)],
+    field: BuildTargetField,
+) -> Result<Option<String>, BuildGraphError> {
+    let Some(value) = field_value(fields, field) else {
+        return Ok(None);
+    };
+    match value {
+        Expression::StringLiteral { value, .. } => Ok(Some(value.clone())),
+        _ => Err(BuildGraphError::UnsupportedBuildScript(format!(
+            "field `{field}` in `{kind}` build target must be a string"
+        ))),
+    }
+}
+
+pub(super) fn required_string_array_field(
+    kind: BuildTargetDslKind,
+    fields: &[(String, Expression)],
+    field: BuildTargetField,
+) -> Result<Vec<String>, BuildGraphError> {
+    optional_string_array_field(kind, fields, field)?.ok_or_else(|| {
+        BuildGraphError::UnsupportedBuildScript(format!(
+            "missing required field `{field}` in `{kind}` build target"
+        ))
+    })
+}
+
+pub(super) fn optional_string_array_field(
+    kind: BuildTargetDslKind,
+    fields: &[(String, Expression)],
+    field: BuildTargetField,
+) -> Result<Option<Vec<String>>, BuildGraphError> {
+    let Some(value) = field_value(fields, field) else {
+        return Ok(None);
+    };
+    let Expression::ArrayLiteral { elements, .. } = value else {
+        return Err(BuildGraphError::UnsupportedBuildScript(format!(
+            "field `{field}` in `{kind}` build target must be an array of strings"
+        )));
+    };
+    let mut values = Vec::with_capacity(elements.len());
+    for element in elements {
+        let Expression::StringLiteral { value, .. } = element else {
+            return Err(BuildGraphError::UnsupportedBuildScript(format!(
+                "field `{field}` in `{kind}` build target must be an array of strings"
+            )));
+        };
+        values.push(value.clone());
+    }
+    Ok(Some(values))
+}
+
+fn field_value(fields: &[(String, Expression)], field: BuildTargetField) -> Option<&Expression> {
+    fields
+        .iter()
+        .find_map(|(name, value)| (name == field.as_str()).then_some(value))
+}

--- a/src/build_graph/lowering/targets.rs
+++ b/src/build_graph/lowering/targets.rs
@@ -1,6 +1,10 @@
 use crate::ast::Expression;
 
 use super::dsl::{BuildTargetDslIdent, BuildTargetDslKind, BuildTargetField};
+use super::target_fields::{
+    optional_string_array_field, optional_string_field, required_one_of_string_fields,
+    required_string_array_field, required_string_field,
+};
 use super::{BuildGraphError, BuildTargetInput, BuildTargetKind};
 
 pub(super) fn build_target_from_builder_add(
@@ -202,104 +206,4 @@ fn target_name_from_root(root: &str) -> String {
         .filter(|stem| !stem.is_empty())
         .unwrap_or("test")
         .to_string()
-}
-
-fn required_string_field(
-    kind: BuildTargetDslKind,
-    fields: &[(String, Expression)],
-    field: BuildTargetField,
-) -> Result<String, BuildGraphError> {
-    optional_string_field(kind, fields, field)?.ok_or_else(|| {
-        BuildGraphError::UnsupportedBuildScript(format!(
-            "missing required field `{field}` in `{kind}` build target"
-        ))
-    })
-}
-
-fn required_one_of_string_fields(
-    kind: BuildTargetDslKind,
-    fields: &[(String, Expression)],
-    options: &[BuildTargetField],
-) -> Result<String, BuildGraphError> {
-    for field in options {
-        if let Some(value) = optional_string_field(kind, fields, *field)? {
-            return Ok(value);
-        }
-    }
-    let names = options
-        .iter()
-        .map(|field| format!("`{field}`"))
-        .collect::<Vec<_>>();
-    let Some((last, rest)) = names.split_last() else {
-        return Err(BuildGraphError::UnsupportedBuildScript(format!(
-            "missing required source field in `{kind}` build target"
-        )));
-    };
-    let display = if rest.is_empty() {
-        last.clone()
-    } else {
-        format!("{} or {last}", rest.join(", "))
-    };
-    Err(BuildGraphError::UnsupportedBuildScript(format!(
-        "missing required field {display} in `{kind}` build target"
-    )))
-}
-
-fn optional_string_field(
-    kind: BuildTargetDslKind,
-    fields: &[(String, Expression)],
-    field: BuildTargetField,
-) -> Result<Option<String>, BuildGraphError> {
-    let Some(value) = field_value(fields, field) else {
-        return Ok(None);
-    };
-    match value {
-        Expression::StringLiteral { value, .. } => Ok(Some(value.clone())),
-        _ => Err(BuildGraphError::UnsupportedBuildScript(format!(
-            "field `{field}` in `{kind}` build target must be a string"
-        ))),
-    }
-}
-
-fn required_string_array_field(
-    kind: BuildTargetDslKind,
-    fields: &[(String, Expression)],
-    field: BuildTargetField,
-) -> Result<Vec<String>, BuildGraphError> {
-    optional_string_array_field(kind, fields, field)?.ok_or_else(|| {
-        BuildGraphError::UnsupportedBuildScript(format!(
-            "missing required field `{field}` in `{kind}` build target"
-        ))
-    })
-}
-
-fn optional_string_array_field(
-    kind: BuildTargetDslKind,
-    fields: &[(String, Expression)],
-    field: BuildTargetField,
-) -> Result<Option<Vec<String>>, BuildGraphError> {
-    let Some(value) = field_value(fields, field) else {
-        return Ok(None);
-    };
-    let Expression::ArrayLiteral { elements, .. } = value else {
-        return Err(BuildGraphError::UnsupportedBuildScript(format!(
-            "field `{field}` in `{kind}` build target must be an array of strings"
-        )));
-    };
-    let mut values = Vec::with_capacity(elements.len());
-    for element in elements {
-        let Expression::StringLiteral { value, .. } = element else {
-            return Err(BuildGraphError::UnsupportedBuildScript(format!(
-                "field `{field}` in `{kind}` build target must be an array of strings"
-            )));
-        };
-        values.push(value.clone());
-    }
-    Ok(Some(values))
-}
-
-fn field_value(fields: &[(String, Expression)], field: BuildTargetField) -> Option<&Expression> {
-    fields
-        .iter()
-        .find_map(|(name, value)| (name == field.as_str()).then_some(value))
 }

--- a/tests/docs_truth/repo_hygiene/build_graph_dsl.rs
+++ b/tests/docs_truth/repo_hygiene/build_graph_dsl.rs
@@ -55,3 +55,31 @@ fn build_graph_dependency_order_lives_in_focused_helper() {
         "build graph root should include focused dependency ordering module"
     );
 }
+
+#[test]
+fn build_target_field_extraction_lives_in_focused_helper() {
+    let targets = read("src/build_graph/lowering/targets.rs");
+    let fields = read("src/build_graph/lowering/target_fields.rs");
+
+    assert!(
+        targets.lines().count() < 220,
+        "build target construction should stay focused on target shapes"
+    );
+    for helper in [
+        "required_string_field",
+        "required_one_of_string_fields",
+        "optional_string_field",
+        "required_string_array_field",
+        "optional_string_array_field",
+        "field_value",
+    ] {
+        assert!(
+            !targets.contains(&format!("fn {helper}")),
+            "build target field extraction should live in target_fields.rs: {helper}"
+        );
+        assert!(
+            fields.contains(&format!("fn {helper}")),
+            "target_fields.rs should own build target field extraction: {helper}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Move build target field extraction and typed field parsing into `target_fields.rs`.
- Keep `targets.rs` focused on recognizing builder.add target literals and constructing target shapes.
- Add a docs-truth guard that preserves the split.

## TDD
- First added `build_target_field_extraction_lives_in_focused_helper` and confirmed it failed because `target_fields.rs` did not exist.

## Validation
- `cargo test --test docs_truth build_target_field_extraction_lives_in_focused_helper -- --nocapture`
- `cargo test --lib build_graph -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Push-triggered Actions check: `[]`