### PR TITLE
Split module graph export lookup

### DIFF
--- a/src/module_system/graph_loading.rs
+++ b/src/module_system/graph_loading.rs
@@ -3,10 +3,14 @@ use std::path::{Path, PathBuf};
 
 use crate::ast::{Declaration, Program};
 use crate::error::{CompileError, FileTable, Span};
-use crate::resolver::{Namespace, Resolver, SymbolTable};
+use crate::resolver::Resolver;
+
+#[path = "graph_loading/exported_symbols.rs"]
+mod exported_symbols;
 
 use super::root_prefix::parse_module_root_prefix;
 use super::{ImportBinding, ModuleId, ModuleSystem, ResolvedModule, ResolvedModuleGraph};
+use exported_symbols::{exported_module_symbol, ExportedModuleSymbol};
 
 impl ModuleSystem {
     /// Load a module graph with validated import bindings.
@@ -198,91 +202,5 @@ impl ModuleSystem {
         }
 
         Ok(())
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ExportedModuleSymbol {
-    Public,
-    Private,
-    Missing,
-}
-
-fn exported_module_symbol(symbols: &SymbolTable, name: &str) -> ExportedModuleSymbol {
-    let mut found_private = false;
-
-    for namespace in [Namespace::Value, Namespace::Type, Namespace::Behavior] {
-        let Some(symbol) = symbols.lookup(namespace, name) else {
-            continue;
-        };
-        if symbol.is_public {
-            return ExportedModuleSymbol::Public;
-        }
-        found_private = true;
-    }
-
-    if found_private {
-        ExportedModuleSymbol::Private
-    } else {
-        ExportedModuleSymbol::Missing
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::{lexer, parser};
-
-    fn resolve_symbols(source: &str) -> SymbolTable {
-        let tokens = lexer::tokenize(source, 0).expect("lex source");
-        let program = parser::parse(tokens, 0).expect("parse source");
-        Resolver::new()
-            .resolve_program(&program)
-            .expect("resolve source")
-    }
-
-    #[test]
-    fn exported_module_symbol_reads_resolver_public_visibility() {
-        let symbols = resolve_symbols(
-            r#"
-hidden = () i32 { 1 }
-pub Model: { value: i32 }
-pub Json<T>: behavior {
-    encode: (Self) T
-}
-"#,
-        );
-
-        assert_eq!(
-            exported_module_symbol(&symbols, "hidden"),
-            ExportedModuleSymbol::Private
-        );
-        assert_eq!(
-            exported_module_symbol(&symbols, "Model"),
-            ExportedModuleSymbol::Public
-        );
-        assert_eq!(
-            exported_module_symbol(&symbols, "Json"),
-            ExportedModuleSymbol::Public
-        );
-        assert_eq!(
-            exported_module_symbol(&symbols, "Missing"),
-            ExportedModuleSymbol::Missing
-        );
-    }
-
-    #[test]
-    fn exported_module_symbol_accepts_public_symbol_over_private_symbol_in_other_namespace() {
-        let symbols = resolve_symbols(
-            r#"
-Name = () i32 { 1 }
-pub Name: { value: i32 }
-"#,
-        );
-
-        assert_eq!(
-            exported_module_symbol(&symbols, "Name"),
-            ExportedModuleSymbol::Public
-        );
     }
 }

--- a/src/module_system/graph_loading/exported_symbols.rs
+++ b/src/module_system/graph_loading/exported_symbols.rs
@@ -1,0 +1,87 @@
+use crate::resolver::{Namespace, SymbolTable};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ExportedModuleSymbol {
+    Public,
+    Private,
+    Missing,
+}
+
+pub(super) fn exported_module_symbol(symbols: &SymbolTable, name: &str) -> ExportedModuleSymbol {
+    let mut found_private = false;
+
+    for namespace in [Namespace::Value, Namespace::Type, Namespace::Behavior] {
+        let Some(symbol) = symbols.lookup(namespace, name) else {
+            continue;
+        };
+        if symbol.is_public {
+            return ExportedModuleSymbol::Public;
+        }
+        found_private = true;
+    }
+
+    if found_private {
+        ExportedModuleSymbol::Private
+    } else {
+        ExportedModuleSymbol::Missing
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{lexer, parser, resolver::Resolver};
+
+    fn resolve_symbols(source: &str) -> SymbolTable {
+        let tokens = lexer::tokenize(source, 0).expect("lex source");
+        let program = parser::parse(tokens, 0).expect("parse source");
+        Resolver::new()
+            .resolve_program(&program)
+            .expect("resolve source")
+    }
+
+    #[test]
+    fn exported_module_symbol_reads_resolver_public_visibility() {
+        let symbols = resolve_symbols(
+            r#"
+hidden = () i32 { 1 }
+pub Model: { value: i32 }
+pub Json<T>: behavior {
+    encode: (Self) T
+}
+"#,
+        );
+
+        assert_eq!(
+            exported_module_symbol(&symbols, "hidden"),
+            ExportedModuleSymbol::Private
+        );
+        assert_eq!(
+            exported_module_symbol(&symbols, "Model"),
+            ExportedModuleSymbol::Public
+        );
+        assert_eq!(
+            exported_module_symbol(&symbols, "Json"),
+            ExportedModuleSymbol::Public
+        );
+        assert_eq!(
+            exported_module_symbol(&symbols, "Missing"),
+            ExportedModuleSymbol::Missing
+        );
+    }
+
+    #[test]
+    fn exported_module_symbol_accepts_public_symbol_over_private_symbol_in_other_namespace() {
+        let symbols = resolve_symbols(
+            r#"
+Name = () i32 { 1 }
+pub Name: { value: i32 }
+"#,
+        );
+
+        assert_eq!(
+            exported_module_symbol(&symbols, "Name"),
+            ExportedModuleSymbol::Public
+        );
+    }
+}

--- a/tests/docs_truth/repo_hygiene/module_system.rs
+++ b/tests/docs_truth/repo_hygiene/module_system.rs
@@ -87,3 +87,33 @@ fn stdlib_path_resolution_lives_in_focused_helper() {
         "import routing should load focused stdlib path helper"
     );
 }
+
+#[test]
+fn graph_loading_export_lookup_lives_in_focused_helper() {
+    let graph_loading = read("src/module_system/graph_loading.rs");
+    let exported_symbols = read("src/module_system/graph_loading/exported_symbols.rs");
+
+    assert!(
+        graph_loading.lines().count() < 240,
+        "module graph loading should stay focused on loading and import traversal"
+    );
+    for helper in ["enum ExportedModuleSymbol", "fn exported_module_symbol"] {
+        assert!(
+            !graph_loading.contains(helper),
+            "exported module symbol definitions should live in exported_symbols.rs: {helper}"
+        );
+        assert!(
+            exported_symbols.contains(helper),
+            "exported_symbols.rs should own exported module symbol definitions: {helper}"
+        );
+    }
+    assert!(
+        graph_loading.contains("mod exported_symbols;"),
+        "graph loading should include the focused exported-symbol helper"
+    );
+    assert!(
+        graph_loading
+            .contains("use exported_symbols::{exported_module_symbol, ExportedModuleSymbol};"),
+        "graph loading should import exported-symbol helpers explicitly"
+    );
+}


### PR DESCRIPTION
## Summary
- Move module graph exported-symbol classification into `src/module_system/graph_loading/exported_symbols.rs`.
- Keep `src/module_system/graph_loading.rs` focused on module loading and import traversal.
- Add docs-truth hygiene coverage requiring export lookup definitions to stay in the focused helper.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Push-event Actions check for `codex/split-module-export-lookup`: `[]`