### PR TITLE
Split gated builtin type names

### DIFF
--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -1,14 +1,15 @@
 use crate::error::Span;
 use serde::Serialize;
 
+mod gated;
 mod names;
 
-pub use names::{
-    gated_builtin_type_name, is_builtin_type_name, BuiltinGenericTypeName, BuiltinTypeName,
-    GatedBuiltinType, ACTOR_REF_TYPE_NAME, ACTOR_TYPE_NAME, ALLOCATOR_TYPE_NAME,
-    ASYNC_EFFECT_TYPE_NAME, DYNAMIC_STRING_TYPE_NAME, MAILBOX_TYPE_NAME, STATIC_STRING_TYPE_NAME,
-    SUPERVISOR_TYPE_NAME, SYNC_EFFECT_TYPE_NAME,
+pub use gated::{
+    gated_builtin_type_name, is_builtin_type_name, GatedBuiltinType, ACTOR_REF_TYPE_NAME,
+    ACTOR_TYPE_NAME, ALLOCATOR_TYPE_NAME, ASYNC_EFFECT_TYPE_NAME, DYNAMIC_STRING_TYPE_NAME,
+    MAILBOX_TYPE_NAME, SUPERVISOR_TYPE_NAME, SYNC_EFFECT_TYPE_NAME,
 };
+pub use names::{BuiltinGenericTypeName, BuiltinTypeName, STATIC_STRING_TYPE_NAME};
 
 /// Parser-level type representation.
 ///

--- a/src/ast/types/gated.rs
+++ b/src/ast/types/gated.rs
@@ -1,0 +1,95 @@
+//! Gated builtin type names and diagnostics.
+
+pub const DYNAMIC_STRING_TYPE_NAME: &str = "String";
+pub const ALLOCATOR_TYPE_NAME: &str = "Allocator";
+pub const SYNC_EFFECT_TYPE_NAME: &str = "Sync";
+pub const ASYNC_EFFECT_TYPE_NAME: &str = "Async";
+pub const ACTOR_TYPE_NAME: &str = "Actor";
+pub const ACTOR_REF_TYPE_NAME: &str = "ActorRef";
+pub const MAILBOX_TYPE_NAME: &str = "Mailbox";
+pub const SUPERVISOR_TYPE_NAME: &str = "Supervisor";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GatedBuiltinType {
+    DynamicString,
+    Allocator,
+    SyncEffect,
+    AsyncEffect,
+    Actor,
+    ActorRef,
+    Mailbox,
+    Supervisor,
+}
+
+impl GatedBuiltinType {
+    pub const ALL: &[GatedBuiltinType] = &[
+        Self::DynamicString,
+        Self::Allocator,
+        Self::SyncEffect,
+        Self::AsyncEffect,
+        Self::Actor,
+        Self::ActorRef,
+        Self::Mailbox,
+        Self::Supervisor,
+    ];
+
+    pub fn from_name(name: &str) -> Option<Self> {
+        GatedBuiltinType::ALL
+            .iter()
+            .copied()
+            .find(|ty| ty.as_str() == name)
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::DynamicString => DYNAMIC_STRING_TYPE_NAME,
+            Self::Allocator => ALLOCATOR_TYPE_NAME,
+            Self::SyncEffect => SYNC_EFFECT_TYPE_NAME,
+            Self::AsyncEffect => ASYNC_EFFECT_TYPE_NAME,
+            Self::Actor => ACTOR_TYPE_NAME,
+            Self::ActorRef => ACTOR_REF_TYPE_NAME,
+            Self::Mailbox => MAILBOX_TYPE_NAME,
+            Self::Supervisor => SUPERVISOR_TYPE_NAME,
+        }
+    }
+
+    pub fn gate_message(self) -> &'static str {
+        match self {
+            Self::DynamicString => {
+                "`String` is gated until allocator-backed dynamic text ownership is implemented; use `StaticString` for baked literal text"
+            }
+            Self::Allocator => {
+                "typed allocators are gated until allocator ownership and effect semantics are implemented"
+            }
+            Self::SyncEffect => {
+                "`Sync` effect mode is gated until Sync/Async effect checking is implemented"
+            }
+            Self::AsyncEffect => {
+                "`Async` effect mode is gated until Sync/Async effect checking is implemented"
+            }
+            Self::Actor => {
+                "`Actor` framework type is gated until std actor scheduling and mailbox semantics are implemented"
+            }
+            Self::ActorRef => {
+                "`ActorRef` framework type is gated until std actor scheduling and mailbox semantics are implemented"
+            }
+            Self::Mailbox => {
+                "`Mailbox` framework type is gated until std actor scheduling and mailbox semantics are implemented"
+            }
+            Self::Supervisor => {
+                "`Supervisor` framework type is gated until std actor scheduling and mailbox semantics are implemented"
+            }
+        }
+    }
+}
+
+pub fn gated_builtin_type_name(name: &str) -> Option<GatedBuiltinType> {
+    GatedBuiltinType::from_name(name)
+}
+
+pub fn is_builtin_type_name(name: &str) -> bool {
+    matches!(
+        gated_builtin_type_name(name),
+        Some(GatedBuiltinType::DynamicString)
+    )
+}

--- a/src/ast/types/names.rs
+++ b/src/ast/types/names.rs
@@ -3,14 +3,6 @@ use std::fmt;
 use std::str::FromStr;
 
 pub const STATIC_STRING_TYPE_NAME: &str = "StaticString";
-pub const DYNAMIC_STRING_TYPE_NAME: &str = "String";
-pub const ALLOCATOR_TYPE_NAME: &str = "Allocator";
-pub const SYNC_EFFECT_TYPE_NAME: &str = "Sync";
-pub const ASYNC_EFFECT_TYPE_NAME: &str = "Async";
-pub const ACTOR_TYPE_NAME: &str = "Actor";
-pub const ACTOR_REF_TYPE_NAME: &str = "ActorRef";
-pub const MAILBOX_TYPE_NAME: &str = "Mailbox";
-pub const SUPERVISOR_TYPE_NAME: &str = "Supervisor";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BuiltinTypeName {
@@ -207,89 +199,4 @@ impl FromStr for BuiltinGenericTypeName {
             .find(|name| name.as_str() == value)
             .ok_or(())
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum GatedBuiltinType {
-    DynamicString,
-    Allocator,
-    SyncEffect,
-    AsyncEffect,
-    Actor,
-    ActorRef,
-    Mailbox,
-    Supervisor,
-}
-
-impl GatedBuiltinType {
-    pub const ALL: &[GatedBuiltinType] = &[
-        Self::DynamicString,
-        Self::Allocator,
-        Self::SyncEffect,
-        Self::AsyncEffect,
-        Self::Actor,
-        Self::ActorRef,
-        Self::Mailbox,
-        Self::Supervisor,
-    ];
-
-    pub fn from_name(name: &str) -> Option<Self> {
-        GatedBuiltinType::ALL
-            .iter()
-            .copied()
-            .find(|ty| ty.as_str() == name)
-    }
-
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::DynamicString => DYNAMIC_STRING_TYPE_NAME,
-            Self::Allocator => ALLOCATOR_TYPE_NAME,
-            Self::SyncEffect => SYNC_EFFECT_TYPE_NAME,
-            Self::AsyncEffect => ASYNC_EFFECT_TYPE_NAME,
-            Self::Actor => ACTOR_TYPE_NAME,
-            Self::ActorRef => ACTOR_REF_TYPE_NAME,
-            Self::Mailbox => MAILBOX_TYPE_NAME,
-            Self::Supervisor => SUPERVISOR_TYPE_NAME,
-        }
-    }
-
-    pub fn gate_message(self) -> &'static str {
-        match self {
-            Self::DynamicString => {
-                "`String` is gated until allocator-backed dynamic text ownership is implemented; use `StaticString` for baked literal text"
-            }
-            Self::Allocator => {
-                "typed allocators are gated until allocator ownership and effect semantics are implemented"
-            }
-            Self::SyncEffect => {
-                "`Sync` effect mode is gated until Sync/Async effect checking is implemented"
-            }
-            Self::AsyncEffect => {
-                "`Async` effect mode is gated until Sync/Async effect checking is implemented"
-            }
-            Self::Actor => {
-                "`Actor` framework type is gated until std actor scheduling and mailbox semantics are implemented"
-            }
-            Self::ActorRef => {
-                "`ActorRef` framework type is gated until std actor scheduling and mailbox semantics are implemented"
-            }
-            Self::Mailbox => {
-                "`Mailbox` framework type is gated until std actor scheduling and mailbox semantics are implemented"
-            }
-            Self::Supervisor => {
-                "`Supervisor` framework type is gated until std actor scheduling and mailbox semantics are implemented"
-            }
-        }
-    }
-}
-
-pub fn gated_builtin_type_name(name: &str) -> Option<GatedBuiltinType> {
-    GatedBuiltinType::from_name(name)
-}
-
-pub fn is_builtin_type_name(name: &str) -> bool {
-    matches!(
-        gated_builtin_type_name(name),
-        Some(GatedBuiltinType::DynamicString)
-    )
 }

--- a/tests/docs_truth/repo_hygiene/builtin_type_spelling.rs
+++ b/tests/docs_truth/repo_hygiene/builtin_type_spelling.rs
@@ -4,7 +4,8 @@ use super::*;
 fn semantic_builtin_type_checks_use_shared_spelling_helper() {
     let helper_root = read("src/ast/types.rs");
     let helper_names = read("src/ast/types/names.rs");
-    let helper = format!("{helper_root}\n{helper_names}");
+    let helper_gated = read("src/ast/types/gated.rs");
+    let helper = format!("{helper_root}\n{helper_names}\n{helper_gated}");
     assert!(
         helper.contains("pub const DYNAMIC_STRING_TYPE_NAME: &str = \"String\""),
         "dynamic String spelling should live in the AST type helper module"
@@ -50,6 +51,26 @@ fn semantic_builtin_type_checks_use_shared_spelling_helper() {
     assert!(
         helper.contains("Some(GatedBuiltinType::DynamicString)"),
         "dynamic String recognition should be expressed through the gated builtin type enum"
+    );
+    assert!(
+        helper_root.contains("mod gated;"),
+        "AST type module should include a focused gated builtin helper"
+    );
+    assert!(
+        helper_root.contains("pub use gated::"),
+        "AST type module should re-export gated builtin names from the focused helper"
+    );
+    assert!(
+        helper_gated.contains("pub enum GatedBuiltinType"),
+        "gated.rs should own gated builtin type classification"
+    );
+    assert!(
+        !helper_names.contains("pub enum GatedBuiltinType"),
+        "names.rs should stay focused on stable builtin and generic type names"
+    );
+    assert!(
+        helper_names.lines().count() < 220,
+        "names.rs should stay compact after gated builtin types move out"
     );
 
     for path in [


### PR DESCRIPTION
## Summary
- Move gated builtin type names, classification, and gate messages into `src/ast/types/gated.rs`.
- Keep `src/ast/types/names.rs` focused on stable builtin and generic type names.
- Tighten docs-truth hygiene so gated type spelling stays centralized without direct dynamic string checks.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Push-triggered Actions check for `codex/split-gated-builtin-types`: `[]`.