### PR TITLE
[codex] Split self type validation tasks

### DIFF
--- a/src/typechecker/self_type_validation.rs
+++ b/src/typechecker/self_type_validation.rs
@@ -1,91 +1,9 @@
 use super::*;
 
 mod expressions;
+mod tasks;
 
 impl TypeChecker {
-    #[cfg(test)]
-    pub(super) fn collect_self_type_context_validation_tasks(
-        decls: &[Declaration],
-    ) -> Vec<SelfTypeContextValidationTask<'_>> {
-        let mut tasks = Vec::new();
-        for decl in decls {
-            Self::push_self_type_context_validation_task(decl, &mut tasks);
-        }
-        tasks
-    }
-
-    pub(super) fn push_self_type_context_validation_task<'a>(
-        decl: &'a Declaration,
-        tasks: &mut Vec<SelfTypeContextValidationTask<'a>>,
-    ) {
-        match decl {
-            Declaration::Struct { fields, .. } => {
-                tasks.push(SelfTypeContextValidationTask::Struct { fields });
-            }
-            Declaration::Enum { variants, .. } => {
-                tasks.push(SelfTypeContextValidationTask::Enum { variants });
-            }
-            Declaration::Function {
-                params,
-                return_type,
-                body,
-                span,
-                ..
-            } => tasks.push(SelfTypeContextValidationTask::Function {
-                params,
-                return_type,
-                body,
-                span: *span,
-            }),
-            Declaration::Method {
-                params,
-                return_type,
-                body,
-                span,
-                ..
-            } => tasks.push(SelfTypeContextValidationTask::Method {
-                params,
-                return_type,
-                body,
-                span: *span,
-            }),
-            Declaration::Behavior { methods, .. } => {
-                tasks.push(SelfTypeContextValidationTask::Behavior { methods });
-            }
-            Declaration::ImplBlock {
-                behavior_type_args,
-                methods,
-                span,
-                ..
-            } => tasks.push(SelfTypeContextValidationTask::ImplBlock {
-                behavior_type_args,
-                methods,
-                span: *span,
-            }),
-            Declaration::Requires {
-                behavior_type_args,
-                span,
-                ..
-            } => tasks.push(SelfTypeContextValidationTask::Requires {
-                behavior_type_args,
-                span: *span,
-            }),
-            Declaration::BehaviorExtends {
-                parent_type_args,
-                span,
-                ..
-            } => tasks.push(SelfTypeContextValidationTask::BehaviorExtends {
-                parent_type_args,
-                span: *span,
-            }),
-            Declaration::TopLevelExpr { expr, .. } => {
-                tasks.push(SelfTypeContextValidationTask::TopLevelExpr { expr });
-            }
-            Declaration::Derive { .. } | Declaration::Import { .. } | Declaration::Error { .. } => {
-            }
-        }
-    }
-
     pub(super) fn validate_self_type_context_tasks(
         &mut self,
         tasks: &[SelfTypeContextValidationTask<'_>],

--- a/src/typechecker/self_type_validation/tasks.rs
+++ b/src/typechecker/self_type_validation/tasks.rs
@@ -1,0 +1,86 @@
+use super::*;
+
+impl TypeChecker {
+    #[cfg(test)]
+    pub(in crate::typechecker) fn collect_self_type_context_validation_tasks(
+        decls: &[Declaration],
+    ) -> Vec<SelfTypeContextValidationTask<'_>> {
+        let mut tasks = Vec::new();
+        for decl in decls {
+            Self::push_self_type_context_validation_task(decl, &mut tasks);
+        }
+        tasks
+    }
+
+    pub(in crate::typechecker) fn push_self_type_context_validation_task<'a>(
+        decl: &'a Declaration,
+        tasks: &mut Vec<SelfTypeContextValidationTask<'a>>,
+    ) {
+        match decl {
+            Declaration::Struct { fields, .. } => {
+                tasks.push(SelfTypeContextValidationTask::Struct { fields });
+            }
+            Declaration::Enum { variants, .. } => {
+                tasks.push(SelfTypeContextValidationTask::Enum { variants });
+            }
+            Declaration::Function {
+                params,
+                return_type,
+                body,
+                span,
+                ..
+            } => tasks.push(SelfTypeContextValidationTask::Function {
+                params,
+                return_type,
+                body,
+                span: *span,
+            }),
+            Declaration::Method {
+                params,
+                return_type,
+                body,
+                span,
+                ..
+            } => tasks.push(SelfTypeContextValidationTask::Method {
+                params,
+                return_type,
+                body,
+                span: *span,
+            }),
+            Declaration::Behavior { methods, .. } => {
+                tasks.push(SelfTypeContextValidationTask::Behavior { methods });
+            }
+            Declaration::ImplBlock {
+                behavior_type_args,
+                methods,
+                span,
+                ..
+            } => tasks.push(SelfTypeContextValidationTask::ImplBlock {
+                behavior_type_args,
+                methods,
+                span: *span,
+            }),
+            Declaration::Requires {
+                behavior_type_args,
+                span,
+                ..
+            } => tasks.push(SelfTypeContextValidationTask::Requires {
+                behavior_type_args,
+                span: *span,
+            }),
+            Declaration::BehaviorExtends {
+                parent_type_args,
+                span,
+                ..
+            } => tasks.push(SelfTypeContextValidationTask::BehaviorExtends {
+                parent_type_args,
+                span: *span,
+            }),
+            Declaration::TopLevelExpr { expr, .. } => {
+                tasks.push(SelfTypeContextValidationTask::TopLevelExpr { expr });
+            }
+            Declaration::Derive { .. } | Declaration::Import { .. } | Declaration::Error { .. } => {
+            }
+        }
+    }
+}

--- a/tests/docs_truth/repo_hygiene/typechecker_semantic_validation.rs
+++ b/tests/docs_truth/repo_hygiene/typechecker_semantic_validation.rs
@@ -31,3 +31,32 @@ fn typechecker_struct_default_validation_lives_in_focused_helper() {
         "typechecker should still load semantic validation root"
     );
 }
+
+#[test]
+fn typechecker_self_type_validation_tasks_live_in_focused_helper() {
+    let root = read("src/typechecker/self_type_validation.rs");
+    let tasks = read("src/typechecker/self_type_validation/tasks.rs");
+
+    for helper in [
+        "collect_self_type_context_validation_tasks",
+        "push_self_type_context_validation_task",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {helper}")),
+            "self_type_validation.rs should not own self-type task collection helper: {helper}"
+        );
+        assert!(
+            tasks.contains(&format!("fn {helper}")),
+            "self-type task collection should live in focused helper: {helper}"
+        );
+    }
+
+    assert!(
+        root.contains("mod tasks;"),
+        "self_type_validation.rs should load focused task collection helper"
+    );
+    assert!(
+        root.lines().count() < 230,
+        "self_type_validation.rs should stay focused on self-type validation"
+    );
+}


### PR DESCRIPTION
## Summary
- move self-type context task collection into `self_type_validation/tasks.rs`
- keep `self_type_validation.rs` focused on validation traversal
- add a docs-truth guard so the task helpers stay in the focused module and the root file stays small

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`

Push-triggered branch workflows checked with `gh run list --event push` and returned `[]`.