### PR TITLE
Split CLI emit-json mode parsing

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,5 @@
 use std::path::Path;
 use std::process;
-use std::str::FromStr;
 
 mod build_graph_execution;
 mod build_graph_loading;
@@ -9,6 +8,7 @@ mod build_graph_targets;
 mod check_emit_commands;
 mod compile;
 mod diagnostics;
+mod emit_json_mode;
 mod execution_commands;
 mod frontend;
 mod json_emit;
@@ -27,6 +27,7 @@ use build_graph_targets::{
 use check_emit_commands::{cmd_check, cmd_emit};
 use compile::{compile_file_to_binary, compile_file_to_c_source, typed_program_to_c_source};
 use diagnostics::{print_diagnostic, print_errors};
+use emit_json_mode::{emit_json_usage, EmitJsonMode};
 use execution_commands::{cmd_build, cmd_build_graph, cmd_run_file, cmd_test};
 use frontend::{graph_frontend, load_module_graph};
 use json_emit::{
@@ -35,98 +36,6 @@ use json_emit::{
     cmd_emit_json_typed,
 };
 use usage::print_usage;
-
-#[derive(Clone, Copy)]
-enum EmitJsonMode {
-    Ast,
-    Symbols,
-    Typed,
-    Diagnostics,
-    BuildGraph,
-    Hir,
-    Mir,
-    Layout,
-    TargetYaml,
-}
-
-impl EmitJsonMode {
-    const AST: &'static str = "ast";
-    const SYMBOLS: &'static str = "symbols";
-    const TYPED: &'static str = "typed";
-    const DIAGNOSTICS: &'static str = "diagnostics";
-    const BUILD_GRAPH: &'static str = "build-graph";
-    const HIR: &'static str = "hir";
-    const MIR: &'static str = "mir";
-    const LAYOUT: &'static str = "layout";
-    const TARGET_YAML: &'static str = "target-yaml";
-
-    const ORDERED: [Self; 9] = [
-        Self::Ast,
-        Self::Symbols,
-        Self::Typed,
-        Self::Diagnostics,
-        Self::BuildGraph,
-        Self::Hir,
-        Self::Mir,
-        Self::Layout,
-        Self::TargetYaml,
-    ];
-
-    const fn as_str(self) -> &'static str {
-        match self {
-            Self::Ast => Self::AST,
-            Self::Symbols => Self::SYMBOLS,
-            Self::Typed => Self::TYPED,
-            Self::Diagnostics => Self::DIAGNOSTICS,
-            Self::BuildGraph => Self::BUILD_GRAPH,
-            Self::Hir => Self::HIR,
-            Self::Mir => Self::MIR,
-            Self::Layout => Self::LAYOUT,
-            Self::TargetYaml => Self::TARGET_YAML,
-        }
-    }
-
-    fn usage() -> String {
-        Self::ORDERED
-            .iter()
-            .map(|mode| mode.as_str())
-            .collect::<Vec<_>>()
-            .join("|")
-    }
-
-    fn gate_message(self) -> Option<&'static str> {
-        match self {
-            Self::Ast
-            | Self::Symbols
-            | Self::Typed
-            | Self::Diagnostics
-            | Self::BuildGraph
-            | Self::Hir
-            | Self::Mir
-            | Self::Layout
-            | Self::TargetYaml => None,
-        }
-    }
-}
-
-impl FromStr for EmitJsonMode {
-    type Err = ();
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        Self::ORDERED
-            .iter()
-            .copied()
-            .find(|mode| mode.as_str() == value)
-            .ok_or(())
-    }
-}
-
-fn emit_json_usage() -> String {
-    format!(
-        "Usage: zen emit-json <{}> <file.zen>",
-        EmitJsonMode::usage()
-    )
-}
 
 pub fn main() {
     let args: Vec<String> = std::env::args().collect();

--- a/src/cli/emit_json_mode.rs
+++ b/src/cli/emit_json_mode.rs
@@ -1,0 +1,93 @@
+use std::str::FromStr;
+
+#[derive(Clone, Copy)]
+pub(super) enum EmitJsonMode {
+    Ast,
+    Symbols,
+    Typed,
+    Diagnostics,
+    BuildGraph,
+    Hir,
+    Mir,
+    Layout,
+    TargetYaml,
+}
+
+impl EmitJsonMode {
+    const AST: &'static str = "ast";
+    const SYMBOLS: &'static str = "symbols";
+    const TYPED: &'static str = "typed";
+    const DIAGNOSTICS: &'static str = "diagnostics";
+    const BUILD_GRAPH: &'static str = "build-graph";
+    const HIR: &'static str = "hir";
+    const MIR: &'static str = "mir";
+    const LAYOUT: &'static str = "layout";
+    const TARGET_YAML: &'static str = "target-yaml";
+
+    const ORDERED: [Self; 9] = [
+        Self::Ast,
+        Self::Symbols,
+        Self::Typed,
+        Self::Diagnostics,
+        Self::BuildGraph,
+        Self::Hir,
+        Self::Mir,
+        Self::Layout,
+        Self::TargetYaml,
+    ];
+
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Ast => Self::AST,
+            Self::Symbols => Self::SYMBOLS,
+            Self::Typed => Self::TYPED,
+            Self::Diagnostics => Self::DIAGNOSTICS,
+            Self::BuildGraph => Self::BUILD_GRAPH,
+            Self::Hir => Self::HIR,
+            Self::Mir => Self::MIR,
+            Self::Layout => Self::LAYOUT,
+            Self::TargetYaml => Self::TARGET_YAML,
+        }
+    }
+
+    fn usage() -> String {
+        Self::ORDERED
+            .iter()
+            .map(|mode| mode.as_str())
+            .collect::<Vec<_>>()
+            .join("|")
+    }
+
+    pub(super) fn gate_message(self) -> Option<&'static str> {
+        match self {
+            Self::Ast
+            | Self::Symbols
+            | Self::Typed
+            | Self::Diagnostics
+            | Self::BuildGraph
+            | Self::Hir
+            | Self::Mir
+            | Self::Layout
+            | Self::TargetYaml => None,
+        }
+    }
+}
+
+impl FromStr for EmitJsonMode {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ORDERED
+            .iter()
+            .copied()
+            .find(|mode| mode.as_str() == value)
+            .ok_or(())
+    }
+}
+
+pub(super) fn emit_json_usage() -> String {
+    format!(
+        "Usage: zen emit-json <{}> <file.zen>",
+        EmitJsonMode::usage()
+    )
+}

--- a/tests/docs_truth/repo_hygiene/parser_enums/codegen_and_tools.rs
+++ b/tests/docs_truth/repo_hygiene/parser_enums/codegen_and_tools.rs
@@ -151,34 +151,45 @@ fn build_graph_host_effect_methods_parse_dsl_ident_enum() {
 
 #[test]
 fn cli_emit_json_modes_use_owned_mode_enum() {
-    let source = read("src/cli.rs");
+    let cli = read("src/cli.rs");
+    let mode = read("src/cli/emit_json_mode.rs");
 
     assert!(
-        source.contains("enum EmitJsonMode"),
+        !cli.contains("enum EmitJsonMode"),
+        "cli.rs should keep command dispatch focused and delegate emit-json mode parsing"
+    );
+    assert!(
+        cli.lines().count() < 260,
+        "cli.rs should stay below the cleanup threshold after extracting emit-json modes"
+    );
+    assert!(
+        mode.contains("pub(super) enum EmitJsonMode"),
         "emit-json command routing should use an owned EmitJsonMode enum"
     );
     assert!(
-        source.contains("mode.parse::<EmitJsonMode>()"),
+        cli.contains("mode.parse::<EmitJsonMode>()"),
         "emit-json command routing should parse modes through EmitJsonMode"
     );
     assert!(
-        source.contains("EmitJsonMode::usage()"),
+        mode.contains("pub(super) fn emit_json_usage() -> String"),
         "emit-json usage should be generated from EmitJsonMode"
     );
     assert!(
-        source.contains(".find(|mode| mode.as_str() == value)"),
+        mode.contains(".find(|mode| mode.as_str() == value)"),
         "emit-json mode parsing should use the enum-owned ordered table"
     );
     assert!(
-        source.contains("fn gate_message(self) -> Option<&'static str>"),
+        mode.contains("pub(super) fn gate_message(self) -> Option<&'static str>"),
         "emit-json gated diagnostics should be owned by EmitJsonMode"
     );
     assert!(
-        source.contains("mode.gate_message()"),
+        cli.contains("mode.gate_message()"),
         "emit-json command routing should read gated diagnostics from EmitJsonMode"
     );
     assert!(
-        !source.contains("<ast|symbols|typed|diagnostics|build-graph|hir|mir|layout|target-yaml>"),
+        !cli.contains("<ast|symbols|typed|diagnostics|build-graph|hir|mir|layout|target-yaml>")
+            && !mode
+                .contains("<ast|symbols|typed|diagnostics|build-graph|hir|mir|layout|target-yaml>"),
         "emit-json usage should not duplicate the mode list as a raw string"
     );
 }


### PR DESCRIPTION
## Summary
- Move `EmitJsonMode` parsing, usage rendering, and gate-message ownership into `src/cli/emit_json_mode.rs`.
- Keep `src/cli.rs` focused on top-level command dispatch.
- Tighten the docs-truth guard so emit-json mode ownership stays out of the CLI router and `src/cli.rs` stays below the cleanup threshold.

## TDD
- First tightened `cli_emit_json_modes_use_owned_mode_enum` to require `src/cli/emit_json_mode.rs` and confirmed it failed because the helper did not exist.

## Validation
- `cargo test --test docs_truth cli_emit_json_modes_use_owned_mode_enum -- --nocapture`
- `cargo test --test integration root_usage_lists_supported_and_gated_emit_json_modes -- --nocapture`
- `cargo test --test integration legacy_emit_json_modes_reject_build_zen_with_graph_diagnostic -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Push-triggered Actions check: `[]`