### PR TITLE
[codex] Split parser module atoms

### DIFF
--- a/src/parser/atoms.rs
+++ b/src/parser/atoms.rs
@@ -1,8 +1,9 @@
 use super::*;
 use crate::error::{REMOVED_AS_CAST_MESSAGE, REMOVED_RETURN_KEYWORD_MESSAGE};
-use crate::parser::keywords::{ParserModuleRoot, ParserPrefixKeyword, ParserThisMethod};
+use crate::parser::keywords::{ParserPrefixKeyword, ParserThisMethod};
 
 mod forms;
+mod module_roots;
 
 impl Parser {
     /// Parse prefix / atom expressions.
@@ -136,75 +137,8 @@ impl Parser {
             Token::Dot => self.parse_shorthand_enum_variant_expr(),
 
             // Module-qualified: @builtin.func(args), @std.mod.func(args)
-            Token::AtBuiltin => {
-                let (_, span) = self.advance();
-                self.expect(&Token::Dot)?;
-                let (func_name, _) = self.expect_identifier()?;
-
-                // Check for type args
-                let type_args = if matches!(self.peek(), Token::Lt) {
-                    self.parse_type_arg_list()?
-                } else {
-                    Vec::new()
-                };
-
-                self.expect(&Token::LParen)?;
-                let args = self.parse_arg_list()?;
-                let end = self.expect(&Token::RParen)?;
-
-                Ok(Expression::FunctionCall {
-                    name: func_name,
-                    module: Some(ParserModuleRoot::AtBuiltin.as_str().to_string()),
-                    type_args,
-                    args,
-                    span: span.merge(end),
-                })
-            }
-
-            Token::AtStd => {
-                let (_, span) = self.advance();
-                self.expect(&Token::Dot)?;
-                let mut module_parts = Vec::new();
-                let (first, _) = self.expect_identifier()?;
-                module_parts.push(first);
-
-                // Collect module.sub.func path
-                while matches!(self.peek(), Token::Dot) {
-                    let saved = self.pos;
-                    self.advance(); // consume .
-                    if let Token::Identifier(_) = self.peek() {
-                        let (part, _) = self.expect_identifier()?;
-                        module_parts.push(part);
-                    } else {
-                        self.pos = saved;
-                        break;
-                    }
-                }
-
-                // Last part is the function name
-                let func_name = module_parts.pop().unwrap();
-                let module = ParserModuleRoot::AtStd.join_module_parts(&module_parts);
-
-                if matches!(self.peek(), Token::LParen) {
-                    self.advance();
-                    let args = self.parse_arg_list()?;
-                    let end = self.expect(&Token::RParen)?;
-                    Ok(Expression::FunctionCall {
-                        name: func_name,
-                        module: Some(module),
-                        type_args: Vec::new(),
-                        args,
-                        span: span.merge(end),
-                    })
-                } else {
-                    // Might be a member access
-                    Ok(Expression::MemberAccess {
-                        object: Box::new(Expression::Identifier { name: module, span }),
-                        field: func_name,
-                        span: span.merge(self.prev_span()),
-                    })
-                }
-            }
+            Token::AtBuiltin => self.parse_builtin_module_call_expr(),
+            Token::AtStd => self.parse_std_module_root_expr(),
 
             // Parenthesized expression or closure
             Token::LParen => {

--- a/src/parser/atoms/module_roots.rs
+++ b/src/parser/atoms/module_roots.rs
@@ -1,0 +1,70 @@
+use super::*;
+use crate::parser::keywords::ParserModuleRoot;
+
+impl Parser {
+    pub(super) fn parse_builtin_module_call_expr(&mut self) -> Result<Expression, CompileError> {
+        let (_, span) = self.advance();
+        self.expect(&Token::Dot)?;
+        let (func_name, _) = self.expect_identifier()?;
+
+        let type_args = if matches!(self.peek(), Token::Lt) {
+            self.parse_type_arg_list()?
+        } else {
+            Vec::new()
+        };
+
+        self.expect(&Token::LParen)?;
+        let args = self.parse_arg_list()?;
+        let end = self.expect(&Token::RParen)?;
+
+        Ok(Expression::FunctionCall {
+            name: func_name,
+            module: Some(ParserModuleRoot::AtBuiltin.as_str().to_string()),
+            type_args,
+            args,
+            span: span.merge(end),
+        })
+    }
+
+    pub(super) fn parse_std_module_root_expr(&mut self) -> Result<Expression, CompileError> {
+        let (_, span) = self.advance();
+        self.expect(&Token::Dot)?;
+        let mut module_parts = Vec::new();
+        let (first, _) = self.expect_identifier()?;
+        module_parts.push(first);
+
+        while matches!(self.peek(), Token::Dot) {
+            let saved = self.pos;
+            self.advance();
+            if let Token::Identifier(_) = self.peek() {
+                let (part, _) = self.expect_identifier()?;
+                module_parts.push(part);
+            } else {
+                self.pos = saved;
+                break;
+            }
+        }
+
+        let func_name = module_parts.pop().unwrap();
+        let module = ParserModuleRoot::AtStd.join_module_parts(&module_parts);
+
+        if matches!(self.peek(), Token::LParen) {
+            self.advance();
+            let args = self.parse_arg_list()?;
+            let end = self.expect(&Token::RParen)?;
+            Ok(Expression::FunctionCall {
+                name: func_name,
+                module: Some(module),
+                type_args: Vec::new(),
+                args,
+                span: span.merge(end),
+            })
+        } else {
+            Ok(Expression::MemberAccess {
+                object: Box::new(Expression::Identifier { name: module, span }),
+                field: func_name,
+                span: span.merge(self.prev_span()),
+            })
+        }
+    }
+}

--- a/tests/docs_truth/repo_hygiene/parser_keywords.rs
+++ b/tests/docs_truth/repo_hygiene/parser_keywords.rs
@@ -89,6 +89,8 @@ fn parser_this_methods_use_owned_method_enum() {
 
 #[test]
 fn parser_module_roots_use_owned_root_enum() {
+    let module_roots = read("src/parser/atoms/module_roots.rs");
+
     for path in ["src/parser/atoms.rs", "src/parser/import_declarations.rs"] {
         let source = read(path);
         for forbidden in [
@@ -103,6 +105,28 @@ fn parser_module_roots_use_owned_root_enum() {
         }
     }
 
+    let atoms = read("src/parser/atoms.rs");
+    for forbidden in [
+        "ParserModuleRoot::AtBuiltin",
+        "ParserModuleRoot::AtStd",
+        "module_parts",
+    ] {
+        assert!(
+            !atoms.contains(forbidden),
+            "parser atom dispatch should not own module-root parsing detail: {forbidden}"
+        );
+    }
+
+    for helper in [
+        "parse_builtin_module_call_expr",
+        "parse_std_module_root_expr",
+    ] {
+        assert!(
+            module_roots.contains(&format!("fn {helper}")),
+            "module-root atom parsing should live in module_roots.rs: {helper}"
+        );
+    }
+
     let keywords = read("src/parser/keywords.rs");
     for required in [
         "enum ParserModuleRoot",
@@ -114,6 +138,7 @@ fn parser_module_roots_use_owned_root_enum() {
     ] {
         assert!(
             keywords.contains(required)
+                || module_roots.contains(required)
                 || read("src/parser/atoms.rs").contains(required)
                 || read("src/parser/import_declarations.rs").contains(required),
             "parser module root spelling should live in ParserModuleRoot: {required}"


### PR DESCRIPTION
## Summary
- Move `@builtin` and `@std` atom parsing into `src/parser/atoms/module_roots.rs`.
- Keep `src/parser/atoms.rs` focused on prefix atom dispatch.
- Tighten the docs-truth guard so module-root parsing detail stays out of the atom dispatcher and continues to route through `ParserModuleRoot`.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Push workflow guard: `gh run list --repo lantos1618/zenlang --branch codex/split-parser-module-atoms --event push --limit 10 --json databaseId,status,conclusion,workflowName,headSha,createdAt,url` returned `[]`.