### PR TITLE
[codex] Split behavior impl signature collection

### DIFF
--- a/src/typechecker/behavior_impl_signature_collection.rs
+++ b/src/typechecker/behavior_impl_signature_collection.rs
@@ -1,0 +1,123 @@
+use super::*;
+
+impl TypeChecker {
+    pub(super) fn collect_impl_method_signature(&mut self, type_name: &str, method: &Declaration) {
+        let Declaration::Function {
+            name,
+            type_params,
+            params,
+            return_type,
+            body,
+            span,
+            ..
+        } = method
+        else {
+            return;
+        };
+
+        self.validate_generic_bounds(type_params);
+        let key = Self::method_key(type_name, name);
+        self.methods.insert(
+            key.clone(),
+            func_info_from_ast_signature(key.clone(), type_params, params, return_type),
+        );
+        if let Some(template) =
+            generic_template_from_type_params(type_params, params, return_type, body, *span)
+        {
+            self.generic_methods.insert(key, template);
+        }
+    }
+
+    pub(super) fn collect_resolver_backed_impl_method_template(
+        &mut self,
+        type_name: &str,
+        method: &Declaration,
+    ) {
+        let Declaration::Function {
+            name,
+            type_params,
+            params,
+            body,
+            span,
+            ..
+        } = method
+        else {
+            return;
+        };
+        if let Some(template) =
+            generic_template_body_stub_from_type_params(type_params, params, body, *span)
+        {
+            self.generic_methods
+                .insert(Self::method_key(type_name, name), template);
+        }
+    }
+
+    pub(super) fn collect_resolver_behavior_impl_method_signatures(
+        &mut self,
+        symbols: &SymbolTable,
+        ast_type_name: &str,
+        type_name: &str,
+        behavior: &str,
+        behavior_type_args: &[AstType],
+        methods: &[Declaration],
+    ) {
+        let (behavior, behavior_type_args) =
+            self.resolver_behavior_impl_ref_parts(type_name, behavior, behavior_type_args);
+        let behavior_substitutions =
+            self.behavior_type_param_substitutions(behavior, behavior_type_args);
+        let mut required_methods: VecDeque<ast::BehaviorMethod> = self
+            .behavior_methods_for_impl(behavior, &behavior_substitutions, &mut HashSet::new())
+            .into_iter()
+            .collect();
+
+        for method in methods {
+            let Declaration::Function { name, span, .. } = method else {
+                continue;
+            };
+            let ast_key = Self::method_key(ast_type_name, name);
+            let resolver_owned_key =
+                self.resolver_backed_impl_method_key(Some(symbols), &ast_key, type_name, *span);
+            let restored_name = self.resolver_backed_behavior_impl_method_signature_name(
+                &mut required_methods,
+                name,
+                resolver_owned_key.as_deref(),
+                type_name,
+            );
+            let Some(restored_name) = restored_name else {
+                continue;
+            };
+            let restored_key =
+                resolver_owned_key.unwrap_or_else(|| Self::method_key(type_name, &restored_name));
+            self.collect_resolver_callable_signature_for_key(
+                symbols,
+                &ast_key,
+                &restored_key,
+                *span,
+            );
+        }
+    }
+
+    pub(super) fn collect_behavior_default_method_signatures(
+        &mut self,
+        type_name: &str,
+        behavior: &str,
+        behavior_type_args: &[AstType],
+        methods: &[Declaration],
+    ) {
+        if self.should_skip_behavior_default_synthesis(type_name) {
+            return;
+        }
+        let (behavior, behavior_type_args) =
+            self.resolver_behavior_impl_ref_parts(type_name, behavior, behavior_type_args);
+        for default in
+            self.behavior_default_methods_for_impl(type_name, behavior, behavior_type_args, methods)
+        {
+            self.seed_behavior_default_method_signature(type_name, &default);
+        }
+    }
+
+    pub(super) fn should_skip_behavior_default_synthesis(&self, type_name: &str) -> bool {
+        self.resolver_backed_collection
+            && self.resolver_missing_behavior_impl_refs.contains(type_name)
+    }
+}

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -10,6 +10,7 @@
 
 mod behavior_associations;
 mod behavior_impl_methods;
+mod behavior_impl_signature_collection;
 mod behavior_impl_support;
 mod behavior_impl_validation;
 mod behavior_ref_metadata;
@@ -74,126 +75,6 @@ include!("declaration_tasks.rs");
 include!("state.rs");
 
 impl TypeChecker {
-    fn collect_impl_method_signature(&mut self, type_name: &str, method: &Declaration) {
-        let Declaration::Function {
-            name,
-            type_params,
-            params,
-            return_type,
-            body,
-            span,
-            ..
-        } = method
-        else {
-            return;
-        };
-
-        self.validate_generic_bounds(type_params);
-        let key = Self::method_key(type_name, name);
-        self.methods.insert(
-            key.clone(),
-            func_info_from_ast_signature(key.clone(), type_params, params, return_type),
-        );
-        if let Some(template) =
-            generic_template_from_type_params(type_params, params, return_type, body, *span)
-        {
-            self.generic_methods.insert(key, template);
-        }
-    }
-
-    fn collect_resolver_backed_impl_method_template(
-        &mut self,
-        type_name: &str,
-        method: &Declaration,
-    ) {
-        let Declaration::Function {
-            name,
-            type_params,
-            params,
-            body,
-            span,
-            ..
-        } = method
-        else {
-            return;
-        };
-        if let Some(template) =
-            generic_template_body_stub_from_type_params(type_params, params, body, *span)
-        {
-            self.generic_methods
-                .insert(Self::method_key(type_name, name), template);
-        }
-    }
-
-    fn collect_resolver_behavior_impl_method_signatures(
-        &mut self,
-        symbols: &SymbolTable,
-        ast_type_name: &str,
-        type_name: &str,
-        behavior: &str,
-        behavior_type_args: &[AstType],
-        methods: &[Declaration],
-    ) {
-        let (behavior, behavior_type_args) =
-            self.resolver_behavior_impl_ref_parts(type_name, behavior, behavior_type_args);
-        let behavior_substitutions =
-            self.behavior_type_param_substitutions(behavior, behavior_type_args);
-        let mut required_methods: VecDeque<ast::BehaviorMethod> = self
-            .behavior_methods_for_impl(behavior, &behavior_substitutions, &mut HashSet::new())
-            .into_iter()
-            .collect();
-
-        for method in methods {
-            let Declaration::Function { name, span, .. } = method else {
-                continue;
-            };
-            let ast_key = Self::method_key(ast_type_name, name);
-            let resolver_owned_key =
-                self.resolver_backed_impl_method_key(Some(symbols), &ast_key, type_name, *span);
-            let restored_name = self.resolver_backed_behavior_impl_method_signature_name(
-                &mut required_methods,
-                name,
-                resolver_owned_key.as_deref(),
-                type_name,
-            );
-            let Some(restored_name) = restored_name else {
-                continue;
-            };
-            let restored_key =
-                resolver_owned_key.unwrap_or_else(|| Self::method_key(type_name, &restored_name));
-            self.collect_resolver_callable_signature_for_key(
-                symbols,
-                &ast_key,
-                &restored_key,
-                *span,
-            );
-        }
-    }
-
-    fn collect_behavior_default_method_signatures(
-        &mut self,
-        type_name: &str,
-        behavior: &str,
-        behavior_type_args: &[AstType],
-        methods: &[Declaration],
-    ) {
-        if self.should_skip_behavior_default_synthesis(type_name) {
-            return;
-        }
-        let (behavior, behavior_type_args) =
-            self.resolver_behavior_impl_ref_parts(type_name, behavior, behavior_type_args);
-        for default in
-            self.behavior_default_methods_for_impl(type_name, behavior, behavior_type_args, methods)
-        {
-            self.seed_behavior_default_method_signature(type_name, &default);
-        }
-    }
-
-    fn should_skip_behavior_default_synthesis(&self, type_name: &str) -> bool {
-        self.resolver_backed_collection
-            && self.resolver_missing_behavior_impl_refs.contains(type_name)
-    }
-
     fn behavior_type_arg_substitutions(
         &mut self,
         behavior: &str,

--- a/tests/docs_truth/repo_hygiene/typechecker_behavior_impls.rs
+++ b/tests/docs_truth/repo_hygiene/typechecker_behavior_impls.rs
@@ -94,3 +94,35 @@ fn behavior_association_inheritance_lives_in_focused_helper() {
         "behavior associations should load the focused inheritance/coherence helper"
     );
 }
+
+#[test]
+fn behavior_impl_signature_collection_lives_in_focused_helper() {
+    let root = read("src/typechecker/mod.rs");
+    let focused = read("src/typechecker/behavior_impl_signature_collection.rs");
+
+    for helper in [
+        "collect_impl_method_signature",
+        "collect_resolver_backed_impl_method_template",
+        "collect_resolver_behavior_impl_method_signatures",
+        "collect_behavior_default_method_signatures",
+        "should_skip_behavior_default_synthesis",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {helper}")),
+            "typechecker root should not own behavior impl signature helper: {helper}"
+        );
+        assert!(
+            focused.contains(&format!("fn {helper}")),
+            "behavior impl signature collection should live in focused helper: {helper}"
+        );
+    }
+
+    assert!(
+        root.lines().count() < 190,
+        "typechecker root should stay focused on module wiring and shared imports"
+    );
+    assert!(
+        root.contains("mod behavior_impl_signature_collection;"),
+        "typechecker root should include focused behavior impl signature collection"
+    );
+}


### PR DESCRIPTION
## Summary

- Move behavior impl method-signature collection helpers out of `typechecker/mod.rs` into `behavior_impl_signature_collection.rs`.
- Preserve sibling-module access with `pub(super)` visibility for the moved helpers.
- Add a docs-truth guard so the typechecker root stays focused on module wiring/shared imports and remains below 190 lines.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Normal branch push Actions check: `gh run list --repo lantos1618/zenlang --branch codex/split-behavior-impl-signatures --event push --limit 10 --json databaseId,status,conclusion,workflowName,headSha,createdAt,url` returned `[]`.