### PR TITLE
[codex] Compact Learn Zen guide

### DIFF
--- a/docs/learn_zen_in_y_minutes.md
+++ b/docs/learn_zen_in_y_minutes.md
@@ -37,10 +37,8 @@ first:
 main = () i32 {
     answer = 42
     label: StaticString = "zen"
-
     count ::= 0
     count = count + 1
-
     answer + count
 }
 ```
@@ -84,19 +82,9 @@ fields explicitly; field access uses dot syntax.
 ## Enums And Matching
 
 ```zen
-Direction:
-    North,
-    South,
-    East,
-    West
-
-Option<T>:
-    None,
-    Some(T)
-
-Result<T, E>:
-    Ok(T),
-    Err(E)
+Direction: North, South, East, West
+Option<T>: None, Some(T)
+Result<T, E>: Ok(T), Err(E)
 
 unwrap_or<T> = (value: Option<T>, fallback: T) T {
     value ?
@@ -129,14 +117,10 @@ Behaviors describe required methods. Generic functions use behavior bounds when
 they need a capability.
 
 ```zen
-Display: behavior {
-    display: (Self) StaticString
-}
+Display: behavior { display: (Self) StaticString }
 
 Point.implements(Display) {
-    display = (self: Point) StaticString {
-        "Point"
-    }
+    display = (self: Point) StaticString { "Point" }
 }
 
 show<T: Display> = (value: T) StaticString {
@@ -236,13 +220,8 @@ read_later = (source: Source, allocator: Allocator<u8, Async>) Task<Result<Bytes
     source.read_all_async(allocator)
 }
 
-Allocator<T, Sync>: behavior {
-    alloc: (Self, count: usize) Result<RawPtr<T>, AllocError>
-}
-
-Allocator<T, Async>: behavior {
-    alloc: (Self, count: usize) Task<Result<RawPtr<T>, AllocError>>
-}
+Allocator<T, Sync>: behavior { alloc: (Self, count: usize) Result<RawPtr<T>, AllocError> }
+Allocator<T, Async>: behavior { alloc: (Self, count: usize) Task<Result<RawPtr<T>, AllocError>> }
 ```
 
 Read the outer type first:
@@ -260,13 +239,14 @@ is complete now; `Task<Result<...>>` completes later at a scheduler boundary.
 Allocator-backed construction carries the allocator through the owner:
 
 ```zen
-Buffer<T, A: Allocator<T, Sync>>: {
-    ptr: RawPtr<T>, len: usize, capacity: usize, allocator: A,
-}
+Buffer<T, A: Allocator<T, Sync>>: { ptr: RawPtr<T>, len: usize, capacity: usize, allocator: A }
 
 make_buffer<T, A: Allocator<T, Sync>> = (allocator: A, len: usize) Result<Buffer<T, A>, AllocError> {
     allocator.alloc(len) ?
-        | Ok(ptr) { Result<Buffer<T, A>, AllocError>.Ok(Buffer<T, A> { ptr: ptr, len: len, capacity: len, allocator: allocator }) }
+        | Ok(ptr) {
+            buffer = Buffer<T, A> { ptr: ptr, len: len, capacity: len, allocator: allocator }
+            Result<Buffer<T, A>, AllocError>.Ok(buffer)
+        }
         | Err(error) { Result<Buffer<T, A>, AllocError>.Err(error) }
 }
 ```

--- a/tests/docs_truth/public_docs/learn_zen.rs
+++ b/tests/docs_truth/public_docs/learn_zen.rs
@@ -108,7 +108,7 @@ fn learn_zen_guide_covers_core_tour_and_gated_previews() {
     }
 
     assert!(
-        guide.lines().count() <= 340,
+        guide.lines().count() <= 320,
         "Learn guide should stay compact; move detailed status or evidence to phase docs and tests"
     );
 }


### PR DESCRIPTION
## Summary

- Compact `docs/learn_zen_in_y_minutes.md` from 335 lines to 315 lines while preserving the required language-tour coverage.
- Tighten the Learn guide docs-truth cap from 340 to 320 lines so status/detail drift stays out of the quick tour.
- Keep allocator, sync/async, loop-control, static-string, behavior, Option, and Result coverage in the guide.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Normal branch push Actions check: `gh run list --repo lantos1618/zenlang --branch codex/compact-learn-guide-320 --event push --limit 10 --json databaseId,status,conclusion,workflowName,headSha,createdAt,url` returned `[]`.