### PR TITLE
[codex] Compact docs headroom

### DIFF
--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1,14 +1,12 @@
 # Phase Plan
 
 ## Recovery Point
-
 Recovered branch: `codex/phase0-1-truth-gates`.
 Recovery commit: `183d140c` from 2026-05-12 08:18:35 UTC.
 Treat unpushed `/tmp` work after that commit as lost; continue from checked-in
 docs, tests, and commits only.
 
 ## Design Decisions To Preserve
-
 - Sync/Async are real effects, not marker-only types.
 - typed allocators are central to allocation and effect decisions.
 - actors live in std first; no actor syntax is v1-stable yet.
@@ -23,89 +21,45 @@ docs, tests, and commits only.
 - Dev UX and Agent UX are product requirements, not polish.
 
 ## Dev UX And Agent UX Track
-
-MoonBit-style toolchain integration is the benchmark: compiler, build graph,
-package surface, language server, VS Code extension, web/editor entry point,
-and machine-readable outputs should feel coherent.
-
-Required Dev UX: syntax, semantic diagnostics, go-to-definition, hover,
-completion, formatting, run/test code lenses, target selection, language server
-restart, compiler version display, local toolchain validation, and `zen lsp`.
-
-Required Agent UX: agent-readable diagnostics with stable codes, spans, related
-locations, suggested_fixes, feature_gate metadata, CLI/editor-aligned JSON,
-Machine-readable project graph and symbol graph output, deterministic quiet commands,
-structured fix suggestions, retrieval-friendly docs, and quiet normal branch pushes.
+MoonBit-style toolchain integration is the benchmark: compiler, build graph, package surface, language server, VS Code extension, web/editor entry point, and machine-readable outputs should feel coherent.
+Required Dev UX: syntax/semantic diagnostics, go-to-definition, hover, completion, formatting, run/test code lenses, target selection, language server restart, compiler version display, local toolchain validation, and `zen lsp`.
+Required Agent UX: agent-readable diagnostics with stable codes, spans, related locations, suggested_fixes, feature_gate metadata, CLI/editor-aligned JSON, Machine-readable project graph and symbol graph output, deterministic quiet commands, structured fix suggestions, retrieval-friendly docs, and quiet normal branch pushes.
 
 ## Compressed Evidence Map
-
 This is a capability index, not a changelog. Granular evidence belongs in tests,
 golden fixtures, and git history.
 
-- Phase 0 truth gates: README, contributor docs, stdlib, CI, release, old-spec
-  quarantine, and docs shape are guarded by `tests/docs_truth`.
-- Phase 1 frontend and C-backend baseline: syntax and C execution are covered by
-  `docs/V1_SPEC.md`, `tests/zen`, integration tests, and generated-C checks.
-- generic specialization: functions, structs, enums, methods, recursive
-  worklists, imports, nested `Result<Option<T>, StaticString>`, and generated-C
-  consistency are covered by executable and JSON-golden integration tests.
-- resolver/typechecker replay: resolver-owned metadata, callable signatures,
-  behavior impl passes, stale AST protection,
-  `generic_struct_constructor_without_type_args_is_error`, and generic arity
-  diagnostics are covered by `tests/resolver_phase2.rs`, typechecker unit tests,
-  and integration diagnostics.
-- diagnostics JSON: `emit_json_diagnostics_command_outputs_machine_readable_errors`,
-  `emit_json_diagnostics_includes_structured_return_keyword_fix`, and
-  `emit_json_diagnostics_includes_structured_missing_bool_match_arm_fix` pin
-  stable diagnostics with suggested_fixes and feature_gate data.
+- Phase 0 truth gates: README, contributor docs, stdlib, CI, release, old-spec quarantine, and docs shape are guarded by `tests/docs_truth`.
+- Phase 1 frontend and C-backend baseline: syntax and C execution are covered by `docs/V1_SPEC.md`, `tests/zen`, integration tests, and generated-C checks.
+- generic specialization: functions, structs, enums, methods, recursive worklists, imports, nested `Result<Option<T>, StaticString>`, and generated-C consistency are covered by executable and JSON-golden integration tests.
+- resolver/typechecker replay: resolver-owned metadata, callable signatures, behavior impl passes, stale AST protection, `generic_struct_constructor_without_type_args_is_error`, and generic arity diagnostics are covered by `tests/resolver_phase2.rs`, typechecker unit tests, and integration diagnostics.
+- diagnostics JSON: `emit_json_diagnostics_command_outputs_machine_readable_errors`, `emit_json_diagnostics_includes_structured_return_keyword_fix`, and `emit_json_diagnostics_includes_structured_missing_bool_match_arm_fix` pin stable diagnostics with suggested_fixes and feature_gate data.
 - Typed/HIR/MIR JSON: `emit_json_ast_marks_semantically_unchecked_sources_that_typed_json_rejects`
   and `emit_json_typed_command_outputs_checked_program` guard checked output.
-- build graph: deterministic build.zen graph behavior is guarded by parser,
-  lowering, JSON, CLI tests, and `deterministic_build_graph_creates_one_executable_target`.
-- Gated effects/intrinsics: `async_scheduler_intrinsics_are_rejected_as_gated_not_unknown`,
-  `atomic_intrinsics_are_rejected_as_effect_gates`,
-  `comptime_type_match_intrinsic_is_rejected_as_gated_not_unknown`,
-  `dynamic_string_type_is_rejected_as_allocator_backed_gate`,
-  `raw_memory_intrinsics_are_rejected_as_allocator_gates`, and
-  `syscall_intrinsics_are_rejected_as_host_effect_gates`.
-- repo hygiene: file-size tests, owned spelling enums, syntax cleanup tests, and
-  docs-truth caps prevent large-file and status-doc regressions.
+- build graph: deterministic build.zen graph behavior is guarded by parser, lowering, JSON, CLI tests, and `deterministic_build_graph_creates_one_executable_target`.
+- Gated effects/intrinsics: `async_scheduler_intrinsics_are_rejected_as_gated_not_unknown`, `atomic_intrinsics_are_rejected_as_effect_gates`, `comptime_type_match_intrinsic_is_rejected_as_gated_not_unknown`, `dynamic_string_type_is_rejected_as_allocator_backed_gate`, `raw_memory_intrinsics_are_rejected_as_allocator_gates`, and `syscall_intrinsics_are_rejected_as_host_effect_gates`.
+- repo hygiene: file-size tests, owned spelling enums, syntax cleanup tests, and docs-truth caps prevent large-file and status-doc regressions.
 
 ## Current Phase
-
 Phase 5 is in evidence-hardening and cleanup. The generic specialization
 surfaces are implemented; continue closing proof gaps, keeping generated C
 consistent, and preventing large-file/slop regressions.
 
 ## Phase 5 Acceptance Evidence
-
-- generic enum specialization: `Option<T>`, `Result<T, E>`, nested results,
-  duplicate variants, multi-file dependencies, executable fixtures, typed/HIR/MIR
-  golden tests, and generated-C tests.
-- generic method specialization: generic, `Self`, type impl, enum, imported
-  dependency, nested result cases, JSON golden tests, and method worklist
-  generated-C checks.
-- worklist monomorphization: recursive functions/methods, imported transitive
-  dependencies, deduped instantiations, and generated-C definition-count checks.
-- generated-C call/definition consistency:
-  `compile_to_c_with_generated_call_check`, `undefined_generated_c_calls`, and
-  duplicate-definition scans.
-- generic arity, inference, and bound diagnostics: E5000, E5001, E5002, and
-  E6004 across unit, CLI, and JSON golden tests.
+- generic enum specialization: `Option<T>`, `Result<T, E>`, nested results, duplicate variants, multi-file dependencies, executable fixtures, typed/HIR/MIR golden tests, and generated-C tests.
+- generic method specialization: generic, `Self`, type impl, enum, imported dependency, nested result cases, JSON golden tests, and method worklist generated-C checks.
+- worklist monomorphization: recursive functions/methods, imported transitive dependencies, deduped instantiations, and generated-C definition-count checks.
+- generated-C call/definition consistency: `compile_to_c_with_generated_call_check`, `undefined_generated_c_calls`, and duplicate-definition scans.
+- generic arity, inference, and bound diagnostics: E5000, E5001, E5002, and E6004 across unit, CLI, and JSON golden tests.
 
 Non-Phase-5 gaps remain Dev UX, Agent UX, full LSP/editor workflows,
 allocator-backed dynamic strings, Sync/Async lowering, raw memory semantics,
 advanced comptime type matching, and broad package/link build-driver behavior.
 
 ## Next Small Slice
-
-Pick one oversized Rust file, add or tighten a focused repo-hygiene/test guard,
-move one coherent responsibility into a focused module, run local gates, confirm
-normal branch-push Actions stay quiet, open a ready PR, and merge only when PR
-checks pass.
+Pick one oversized Rust file, add or tighten a focused repo-hygiene/test guard, move one coherent responsibility into a focused module, run local gates, confirm normal branch-push Actions stay quiet, open a ready PR, and merge only when PR checks pass.
 
 ## Detailed Evidence References
-
 Use `docs/V1_SPEC.md`, `docs/DIAGNOSTICS.md`,
 `docs/learn_zen_in_y_minutes.md`, `docs/COMPLETION_AUDIT.md`,
 `tests/docs_truth`, `tests/integration`, `tests/resolver_phase2.rs`,

--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -5,14 +5,12 @@ the feature matrix controls what the rewrite compiler may currently advertise.
 Exhaustive proof belongs in tests, golden fixtures, and git history.
 
 ## Baseline
-
 The active implementation is the rewrite compiler:
 `source -> tokens -> AST -> module loader -> typechecker -> typed AST -> C backend -> cc`.
 Compiler-owned semantic data is the source of truth; serialized JSON and YAML are
 interface formats generated from or validated against checked compiler data.
 
 ## Syntax Contract
-
 Implemented syntax forms are limited to forms covered by `tests/zen` and Rust
 tests: declarations, calls, imports, bindings, structs, enums, field access,
 method-style calls, final-expression results, prefix loops, `defer`, casts,
@@ -34,7 +32,6 @@ quiet deterministic commands such as `zen check`, `zen test`, and `zen emit-json
 gate automated fix or package workflows.
 
 ## Accepted Syntax Forms
-
 Every accepted syntax form must have a spec entry and Test Evidence before it is
 advertised as implemented.
 
@@ -63,7 +60,6 @@ advertised as implemented.
 | Behavior inheritance `.extends` | experimental | `resolver_rejects_duplicate_behavior_parent_edges`, `imported_behavior_extends_requires_parent_methods`, `imported_behavior_extends_imported_parent_requires_parent_methods`, `imported_behavior_extends_requires_transitive_parent_methods` |
 
 ## Type, Module, ABI, Error, Effect, And Comptime Decisions
-
 - `StaticString` is baked into the program. It denotes literal/static text with
   stable storage and compile-time length in the generated runtime layout.
   The allocator-backed `String` type is owned, dynamic text and carries allocator
@@ -136,15 +132,12 @@ advertised as implemented.
   exist.
 
 ## JSON/YAML IR Boundaries
-
 JSON/YAML IR boundaries are constrained. JSON is the machine-readable exchange
 format for compiler-owned AST, symbols, typed programs, diagnostics, HIR, MIR,
 layout, and deterministic build graphs. YAML is the human-authored format for
 target/build input.
 
-Current commands: `zen emit-json ast <file>`, `zen emit-json symbols <file>`,
-`zen emit-json typed <file>`, `zen emit-json diagnostics <file>`,
-`zen emit-json hir <file>`, `zen emit-json mir <file>`, `zen emit-json layout <file>`, `zen emit-json build-graph <file>`, and `zen emit-json target-yaml <file>`.
+Current commands: `zen emit-json ast <file>`, `zen emit-json symbols <file>`, `zen emit-json typed <file>`, `zen emit-json diagnostics <file>`, `zen emit-json hir <file>`, `zen emit-json mir <file>`, `zen emit-json layout <file>`, `zen emit-json build-graph <file>`, and `zen emit-json target-yaml <file>`.
 
 Schema status: AST JSON is unchecked; symbols JSON is resolved; typed JSON is explicitly marked checked; diagnostics JSON is explicitly marked diagnostic. All schemas use `schema_version: 0` until promoted.
 
@@ -167,7 +160,6 @@ Representative golden anchors:
   `emit_json_target_yaml_rejects_unsupported_backend_codegen`.
 
 ## Build Graph
-
 `build.zen` is constrained. `zen check build.zen` validates a deterministic
 graph and verifies declared target sources exist. `zen emit build.zen` emits C
 for one target. `zen build build.zen` compiles executable targets, and direct
@@ -183,7 +175,6 @@ Deterministic build graph compiles executable and test targets, while build
 scripts using undeclared host side effects are rejected.
 
 ## Feature Matrix
-
 | Feature | Status | Gate |
 |---|---|---|
 | Lexer/parser for tested fixtures | implemented | Unit and integration tests |
@@ -207,7 +198,6 @@ scripts using undeclared host side effects are rejected.
 | Formatter, package manager, alternate backends | removed | Reintroduce only with tests and binaries |
 
 ## Required Test Backlog
-
 Every remaining v1 effect/type-match/allocator/actor/IR claim needs at least one
 Planned Positive Test and one Planned Negative Test before implementation.
 
@@ -220,17 +210,10 @@ Planned Positive Test and one Planned Negative Test before implementation.
 | Actors in std | Actor mailbox send/receive works with scheduler and allocator integration | Actor using async mailbox from sync-only context is rejected |
 | JSON/YAML IR boundaries | Checked layout JSON, checked MIR JSON, and target YAML validate against schemas | Hand-authored JSON IR cannot override compiler-owned types or layouts |
 
-Generated/fallback behavior association syntax is reserved but not implemented:
-`Type.derive(Json)` currently parses into a reserved AST declaration and then
-reports an explicit resolver gate, covered by
-`parser::tests::parse_generated_behavior_derive_association`,
-`resolver_gates_generated_behavior_derive_association`,
-`emit_json_diagnostics_spans_full_gated_behavior_derive_association`,
-`emit_json_diagnostics_spans_full_gated_generic_association_target`, and
-`emit_json_diagnostics_generic_association_gate_schema_matches_golden`.
+Generated/fallback behavior association syntax is reserved but not implemented: `Type.derive(Json)` currently parses into a reserved AST declaration and reports an explicit resolver gate.
+Evidence: `parser::tests::parse_generated_behavior_derive_association`, `resolver_gates_generated_behavior_derive_association`, `emit_json_diagnostics_spans_full_gated_behavior_derive_association`, `emit_json_diagnostics_spans_full_gated_generic_association_target`, and `emit_json_diagnostics_generic_association_gate_schema_matches_golden`.
 
 ## Stdlib Gate
-
 Files under `stdlib/` are experimental unless a test proves they parse, typecheck,
 and build through the same compiler path as user modules. Aspirational stdlib
 APIs must not be described as implemented until promoted by tests.

--- a/docs/learn_zen_in_y_minutes.md
+++ b/docs/learn_zen_in_y_minutes.md
@@ -9,7 +9,6 @@ Preview examples cover gated surfaces: allocator-backed strings, sync/async
 effects, raw memory, actors, and comptime type matching.
 
 ## The Shape
-
 Declarations are prefix-first. The name being introduced or changed comes
 first:
 
@@ -32,7 +31,6 @@ first:
 | Inheritance | `ChildBehavior.extends(ParentBehavior)` |
 
 ## Values And Results
-
 ```zen
 main = () i32 {
     answer = 42
@@ -61,26 +59,22 @@ Numeric conversions are explicit and prefix-first: `cast(value, Type)`.
 String literals are `StaticString`, not allocator-backed strings.
 
 ## StaticString
-
 `StaticString` is baked into the program: static bytes plus a fixed byte count
 known after compilation. Passing it around copies a pointer-and-length view into
 program storage. It does not allocate, resize, free, or transfer heap ownership.
 
 ## Dynamic String Preview
-
 `String<A>` is preview syntax for owned runtime text. It can grow or be
 released, so the owner must carry allocator state. A literal such as `"Zen"`
 never silently becomes `String<A>`; runtime text construction belongs on an
 allocator-aware API.
 
 ## Calls, Structs, And Data
-
 `value.method(args)` and `method(value, args)` are call-site spellings for the
 same attached function, not alternate declaration forms. Struct literals name
 fields explicitly; field access uses dot syntax.
 
 ## Enums And Matching
-
 ```zen
 Direction: North, South, East, West
 Option<T>: None, Some(T)
@@ -97,7 +91,6 @@ The `?` operator is the pattern-match form for bools, enums, `Option`, and
 `Result`.
 
 ## Result And Error Handling
-
 Zen models failure with data. There are no exceptions and no null.
 
 ```zen
@@ -112,7 +105,6 @@ Nested generic types are written directly, such as
 `Result<Option<i32>, StaticString>`.
 
 ## Behaviors
-
 Behaviors describe required methods. Generic functions use behavior bounds when
 they need a capability.
 
@@ -133,7 +125,6 @@ Relationship declarations keep the changed type or behavior on the left:
 `PrettyDisplay.extends(Display)`. There is no `impl Type for Behavior` spelling.
 
 ## Loops
-
 Zen has one loop entry form. The handle is compiler-owned, and `done`/`next`
 are closed control verbs for that handle, not user methods or stringly names.
 
@@ -185,16 +176,13 @@ There is no `while`, `for`, `break`, `continue`, suffix loop, or hidden result
 channel. Accumulated values live in explicit mutable bindings outside the loop.
 
 ## Defer
-
 `defer` runs cleanup expressions before leaving the current scope.
 
 ## Imports And Modules
-
 Imports use destructuring-style binding from a module path; local files import
 by module name, and dotted paths resolve through subdirectories.
 
 ## Memory And Ownership
-
 Stable Zen does not hide heap allocation behind literals, interpolation, method
 calls, or generic containers. Heap APIs show the owner and allocator path.
 
@@ -206,7 +194,6 @@ Pointer, length, capacity, and allocator travel together; a pointer alone is
 just an address.
 
 ## Sync, Async, And Allocator Preview
-
 `Sync` and `Async` are effect modes in type surfaces, not source keywords; there
 is no `async fn` spelling. Sync work returns checked data now. Async work
 returns task-shaped data.
@@ -256,7 +243,6 @@ Raw allocation intrinsics such as `@builtin.raw_allocate`,
 preview names; stable source should not call them directly.
 
 ## Pointer, Slice, Array, Actor, And Comptime Preview
-
 `RawPtr<T>` is the raw-memory spelling used in allocator previews. `Ptr<T>`,
 `MutPtr<T>`, `Slice<T>`, and `[T; N]` name pointer, mutable pointer, slice, and
 fixed-array shapes. Raw pointer offset, casts, integer conversion, load, store,
@@ -265,7 +251,6 @@ scheduler operations stay gated until layout, ownership, effects, and runtime
 contracts are promoted.
 
 ## Translation Cheat Sheet
-
 | If you reach for | Use |
 | --- | --- |
 | keyword exit value | final expression |
@@ -281,7 +266,6 @@ contracts are promoted.
 | growable owned text | `String<A>` or another owner that carries allocator ownership |
 
 ## One Page Example
-
 ```zen
 { io } = std
 

--- a/tests/docs_truth/phase_audit/phase_plan.rs
+++ b/tests/docs_truth/phase_audit/phase_plan.rs
@@ -76,7 +76,7 @@ fn phase_plan_records_recovered_progress_and_next_slice() {
     }
 
     assert!(
-        plan.lines().count() <= 115,
+        plan.lines().count() <= 100,
         "docs/PHASE_PLAN.md should stay compact; move granular evidence to tests or git history"
     );
 

--- a/tests/docs_truth/public_docs/learn_zen.rs
+++ b/tests/docs_truth/public_docs/learn_zen.rs
@@ -108,7 +108,7 @@ fn learn_zen_guide_covers_core_tour_and_gated_previews() {
     }
 
     assert!(
-        guide.lines().count() <= 320,
+        guide.lines().count() <= 305,
         "Learn guide should stay compact; move detailed status or evidence to phase docs and tests"
     );
 }

--- a/tests/docs_truth/v1_spec/implementation_evidence.rs
+++ b/tests/docs_truth/v1_spec/implementation_evidence.rs
@@ -64,7 +64,7 @@ fn v1_spec_records_resolver_generic_and_behavior_evidence() {
     }
 
     assert!(
-        spec.lines().count() <= 240,
+        spec.lines().count() <= 220,
         "docs/V1_SPEC.md should stay compact; move exhaustive evidence to tests, golden fixtures, or git history"
     );
 }


### PR DESCRIPTION
## Summary
- compact the phase plan, V1 spec, and Learn Zen guide to keep docs easier to load into agent context
- tighten docs-truth line caps for those files so they keep headroom instead of drifting back to the limit
- preserve required language examples, gated-preview text, UX requirements, and evidence anchors

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Push-triggered branch workflows checked with `gh run list --event push` and returned `[]`.