### PR TITLE
Split MIR expression lowering

### DIFF
--- a/src/ir_json/mir.rs
+++ b/src/ir_json/mir.rs
@@ -1,13 +1,15 @@
 use crate::ast::typed::{
-    MatchKind, TypedBlock, TypedExprKind, TypedExpression, TypedFunction, TypedMatchArm,
-    TypedParam, TypedPattern, TypedProgram, TypedStatement, TypedStatementKind,
+    TypedBlock, TypedFunction, TypedMatchArm, TypedParam, TypedPattern, TypedProgram,
+    TypedStatement, TypedStatementKind,
 };
 
+mod expression;
 mod schema;
 
+use expression::mir_expression;
 use schema::{
-    MirBlock, MirExpression, MirFunction, MirJsonProgram, MirMatchArm, MirParam, MirPattern,
-    MirPatternBinding, MirStatement, MirTerminator,
+    MirBlock, MirFunction, MirJsonProgram, MirMatchArm, MirParam, MirPattern, MirPatternBinding,
+    MirStatement, MirTerminator,
 };
 
 pub(super) fn program_to_json(program: &TypedProgram) -> serde_json::Result<String> {
@@ -79,7 +81,7 @@ fn mir_statement(statement: &TypedStatement) -> MirStatement {
     }
 }
 
-fn mir_match_arm(arm: &TypedMatchArm) -> MirMatchArm {
+pub(in crate::ir_json::mir) fn mir_match_arm(arm: &TypedMatchArm) -> MirMatchArm {
     MirMatchArm {
         pattern: mir_pattern(&arm.pattern),
         body: mir_entry_block(&arm.body),
@@ -122,181 +124,5 @@ fn mir_pattern(pattern: &TypedPattern) -> MirPattern {
             value: Some(serde_json::to_value(mir_expression(value)).unwrap_or_default()),
             bindings: Vec::new(),
         },
-    }
-}
-
-fn mir_expression(expr: &TypedExpression) -> MirExpression {
-    let mut lowered = MirExpression {
-        kind: mir_expression_kind(expr),
-        ty: expr.ty.display_name(),
-        name: None,
-        value: None,
-        op: None,
-        left: None,
-        right: None,
-        target: None,
-        field: None,
-        function: None,
-        match_kind: None,
-        args: Vec::new(),
-        arms: Vec::new(),
-    };
-
-    match &expr.kind {
-        TypedExprKind::IntLiteral(value) => {
-            lowered.value = Some(serde_json::json!(value));
-        }
-        TypedExprKind::FloatLiteral(value) => {
-            lowered.value = Some(serde_json::json!(value));
-        }
-        TypedExprKind::StringLiteral(value) => {
-            lowered.value = Some(serde_json::json!(value));
-        }
-        TypedExprKind::BoolLiteral(value) => {
-            lowered.value = Some(serde_json::json!(value));
-        }
-        TypedExprKind::Variable(name) => {
-            lowered.name = Some(name.clone());
-        }
-        TypedExprKind::BinaryOp { op, left, right } => {
-            lowered.op = Some(op.symbol());
-            lowered.left = Some(Box::new(mir_expression(left)));
-            lowered.right = Some(Box::new(mir_expression(right)));
-        }
-        TypedExprKind::UnaryOp { op, operand } => {
-            lowered.op = Some(op.symbol());
-            lowered.target = Some(Box::new(mir_expression(operand)));
-        }
-        TypedExprKind::FunctionCall { function, args } => {
-            lowered.function = Some(function.clone());
-            lowered.args = args.iter().map(mir_expression).collect();
-        }
-        TypedExprKind::FieldAccess { object, field } => {
-            lowered.target = Some(Box::new(mir_expression(object)));
-            lowered.field = Some(field.clone());
-        }
-        TypedExprKind::IndexAccess { object, index } => {
-            lowered.target = Some(Box::new(mir_expression(object)));
-            lowered.args = vec![mir_expression(index)];
-        }
-        TypedExprKind::StructLiteral { type_name, fields } => {
-            lowered.name = Some(type_name.clone());
-            lowered.args = fields
-                .iter()
-                .map(|(_, value)| mir_expression(value))
-                .collect();
-        }
-        TypedExprKind::EnumVariant {
-            type_name,
-            variant,
-            payload,
-        } => {
-            lowered.name = Some(format!("{type_name}.{variant}"));
-            if let Some(payload) = payload {
-                lowered.args = vec![mir_expression(payload)];
-            }
-        }
-        TypedExprKind::ArrayLiteral { elements } => {
-            lowered.args = elements.iter().map(mir_expression).collect();
-        }
-        TypedExprKind::Match {
-            scrutinee,
-            arms,
-            kind,
-        } => {
-            lowered.target = Some(Box::new(mir_expression(scrutinee)));
-            lowered.match_kind = Some(mir_match_kind(kind));
-            lowered.arms = arms.iter().map(mir_match_arm).collect();
-        }
-        TypedExprKind::Cast {
-            expr,
-            from_type,
-            to_type,
-        } => {
-            lowered.target = Some(Box::new(mir_expression(expr)));
-            lowered.name = Some(format!(
-                "{}->{}",
-                from_type.display_name(),
-                to_type.display_name()
-            ));
-        }
-        TypedExprKind::Ref(inner) | TypedExprKind::MutRef(inner) | TypedExprKind::Deref(inner) => {
-            lowered.target = Some(Box::new(mir_expression(inner)));
-        }
-        TypedExprKind::Closure { fn_name, .. } => {
-            lowered.function = Some(fn_name.clone());
-        }
-        TypedExprKind::StringInterpolation { parts } => {
-            lowered.value = Some(serde_json::json!({ "parts": parts.len() }));
-        }
-        TypedExprKind::Intrinsic { name, args } => {
-            lowered.function = Some(name.clone());
-            lowered.args = args.iter().map(mir_expression).collect();
-        }
-        TypedExprKind::Assign { target, value } => {
-            lowered.target = Some(Box::new(mir_expression(target)));
-            lowered.value = Some(serde_json::to_value(mir_expression(value)).unwrap_or_default());
-        }
-        TypedExprKind::Block(block) => {
-            let result = block
-                .expr
-                .as_ref()
-                .map(|expr| serde_json::to_value(mir_expression(expr)).unwrap_or_default());
-            lowered.value = Some(serde_json::json!({
-                "statement_count": block.statements.len(),
-                "has_result": block.expr.is_some(),
-                "result": result,
-            }));
-        }
-        TypedExprKind::LoopControl { action, label } => {
-            lowered.op = Some(action.as_str());
-            lowered.name = Some(label.clone());
-        }
-        TypedExprKind::Break | TypedExprKind::Continue | TypedExprKind::Error => {}
-    }
-
-    lowered
-}
-
-fn mir_match_kind(kind: &MatchKind) -> &'static str {
-    match kind {
-        MatchKind::ConditionalElse => "conditional_else",
-        MatchKind::Conditional => "conditional",
-        MatchKind::WhileLoop => "while_loop",
-        MatchKind::ControlledLoop { .. } => "controlled_loop",
-        MatchKind::EnumMatch => "enum",
-        MatchKind::ValueMatch => "value",
-    }
-}
-
-fn mir_expression_kind(expr: &TypedExpression) -> &'static str {
-    match &expr.kind {
-        TypedExprKind::IntLiteral(_) => "int",
-        TypedExprKind::FloatLiteral(_) => "float",
-        TypedExprKind::StringLiteral(_) => "static_string",
-        TypedExprKind::BoolLiteral(_) => "bool",
-        TypedExprKind::Variable(_) => "local",
-        TypedExprKind::BinaryOp { .. } => "binary",
-        TypedExprKind::UnaryOp { .. } => "unary",
-        TypedExprKind::FunctionCall { .. } => "call",
-        TypedExprKind::FieldAccess { .. } => "field",
-        TypedExprKind::IndexAccess { .. } => "index",
-        TypedExprKind::StructLiteral { .. } => "struct",
-        TypedExprKind::EnumVariant { .. } => "enum_variant",
-        TypedExprKind::ArrayLiteral { .. } => "array",
-        TypedExprKind::Match { .. } => "match",
-        TypedExprKind::Cast { .. } => "cast",
-        TypedExprKind::Ref(_) => "ref",
-        TypedExprKind::MutRef(_) => "mut_ref",
-        TypedExprKind::Deref(_) => "deref",
-        TypedExprKind::Closure { .. } => "closure",
-        TypedExprKind::StringInterpolation { .. } => "string_interpolation",
-        TypedExprKind::Intrinsic { .. } => "intrinsic",
-        TypedExprKind::Assign { .. } => "assign",
-        TypedExprKind::Block(_) => "block",
-        TypedExprKind::Break => "break",
-        TypedExprKind::Continue => "continue",
-        TypedExprKind::LoopControl { .. } => "loop_control",
-        TypedExprKind::Error => "error",
     }
 }

--- a/src/ir_json/mir/expression.rs
+++ b/src/ir_json/mir/expression.rs
@@ -1,0 +1,180 @@
+use crate::ast::typed::{MatchKind, TypedExprKind, TypedExpression};
+
+use super::mir_match_arm;
+use super::schema::MirExpression;
+
+pub(super) fn mir_expression(expr: &TypedExpression) -> MirExpression {
+    let mut lowered = MirExpression {
+        kind: mir_expression_kind(expr),
+        ty: expr.ty.display_name(),
+        name: None,
+        value: None,
+        op: None,
+        left: None,
+        right: None,
+        target: None,
+        field: None,
+        function: None,
+        match_kind: None,
+        args: Vec::new(),
+        arms: Vec::new(),
+    };
+
+    match &expr.kind {
+        TypedExprKind::IntLiteral(value) => {
+            lowered.value = Some(serde_json::json!(value));
+        }
+        TypedExprKind::FloatLiteral(value) => {
+            lowered.value = Some(serde_json::json!(value));
+        }
+        TypedExprKind::StringLiteral(value) => {
+            lowered.value = Some(serde_json::json!(value));
+        }
+        TypedExprKind::BoolLiteral(value) => {
+            lowered.value = Some(serde_json::json!(value));
+        }
+        TypedExprKind::Variable(name) => {
+            lowered.name = Some(name.clone());
+        }
+        TypedExprKind::BinaryOp { op, left, right } => {
+            lowered.op = Some(op.symbol());
+            lowered.left = Some(Box::new(mir_expression(left)));
+            lowered.right = Some(Box::new(mir_expression(right)));
+        }
+        TypedExprKind::UnaryOp { op, operand } => {
+            lowered.op = Some(op.symbol());
+            lowered.target = Some(Box::new(mir_expression(operand)));
+        }
+        TypedExprKind::FunctionCall { function, args } => {
+            lowered.function = Some(function.clone());
+            lowered.args = args.iter().map(mir_expression).collect();
+        }
+        TypedExprKind::FieldAccess { object, field } => {
+            lowered.target = Some(Box::new(mir_expression(object)));
+            lowered.field = Some(field.clone());
+        }
+        TypedExprKind::IndexAccess { object, index } => {
+            lowered.target = Some(Box::new(mir_expression(object)));
+            lowered.args = vec![mir_expression(index)];
+        }
+        TypedExprKind::StructLiteral { type_name, fields } => {
+            lowered.name = Some(type_name.clone());
+            lowered.args = fields
+                .iter()
+                .map(|(_, value)| mir_expression(value))
+                .collect();
+        }
+        TypedExprKind::EnumVariant {
+            type_name,
+            variant,
+            payload,
+        } => {
+            lowered.name = Some(format!("{type_name}.{variant}"));
+            if let Some(payload) = payload {
+                lowered.args = vec![mir_expression(payload)];
+            }
+        }
+        TypedExprKind::ArrayLiteral { elements } => {
+            lowered.args = elements.iter().map(mir_expression).collect();
+        }
+        TypedExprKind::Match {
+            scrutinee,
+            arms,
+            kind,
+        } => {
+            lowered.target = Some(Box::new(mir_expression(scrutinee)));
+            lowered.match_kind = Some(mir_match_kind(kind));
+            lowered.arms = arms.iter().map(mir_match_arm).collect();
+        }
+        TypedExprKind::Cast {
+            expr,
+            from_type,
+            to_type,
+        } => {
+            lowered.target = Some(Box::new(mir_expression(expr)));
+            lowered.name = Some(format!(
+                "{}->{}",
+                from_type.display_name(),
+                to_type.display_name()
+            ));
+        }
+        TypedExprKind::Ref(inner) | TypedExprKind::MutRef(inner) | TypedExprKind::Deref(inner) => {
+            lowered.target = Some(Box::new(mir_expression(inner)));
+        }
+        TypedExprKind::Closure { fn_name, .. } => {
+            lowered.function = Some(fn_name.clone());
+        }
+        TypedExprKind::StringInterpolation { parts } => {
+            lowered.value = Some(serde_json::json!({ "parts": parts.len() }));
+        }
+        TypedExprKind::Intrinsic { name, args } => {
+            lowered.function = Some(name.clone());
+            lowered.args = args.iter().map(mir_expression).collect();
+        }
+        TypedExprKind::Assign { target, value } => {
+            lowered.target = Some(Box::new(mir_expression(target)));
+            lowered.value = Some(serde_json::to_value(mir_expression(value)).unwrap_or_default());
+        }
+        TypedExprKind::Block(block) => {
+            let result = block
+                .expr
+                .as_ref()
+                .map(|expr| serde_json::to_value(mir_expression(expr)).unwrap_or_default());
+            lowered.value = Some(serde_json::json!({
+                "statement_count": block.statements.len(),
+                "has_result": block.expr.is_some(),
+                "result": result,
+            }));
+        }
+        TypedExprKind::LoopControl { action, label } => {
+            lowered.op = Some(action.as_str());
+            lowered.name = Some(label.clone());
+        }
+        TypedExprKind::Break | TypedExprKind::Continue | TypedExprKind::Error => {}
+    }
+
+    lowered
+}
+
+fn mir_match_kind(kind: &MatchKind) -> &'static str {
+    match kind {
+        MatchKind::ConditionalElse => "conditional_else",
+        MatchKind::Conditional => "conditional",
+        MatchKind::WhileLoop => "while_loop",
+        MatchKind::ControlledLoop { .. } => "controlled_loop",
+        MatchKind::EnumMatch => "enum",
+        MatchKind::ValueMatch => "value",
+    }
+}
+
+fn mir_expression_kind(expr: &TypedExpression) -> &'static str {
+    match &expr.kind {
+        TypedExprKind::IntLiteral(_) => "int",
+        TypedExprKind::FloatLiteral(_) => "float",
+        TypedExprKind::StringLiteral(_) => "static_string",
+        TypedExprKind::BoolLiteral(_) => "bool",
+        TypedExprKind::Variable(_) => "local",
+        TypedExprKind::BinaryOp { .. } => "binary",
+        TypedExprKind::UnaryOp { .. } => "unary",
+        TypedExprKind::FunctionCall { .. } => "call",
+        TypedExprKind::FieldAccess { .. } => "field",
+        TypedExprKind::IndexAccess { .. } => "index",
+        TypedExprKind::StructLiteral { .. } => "struct",
+        TypedExprKind::EnumVariant { .. } => "enum_variant",
+        TypedExprKind::ArrayLiteral { .. } => "array",
+        TypedExprKind::Match { .. } => "match",
+        TypedExprKind::Cast { .. } => "cast",
+        TypedExprKind::Ref(_) => "ref",
+        TypedExprKind::MutRef(_) => "mut_ref",
+        TypedExprKind::Deref(_) => "deref",
+        TypedExprKind::Closure { .. } => "closure",
+        TypedExprKind::StringInterpolation { .. } => "string_interpolation",
+        TypedExprKind::Intrinsic { .. } => "intrinsic",
+        TypedExprKind::Assign { .. } => "assign",
+        TypedExprKind::Block(_) => "block",
+        TypedExprKind::Break => "break",
+        TypedExprKind::Continue => "continue",
+        TypedExprKind::LoopControl { .. } => "loop_control",
+        TypedExprKind::Error => "error",
+    }
+}

--- a/tests/docs_truth/repo_hygiene/ir_json.rs
+++ b/tests/docs_truth/repo_hygiene/ir_json.rs
@@ -4,6 +4,7 @@ use super::*;
 fn mir_json_schema_types_live_in_focused_helper() {
     let mir_lowering = read("src/ir_json/mir.rs");
     let mir_schema = read("src/ir_json/mir/schema.rs");
+    let mir_expression = read("src/ir_json/mir/expression.rs");
 
     for moved_schema_type in [
         "struct MirJsonProgram",
@@ -24,6 +25,22 @@ fn mir_json_schema_types_live_in_focused_helper() {
     assert!(
         mir_schema.contains("use serde::Serialize"),
         "MIR JSON schema helper should own serialization derives"
+    );
+    assert!(
+        mir_lowering.lines().count() < 220,
+        "MIR JSON root lowering should stay focused on programs, functions, blocks, and patterns"
+    );
+    assert!(
+        !mir_lowering.contains("fn mir_expression_kind"),
+        "MIR expression kind lowering should live in expression.rs"
+    );
+    assert!(
+        mir_expression.contains("pub(super) fn mir_expression"),
+        "expression.rs should own MIR expression lowering"
+    );
+    assert!(
+        mir_expression.contains("fn mir_expression_kind"),
+        "expression.rs should own MIR expression kind classification"
     );
 }
 


### PR DESCRIPTION
## Summary
- Move MIR expression lowering and expression-kind classification into `src/ir_json/mir/expression.rs`.
- Keep `src/ir_json/mir.rs` focused on program, function, block, statement, and pattern lowering.
- Tighten the docs-truth guard so MIR expression lowering stays in the focused helper and the root stays compact.

## TDD
- First tightened `mir_json_schema_types_live_in_focused_helper` to require `src/ir_json/mir/expression.rs` and confirmed it failed because the helper did not exist.

## Validation
- `cargo test --test docs_truth mir_json_schema_types_live_in_focused_helper -- --nocapture`
- `cargo test --test integration emit_json_mir_outputs_checked_minimal_function_graph -- --nocapture`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo test --lib`
- `cargo test --tests`
- Push-triggered Actions check: `[]`