### PR TITLE
[codex] Split gated method support

### DIFF
--- a/src/typechecker/expressions.rs
+++ b/src/typechecker/expressions.rs
@@ -8,6 +8,7 @@ mod call_validation;
 mod control_flow_support;
 mod enum_variant;
 mod function_checking;
+mod gated_methods;
 mod generic_call_validation;
 mod method_call_support;
 mod simple_forms;

--- a/src/typechecker/expressions/gated_methods.rs
+++ b/src/typechecker/expressions/gated_methods.rs
@@ -1,0 +1,56 @@
+use super::*;
+use std::fmt;
+use std::str::FromStr;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum GatedMethod {
+    ResultRaise,
+    EffectAwait,
+}
+
+impl GatedMethod {
+    const RAISE: &'static str = "raise";
+    const AWAIT: &'static str = "await";
+
+    const ALL: &[GatedMethod] = &[Self::ResultRaise, Self::EffectAwait];
+
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::ResultRaise => Self::RAISE,
+            Self::EffectAwait => Self::AWAIT,
+        }
+    }
+
+    pub(super) fn diagnostic(self, span: Span) -> Diagnostic {
+        match self {
+            Self::ResultRaise => Diagnostic::error(
+                "E3054",
+                "`.raise()` is gated until Result propagation typing and lowering are implemented",
+                span,
+            ),
+            Self::EffectAwait => Diagnostic::error(
+                "E3055",
+                "`.await()` is gated until Sync/Async effect checking and task lowering are implemented",
+                span,
+            ),
+        }
+    }
+}
+
+impl fmt::Display for GatedMethod {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for GatedMethod {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        GatedMethod::ALL
+            .iter()
+            .copied()
+            .find(|method| method.as_str() == value)
+            .ok_or(())
+    }
+}

--- a/src/typechecker/expressions/method_call_support.rs
+++ b/src/typechecker/expressions/method_call_support.rs
@@ -1,62 +1,8 @@
+use super::gated_methods::GatedMethod;
 use super::*;
 use crate::typechecker::FuncInfo;
-use std::fmt;
-use std::str::FromStr;
 
 mod module_calls;
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum GatedMethod {
-    ResultRaise,
-    EffectAwait,
-}
-
-impl GatedMethod {
-    const RAISE: &'static str = "raise";
-    const AWAIT: &'static str = "await";
-
-    const ALL: &[GatedMethod] = &[Self::ResultRaise, Self::EffectAwait];
-
-    const fn as_str(self) -> &'static str {
-        match self {
-            Self::ResultRaise => Self::RAISE,
-            Self::EffectAwait => Self::AWAIT,
-        }
-    }
-
-    fn diagnostic(self, span: Span) -> Diagnostic {
-        match self {
-            Self::ResultRaise => Diagnostic::error(
-                "E3054",
-                "`.raise()` is gated until Result propagation typing and lowering are implemented",
-                span,
-            ),
-            Self::EffectAwait => Diagnostic::error(
-                "E3055",
-                "`.await()` is gated until Sync/Async effect checking and task lowering are implemented",
-                span,
-            ),
-        }
-    }
-}
-
-impl fmt::Display for GatedMethod {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-impl FromStr for GatedMethod {
-    type Err = ();
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        GatedMethod::ALL
-            .iter()
-            .copied()
-            .find(|method| method.as_str() == value)
-            .ok_or(())
-    }
-}
 
 impl TypeChecker {
     pub(super) fn check_method_call_expr(

--- a/tests/docs_truth/repo_hygiene/parser_enums/typechecker_gates.rs
+++ b/tests/docs_truth/repo_hygiene/parser_enums/typechecker_gates.rs
@@ -2,7 +2,9 @@ use super::*;
 
 #[test]
 fn typechecker_gated_methods_use_owned_action_enum() {
+    let root = read("src/typechecker/expressions.rs");
     let source = read("src/typechecker/expressions/method_call_support.rs");
+    let gated_methods = read("src/typechecker/expressions/gated_methods.rs");
 
     for forbidden in [
         r#""raise" => Some(Self::ResultRaise)"#,
@@ -21,15 +23,31 @@ fn typechecker_gated_methods_use_owned_action_enum() {
         "typechecker gated method dispatch should parse through GatedMethod"
     );
     assert!(
-        source.contains("const ALL: &[GatedMethod]"),
-        "typechecker gated methods should keep an enum-owned static table"
+        !source.contains("enum GatedMethod") && !source.contains("const ALL: &[GatedMethod]"),
+        "method call resolution should not own gated method enum details"
     );
     assert!(
-        source.contains("GatedMethod::ALL")
-            && source.contains(".iter()")
-            && source.contains(".copied()")
-            && source.contains(".find(|method| method.as_str() == value)"),
+        gated_methods.contains("enum GatedMethod"),
+        "gated_methods.rs should own the gated method enum"
+    );
+    assert!(
+        gated_methods.contains("const ALL: &[GatedMethod]"),
+        "gated_methods.rs should keep an enum-owned static table"
+    );
+    assert!(
+        gated_methods.contains("GatedMethod::ALL")
+            && gated_methods.contains(".iter()")
+            && gated_methods.contains(".copied()")
+            && gated_methods.contains(".find(|method| method.as_str() == value)"),
         "typechecker gated method parsing should use the enum-owned static table"
+    );
+    assert!(
+        root.contains("mod gated_methods;"),
+        "expression checker root should include the focused gated methods module"
+    );
+    assert!(
+        source.lines().count() < 220,
+        "method_call_support.rs should stay focused on method and UFC resolution"
     );
 }
 


### PR DESCRIPTION
## Summary
- Move gated method parsing/display/diagnostics into `expressions/gated_methods.rs`.
- Keep method-call support focused on method, generic method, and UFC resolution.
- Tighten docs-truth coverage so gated method spellings stay enum-owned and out of method dispatch details.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Push-triggered workflows for this branch returned `[]`.