### PR TITLE
Split build graph host effect lowering

### DIFF
--- a/src/build_graph/lowering.rs
+++ b/src/build_graph/lowering.rs
@@ -2,6 +2,8 @@ use crate::ast::{Declaration, Expression, MatchArm, Program, Statement};
 
 #[path = "lowering/dsl.rs"]
 mod dsl;
+#[path = "lowering/host_effects.rs"]
+mod host_effects;
 #[path = "lowering/target_fields.rs"]
 mod target_fields;
 #[path = "lowering/targets.rs"]
@@ -10,6 +12,7 @@ mod targets;
 use dsl::{BuildTargetDslIdent, HostEffectResultVariant};
 #[cfg(test)]
 use dsl::{BuildTargetDslKind, BuildTargetField};
+use host_effects::{declared_host_effect, host_effect};
 use targets::build_target_from_builder_add;
 
 impl BuildGraph {
@@ -224,63 +227,6 @@ fn is_builder_add_call(expr: &Expression) -> bool {
             if method == BuildTargetDslIdent::Add.as_str()
                 && matches!(
                     receiver.as_ref(),
-                    Expression::Identifier { name, .. }
-                        if name == BuildTargetDslIdent::Builder.as_str()
-                )
-    )
-}
-
-fn declared_host_effect(expr: &Expression) -> Option<HostEffect> {
-    let Expression::Match {
-        scrutinee, arms, ..
-    } = expr
-    else {
-        return None;
-    };
-    let has_fallback = arms.iter().any(|arm| host_effect_arm_declares_fallback(&arm.pattern));
-    has_fallback.then(|| host_effect(scrutinee)).flatten()
-}
-
-fn host_effect_arm_declares_fallback(pattern: &crate::ast::Pattern) -> bool {
-    match pattern {
-        crate::ast::Pattern::Wildcard { .. } | crate::ast::Pattern::Identifier { .. } => true,
-        crate::ast::Pattern::Enum { variant, .. } => {
-            variant.parse::<HostEffectResultVariant>() == Ok(HostEffectResultVariant::Err)
-        }
-        _ => false,
-    }
-}
-
-fn host_effect(expr: &Expression) -> Option<HostEffect> {
-    let Expression::MethodCall {
-        receiver,
-        method,
-        args,
-        ..
-    } = expr
-    else {
-        return None;
-    };
-    if !is_builder_os(receiver) {
-        return None;
-    }
-    let [Expression::StringLiteral { value: argument, .. }] = args.as_slice() else {
-        return None;
-    };
-    match method.parse::<BuildTargetDslIdent>() {
-        Ok(BuildTargetDslIdent::Env) => Some(HostEffect::ReadEnv(argument.clone())),
-        Ok(BuildTargetDslIdent::ReadFile) => Some(HostEffect::ReadFile(argument.clone())),
-        _ => None,
-    }
-}
-
-fn is_builder_os(expr: &Expression) -> bool {
-    matches!(
-        expr,
-        Expression::MemberAccess { object, field, .. }
-            if field == BuildTargetDslIdent::Os.as_str()
-                && matches!(
-                    object.as_ref(),
                     Expression::Identifier { name, .. }
                         if name == BuildTargetDslIdent::Builder.as_str()
                 )

--- a/src/build_graph/lowering/host_effects.rs
+++ b/src/build_graph/lowering/host_effects.rs
@@ -1,0 +1,61 @@
+use super::{BuildTargetDslIdent, HostEffect, HostEffectResultVariant};
+use crate::ast::{Expression, Pattern};
+
+pub(super) fn declared_host_effect(expr: &Expression) -> Option<HostEffect> {
+    let Expression::Match {
+        scrutinee, arms, ..
+    } = expr
+    else {
+        return None;
+    };
+    let has_fallback = arms
+        .iter()
+        .any(|arm| host_effect_arm_declares_fallback(&arm.pattern));
+    has_fallback.then(|| host_effect(scrutinee)).flatten()
+}
+
+fn host_effect_arm_declares_fallback(pattern: &Pattern) -> bool {
+    match pattern {
+        Pattern::Wildcard { .. } | Pattern::Identifier { .. } => true,
+        Pattern::Enum { variant, .. } => {
+            variant.parse::<HostEffectResultVariant>() == Ok(HostEffectResultVariant::Err)
+        }
+        _ => false,
+    }
+}
+
+pub(super) fn host_effect(expr: &Expression) -> Option<HostEffect> {
+    let Expression::MethodCall {
+        receiver,
+        method,
+        args,
+        ..
+    } = expr
+    else {
+        return None;
+    };
+    if !is_builder_os(receiver) {
+        return None;
+    }
+    let [Expression::StringLiteral { value: argument, .. }] = args.as_slice() else {
+        return None;
+    };
+    match method.parse::<BuildTargetDslIdent>() {
+        Ok(BuildTargetDslIdent::Env) => Some(HostEffect::ReadEnv(argument.clone())),
+        Ok(BuildTargetDslIdent::ReadFile) => Some(HostEffect::ReadFile(argument.clone())),
+        _ => None,
+    }
+}
+
+fn is_builder_os(expr: &Expression) -> bool {
+    matches!(
+        expr,
+        Expression::MemberAccess { object, field, .. }
+            if field == BuildTargetDslIdent::Os.as_str()
+                && matches!(
+                    object.as_ref(),
+                    Expression::Identifier { name, .. }
+                        if name == BuildTargetDslIdent::Builder.as_str()
+                )
+    )
+}

--- a/tests/docs_truth/repo_hygiene/build_graph_dsl.rs
+++ b/tests/docs_truth/repo_hygiene/build_graph_dsl.rs
@@ -83,3 +83,37 @@ fn build_target_field_extraction_lives_in_focused_helper() {
         );
     }
 }
+
+#[test]
+fn build_graph_host_effect_detection_lives_in_focused_helper() {
+    let lowering = read("src/build_graph/lowering.rs");
+    let host_effects = read("src/build_graph/lowering/host_effects.rs");
+
+    assert!(
+        lowering.lines().count() < 240,
+        "build graph lowering should stay focused on traversal and target collection"
+    );
+    for helper in [
+        "declared_host_effect",
+        "host_effect_arm_declares_fallback",
+        "host_effect",
+        "is_builder_os",
+    ] {
+        assert!(
+            !lowering.contains(&format!("fn {helper}")),
+            "build graph host-effect detection should live in host_effects.rs: {helper}"
+        );
+        assert!(
+            host_effects.contains(&format!("fn {helper}")),
+            "host_effects.rs should own build graph host-effect detection: {helper}"
+        );
+    }
+    assert!(
+        lowering.contains("mod host_effects;"),
+        "build graph lowering should include the focused host-effect helper"
+    );
+    assert!(
+        lowering.contains("use host_effects::{declared_host_effect, host_effect};"),
+        "build graph lowering should import host-effect detection from the focused helper"
+    );
+}

--- a/tests/docs_truth/repo_hygiene/parser_enums/codegen_and_tools.rs
+++ b/tests/docs_truth/repo_hygiene/parser_enums/codegen_and_tools.rs
@@ -181,7 +181,9 @@ fn codegen_c_pointer_intrinsics_live_in_focused_helper() {
 #[test]
 fn build_graph_host_effect_methods_parse_dsl_ident_enum() {
     let lowering = read("src/build_graph/lowering.rs");
+    let host_effects = read("src/build_graph/lowering/host_effects.rs");
     let dsl = read("src/build_graph/lowering/dsl.rs");
+    let source = format!("{lowering}\n{host_effects}");
 
     for forbidden in [
         "match method.as_str()",
@@ -189,12 +191,12 @@ fn build_graph_host_effect_methods_parse_dsl_ident_enum() {
         "method == BuildTargetDslIdent::ReadFile.as_str()",
     ] {
         assert!(
-            !lowering.contains(forbidden),
+            !source.contains(forbidden),
             "build graph host-effect method dispatch should parse through BuildTargetDslIdent: {forbidden}"
         );
     }
     assert!(
-        lowering.contains("method.parse::<BuildTargetDslIdent>()"),
+        source.contains("method.parse::<BuildTargetDslIdent>()"),
         "build graph host-effect method dispatch should parse method names through BuildTargetDslIdent"
     );
     assert!(


### PR DESCRIPTION
## Summary
- Move build graph host-effect detection into `src/build_graph/lowering/host_effects.rs`.
- Keep `src/build_graph/lowering.rs` focused on traversal and target collection.
- Add docs-truth hygiene coverage requiring host-effect detection to stay in the focused helper and update the enum-parsing guard to cover the moved source.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Push-event Actions check for `codex/split-build-host-effects`: `[]`