### PR TITLE
Split layout JSON schema

### DIFF
--- a/src/ir_json/layout.rs
+++ b/src/ir_json/layout.rs
@@ -1,50 +1,16 @@
 use std::collections::BTreeMap;
 
-use serde::Serialize;
-
 use crate::ast::typed::{Type, TypeDefKind, TypedProgram, TypedTypeDef};
 
-#[derive(Serialize)]
-struct LayoutJsonProgram {
-    format: &'static str,
-    schema_version: u32,
-    semantic_status: &'static str,
-    target: LayoutJsonTarget,
-    layouts: BTreeMap<String, LayoutJsonType>,
-}
+#[path = "layout/metrics.rs"]
+mod metrics;
+#[path = "layout/schema.rs"]
+mod schema;
 
-#[derive(Serialize)]
-struct LayoutJsonTarget {
-    pointer_size: u32,
-    pointer_alignment: u32,
-    usize_size: u32,
-}
-
-#[derive(Clone, Serialize)]
-struct LayoutJsonType {
-    kind: &'static str,
-    size: u32,
-    alignment: u32,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    fields: Vec<LayoutJsonField>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    variants: Vec<LayoutJsonVariant>,
-}
-
-#[derive(Clone, Serialize)]
-struct LayoutJsonField {
-    name: String,
-    r#type: String,
-    offset: u32,
-}
-
-#[derive(Clone, Serialize)]
-struct LayoutJsonVariant {
-    name: String,
-    tag: u32,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    payload_fields: Vec<LayoutJsonField>,
-}
+use metrics::{align_to, scalar_layout, POINTER_ALIGN, POINTER_SIZE, USIZE_SIZE};
+use schema::{
+    LayoutJsonField, LayoutJsonProgram, LayoutJsonTarget, LayoutJsonType, LayoutJsonVariant,
+};
 
 pub(super) fn program_to_json(program: &TypedProgram) -> serde_json::Result<String> {
     let context = LayoutContext::new(program);
@@ -62,10 +28,6 @@ pub(super) fn program_to_json(program: &TypedProgram) -> serde_json::Result<Stri
 
     serde_json::to_string_pretty(&graph)
 }
-
-const POINTER_SIZE: u32 = 8;
-const POINTER_ALIGN: u32 = 8;
-const USIZE_SIZE: u32 = 8;
 
 struct LayoutContext<'a> {
     types: BTreeMap<&'a str, &'a TypedTypeDef>,
@@ -266,23 +228,5 @@ impl<'a> LayoutContext<'a> {
             .get(name)
             .cloned()
             .unwrap_or_else(|| scalar_layout("opaque", 0, 1))
-    }
-}
-
-fn scalar_layout(kind: &'static str, size: u32, alignment: u32) -> LayoutJsonType {
-    LayoutJsonType {
-        kind,
-        size,
-        alignment,
-        fields: Vec::new(),
-        variants: Vec::new(),
-    }
-}
-
-fn align_to(value: u32, alignment: u32) -> u32 {
-    if alignment <= 1 {
-        value
-    } else {
-        value.div_ceil(alignment) * alignment
     }
 }

--- a/src/ir_json/layout/metrics.rs
+++ b/src/ir_json/layout/metrics.rs
@@ -1,0 +1,23 @@
+use super::schema::LayoutJsonType;
+
+pub(super) const POINTER_SIZE: u32 = 8;
+pub(super) const POINTER_ALIGN: u32 = 8;
+pub(super) const USIZE_SIZE: u32 = 8;
+
+pub(super) fn scalar_layout(kind: &'static str, size: u32, alignment: u32) -> LayoutJsonType {
+    LayoutJsonType {
+        kind,
+        size,
+        alignment,
+        fields: Vec::new(),
+        variants: Vec::new(),
+    }
+}
+
+pub(super) fn align_to(value: u32, alignment: u32) -> u32 {
+    if alignment <= 1 {
+        value
+    } else {
+        value.div_ceil(alignment) * alignment
+    }
+}

--- a/src/ir_json/layout/schema.rs
+++ b/src/ir_json/layout/schema.rs
@@ -1,0 +1,45 @@
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub(super) struct LayoutJsonProgram {
+    pub(super) format: &'static str,
+    pub(super) schema_version: u32,
+    pub(super) semantic_status: &'static str,
+    pub(super) target: LayoutJsonTarget,
+    pub(super) layouts: BTreeMap<String, LayoutJsonType>,
+}
+
+#[derive(Serialize)]
+pub(super) struct LayoutJsonTarget {
+    pub(super) pointer_size: u32,
+    pub(super) pointer_alignment: u32,
+    pub(super) usize_size: u32,
+}
+
+#[derive(Clone, Serialize)]
+pub(super) struct LayoutJsonType {
+    pub(super) kind: &'static str,
+    pub(super) size: u32,
+    pub(super) alignment: u32,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(super) fields: Vec<LayoutJsonField>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(super) variants: Vec<LayoutJsonVariant>,
+}
+
+#[derive(Clone, Serialize)]
+pub(super) struct LayoutJsonField {
+    pub(super) name: String,
+    pub(super) r#type: String,
+    pub(super) offset: u32,
+}
+
+#[derive(Clone, Serialize)]
+pub(super) struct LayoutJsonVariant {
+    pub(super) name: String,
+    pub(super) tag: u32,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(super) payload_fields: Vec<LayoutJsonField>,
+}

--- a/tests/docs_truth/repo_hygiene/ir_json.rs
+++ b/tests/docs_truth/repo_hygiene/ir_json.rs
@@ -70,3 +70,35 @@ fn diagnostics_json_schema_types_live_in_focused_helper() {
         "diagnostics JSON helper should own diagnostics serialization entry point"
     );
 }
+
+#[test]
+fn layout_json_schema_types_live_in_focused_helper() {
+    let layout = read("src/ir_json/layout.rs");
+    let schema = read("src/ir_json/layout/schema.rs");
+
+    for moved_schema_type in [
+        "struct LayoutJsonProgram",
+        "struct LayoutJsonTarget",
+        "struct LayoutJsonType",
+        "struct LayoutJsonField",
+        "struct LayoutJsonVariant",
+    ] {
+        assert!(
+            !layout.contains(moved_schema_type),
+            "layout JSON lowering should not own schema type definitions: {moved_schema_type}"
+        );
+        assert!(
+            schema.contains(moved_schema_type),
+            "layout JSON schema definitions should live in the focused schema helper: {moved_schema_type}"
+        );
+    }
+
+    assert!(
+        schema.contains("use serde::Serialize"),
+        "layout JSON schema helper should own serialization derives"
+    );
+    assert!(
+        layout.lines().count() < 240,
+        "layout JSON lowering should stay focused on layout calculation"
+    );
+}


### PR DESCRIPTION
## Summary
- Move layout JSON schema structs into `src/ir_json/layout/schema.rs`.
- Move fixed layout metrics and scalar/align helpers into `src/ir_json/layout/metrics.rs`.
- Add docs-truth coverage requiring layout schema types to stay in the focused helper and keeping `layout.rs` under 240 lines.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Push-event Actions check for `codex/split-layout-json-schema`: `[]`