### PR TITLE
[codex] Split symbol definition metadata

### DIFF
--- a/src/resolver/symbol_table.rs
+++ b/src/resolver/symbol_table.rs
@@ -42,6 +42,7 @@ impl SymbolTable {
     }
 }
 
+include!("symbol_table/definition_metadata.rs");
 include!("symbol_table/definitions.rs");
 include!("symbol_table/storage.rs");
 include!("symbol_table/behavior_edges.rs");

--- a/src/resolver/symbol_table/definition_metadata.rs
+++ b/src/resolver/symbol_table/definition_metadata.rs
@@ -1,0 +1,93 @@
+use super::metadata_helpers::{
+    resolver_type_parameter_bound_refs, resolver_type_parameter_bounds,
+    resolver_type_parameter_names,
+};
+
+fn empty_symbol_metadata(import_source: Option<String>) -> SymbolMetadata {
+    SymbolMetadata {
+        import_source,
+        ..SymbolMetadata::default()
+    }
+}
+
+fn value_symbol_metadata(signature: ValueSignatureMetadata) -> SymbolMetadata {
+    let parameter_count = signature.parameter_type_names.len();
+
+    SymbolMetadata {
+        parameter_count: Some(parameter_count),
+        parameter_names: Some(signature.parameter_names),
+        parameter_types: Some(signature.parameter_types),
+        parameter_type_names: Some(signature.parameter_type_names),
+        return_type: Some(signature.return_type),
+        return_type_name: Some(signature.return_type_name),
+        type_parameter_count: Some(signature.type_parameter_count),
+        type_parameter_names: Some(signature.type_parameter_names),
+        type_parameter_bounds: Some(signature.type_parameter_bounds),
+        type_parameter_bound_refs: Some(signature.type_parameter_bound_refs),
+        ..empty_symbol_metadata(None)
+    }
+}
+
+fn type_like_symbol_metadata(
+    type_params: &[crate::ast::TypeParam],
+    members: TypeLikeMembers,
+) -> SymbolMetadata {
+    let (field_types, field_type_names, variant_names) = match members {
+        TypeLikeMembers::Fields(fields) => {
+            let typed = fields
+                .iter()
+                .map(|(name, ty, _)| (name.clone(), ty.clone()))
+                .collect();
+            let names = fields
+                .into_iter()
+                .map(|(name, _, type_name)| (name, type_name))
+                .collect();
+            (Some(typed), Some(names), None)
+        }
+        TypeLikeMembers::Variants(variants) => (None, None, Some(variants)),
+    };
+
+    SymbolMetadata {
+        type_parameter_count: Some(type_params.len()),
+        type_parameter_names: Some(resolver_type_parameter_names(type_params)),
+        type_parameter_bounds: Some(resolver_type_parameter_bounds(type_params)),
+        type_parameter_bound_refs: Some(resolver_type_parameter_bound_refs(type_params)),
+        field_count: field_type_names.as_ref().map(Vec::len),
+        field_types,
+        field_type_names,
+        variant_names,
+        ..empty_symbol_metadata(None)
+    }
+}
+
+fn variant_symbol_metadata(
+    owner_name: &str,
+    variant_payload_type: Option<AstType>,
+) -> SymbolMetadata {
+    let variant_payload_count = usize::from(variant_payload_type.is_some());
+    let variant_payload_type_name = variant_payload_type.as_ref().map(AstType::display_name);
+
+    SymbolMetadata {
+        variant_owner_name: Some(owner_name.to_string()),
+        variant_payload_count: Some(variant_payload_count),
+        variant_payload_type,
+        variant_payload_type_name,
+        ..empty_symbol_metadata(None)
+    }
+}
+
+fn behavior_symbol_metadata(
+    type_params: &[crate::ast::TypeParam],
+    behavior_method_signatures: Vec<MethodSignatureMetadata>,
+    behavior_method_types: Vec<BehaviorMethodTypeMetadata>,
+) -> SymbolMetadata {
+    SymbolMetadata {
+        type_parameter_count: Some(type_params.len()),
+        type_parameter_names: Some(resolver_type_parameter_names(type_params)),
+        type_parameter_bounds: Some(resolver_type_parameter_bounds(type_params)),
+        type_parameter_bound_refs: Some(resolver_type_parameter_bound_refs(type_params)),
+        behavior_method_signatures: Some(behavior_method_signatures),
+        behavior_method_types: Some(behavior_method_types),
+        ..empty_symbol_metadata(None)
+    }
+}

--- a/src/resolver/symbol_table/definitions.rs
+++ b/src/resolver/symbol_table/definitions.rs
@@ -1,11 +1,6 @@
 use crate::ast::TypeParam;
 use crate::error::Diagnostic;
 
-use super::metadata_helpers::{
-    resolver_type_parameter_bound_refs, resolver_type_parameter_bounds,
-    resolver_type_parameter_names,
-};
-
 impl SymbolTable {
     pub(super) fn define(
         &mut self,
@@ -19,36 +14,7 @@ impl SymbolTable {
             namespace,
             name,
             is_public,
-            SymbolMetadata {
-                import_source,
-                parameter_count: None,
-                parameter_names: None,
-                parameter_types: None,
-                parameter_type_names: None,
-                return_type: None,
-                return_type_name: None,
-                type_parameter_count: None,
-                type_parameter_names: None,
-                type_parameter_bounds: None,
-                type_parameter_bound_refs: None,
-                field_count: None,
-                field_types: None,
-                field_type_names: None,
-                variant_names: None,
-                variant_owner_name: None,
-                variant_payload_count: None,
-                variant_payload_type: None,
-                variant_payload_type_name: None,
-                behavior_method_signatures: None,
-                behavior_method_types: None,
-                behavior_parent_names: None,
-                behavior_parent_refs: None,
-                behavior_impl_names: None,
-                behavior_impl_refs: None,
-                behavior_required_names: None,
-                behavior_required_refs: None,
-                is_mutable: None,
-            },
+            empty_symbol_metadata(import_source),
             0,
             definition_span,
         )
@@ -61,41 +27,11 @@ impl SymbolTable {
         signature: ValueSignatureMetadata,
         definition_span: Span,
     ) -> Result<SymbolId, Box<Diagnostic>> {
-        let parameter_count = signature.parameter_type_names.len();
         self.define_in_scope(
             Namespace::Value,
             name,
             is_public,
-            SymbolMetadata {
-                import_source: None,
-                parameter_count: Some(parameter_count),
-                parameter_names: Some(signature.parameter_names),
-                parameter_types: Some(signature.parameter_types),
-                parameter_type_names: Some(signature.parameter_type_names),
-                return_type: Some(signature.return_type),
-                return_type_name: Some(signature.return_type_name),
-                type_parameter_count: Some(signature.type_parameter_count),
-                type_parameter_names: Some(signature.type_parameter_names),
-                type_parameter_bounds: Some(signature.type_parameter_bounds),
-                type_parameter_bound_refs: Some(signature.type_parameter_bound_refs),
-                field_count: None,
-                field_types: None,
-                field_type_names: None,
-                variant_names: None,
-                variant_owner_name: None,
-                variant_payload_count: None,
-                variant_payload_type: None,
-                variant_payload_type_name: None,
-                behavior_method_signatures: None,
-                behavior_method_types: None,
-                behavior_parent_names: None,
-                behavior_parent_refs: None,
-                behavior_impl_names: None,
-                behavior_impl_refs: None,
-                behavior_required_names: None,
-                behavior_required_refs: None,
-                is_mutable: None,
-            },
+            value_symbol_metadata(signature),
             0,
             definition_span,
         )
@@ -110,56 +46,11 @@ impl SymbolTable {
         members: TypeLikeMembers,
         definition_span: Span,
     ) -> Result<SymbolId, Box<Diagnostic>> {
-        let (field_types, field_type_names, variant_names) = match members {
-            TypeLikeMembers::Fields(fields) => {
-                let typed = fields
-                    .iter()
-                    .map(|(name, ty, _)| (name.clone(), ty.clone()))
-                    .collect();
-                let names = fields
-                    .into_iter()
-                    .map(|(name, _, type_name)| (name, type_name))
-                    .collect();
-                (Some(typed), Some(names), None)
-            }
-            TypeLikeMembers::Variants(variants) => (None, None, Some(variants)),
-        };
-        let field_count = field_type_names.as_ref().map(Vec::len);
-        let type_parameter_count = type_params.len();
         self.define_in_scope(
             namespace,
             name,
             is_public,
-            SymbolMetadata {
-                import_source: None,
-                parameter_count: None,
-                parameter_names: None,
-                parameter_types: None,
-                parameter_type_names: None,
-                return_type: None,
-                return_type_name: None,
-                type_parameter_count: Some(type_parameter_count),
-                type_parameter_names: Some(resolver_type_parameter_names(type_params)),
-                type_parameter_bounds: Some(resolver_type_parameter_bounds(type_params)),
-                type_parameter_bound_refs: Some(resolver_type_parameter_bound_refs(type_params)),
-                field_count,
-                field_types,
-                field_type_names,
-                variant_names,
-                variant_owner_name: None,
-                variant_payload_count: None,
-                variant_payload_type: None,
-                variant_payload_type_name: None,
-                behavior_method_signatures: None,
-                behavior_method_types: None,
-                behavior_parent_names: None,
-                behavior_parent_refs: None,
-                behavior_impl_names: None,
-                behavior_impl_refs: None,
-                behavior_required_names: None,
-                behavior_required_refs: None,
-                is_mutable: None,
-            },
+            type_like_symbol_metadata(type_params, members),
             0,
             definition_span,
         )
@@ -173,42 +64,11 @@ impl SymbolTable {
         variant_payload_type: Option<AstType>,
         definition_span: Span,
     ) -> Result<SymbolId, Box<Diagnostic>> {
-        let variant_payload_count = usize::from(variant_payload_type.is_some());
-        let variant_payload_type_name = variant_payload_type.as_ref().map(AstType::display_name);
         self.define_in_scope(
             Namespace::Variant,
             name,
             is_public,
-            SymbolMetadata {
-                import_source: None,
-                parameter_count: None,
-                parameter_names: None,
-                parameter_types: None,
-                parameter_type_names: None,
-                return_type: None,
-                return_type_name: None,
-                type_parameter_count: None,
-                type_parameter_names: None,
-                type_parameter_bounds: None,
-                type_parameter_bound_refs: None,
-                field_count: None,
-                field_types: None,
-                field_type_names: None,
-                variant_names: None,
-                variant_owner_name: Some(owner_name.to_string()),
-                variant_payload_count: Some(variant_payload_count),
-                variant_payload_type,
-                variant_payload_type_name,
-                behavior_method_signatures: None,
-                behavior_method_types: None,
-                behavior_parent_names: None,
-                behavior_parent_refs: None,
-                behavior_impl_names: None,
-                behavior_impl_refs: None,
-                behavior_required_names: None,
-                behavior_required_refs: None,
-                is_mutable: None,
-            },
+            variant_symbol_metadata(owner_name, variant_payload_type),
             0,
             definition_span,
         )
@@ -223,41 +83,11 @@ impl SymbolTable {
         behavior_method_types: Vec<BehaviorMethodTypeMetadata>,
         definition_span: Span,
     ) -> Result<SymbolId, Box<Diagnostic>> {
-        let type_parameter_count = type_params.len();
         self.define_in_scope(
             Namespace::Behavior,
             name,
             is_public,
-            SymbolMetadata {
-                import_source: None,
-                parameter_count: None,
-                parameter_names: None,
-                parameter_types: None,
-                parameter_type_names: None,
-                return_type: None,
-                return_type_name: None,
-                type_parameter_count: Some(type_parameter_count),
-                type_parameter_names: Some(resolver_type_parameter_names(type_params)),
-                type_parameter_bounds: Some(resolver_type_parameter_bounds(type_params)),
-                type_parameter_bound_refs: Some(resolver_type_parameter_bound_refs(type_params)),
-                field_count: None,
-                field_types: None,
-                field_type_names: None,
-                variant_names: None,
-                variant_owner_name: None,
-                variant_payload_count: None,
-                variant_payload_type: None,
-                variant_payload_type_name: None,
-                behavior_method_signatures: Some(behavior_method_signatures),
-                behavior_method_types: Some(behavior_method_types),
-                behavior_parent_names: None,
-                behavior_parent_refs: None,
-                behavior_impl_names: None,
-                behavior_impl_refs: None,
-                behavior_required_names: None,
-                behavior_required_refs: None,
-                is_mutable: None,
-            },
+            behavior_symbol_metadata(type_params, behavior_method_signatures, behavior_method_types),
             0,
             definition_span,
         )

--- a/tests/docs_truth/repo_hygiene/resolver_symbol_table.rs
+++ b/tests/docs_truth/repo_hygiene/resolver_symbol_table.rs
@@ -22,3 +22,40 @@ fn resolver_symbol_table_storage_lives_in_focused_helper() {
         "symbol table should include focused storage helper"
     );
 }
+
+#[test]
+fn resolver_symbol_definition_metadata_lives_in_focused_helper() {
+    let root = read("src/resolver/symbol_table.rs");
+    let definitions = read("src/resolver/symbol_table/definitions.rs");
+    let metadata = read("src/resolver/symbol_table/definition_metadata.rs");
+
+    for helper in [
+        "empty_symbol_metadata",
+        "value_symbol_metadata",
+        "type_like_symbol_metadata",
+        "variant_symbol_metadata",
+        "behavior_symbol_metadata",
+    ] {
+        assert!(
+            !definitions.contains(&format!("fn {helper}")),
+            "symbol definition dispatch should not own metadata helper: {helper}"
+        );
+        assert!(
+            metadata.contains(&format!("fn {helper}")),
+            "symbol definition metadata helper should live in focused helper: {helper}"
+        );
+    }
+
+    assert!(
+        !definitions.contains("SymbolMetadata {"),
+        "symbol definition dispatch should call metadata helpers instead of building raw SymbolMetadata"
+    );
+    assert!(
+        definitions.lines().count() < 180,
+        "symbol definition dispatch should stay focused on definition routing"
+    );
+    assert!(
+        root.contains("include!(\"symbol_table/definition_metadata.rs\");"),
+        "symbol table should include focused definition metadata helper"
+    );
+}


### PR DESCRIPTION
## Summary
- Move symbol definition metadata builders into a focused helper include.
- Keep definition routing responsible for dispatch, not raw `SymbolMetadata` construction.
- Add a docs-truth hygiene guard for the new boundary.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Push-triggered workflows for this branch returned `[]`.