### PR TITLE
[codex] Split program global lowering

### DIFF
--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -36,6 +36,7 @@ mod monomorphize_substitution;
 mod monomorphize_types;
 mod patterns;
 mod program_checking;
+mod program_globals;
 mod program_module_graph;
 mod resolve;
 mod resolve_binary_ops;

--- a/src/typechecker/program_checking.rs
+++ b/src/typechecker/program_checking.rs
@@ -1,3 +1,4 @@
+use super::program_globals::push_typed_global;
 use super::*;
 
 impl TypeChecker {
@@ -242,35 +243,4 @@ impl TypeChecker {
     pub fn diagnostics(&self) -> &[Diagnostic] {
         &self.diagnostics
     }
-}
-
-fn push_typed_global(globals: &mut Vec<TypedGlobal>, typed_expr: TypedExpression, span: Span) {
-    if let TypedExprKind::Block(block) = &typed_expr.kind {
-        if block.expr.is_none() && block.statements.len() == 1 {
-            if let TypedStatementKind::VarDecl {
-                name,
-                ty,
-                value,
-                mutable,
-            } = &block.statements[0].kind
-            {
-                globals.push(TypedGlobal {
-                    name: name.clone(),
-                    ty: ty.clone(),
-                    value: value.clone(),
-                    mutable: *mutable,
-                    span,
-                });
-                return;
-            }
-        }
-    }
-
-    globals.push(TypedGlobal {
-        name: "__top_level__".into(),
-        ty: typed_expr.ty.clone(),
-        value: typed_expr,
-        mutable: false,
-        span,
-    });
 }

--- a/src/typechecker/program_globals.rs
+++ b/src/typechecker/program_globals.rs
@@ -1,0 +1,36 @@
+use super::*;
+
+pub(super) fn push_typed_global(
+    globals: &mut Vec<TypedGlobal>,
+    typed_expr: TypedExpression,
+    span: Span,
+) {
+    if let TypedExprKind::Block(block) = &typed_expr.kind {
+        if block.expr.is_none() && block.statements.len() == 1 {
+            if let TypedStatementKind::VarDecl {
+                name,
+                ty,
+                value,
+                mutable,
+            } = &block.statements[0].kind
+            {
+                globals.push(TypedGlobal {
+                    name: name.clone(),
+                    ty: ty.clone(),
+                    value: value.clone(),
+                    mutable: *mutable,
+                    span,
+                });
+                return;
+            }
+        }
+    }
+
+    globals.push(TypedGlobal {
+        name: "__top_level__".into(),
+        ty: typed_expr.ty.clone(),
+        value: typed_expr,
+        mutable: false,
+        span,
+    });
+}

--- a/tests/docs_truth/repo_hygiene/typechecker_program_checking.rs
+++ b/tests/docs_truth/repo_hygiene/typechecker_program_checking.rs
@@ -22,3 +22,27 @@ fn typechecker_module_graph_program_checking_lives_in_focused_helper() {
         "typechecker root should include focused module graph checking module"
     );
 }
+
+#[test]
+fn typechecker_program_global_lowering_lives_in_focused_helper() {
+    let root = read("src/typechecker/mod.rs");
+    let program_checking = read("src/typechecker/program_checking.rs");
+    let globals = read("src/typechecker/program_globals.rs");
+
+    assert!(
+        !program_checking.contains("fn push_typed_global"),
+        "program_checking.rs should not own top-level global lowering"
+    );
+    assert!(
+        globals.contains("fn push_typed_global"),
+        "program global lowering should live in focused helper"
+    );
+    assert!(
+        program_checking.lines().count() < 260,
+        "program_checking.rs should stay focused on program declaration checking"
+    );
+    assert!(
+        root.contains("mod program_globals;"),
+        "typechecker root should include focused program global helper"
+    );
+}


### PR DESCRIPTION
## Summary

- Move top-level global lowering out of `program_checking.rs` into `program_globals.rs`.
- Add a docs-truth guard so program checking stays focused on declaration checking and remains below 260 lines.
- Keep behavior unchanged; this is a focused extraction of the existing `push_typed_global` helper.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Normal branch push Actions check: `gh run list --repo lantos1618/zenlang --branch codex/split-program-globals --event push --limit 10 --json databaseId,status,conclusion,workflowName,headSha,createdAt,url` returned `[]`.