### PR TITLE
Split C pointer intrinsic lowering

### DIFF
--- a/src/codegen/c/intrinsics.rs
+++ b/src/codegen/c/intrinsics.rs
@@ -3,6 +3,7 @@ use names::CIntrinsic;
 
 mod memory;
 mod names;
+mod pointers;
 mod syscalls;
 
 impl CEmitter {
@@ -22,49 +23,14 @@ impl CEmitter {
         if intrinsic.is_syscall() {
             return intrinsic.emit_syscall(self, args);
         }
+        if let Some(emitted) = intrinsic.emit_pointer(self, args, result_ty) {
+            return emitted;
+        }
         if let Some(emitted) = intrinsic.emit_memory(self, args, result_ty) {
             return emitted;
         }
 
         match intrinsic {
-            // -- Pointer operations ---------------------------------------
-            CIntrinsic::IntToPtr => {
-                let val = self.emit_expr_inline(&args[0]);
-                format!("((void*)(uintptr_t)({}))", val)
-            }
-            CIntrinsic::PtrToInt => {
-                let ptr = self.emit_expr_inline(&args[0]);
-                format!("((uintptr_t)({}))", ptr)
-            }
-            CIntrinsic::Gep => {
-                let base = self.emit_expr_inline(&args[0]);
-                let offset = self.emit_expr_inline(&args[1]);
-                format!("((uint8_t*)({}) + ({}))", base, offset)
-            }
-            CIntrinsic::GepStruct => {
-                // Struct GEP: byte-offset into a struct by field index.
-                // In C we just cast to uint8_t* and offset, since the
-                // actual field layout matches.
-                let ptr = self.emit_expr_inline(&args[0]);
-                let idx = self.emit_expr_inline(&args[1]);
-                format!("((uint8_t*)({}) + ({}))", ptr, idx)
-            }
-            CIntrinsic::RawPtrOffset => {
-                let ptr = self.emit_expr_inline(&args[0]);
-                let offset = self.emit_expr_inline(&args[1]);
-                format!("((uint8_t*)({}) + ({}))", ptr, offset)
-            }
-            CIntrinsic::RawPtrCast => {
-                let ptr = self.emit_expr_inline(&args[0]);
-                let ty = self.c_type(result_ty);
-                format!("(({})({})", ty, ptr)
-            }
-            CIntrinsic::NullPtr | CIntrinsic::Nullptr => "(NULL)".into(),
-            CIntrinsic::IsNull => {
-                let ptr = self.emit_expr_inline(&args[0]);
-                format!("(({}) == NULL)", ptr)
-            }
-
             // -- Atomic operations ----------------------------------------
             CIntrinsic::AtomicLoad => {
                 let ptr = self.emit_expr_inline(&args[0]);

--- a/src/codegen/c/intrinsics/pointers.rs
+++ b/src/codegen/c/intrinsics/pointers.rs
@@ -1,0 +1,47 @@
+use super::*;
+
+impl CIntrinsic {
+    pub(super) fn emit_pointer(
+        self,
+        emitter: &mut CEmitter,
+        args: &[TypedExpression],
+        result_ty: &Type,
+    ) -> Option<String> {
+        match self {
+            CIntrinsic::IntToPtr => {
+                let val = emitter.emit_expr_inline(&args[0]);
+                Some(format!("((void*)(uintptr_t)({}))", val))
+            }
+            CIntrinsic::PtrToInt => {
+                let ptr = emitter.emit_expr_inline(&args[0]);
+                Some(format!("((uintptr_t)({}))", ptr))
+            }
+            CIntrinsic::Gep => {
+                let base = emitter.emit_expr_inline(&args[0]);
+                let offset = emitter.emit_expr_inline(&args[1]);
+                Some(format!("((uint8_t*)({}) + ({}))", base, offset))
+            }
+            CIntrinsic::GepStruct => {
+                let ptr = emitter.emit_expr_inline(&args[0]);
+                let idx = emitter.emit_expr_inline(&args[1]);
+                Some(format!("((uint8_t*)({}) + ({}))", ptr, idx))
+            }
+            CIntrinsic::RawPtrOffset => {
+                let ptr = emitter.emit_expr_inline(&args[0]);
+                let offset = emitter.emit_expr_inline(&args[1]);
+                Some(format!("((uint8_t*)({}) + ({}))", ptr, offset))
+            }
+            CIntrinsic::RawPtrCast => {
+                let ptr = emitter.emit_expr_inline(&args[0]);
+                let ty = emitter.c_type(result_ty);
+                Some(format!("(({})({})", ty, ptr))
+            }
+            CIntrinsic::NullPtr | CIntrinsic::Nullptr => Some("(NULL)".into()),
+            CIntrinsic::IsNull => {
+                let ptr = emitter.emit_expr_inline(&args[0]);
+                Some(format!("(({}) == NULL)", ptr))
+            }
+            _ => None,
+        }
+    }
+}

--- a/tests/docs_truth/repo_hygiene/parser_enums/codegen_and_tools.rs
+++ b/tests/docs_truth/repo_hygiene/parser_enums/codegen_and_tools.rs
@@ -140,6 +140,45 @@ fn codegen_c_memory_intrinsics_live_in_focused_helper() {
 }
 
 #[test]
+fn codegen_c_pointer_intrinsics_live_in_focused_helper() {
+    let lowering = read("src/codegen/c/intrinsics.rs");
+    let pointers = read("src/codegen/c/intrinsics/pointers.rs");
+
+    for pointer_variant in [
+        "CIntrinsic::IntToPtr =>",
+        "CIntrinsic::PtrToInt =>",
+        "CIntrinsic::Gep =>",
+        "CIntrinsic::GepStruct =>",
+        "CIntrinsic::RawPtrOffset =>",
+        "CIntrinsic::RawPtrCast =>",
+        "CIntrinsic::NullPtr | CIntrinsic::Nullptr =>",
+        "CIntrinsic::IsNull =>",
+    ] {
+        assert!(
+            !lowering.contains(pointer_variant),
+            "main C intrinsic dispatcher should route pointer lowering to a focused helper: {pointer_variant}"
+        );
+        assert!(
+            pointers.contains(pointer_variant),
+            "C pointer intrinsic lowering should live in the focused pointer helper: {pointer_variant}"
+        );
+    }
+
+    assert!(
+        lowering.contains("intrinsic.emit_pointer(self, args, result_ty)"),
+        "main C intrinsic dispatcher should delegate pointer lowering through CIntrinsic"
+    );
+    assert!(
+        pointers.contains("pub(super) fn emit_pointer"),
+        "pointer helper should own the C pointer lowering entry point"
+    );
+    assert!(
+        lowering.lines().count() < 240,
+        "C intrinsic dispatcher should stay compact after category helpers own detailed lowering"
+    );
+}
+
+#[test]
 fn build_graph_host_effect_methods_parse_dsl_ident_enum() {
     let lowering = read("src/build_graph/lowering.rs");
     let dsl = read("src/build_graph/lowering/dsl.rs");


### PR DESCRIPTION
## Summary
- Move C pointer intrinsic lowering into `src/codegen/c/intrinsics/pointers.rs`.
- Keep `src/codegen/c/intrinsics.rs` as the category dispatcher plus remaining smaller lowering groups.
- Add docs-truth hygiene coverage requiring pointer intrinsic cases to stay in the focused helper.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Push-event Actions check for `codex/split-c-pointer-intrinsics`: `[]`