### PR TITLE
[codex] Compact language docs

### DIFF
--- a/docs/V1_SPEC.md
+++ b/docs/V1_SPEC.md
@@ -1,35 +1,24 @@
 # Zen v1 Specification Draft
 
-Status: v1 draft. This document is normative for intended v1 behavior, while
-the feature matrix controls what the rewrite compiler may currently advertise.
-Exhaustive proof belongs in tests, golden fixtures, and git history.
-
-## Baseline
-The active implementation is the rewrite compiler:
-`source -> tokens -> AST -> module loader -> typechecker -> typed AST -> C backend -> cc`.
-Compiler-owned semantic data is the source of truth; serialized JSON and YAML are
-interface formats generated from or validated against checked compiler data.
+Status: v1 draft. This document is normative for intended v1 behavior; the
+feature matrix controls what the rewrite compiler may advertise, and exhaustive
+proof belongs in tests, golden fixtures, and git history.
 
 ## Syntax Contract
-Implemented syntax forms are limited to forms covered by `tests/zen` and Rust
-tests: declarations, calls, imports, bindings, structs, enums, field access,
+The active implementation is the rewrite compiler:
+`source -> tokens -> AST -> module loader -> typechecker -> typed AST -> C backend -> cc`.
+Implemented syntax is limited to forms covered by `tests/zen` and Rust tests:
+declarations, calls, imports, bindings, structs, enums, field access,
 method-style calls, final-expression results, prefix loops, `defer`, casts,
-string interpolation, and parser/codegen-supported `?` arms.
-
-Unsupported spec-like constructs stay gated until parser, resolver, typechecker,
-codegen, diagnostics, JSON, and public examples agree on the shape. This includes
-unspecialized generic behavior targets, comptime execution, type matching, async
-operations, actor syntax, package manifests, and broader `build.zen` execution.
+string interpolation, and parser/codegen-supported `?` arms. Unsupported
+spec-like constructs stay gated until parser, resolver, typechecker, codegen,
+diagnostics, JSON, and public examples agree on the shape.
 
 Developer UX and Agent UX are product requirements, not polish. The v1 surface
 should grow toward MoonBit-style toolchain integration, but the compiler must not advertise unsupported language-server binaries or editor features as implemented.
-Current contract: VS Code extension remains a constrained editor wrapper;
-`zen lsp` remains gated until it shares parser, resolver, typechecker, build
-graph, and diagnostics with the CLI. Agent-readable diagnostics keep stable
-codes, spans, related locations, structured fix suggestions, feature_gate
-metadata, and JSON; machine-readable project graph and symbol graph JSON remain
-compiler-owned; quiet deterministic commands such as `zen check`, `zen test`,
-and `zen emit-json` gate automated fix or package workflows.
+Current contract: VS Code extension remains a constrained editor wrapper; `zen lsp` remains gated until it shares parser, resolver, typechecker, build graph, and diagnostics with the CLI.
+Agent-readable diagnostics keep stable codes, spans, related locations,
+structured fix suggestions, feature_gate metadata, and JSON; machine-readable project graph and symbol graph JSON remain compiler-owned; quiet deterministic commands such as `zen check`, `zen test`, and `zen emit-json` gate automated fix or package workflows.
 
 ## Accepted Syntax Forms
 Every accepted syntax form must have a spec entry and Test Evidence before it is

--- a/docs/learn_zen_in_y_minutes.md
+++ b/docs/learn_zen_in_y_minutes.md
@@ -9,8 +9,7 @@ Preview examples cover gated surfaces: allocator-backed strings, sync/async
 effects, raw memory, actors, and comptime type matching.
 
 ## The Shape
-Declarations are prefix-first. The name being introduced or changed comes
-first:
+Declarations are prefix-first. The name being introduced or changed comes first:
 
 | Need | Spell it like this |
 | --- | --- |
@@ -31,29 +30,9 @@ first:
 | Inheritance | `ChildBehavior.extends(ParentBehavior)` |
 
 ## Values And Results
-```zen
-main = () i32 {
-    answer = 42
-    label: StaticString = "zen"
-    count ::= 0
-    count = count + 1
-    answer + count
-}
-```
-
 Local bindings are immutable by default. Use `::=` for mutable inferred locals;
-after that, plain `=` assigns a new value.
-
-Zen does not use a `return` keyword. Function bodies, match arms, and nested
-blocks produce their final expression.
-
-```zen
-max = (a: i32, b: i32) i32 {
-    a > b ?
-        | true { a }
-        | false { b }
-}
-```
+after that, plain `=` assigns a new value. Zen does not use a `return` keyword.
+Function bodies, match arms, and nested blocks produce their final expression.
 
 Numeric conversions are explicit and prefix-first: `cast(value, Type)`.
 String literals are `StaticString`, not allocator-backed strings.
@@ -76,7 +55,6 @@ fields explicitly; field access uses dot syntax.
 
 ## Enums And Matching
 ```zen
-Direction: North, South, East, West
 Option<T>: None, Some(T)
 Result<T, E>: Ok(T), Err(E)
 
@@ -92,14 +70,6 @@ The `?` operator is the pattern-match form for bools, enums, `Option`, and
 
 ## Result And Error Handling
 Zen models failure with data. There are no exceptions and no null.
-
-```zen
-divide = (a: f64, b: f64) Result<f64, StaticString> {
-    b == 0.0 ?
-        | true { Result<f64, StaticString>.Err("division by zero") }
-        | false { Result<f64, StaticString>.Ok(a / b) }
-}
-```
 
 Nested generic types are written directly, such as
 `Result<Option<i32>, StaticString>`.
@@ -199,14 +169,6 @@ is no `async fn` spelling. Sync work returns checked data now. Async work
 returns task-shaped data.
 
 ```zen
-read_now = (source: Source, allocator: Allocator<u8, Sync>) Result<Bytes<u8>, IoError> {
-    source.read_all(allocator)
-}
-
-read_later = (source: Source, allocator: Allocator<u8, Async>) Task<Result<Bytes<u8>, IoError>> {
-    source.read_all_async(allocator)
-}
-
 Allocator<T, Sync>: behavior { alloc: (Self, count: usize) Result<RawPtr<T>, AllocError> }
 Allocator<T, Async>: behavior { alloc: (Self, count: usize) Task<Result<RawPtr<T>, AllocError>> }
 ```
@@ -223,7 +185,6 @@ Read the outer type first:
 
 There is no hidden conversion between sync and async allocation. `Result<...>`
 is complete now; `Task<Result<...>>` completes later at a scheduler boundary.
-Allocator-backed construction carries the allocator through the owner:
 
 ```zen
 Buffer<T, A: Allocator<T, Sync>>: { ptr: RawPtr<T>, len: usize, capacity: usize, allocator: A }
@@ -268,9 +229,7 @@ contracts are promoted.
 ## One Page Example
 ```zen
 { io } = std
-
 Display: behavior { display: (Self) StaticString }
-
 Point: { x: i32, y: i32 }
 
 Point.sum = (self: Point) i32 {
@@ -284,7 +243,6 @@ Point.implements(Display) {
 show<T: Display> = (value: T) StaticString {
     value.display()
 }
-
 main = () i32 {
     point = Point { x: 20, y: 22 }
     io.println("${show(point)}: ${point.sum()}")

--- a/tests/docs_truth/public_docs/learn_zen.rs
+++ b/tests/docs_truth/public_docs/learn_zen.rs
@@ -108,7 +108,7 @@ fn learn_zen_guide_covers_core_tour_and_gated_previews() {
     }
 
     assert!(
-        guide.lines().count() <= 305,
+        guide.lines().count() <= 270,
         "Learn guide should stay compact; move detailed status or evidence to phase docs and tests"
     );
 }

--- a/tests/docs_truth/v1_spec/implementation_evidence.rs
+++ b/tests/docs_truth/v1_spec/implementation_evidence.rs
@@ -64,7 +64,7 @@ fn v1_spec_records_resolver_generic_and_behavior_evidence() {
     }
 
     assert!(
-        spec.lines().count() <= 220,
+        spec.lines().count() <= 200,
         "docs/V1_SPEC.md should stay compact; move exhaustive evidence to tests, golden fixtures, or git history"
     );
 }


### PR DESCRIPTION
## Summary
- Compact `docs/learn_zen_in_y_minutes.md` by removing redundant mini-examples while keeping the canonical loops, allocator, sync/async, behavior, and full-page examples.
- Compact the top of `docs/V1_SPEC.md` so status/baseline language stays dense and evidence remains in tests/golden fixtures.
- Tighten docs-truth caps for the learn guide and V1 spec to prevent context bloat from returning.

## Result
- `docs/learn_zen_in_y_minutes.md`: 299 -> 257 lines.
- `docs/V1_SPEC.md`: 208 -> 197 lines.
- Net diff: 17 insertions, 70 deletions.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Push workflow guard: `gh run list --repo lantos1618/zenlang --branch codex/compact-language-docs --event push --limit 10 --json databaseId,status,conclusion,workflowName,headSha,createdAt,url` returned `[]`.