### PR TITLE
[codex] Split imported declaration selection

### DIFF
--- a/src/module_system/import_resolution.rs
+++ b/src/module_system/import_resolution.rs
@@ -7,6 +7,7 @@ use crate::error::{CompileError, FileTable, Span};
 use super::root_prefix::parse_module_root_prefix;
 use super::ModuleSystem;
 
+mod imported_declarations;
 mod stdlib_gates;
 mod stdlib_paths;
 
@@ -143,58 +144,6 @@ impl ModuleSystem {
                 )]);
             }
         }
-        Ok(())
-    }
-
-    fn collect_imported_declarations(
-        &self,
-        dep_program: &Program,
-        names: &[String],
-        module_name: &str,
-        import_span: Span,
-        imported_decls: &mut Vec<Declaration>,
-    ) -> Result<(), Vec<CompileError>> {
-        for name in names {
-            let mut found_private = false;
-            let mut found_public = false;
-
-            for decl in &dep_program.declarations {
-                if decl.name() == Some(name.as_str()) {
-                    if decl.is_public() {
-                        found_public = true;
-                        imported_decls.push(decl.clone());
-                    } else {
-                        found_private = true;
-                    }
-                }
-
-                if let Declaration::Method {
-                    type_name, public, ..
-                } = decl
-                {
-                    if type_name == name && *public {
-                        imported_decls.push(decl.clone());
-                    }
-                }
-            }
-
-            if !found_public {
-                if found_private {
-                    return Err(vec![CompileError::Resolution(
-                        format!(
-                            "symbol '{}' in module '{}' is not exported",
-                            name, module_name
-                        ),
-                        Some(import_span),
-                    )]);
-                }
-                return Err(vec![CompileError::Resolution(
-                    format!("module '{}' does not export '{}'", module_name, name),
-                    Some(import_span),
-                )]);
-            }
-        }
-
         Ok(())
     }
 

--- a/src/module_system/import_resolution/imported_declarations.rs
+++ b/src/module_system/import_resolution/imported_declarations.rs
@@ -1,0 +1,55 @@
+use super::*;
+
+impl ModuleSystem {
+    pub(super) fn collect_imported_declarations(
+        &self,
+        dep_program: &Program,
+        names: &[String],
+        module_name: &str,
+        import_span: Span,
+        imported_decls: &mut Vec<Declaration>,
+    ) -> Result<(), Vec<CompileError>> {
+        for name in names {
+            let mut found_private = false;
+            let mut found_public = false;
+
+            for decl in &dep_program.declarations {
+                if decl.name() == Some(name.as_str()) {
+                    if decl.is_public() {
+                        found_public = true;
+                        imported_decls.push(decl.clone());
+                    } else {
+                        found_private = true;
+                    }
+                }
+
+                if let Declaration::Method {
+                    type_name, public, ..
+                } = decl
+                {
+                    if type_name == name && *public {
+                        imported_decls.push(decl.clone());
+                    }
+                }
+            }
+
+            if !found_public {
+                if found_private {
+                    return Err(vec![CompileError::Resolution(
+                        format!(
+                            "symbol '{}' in module '{}' is not exported",
+                            name, module_name
+                        ),
+                        Some(import_span),
+                    )]);
+                }
+                return Err(vec![CompileError::Resolution(
+                    format!("module '{}' does not export '{}'", module_name, name),
+                    Some(import_span),
+                )]);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/tests/docs_truth/repo_hygiene/module_system.rs
+++ b/tests/docs_truth/repo_hygiene/module_system.rs
@@ -89,6 +89,30 @@ fn stdlib_path_resolution_lives_in_focused_helper() {
 }
 
 #[test]
+fn imported_declaration_selection_lives_in_focused_helper() {
+    let import_resolution = read("src/module_system/import_resolution.rs");
+    let imported_declarations =
+        read("src/module_system/import_resolution/imported_declarations.rs");
+
+    assert!(
+        !import_resolution.contains("fn collect_imported_declarations"),
+        "import routing dispatcher should not own imported declaration selection"
+    );
+    assert!(
+        imported_declarations.contains("fn collect_imported_declarations"),
+        "imported declaration selection should live in focused helper"
+    );
+    assert!(
+        import_resolution.lines().count() < 240,
+        "import routing dispatcher should stay focused on routing imports"
+    );
+    assert!(
+        import_resolution.contains("mod imported_declarations;"),
+        "import routing should load focused imported declaration helper"
+    );
+}
+
+#[test]
 fn graph_loading_export_lookup_lives_in_focused_helper() {
     let graph_loading = read("src/module_system/graph_loading.rs");
     let exported_symbols = read("src/module_system/graph_loading/exported_symbols.rs");


### PR DESCRIPTION
## Summary

- Move imported declaration selection out of `import_resolution.rs` into `import_resolution/imported_declarations.rs`.
- Add a docs-truth guard so the import routing dispatcher stays focused and under 240 lines.
- Keep import behavior unchanged; this is a focused extraction of the existing `collect_imported_declarations` logic.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Normal branch push Actions check: `gh run list --repo lantos1618/zenlang --branch codex/split-imported-declarations --event push --limit 10 --json databaseId,status,conclusion,workflowName,headSha,createdAt,url` returned `[]`.