### PR TITLE
Split C expression helpers

### DIFF
--- a/src/codegen/c/emit.rs
+++ b/src/codegen/c/emit.rs
@@ -1,6 +1,5 @@
-use crate::ast::expressions::{BinaryOp, UnaryOp};
-
 use super::*;
+use operators::{c_binary_op, c_unary_op};
 
 impl CEmitter {
     // ── Block body ────────────────────────────────────────────
@@ -106,36 +105,13 @@ impl CEmitter {
             TypedExprKind::BinaryOp { op, left, right } => {
                 let l = self.emit_expr_inline(left);
                 let r = self.emit_expr_inline(right);
-                let op_str = match op {
-                    BinaryOp::Add => "+",
-                    BinaryOp::Sub => "-",
-                    BinaryOp::Mul => "*",
-                    BinaryOp::Div => "/",
-                    BinaryOp::Mod => "%",
-                    BinaryOp::Eq => "==",
-                    BinaryOp::NotEq => "!=",
-                    BinaryOp::Lt => "<",
-                    BinaryOp::Gt => ">",
-                    BinaryOp::LtEq => "<=",
-                    BinaryOp::GtEq => ">=",
-                    BinaryOp::And => "&&",
-                    BinaryOp::Or => "||",
-                    BinaryOp::BitAnd => "&",
-                    BinaryOp::BitOr => "|",
-                    BinaryOp::BitXor => "^",
-                    BinaryOp::ShiftLeft => "<<",
-                    BinaryOp::ShiftRight => ">>",
-                };
+                let op_str = c_binary_op(*op);
                 format!("({} {} {})", l, op_str, r)
             }
 
             TypedExprKind::UnaryOp { op, operand } => {
                 let o = self.emit_expr_inline(operand);
-                match op {
-                    UnaryOp::Neg => format!("(-{})", o),
-                    UnaryOp::Not => format!("(!{})", o),
-                    UnaryOp::BitNot => format!("(~{})", o),
-                }
+                format!("({}{})", c_unary_op(*op), o)
             }
 
             TypedExprKind::FunctionCall { function, args } => {
@@ -162,46 +138,16 @@ impl CEmitter {
             }
 
             TypedExprKind::StructLiteral { type_name, fields } => {
-                let name = c_ident(type_name);
-                let field_strs: Vec<_> = fields
-                    .iter()
-                    .map(|(fname, fval)| {
-                        let v = self.emit_expr_inline(fval);
-                        format!(".{} = {}", c_ident(fname), v)
-                    })
-                    .collect();
-                format!("({}){{ {} }}", name, field_strs.join(", "))
+                self.emit_struct_literal(type_name, fields)
             }
 
             TypedExprKind::EnumVariant {
                 type_name,
                 variant,
                 payload,
-            } => {
-                let name = c_ident(type_name);
-                let var = c_ident(variant);
-                match payload {
-                    None => {
-                        format!("({}){{ .tag = {}_{} }}", name, name, var)
-                    }
-                    Some(val) => {
-                        let v = self.emit_expr_inline(val);
-                        format!(
-                            "({}){{ .tag = {}_{}, .data.{} = {} }}",
-                            name,
-                            name,
-                            var,
-                            var.to_lowercase(),
-                            v
-                        )
-                    }
-                }
-            }
+            } => self.emit_enum_variant_literal(type_name, variant, payload.as_deref()),
 
-            TypedExprKind::ArrayLiteral { elements } => {
-                let elems: Vec<_> = elements.iter().map(|e| self.emit_expr_inline(e)).collect();
-                format!("{{ {} }}", elems.join(", "))
-            }
+            TypedExprKind::ArrayLiteral { elements } => self.emit_array_literal(elements),
 
             TypedExprKind::Cast { expr, to_type, .. } => {
                 let e = self.emit_expr_inline(expr);

--- a/src/codegen/c/literals.rs
+++ b/src/codegen/c/literals.rs
@@ -1,0 +1,53 @@
+use super::*;
+
+impl CEmitter {
+    pub(super) fn emit_struct_literal(
+        &mut self,
+        type_name: &str,
+        fields: &[(String, TypedExpression)],
+    ) -> String {
+        let name = c_ident(type_name);
+        let field_strs: Vec<_> = fields
+            .iter()
+            .map(|(fname, fval)| {
+                let value = self.emit_expr_inline(fval);
+                format!(".{} = {}", c_ident(fname), value)
+            })
+            .collect();
+        format!("({}){{ {} }}", name, field_strs.join(", "))
+    }
+
+    pub(super) fn emit_enum_variant_literal(
+        &mut self,
+        type_name: &str,
+        variant: &str,
+        payload: Option<&TypedExpression>,
+    ) -> String {
+        let name = c_ident(type_name);
+        let variant_ident = c_ident(variant);
+        match payload {
+            None => {
+                format!("({}){{ .tag = {}_{} }}", name, name, variant_ident)
+            }
+            Some(value) => {
+                let payload_value = self.emit_expr_inline(value);
+                format!(
+                    "({}){{ .tag = {}_{}, .data.{} = {} }}",
+                    name,
+                    name,
+                    variant_ident,
+                    variant_ident.to_lowercase(),
+                    payload_value
+                )
+            }
+        }
+    }
+
+    pub(super) fn emit_array_literal(&mut self, elements: &[TypedExpression]) -> String {
+        let elems: Vec<_> = elements
+            .iter()
+            .map(|element| self.emit_expr_inline(element))
+            .collect();
+        format!("{{ {} }}", elems.join(", "))
+    }
+}

--- a/src/codegen/c/mod.rs
+++ b/src/codegen/c/mod.rs
@@ -2,7 +2,9 @@ mod closures;
 mod emit;
 mod functions;
 mod intrinsics;
+mod literals;
 mod matches;
+mod operators;
 mod strings;
 mod types;
 

--- a/src/codegen/c/operators.rs
+++ b/src/codegen/c/operators.rs
@@ -1,0 +1,32 @@
+use crate::ast::expressions::{BinaryOp, UnaryOp};
+
+pub(super) fn c_binary_op(op: BinaryOp) -> &'static str {
+    match op {
+        BinaryOp::Add => "+",
+        BinaryOp::Sub => "-",
+        BinaryOp::Mul => "*",
+        BinaryOp::Div => "/",
+        BinaryOp::Mod => "%",
+        BinaryOp::Eq => "==",
+        BinaryOp::NotEq => "!=",
+        BinaryOp::Lt => "<",
+        BinaryOp::Gt => ">",
+        BinaryOp::LtEq => "<=",
+        BinaryOp::GtEq => ">=",
+        BinaryOp::And => "&&",
+        BinaryOp::Or => "||",
+        BinaryOp::BitAnd => "&",
+        BinaryOp::BitOr => "|",
+        BinaryOp::BitXor => "^",
+        BinaryOp::ShiftLeft => "<<",
+        BinaryOp::ShiftRight => ">>",
+    }
+}
+
+pub(super) fn c_unary_op(op: UnaryOp) -> &'static str {
+    match op {
+        UnaryOp::Neg => "-",
+        UnaryOp::Not => "!",
+        UnaryOp::BitNot => "~",
+    }
+}

--- a/tests/docs_truth/repo_hygiene/codegen_c.rs
+++ b/tests/docs_truth/repo_hygiene/codegen_c.rs
@@ -27,3 +27,48 @@ fn codegen_c_function_emission_lives_in_focused_helper() {
         "C codegen should load focused function/global emission helper"
     );
 }
+
+#[test]
+fn codegen_c_expression_operator_spelling_lives_in_focused_helper() {
+    let emit = read("src/codegen/c/emit.rs");
+    let operators = read("src/codegen/c/operators.rs");
+    let literals = read("src/codegen/c/literals.rs");
+    let c_mod = read("src/codegen/c/mod.rs");
+
+    assert!(
+        emit.lines().count() < 240,
+        "C expression emission should stay focused on expression routing"
+    );
+    for helper in ["fn c_binary_op", "fn c_unary_op"] {
+        assert!(
+            !emit.contains(helper),
+            "C expression emitter should not own operator spelling helper: {helper}"
+        );
+        assert!(
+            operators.contains(helper),
+            "C operator spelling should live in focused helper: {helper}"
+        );
+    }
+    assert!(
+        c_mod.contains("mod operators;"),
+        "C codegen should load focused operator spelling helper"
+    );
+    for helper in [
+        "emit_struct_literal",
+        "emit_enum_variant_literal",
+        "emit_array_literal",
+    ] {
+        assert!(
+            !emit.contains(&format!("fn {helper}")),
+            "C expression emitter should route aggregate literals to focused helper: {helper}"
+        );
+        assert!(
+            literals.contains(&format!("fn {helper}")),
+            "C aggregate literal emission should live in focused helper: {helper}"
+        );
+    }
+    assert!(
+        c_mod.contains("mod literals;"),
+        "C codegen should load focused aggregate literal helper"
+    );
+}


### PR DESCRIPTION
## Summary
- Move C binary/unary operator spelling into `src/codegen/c/operators.rs`.
- Move C aggregate literal emission into `src/codegen/c/literals.rs`.
- Add docs-truth coverage keeping `emit.rs` focused on expression routing and under 240 lines.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Push-event Actions check for `codex/split-c-expression-operators`: `[]`