### PR TITLE
[codex] Split generated C test support

### DIFF
--- a/tests/docs_truth/repo_hygiene/file_size.rs
+++ b/tests/docs_truth/repo_hygiene/file_size.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[test]
 fn production_rust_files_stay_below_cleanup_threshold() {
-    const MAX_LINES: usize = 400;
+    const MAX_LINES: usize = 305;
 
     let output = std::process::Command::new("git")
         .args(["ls-files", "*.rs"])

--- a/tests/integration/support.rs
+++ b/tests/integration/support.rs
@@ -7,6 +7,16 @@ use zen::error::FileTable;
 use zen::module_system::ModuleSystem;
 use zen::typechecker::TypeChecker;
 
+#[path = "support/generated_c.rs"]
+mod generated_c;
+
+pub use generated_c::{
+    assert_c_call_resolves_to_definition, assert_c_function_definition_count,
+    assert_generated_c_calls_resolve_to_definitions,
+    assert_generated_c_function_definitions_are_unique, has_c_call_outside_signature,
+    undefined_generated_c_calls,
+};
+
 /// Root of the test fixtures.
 pub fn test_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/zen")
@@ -115,193 +125,4 @@ pub fn run_test(name: &str) {
         "\n--- test: {} ---\nexpected:\n{}\nactual:\n{}",
         name, expected, actual
     );
-}
-
-pub fn assert_c_function_definition(c_source: &str, name: &str) {
-    let needle = format!(" {name}(");
-    assert!(
-        c_source
-            .lines()
-            .any(|line| line.trim_end().ends_with('{') && line.contains(&needle)),
-        "expected generated C definition for `{name}`:\n{c_source}"
-    );
-}
-
-pub fn assert_c_function_definition_count(c_source: &str, name: &str, expected: usize) {
-    let actual = c_function_definitions(c_source)
-        .iter()
-        .filter(|definition| definition.as_str() == name)
-        .count();
-    assert_eq!(
-        actual, expected,
-        "expected {expected} generated C definitions for `{name}`, found {actual}:\n{c_source}"
-    );
-}
-
-pub fn assert_generated_c_function_definitions_are_unique(c_source: &str) {
-    let definitions = c_function_definitions(c_source);
-    let mut duplicates = Vec::new();
-
-    for definition in &definitions {
-        if definitions
-            .iter()
-            .filter(|candidate| *candidate == definition)
-            .count()
-            > 1
-            && !duplicates.contains(definition)
-        {
-            duplicates.push(definition.clone());
-        }
-    }
-
-    assert!(
-        duplicates.is_empty(),
-        "generated C emitted duplicate function definitions: {duplicates:?}\n{c_source}"
-    );
-}
-
-pub fn assert_c_call_resolves_to_definition(c_source: &str, name: &str) {
-    assert_c_function_definition(c_source, name);
-    assert!(
-        has_c_call_outside_signature(c_source, name),
-        "expected generated C call to `{name}` outside declarations/definitions:\n{c_source}"
-    );
-}
-
-pub fn assert_generated_c_calls_resolve_to_definitions(c_source: &str) {
-    let undefined = undefined_generated_c_calls(c_source);
-    assert!(
-        undefined.is_empty(),
-        "generated C calls missing emitted definitions: {undefined:?}\n{c_source}"
-    );
-}
-
-pub fn undefined_generated_c_calls(c_source: &str) -> Vec<String> {
-    let definitions = c_function_definitions(c_source);
-    let mut undefined = Vec::new();
-
-    for line in c_source.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty()
-            || trimmed.starts_with('#')
-            || trimmed.starts_with("typedef ")
-            || is_any_c_function_signature_line(trimmed)
-        {
-            continue;
-        }
-
-        for call in generated_c_calls_on_line(trimmed) {
-            if !definitions.contains(&call) && !undefined.contains(&call) {
-                undefined.push(call);
-            }
-        }
-    }
-
-    undefined
-}
-
-fn c_function_definitions(c_source: &str) -> Vec<String> {
-    c_source
-        .lines()
-        .filter_map(|line| c_function_definition_name(line.trim()))
-        .collect()
-}
-
-fn c_function_definition_name(trimmed: &str) -> Option<String> {
-    if !trimmed.ends_with('{') {
-        return None;
-    }
-
-    let paren = trimmed.find('(')?;
-    let before = trimmed[..paren].trim_end();
-    let name_start = before
-        .rfind(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '_'))
-        .map_or(0, |idx| idx + 1);
-    let name = &before[name_start..];
-
-    if is_generated_c_function_name(name) {
-        Some(name.to_string())
-    } else {
-        None
-    }
-}
-
-fn is_any_c_function_signature_line(trimmed: &str) -> bool {
-    if !(trimmed.ends_with(';') || trimmed.ends_with('{')) {
-        return false;
-    }
-
-    let Some(paren) = trimmed.find('(') else {
-        return false;
-    };
-    let before = &trimmed[..paren];
-    let name_start = before
-        .trim_end()
-        .rfind(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '_'))
-        .map_or(0, |idx| idx + 1);
-    let return_type = before[..name_start].trim();
-    let name = before[name_start..].trim();
-
-    !return_type.is_empty()
-        && is_generated_c_function_name(name)
-        && !before.contains('=')
-        && !before.contains("return")
-}
-
-fn generated_c_calls_on_line(trimmed: &str) -> Vec<String> {
-    let mut calls = Vec::new();
-    let bytes = trimmed.as_bytes();
-    let mut index = 0;
-
-    while let Some(relative) = trimmed[index..].find('(') {
-        let paren = index + relative;
-        let mut start = paren;
-        while start > 0 {
-            let ch = bytes[start - 1] as char;
-            if ch.is_ascii_alphanumeric() || ch == '_' {
-                start -= 1;
-            } else {
-                break;
-            }
-        }
-
-        let name = &trimmed[start..paren];
-        if is_generated_c_function_name(name) && !calls.iter().any(|call| call == name) {
-            calls.push(name.to_string());
-        }
-
-        index = paren + 1;
-    }
-
-    calls
-}
-
-fn is_generated_c_function_name(name: &str) -> bool {
-    name.contains('_')
-        && name
-            .chars()
-            .next()
-            .is_some_and(|ch| ch.is_ascii_alphabetic())
-        && name
-            .chars()
-            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
-}
-
-pub fn has_c_call_outside_signature(c_source: &str, name: &str) -> bool {
-    let call = format!("{name}(");
-    c_source.lines().any(|line| {
-        let trimmed = line.trim();
-        trimmed.contains(&call) && !is_c_function_signature_line(trimmed, name)
-    })
-}
-
-fn is_c_function_signature_line(trimmed: &str, name: &str) -> bool {
-    let needle = format!(" {name}(");
-    let Some(call_start) = trimmed.find(&needle) else {
-        return false;
-    };
-    let prefix = &trimmed[..call_start];
-    !prefix.contains('=')
-        && !prefix.contains("return")
-        && (trimmed.ends_with(';') || trimmed.ends_with('{'))
 }

--- a/tests/integration/support/generated_c.rs
+++ b/tests/integration/support/generated_c.rs
@@ -1,0 +1,188 @@
+fn assert_c_function_definition(c_source: &str, name: &str) {
+    let needle = format!(" {name}(");
+    assert!(
+        c_source
+            .lines()
+            .any(|line| line.trim_end().ends_with('{') && line.contains(&needle)),
+        "expected generated C definition for `{name}`:\n{c_source}"
+    );
+}
+
+pub fn assert_c_function_definition_count(c_source: &str, name: &str, expected: usize) {
+    let actual = c_function_definitions(c_source)
+        .iter()
+        .filter(|definition| definition.as_str() == name)
+        .count();
+    assert_eq!(
+        actual, expected,
+        "expected {expected} generated C definitions for `{name}`, found {actual}:\n{c_source}"
+    );
+}
+
+pub fn assert_generated_c_function_definitions_are_unique(c_source: &str) {
+    let definitions = c_function_definitions(c_source);
+    let mut duplicates = Vec::new();
+
+    for definition in &definitions {
+        if definitions
+            .iter()
+            .filter(|candidate| *candidate == definition)
+            .count()
+            > 1
+            && !duplicates.contains(definition)
+        {
+            duplicates.push(definition.clone());
+        }
+    }
+
+    assert!(
+        duplicates.is_empty(),
+        "generated C emitted duplicate function definitions: {duplicates:?}\n{c_source}"
+    );
+}
+
+pub fn assert_c_call_resolves_to_definition(c_source: &str, name: &str) {
+    assert_c_function_definition(c_source, name);
+    assert!(
+        has_c_call_outside_signature(c_source, name),
+        "expected generated C call to `{name}` outside declarations/definitions:\n{c_source}"
+    );
+}
+
+pub fn assert_generated_c_calls_resolve_to_definitions(c_source: &str) {
+    let undefined = undefined_generated_c_calls(c_source);
+    assert!(
+        undefined.is_empty(),
+        "generated C calls missing emitted definitions: {undefined:?}\n{c_source}"
+    );
+}
+
+pub fn undefined_generated_c_calls(c_source: &str) -> Vec<String> {
+    let definitions = c_function_definitions(c_source);
+    let mut undefined = Vec::new();
+
+    for line in c_source.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty()
+            || trimmed.starts_with('#')
+            || trimmed.starts_with("typedef ")
+            || is_any_c_function_signature_line(trimmed)
+        {
+            continue;
+        }
+
+        for call in generated_c_calls_on_line(trimmed) {
+            if !definitions.contains(&call) && !undefined.contains(&call) {
+                undefined.push(call);
+            }
+        }
+    }
+
+    undefined
+}
+
+fn c_function_definitions(c_source: &str) -> Vec<String> {
+    c_source
+        .lines()
+        .filter_map(|line| c_function_definition_name(line.trim()))
+        .collect()
+}
+
+fn c_function_definition_name(trimmed: &str) -> Option<String> {
+    if !trimmed.ends_with('{') {
+        return None;
+    }
+
+    let paren = trimmed.find('(')?;
+    let before = trimmed[..paren].trim_end();
+    let name_start = before
+        .rfind(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '_'))
+        .map_or(0, |idx| idx + 1);
+    let name = &before[name_start..];
+
+    if is_generated_c_function_name(name) {
+        Some(name.to_string())
+    } else {
+        None
+    }
+}
+
+fn is_any_c_function_signature_line(trimmed: &str) -> bool {
+    if !(trimmed.ends_with(';') || trimmed.ends_with('{')) {
+        return false;
+    }
+
+    let Some(paren) = trimmed.find('(') else {
+        return false;
+    };
+    let before = &trimmed[..paren];
+    let name_start = before
+        .trim_end()
+        .rfind(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '_'))
+        .map_or(0, |idx| idx + 1);
+    let return_type = before[..name_start].trim();
+    let name = before[name_start..].trim();
+
+    !return_type.is_empty()
+        && is_generated_c_function_name(name)
+        && !before.contains('=')
+        && !before.contains("return")
+}
+
+fn generated_c_calls_on_line(trimmed: &str) -> Vec<String> {
+    let mut calls = Vec::new();
+    let bytes = trimmed.as_bytes();
+    let mut index = 0;
+
+    while let Some(relative) = trimmed[index..].find('(') {
+        let paren = index + relative;
+        let mut start = paren;
+        while start > 0 {
+            let ch = bytes[start - 1] as char;
+            if ch.is_ascii_alphanumeric() || ch == '_' {
+                start -= 1;
+            } else {
+                break;
+            }
+        }
+
+        let name = &trimmed[start..paren];
+        if is_generated_c_function_name(name) && !calls.iter().any(|call| call == name) {
+            calls.push(name.to_string());
+        }
+
+        index = paren + 1;
+    }
+
+    calls
+}
+
+fn is_generated_c_function_name(name: &str) -> bool {
+    name.contains('_')
+        && name
+            .chars()
+            .next()
+            .is_some_and(|ch| ch.is_ascii_alphabetic())
+        && name
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+}
+
+pub fn has_c_call_outside_signature(c_source: &str, name: &str) -> bool {
+    let call = format!("{name}(");
+    c_source.lines().any(|line| {
+        let trimmed = line.trim();
+        trimmed.contains(&call) && !is_c_function_signature_line(trimmed, name)
+    })
+}
+
+fn is_c_function_signature_line(trimmed: &str, name: &str) -> bool {
+    let needle = format!(" {name}(");
+    let Some(call_start) = trimmed.find(&needle) else {
+        return false;
+    };
+    let prefix = &trimmed[..call_start];
+    !prefix.contains('=')
+        && !prefix.contains("return")
+        && (trimmed.ends_with(';') || trimmed.ends_with('{'))
+}


### PR DESCRIPTION
## Summary
- Move generated-C assertion and call/definition scanning helpers out of `tests/integration/support.rs` into `tests/integration/support/generated_c.rs`.
- Re-export the public helper API from `support.rs` so existing integration tests keep using the same names.
- Lower the tracked Rust cleanup threshold from 400 to 305 lines after reducing the only file above that cap.

## Result
- `tests/integration/support.rs`: 307 -> 128 lines.
- New generated-C support module: 188 lines.
- Largest tracked Rust file after the split is 303 lines.

## Validation
- TDD guard first: `cargo test --test docs_truth production_rust_files_stay_below_cleanup_threshold -- --nocapture` failed on `tests/integration/support.rs` at 307 lines before the split.
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Push workflow guard: `gh run list --repo lantos1618/zenlang --branch codex/split-integration-generated-c-support --event push --limit 10 --json databaseId,status,conclusion,workflowName,headSha,createdAt,url` returned `[]`.