### PR TITLE
[codex] Split typed expression parts

### DIFF
--- a/src/ast/typed.rs
+++ b/src/ast/typed.rs
@@ -2,8 +2,10 @@ use crate::ast::expressions::{BinaryOp, LoopControlAction, UnaryOp};
 use crate::error::Span;
 use serde::Serialize;
 
+mod expression_parts;
 mod types;
 
+pub use expression_parts::{Capture, MatchKind, TypedMatchArm, TypedPattern, TypedStringPart};
 pub use types::Type;
 
 // ─── Typed AST Nodes ─────────────────────────────────────────────────────────
@@ -116,55 +118,6 @@ pub enum TypedExprKind {
     },
 
     Error,
-}
-
-/// Sema resolves which kind of control flow `?` represents.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub enum MatchKind {
-    /// `expr ? | true { } | false { }` → if/else
-    ConditionalElse,
-    /// `expr ? | true { }` → one-shot conditional
-    Conditional,
-    /// `expr ? { body }` → while loop
-    WhileLoop,
-    /// `loop((l) { ... })` with generated `l.done()` / `l.next()` labels.
-    ControlledLoop { label: std::string::String },
-    /// `enum ? | Variant {} ...` → switch on tag
-    EnumMatch,
-    /// `val ? | X {} | Y {}` → if/else chain on values
-    ValueMatch,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-pub struct TypedMatchArm {
-    pub pattern: TypedPattern,
-    pub body: TypedBlock,
-    pub span: Span,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-pub enum TypedPattern {
-    Bool(bool),
-    EnumVariant {
-        type_name: std::string::String,
-        variant: std::string::String,
-        bindings: Vec<(std::string::String, Type)>,
-    },
-    Wildcard,
-    Value(Box<TypedExpression>),
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-pub struct Capture {
-    pub name: std::string::String,
-    pub ty: Type,
-    pub by_ref: bool,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-pub enum TypedStringPart {
-    Literal(std::string::String),
-    Expr(TypedExpression),
 }
 
 // ─── Typed Statements ────────────────────────────────────────────────────────

--- a/src/ast/typed/expression_parts.rs
+++ b/src/ast/typed/expression_parts.rs
@@ -1,0 +1,52 @@
+use super::{Type, TypedBlock, TypedExpression};
+use crate::error::Span;
+use serde::Serialize;
+
+/// Sema resolves which kind of control flow `?` represents.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum MatchKind {
+    /// `expr ? | true { } | false { }` -> if/else
+    ConditionalElse,
+    /// `expr ? | true { }` -> one-shot conditional
+    Conditional,
+    /// `expr ? { body }` -> while loop
+    WhileLoop,
+    /// `loop((l) { ... })` with generated `l.done()` / `l.next()` labels.
+    ControlledLoop { label: std::string::String },
+    /// `enum ? | Variant {} ...` -> switch on tag
+    EnumMatch,
+    /// `val ? | X {} | Y {}` -> if/else chain on values
+    ValueMatch,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct TypedMatchArm {
+    pub pattern: TypedPattern,
+    pub body: TypedBlock,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub enum TypedPattern {
+    Bool(bool),
+    EnumVariant {
+        type_name: std::string::String,
+        variant: std::string::String,
+        bindings: Vec<(std::string::String, Type)>,
+    },
+    Wildcard,
+    Value(Box<TypedExpression>),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct Capture {
+    pub name: std::string::String,
+    pub ty: Type,
+    pub by_ref: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub enum TypedStringPart {
+    Literal(std::string::String),
+    Expr(TypedExpression),
+}

--- a/tests/docs_truth/repo_hygiene/ast_expression_operators.rs
+++ b/tests/docs_truth/repo_hygiene/ast_expression_operators.rs
@@ -26,3 +26,41 @@ fn ast_expression_operator_spelling_lives_in_focused_helper() {
         );
     }
 }
+
+#[test]
+fn typed_ast_expression_parts_live_in_focused_helper() {
+    let typed = read("src/ast/typed.rs");
+    let parts = read("src/ast/typed/expression_parts.rs");
+
+    for helper in [
+        "MatchKind",
+        "TypedMatchArm",
+        "TypedPattern",
+        "Capture",
+        "TypedStringPart",
+    ] {
+        assert!(
+            !typed.contains(&format!("pub struct {helper}"))
+                && !typed.contains(&format!("pub enum {helper}")),
+            "typed AST root should not own expression part helper: {helper}"
+        );
+        assert!(
+            parts.contains(&format!("pub struct {helper}"))
+                || parts.contains(&format!("pub enum {helper}")),
+            "typed AST expression part helper should live in focused helper: {helper}"
+        );
+    }
+
+    assert!(
+        typed.contains("mod expression_parts;"),
+        "typed AST root should include focused expression parts module"
+    );
+    assert!(
+        typed.contains("pub use expression_parts::{Capture, MatchKind, TypedMatchArm, TypedPattern, TypedStringPart};"),
+        "typed AST root should preserve public re-exports for expression parts"
+    );
+    assert!(
+        typed.lines().count() < 230,
+        "typed.rs should stay focused on typed expression, declaration, and program shells"
+    );
+}


### PR DESCRIPTION
## Summary
- Move typed match kinds, arms, patterns, captures, and string interpolation parts into `ast/typed/expression_parts.rs`.
- Re-export the moved typed AST pieces from `ast::typed` to preserve the public module surface.
- Add a docs-truth guard keeping typed expression parts out of the root typed AST shell.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Push-triggered workflows for this branch returned `[]`.