### PR TITLE
Compact learn guide recap

### DIFF
--- a/docs/learn_zen_in_y_minutes.md
+++ b/docs/learn_zen_in_y_minutes.md
@@ -317,23 +317,6 @@ Point.implements(Display) {
     display = (self: Point) StaticString { "Point" }
 }
 
-sum_to = (limit: i32) i32 {
-    total ::= 0
-    i ::= 0
-
-    loop((l) {
-        i > limit ?
-            | true { l.done() }
-            | false {
-                total = total + i
-                i = i + 1
-                l.next()
-            }
-    })
-
-    total
-}
-
 show<T: Display> = (value: T) StaticString {
     value.display()
 }
@@ -341,7 +324,7 @@ show<T: Display> = (value: T) StaticString {
 main = () i32 {
     point = Point { x: 20, y: 22 }
     io.println("${show(point)}: ${point.sum()}")
-    sum_to(10)
+    point.sum()
 }
 ```
 

--- a/tests/docs_truth/public_docs/learn_zen.rs
+++ b/tests/docs_truth/public_docs/learn_zen.rs
@@ -108,7 +108,7 @@ fn learn_zen_guide_covers_core_tour_and_gated_previews() {
     }
 
     assert!(
-        guide.lines().count() <= 355,
+        guide.lines().count() <= 340,
         "Learn guide should stay compact; move detailed status or evidence to phase docs and tests"
     );
 }


### PR DESCRIPTION
## Summary
- Remove duplicated counted-loop code from the final Learn Zen recap while keeping the dedicated Loops section intact.
- Tighten the Learn Zen compactness guard from 355 to 340 lines.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`

Push-event Actions check for `codex/compact-learn-guide-context`: `[]`