### PR TITLE
[codex] Split parser infix handling

### DIFF
--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -1,13 +1,12 @@
 use super::*;
-use crate::error::REMOVED_INFIX_AS_CAST_MESSAGE;
-use crate::parser::keywords::ParserPrefixKeyword;
 
+mod infix;
 mod suffixes;
+
+use infix::InfixParse;
 
 impl Parser {
     // ── Expressions (Pratt parser) ────────────────────────────
-    const REMOVED_AS_CAST_L_BP: u8 = 1;
-
     pub(super) fn parse_expression(&mut self) -> Result<Expression, CompileError> {
         self.parse_expr_bp(0)
     }
@@ -160,97 +159,16 @@ impl Parser {
                 _ => {}
             }
 
-            if matches!(
-                self.peek(),
-                Token::Identifier(name)
-                    if matches!(name.parse::<ParserPrefixKeyword>(), Ok(ParserPrefixKeyword::As))
-            ) {
-                if Self::REMOVED_AS_CAST_L_BP < min_bp {
-                    break;
-                }
-                self.advance();
-                self.parse_type()?;
-                return Err(CompileError::Syntax(
-                    REMOVED_INFIX_AS_CAST_MESSAGE.into(),
-                    Some(lhs.span().merge(self.prev_span())),
-                ));
-            }
-
-            // Infix binary operators
-            if let Some((l_bp, r_bp)) = infix_bp(self.peek()) {
-                if l_bp < min_bp {
-                    break;
-                }
-
-                let op = match self.peek() {
-                    Token::Plus => BinaryOp::Add,
-                    Token::Minus => BinaryOp::Sub,
-                    Token::Star => BinaryOp::Mul,
-                    Token::Slash => BinaryOp::Div,
-                    Token::Percent => BinaryOp::Mod,
-                    Token::Eq => BinaryOp::Eq,
-                    Token::NotEq => BinaryOp::NotEq,
-                    Token::Lt => BinaryOp::Lt,
-                    Token::Gt => BinaryOp::Gt,
-                    Token::LtEq => BinaryOp::LtEq,
-                    Token::GtEq => BinaryOp::GtEq,
-                    Token::And => BinaryOp::And,
-                    Token::Or => BinaryOp::Or,
-                    Token::BitAnd => BinaryOp::BitAnd,
-                    Token::Pipe => BinaryOp::BitOr,
-                    Token::BitXor => BinaryOp::BitXor,
-                    Token::ShiftLeft => BinaryOp::ShiftLeft,
-                    Token::ShiftRight => BinaryOp::ShiftRight,
-                    _ => break,
-                };
-
-                self.advance(); // consume operator
-                let rhs = self.parse_expr_bp(r_bp)?;
-                let span = lhs.span().merge(rhs.span());
-                lhs = Expression::BinaryOp {
-                    op,
-                    left: Box::new(lhs),
-                    right: Box::new(rhs),
-                    span,
-                };
-                continue;
-            }
-
-            // Range operators: .. and ..=
-            match self.peek() {
-                Token::DotDot => {
-                    let (l_bp, r_bp) = (3, 4);
-                    if l_bp < min_bp {
-                        break;
-                    }
-                    self.advance();
-                    let rhs = self.parse_expr_bp(r_bp)?;
-                    let span = lhs.span().merge(rhs.span());
-                    lhs = Expression::Range {
-                        start: Box::new(lhs),
-                        end: Box::new(rhs),
-                        inclusive: false,
-                        span,
-                    };
+            match self.parse_infix_or_range_expr(lhs, min_bp)? {
+                InfixParse::Parsed(next) => {
+                    lhs = next;
                     continue;
                 }
-                Token::DotDotEq => {
-                    let (l_bp, r_bp) = (3, 4);
-                    if l_bp < min_bp {
-                        break;
-                    }
-                    self.advance();
-                    let rhs = self.parse_expr_bp(r_bp)?;
-                    let span = lhs.span().merge(rhs.span());
-                    lhs = Expression::Range {
-                        start: Box::new(lhs),
-                        end: Box::new(rhs),
-                        inclusive: true,
-                        span,
-                    };
-                    continue;
+                InfixParse::Stop(current) => {
+                    lhs = current;
+                    break;
                 }
-                _ => {}
+                InfixParse::Continue(current) => lhs = current,
             }
 
             break;

--- a/src/parser/expressions/infix.rs
+++ b/src/parser/expressions/infix.rs
@@ -1,0 +1,102 @@
+use super::*;
+use crate::error::REMOVED_INFIX_AS_CAST_MESSAGE;
+use crate::parser::keywords::ParserPrefixKeyword;
+
+pub(super) enum InfixParse {
+    Parsed(Expression),
+    Stop(Expression),
+    Continue(Expression),
+}
+
+impl Parser {
+    const REMOVED_AS_CAST_L_BP: u8 = 1;
+
+    pub(super) fn parse_infix_or_range_expr(
+        &mut self,
+        lhs: Expression,
+        min_bp: u8,
+    ) -> Result<InfixParse, CompileError> {
+        if matches!(
+            self.peek(),
+            Token::Identifier(name)
+                if matches!(name.parse::<ParserPrefixKeyword>(), Ok(ParserPrefixKeyword::As))
+        ) {
+            if Self::REMOVED_AS_CAST_L_BP < min_bp {
+                return Ok(InfixParse::Stop(lhs));
+            }
+            self.advance();
+            self.parse_type()?;
+            return Err(CompileError::Syntax(
+                REMOVED_INFIX_AS_CAST_MESSAGE.into(),
+                Some(lhs.span().merge(self.prev_span())),
+            ));
+        }
+
+        if let Some((l_bp, r_bp)) = infix_bp(self.peek()) {
+            if l_bp < min_bp {
+                return Ok(InfixParse::Stop(lhs));
+            }
+
+            let Some(op) = binary_op_for_token(self.peek()) else {
+                return Ok(InfixParse::Continue(lhs));
+            };
+
+            self.advance();
+            let rhs = self.parse_expr_bp(r_bp)?;
+            let span = lhs.span().merge(rhs.span());
+            return Ok(InfixParse::Parsed(Expression::BinaryOp {
+                op,
+                left: Box::new(lhs),
+                right: Box::new(rhs),
+                span,
+            }));
+        }
+
+        let range = match self.peek() {
+            Token::DotDot => Some(false),
+            Token::DotDotEq => Some(true),
+            _ => None,
+        };
+        let Some(inclusive) = range else {
+            return Ok(InfixParse::Continue(lhs));
+        };
+
+        let (l_bp, r_bp) = (3, 4);
+        if l_bp < min_bp {
+            return Ok(InfixParse::Stop(lhs));
+        }
+        self.advance();
+        let rhs = self.parse_expr_bp(r_bp)?;
+        let span = lhs.span().merge(rhs.span());
+        Ok(InfixParse::Parsed(Expression::Range {
+            start: Box::new(lhs),
+            end: Box::new(rhs),
+            inclusive,
+            span,
+        }))
+    }
+}
+
+fn binary_op_for_token(token: &Token) -> Option<BinaryOp> {
+    match token {
+        Token::Plus => Some(BinaryOp::Add),
+        Token::Minus => Some(BinaryOp::Sub),
+        Token::Star => Some(BinaryOp::Mul),
+        Token::Slash => Some(BinaryOp::Div),
+        Token::Percent => Some(BinaryOp::Mod),
+        Token::Eq => Some(BinaryOp::Eq),
+        Token::NotEq => Some(BinaryOp::NotEq),
+        Token::Lt => Some(BinaryOp::Lt),
+        Token::Gt => Some(BinaryOp::Gt),
+        Token::LtEq => Some(BinaryOp::LtEq),
+        Token::GtEq => Some(BinaryOp::GtEq),
+        Token::And => Some(BinaryOp::And),
+        Token::Or => Some(BinaryOp::Or),
+        Token::BitAnd => Some(BinaryOp::BitAnd),
+        Token::Pipe => Some(BinaryOp::BitOr),
+        Token::BitXor => Some(BinaryOp::BitXor),
+        Token::ShiftLeft => Some(BinaryOp::ShiftLeft),
+        Token::ShiftRight => Some(BinaryOp::ShiftRight),
+        _ => None,
+    }
+}

--- a/tests/docs_truth/repo_hygiene/parser_core.rs
+++ b/tests/docs_truth/repo_hygiene/parser_core.rs
@@ -55,3 +55,45 @@ fn parser_core_navigation_and_lookahead_live_in_focused_helpers() {
         );
     }
 }
+
+#[test]
+fn parser_pratt_infix_lives_in_focused_helper() {
+    let expressions = read("src/parser/expressions.rs");
+    let infix = read("src/parser/expressions/infix.rs");
+
+    for helper in [
+        "fn parse_infix_or_range_expr",
+        "enum InfixParse",
+        "fn binary_op_for_token",
+    ] {
+        assert!(
+            !expressions.contains(helper),
+            "parser expression root should not own Pratt infix helper: {helper}"
+        );
+        assert!(
+            infix.contains(helper),
+            "Pratt infix helper should live in focused helper: {helper}"
+        );
+    }
+
+    for forbidden in [
+        "REMOVED_AS_CAST_L_BP",
+        "REMOVED_INFIX_AS_CAST_MESSAGE",
+        "Token::DotDot",
+        "Token::DotDotEq",
+    ] {
+        assert!(
+            !expressions.contains(forbidden),
+            "parser expression root should not own infix/range detail: {forbidden}"
+        );
+    }
+
+    assert!(
+        expressions.contains("mod infix;"),
+        "parser expression root should include the focused infix module"
+    );
+    assert!(
+        expressions.lines().count() < 220,
+        "parser expression root should stay focused on Pratt dispatch"
+    );
+}


### PR DESCRIPTION
## Summary
- Move Pratt infix, range, and removed infix-`as` handling into `parser/expressions/infix.rs`.
- Keep `parser/expressions.rs` focused on Pratt dispatch and postfix/match routing.
- Add a docs-truth guard for the new parser expression boundary.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Push-triggered workflows for this branch returned `[]`.