### PR TITLE
[codex] Split resolver validation doc guards

### DIFF
--- a/tests/docs_truth/repo_hygiene/file_size.rs
+++ b/tests/docs_truth/repo_hygiene/file_size.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[test]
 fn production_rust_files_stay_below_cleanup_threshold() {
-    const MAX_LINES: usize = 500;
+    const MAX_LINES: usize = 400;
 
     let output = std::process::Command::new("git")
         .args(["ls-files", "*.rs"])

--- a/tests/docs_truth/repo_hygiene/typechecker_resolver_validation.rs
+++ b/tests/docs_truth/repo_hygiene/typechecker_resolver_validation.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod focused_modules;
+
 #[test]
 fn typechecker_resolver_validation_post_pass_lives_in_focused_helper() {
     let entry = read("src/typechecker/resolver_validation/entry_symbols.rs");
@@ -289,114 +291,4 @@ fn typechecker_resolver_absence_diagnostics_live_in_focused_helper() {
         root.contains("include!(\"resolver_validation/metadata_absence.rs\");"),
         "resolver validation should include focused absence diagnostics"
     );
-}
-
-#[test]
-fn typechecker_resolver_type_behavior_metadata_tests_live_in_focused_modules() {
-    let root = read("src/typechecker/tests/resolver_type_behavior_metadata.rs");
-    let type_metadata =
-        read("src/typechecker/tests/resolver_type_behavior_metadata/type_symbols.rs");
-    let behavior_metadata =
-        read("src/typechecker/tests/resolver_type_behavior_metadata/behavior_symbols.rs");
-
-    for test_name in [
-        "check_program_with_symbols_validates_resolver_type_parameter_counts",
-        "check_program_with_symbols_validates_resolver_type_parameter_names",
-        "check_program_with_symbols_validates_resolver_type_visibility",
-        "check_program_with_symbols_validates_resolver_type_parameter_bounds",
-        "check_program_with_symbols_validates_resolver_type_like_absent_value_metadata",
-    ] {
-        assert!(
-            !root.contains(&format!("fn {test_name}")),
-            "resolver_type_behavior_metadata.rs should not own type metadata test: {test_name}"
-        );
-        assert!(
-            type_metadata.contains(&format!("fn {test_name}")),
-            "type metadata tests should live in focused module: {test_name}"
-        );
-    }
-
-    for test_name in [
-        "check_program_with_symbols_validates_resolver_behavior_visibility",
-        "check_program_with_symbols_validates_resolver_behavior_type_parameter_bounds",
-        "check_program_with_symbols_validates_resolver_behavior_absent_type_metadata",
-    ] {
-        assert!(
-            !root.contains(&format!("fn {test_name}")),
-            "resolver_type_behavior_metadata.rs should not own behavior metadata test: {test_name}"
-        );
-        assert!(
-            behavior_metadata.contains(&format!("fn {test_name}")),
-            "behavior metadata tests should live in focused module: {test_name}"
-        );
-    }
-
-    for module_name in ["type_symbols", "behavior_symbols"] {
-        assert!(
-            root.contains(&format!("mod {module_name};")),
-            "resolver type/behavior metadata root should include focused module: {module_name}"
-        );
-    }
-}
-
-#[test]
-fn typechecker_resolver_declaration_tests_live_in_focused_modules() {
-    let root = read("src/typechecker/tests/resolver_declarations.rs");
-    let symbols = read("src/typechecker/tests/resolver_declarations/symbols.rs");
-    let imports = read("src/typechecker/tests/resolver_declarations/imports.rs");
-    let methods = read("src/typechecker/tests/resolver_declarations/methods.rs");
-
-    for test_name in [
-        "check_program_with_symbols_requires_resolver_declarations",
-        "check_program_with_symbols_rejects_extra_resolver_declarations",
-    ] {
-        assert!(
-            !root.contains(&format!("fn {test_name}")),
-            "resolver_declarations.rs should not own symbol declaration test: {test_name}"
-        );
-        assert!(
-            symbols.contains(&format!("fn {test_name}")),
-            "resolver declaration symbol tests should live in focused module: {test_name}"
-        );
-    }
-
-    for test_name in [
-        "check_program_with_symbols_rejects_extra_resolver_imports_when_ast_imports_are_present",
-        "check_program_with_symbols_rejects_extra_resolver_modules_when_ast_imports_are_present",
-        "check_program_with_symbols_uses_resolver_import_bindings",
-        "check_program_with_symbols_validates_stripped_resolver_import_sources",
-        "check_program_with_symbols_validates_stripped_resolver_import_visibility",
-        "check_program_with_symbols_requires_stripped_resolver_import_modules",
-    ] {
-        assert!(
-            !root.contains(&format!("fn {test_name}")),
-            "resolver_declarations.rs should not own resolver import test: {test_name}"
-        );
-        assert!(
-            imports.contains(&format!("fn {test_name}")),
-            "resolver declaration import tests should live in focused module: {test_name}"
-        );
-    }
-
-    for test_name in [
-        "check_program_with_symbols_requires_resolver_method_receiver_type",
-        "check_program_with_symbols_validates_resolver_method_signature",
-        "check_program_with_symbols_validates_resolver_method_function_type_signature",
-    ] {
-        assert!(
-            !root.contains(&format!("fn {test_name}")),
-            "resolver_declarations.rs should not own resolver method test: {test_name}"
-        );
-        assert!(
-            methods.contains(&format!("fn {test_name}")),
-            "resolver declaration method tests should live in focused module: {test_name}"
-        );
-    }
-
-    for module_name in ["symbols", "imports", "methods"] {
-        assert!(
-            root.contains(&format!("mod {module_name};")),
-            "resolver declarations root should include focused module: {module_name}"
-        );
-    }
 }

--- a/tests/docs_truth/repo_hygiene/typechecker_resolver_validation/focused_modules.rs
+++ b/tests/docs_truth/repo_hygiene/typechecker_resolver_validation/focused_modules.rs
@@ -1,0 +1,111 @@
+use super::*;
+
+#[test]
+fn typechecker_resolver_type_behavior_metadata_tests_live_in_focused_modules() {
+    let root = read("src/typechecker/tests/resolver_type_behavior_metadata.rs");
+    let type_metadata =
+        read("src/typechecker/tests/resolver_type_behavior_metadata/type_symbols.rs");
+    let behavior_metadata =
+        read("src/typechecker/tests/resolver_type_behavior_metadata/behavior_symbols.rs");
+
+    for test_name in [
+        "check_program_with_symbols_validates_resolver_type_parameter_counts",
+        "check_program_with_symbols_validates_resolver_type_parameter_names",
+        "check_program_with_symbols_validates_resolver_type_visibility",
+        "check_program_with_symbols_validates_resolver_type_parameter_bounds",
+        "check_program_with_symbols_validates_resolver_type_like_absent_value_metadata",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "resolver_type_behavior_metadata.rs should not own type metadata test: {test_name}"
+        );
+        assert!(
+            type_metadata.contains(&format!("fn {test_name}")),
+            "type metadata tests should live in focused module: {test_name}"
+        );
+    }
+
+    for test_name in [
+        "check_program_with_symbols_validates_resolver_behavior_visibility",
+        "check_program_with_symbols_validates_resolver_behavior_type_parameter_bounds",
+        "check_program_with_symbols_validates_resolver_behavior_absent_type_metadata",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "resolver_type_behavior_metadata.rs should not own behavior metadata test: {test_name}"
+        );
+        assert!(
+            behavior_metadata.contains(&format!("fn {test_name}")),
+            "behavior metadata tests should live in focused module: {test_name}"
+        );
+    }
+
+    for module_name in ["type_symbols", "behavior_symbols"] {
+        assert!(
+            root.contains(&format!("mod {module_name};")),
+            "resolver type/behavior metadata root should include focused module: {module_name}"
+        );
+    }
+}
+
+#[test]
+fn typechecker_resolver_declaration_tests_live_in_focused_modules() {
+    let root = read("src/typechecker/tests/resolver_declarations.rs");
+    let symbols = read("src/typechecker/tests/resolver_declarations/symbols.rs");
+    let imports = read("src/typechecker/tests/resolver_declarations/imports.rs");
+    let methods = read("src/typechecker/tests/resolver_declarations/methods.rs");
+
+    for test_name in [
+        "check_program_with_symbols_requires_resolver_declarations",
+        "check_program_with_symbols_rejects_extra_resolver_declarations",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "resolver_declarations.rs should not own symbol declaration test: {test_name}"
+        );
+        assert!(
+            symbols.contains(&format!("fn {test_name}")),
+            "resolver declaration symbol tests should live in focused module: {test_name}"
+        );
+    }
+
+    for test_name in [
+        "check_program_with_symbols_rejects_extra_resolver_imports_when_ast_imports_are_present",
+        "check_program_with_symbols_rejects_extra_resolver_modules_when_ast_imports_are_present",
+        "check_program_with_symbols_uses_resolver_import_bindings",
+        "check_program_with_symbols_validates_stripped_resolver_import_sources",
+        "check_program_with_symbols_validates_stripped_resolver_import_visibility",
+        "check_program_with_symbols_requires_stripped_resolver_import_modules",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "resolver_declarations.rs should not own resolver import test: {test_name}"
+        );
+        assert!(
+            imports.contains(&format!("fn {test_name}")),
+            "resolver declaration import tests should live in focused module: {test_name}"
+        );
+    }
+
+    for test_name in [
+        "check_program_with_symbols_requires_resolver_method_receiver_type",
+        "check_program_with_symbols_validates_resolver_method_signature",
+        "check_program_with_symbols_validates_resolver_method_function_type_signature",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "resolver_declarations.rs should not own resolver method test: {test_name}"
+        );
+        assert!(
+            methods.contains(&format!("fn {test_name}")),
+            "resolver declaration method tests should live in focused module: {test_name}"
+        );
+    }
+
+    for module_name in ["symbols", "imports", "methods"] {
+        assert!(
+            root.contains(&format!("mod {module_name};")),
+            "resolver declarations root should include focused module: {module_name}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Split resolver-validation docs-truth checks for focused test modules into `typechecker_resolver_validation/focused_modules.rs`.
- Keep the main resolver-validation docs-truth guard focused on implementation helper placement.
- Lower the tracked Rust file cleanup threshold from 500 to 400 lines now that no tracked Rust file exceeds that cap.

## Result
- `tests/docs_truth/repo_hygiene/typechecker_resolver_validation.rs`: 402 -> 294 lines.
- New focused guard module: 111 lines.
- Largest tracked Rust file after the split is 307 lines.

## Validation
- TDD guard first: `cargo test --test docs_truth production_rust_files_stay_below_cleanup_threshold -- --nocapture` failed on the 402-line docs-truth guard before the split.
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Push workflow guard: `gh run list --repo lantos1618/zenlang --branch codex/split-resolver-validation-doc-guards --event push --limit 10 --json databaseId,status,conclusion,workflowName,headSha,createdAt,url` returned `[]`.