### PR TITLE
[codex] Split resolver expr local tests

### DIFF
--- a/tests/docs_truth/repo_hygiene/file_size.rs
+++ b/tests/docs_truth/repo_hygiene/file_size.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[test]
 fn production_rust_files_stay_below_cleanup_threshold() {
-    const MAX_LINES: usize = 305;
+    const MAX_LINES: usize = 300;
 
     let output = std::process::Command::new("git")
         .args(["ls-files", "*.rs"])

--- a/tests/resolver_phase2/expr_locals.rs
+++ b/tests/resolver_phase2/expr_locals.rs
@@ -1,5 +1,10 @@
 use super::*;
 
+#[path = "expr_locals/closures.rs"]
+mod closures;
+#[path = "expr_locals/patterns.rs"]
+mod patterns;
+
 #[test]
 fn resolver_rejects_unknown_unqualified_function_calls() {
     let program = parse_program(
@@ -139,90 +144,6 @@ main = () i32 {
             .contains("enum variant `Maybe.None` does not accept a payload")),
         "expected unexpected enum variant payload diagnostic, got {err:?}"
     );
-}
-
-#[test]
-fn resolver_records_closure_locals() {
-    let program = parse_program(
-        r#"
-main = () i32 {
-    mapper = (input: i32) i32 {
-        inner = input
-        inner
-    }
-    0
-}
-"#,
-    );
-
-    let table = Resolver::new().resolve_program(&program).expect("resolve");
-    let mapper = table
-        .lookup_scoped(Namespace::Local, "mapper")
-        .expect("closure binding local symbol");
-    let input = table
-        .lookup_scoped(Namespace::Local, "input")
-        .expect("closure parameter local symbol");
-    let inner = table
-        .lookup_scoped(Namespace::Local, "inner")
-        .expect("closure body local symbol");
-
-    assert_ne!(mapper.scope_id, input.scope_id);
-    assert_ne!(input.scope_id, inner.scope_id);
-    assert!(inner.scope_id > input.scope_id);
-    assert_eq!(mapper.is_mutable, Some(false));
-    assert_eq!(input.is_mutable, Some(false));
-    assert_eq!(inner.is_mutable, Some(false));
-}
-
-#[test]
-fn resolver_records_mutable_closure_parameter_locals() {
-    let program = parse_program(
-        r#"
-main = () i32 {
-    mapper = (mut input: i32) i32 {
-        input = input + 1
-        input
-    }
-    0
-}
-"#,
-    );
-
-    let table = Resolver::new().resolve_program(&program).expect("resolve");
-    let input = table
-        .lookup_scoped(Namespace::Local, "input")
-        .expect("closure parameter local symbol");
-
-    assert_eq!(input.is_mutable, Some(true));
-}
-
-#[test]
-fn resolver_records_pattern_locals() {
-    let program = parse_program(
-        r#"
-Option:
-    None,
-    Some(i32)
-
-main = (value: Option) i32 {
-    value ?
-        | Some(inner) { inner }
-        | None { 0 }
-}
-"#,
-    );
-
-    let table = Resolver::new().resolve_program(&program).expect("resolve");
-    let value = table
-        .lookup_scoped(Namespace::Local, "value")
-        .expect("parameter local symbol");
-    let inner = table
-        .lookup_scoped(Namespace::Local, "inner")
-        .expect("pattern local symbol");
-
-    assert_ne!(value.scope_id, inner.scope_id);
-    assert_eq!(inner.is_mutable, Some(false));
-    assert!(inner.scope_id > value.scope_id);
 }
 
 #[test]

--- a/tests/resolver_phase2/expr_locals/closures.rs
+++ b/tests/resolver_phase2/expr_locals/closures.rs
@@ -1,0 +1,56 @@
+use super::*;
+
+#[test]
+fn resolver_records_closure_locals() {
+    let program = parse_program(
+        r#"
+main = () i32 {
+    mapper = (input: i32) i32 {
+        inner = input
+        inner
+    }
+    0
+}
+"#,
+    );
+
+    let table = Resolver::new().resolve_program(&program).expect("resolve");
+    let mapper = table
+        .lookup_scoped(Namespace::Local, "mapper")
+        .expect("closure binding local symbol");
+    let input = table
+        .lookup_scoped(Namespace::Local, "input")
+        .expect("closure parameter local symbol");
+    let inner = table
+        .lookup_scoped(Namespace::Local, "inner")
+        .expect("closure body local symbol");
+
+    assert_ne!(mapper.scope_id, input.scope_id);
+    assert_ne!(input.scope_id, inner.scope_id);
+    assert!(inner.scope_id > input.scope_id);
+    assert_eq!(mapper.is_mutable, Some(false));
+    assert_eq!(input.is_mutable, Some(false));
+    assert_eq!(inner.is_mutable, Some(false));
+}
+
+#[test]
+fn resolver_records_mutable_closure_parameter_locals() {
+    let program = parse_program(
+        r#"
+main = () i32 {
+    mapper = (mut input: i32) i32 {
+        input = input + 1
+        input
+    }
+    0
+}
+"#,
+    );
+
+    let table = Resolver::new().resolve_program(&program).expect("resolve");
+    let input = table
+        .lookup_scoped(Namespace::Local, "input")
+        .expect("closure parameter local symbol");
+
+    assert_eq!(input.is_mutable, Some(true));
+}

--- a/tests/resolver_phase2/expr_locals/patterns.rs
+++ b/tests/resolver_phase2/expr_locals/patterns.rs
@@ -1,0 +1,30 @@
+use super::*;
+
+#[test]
+fn resolver_records_pattern_locals() {
+    let program = parse_program(
+        r#"
+Option:
+    None,
+    Some(i32)
+
+main = (value: Option) i32 {
+    value ?
+        | Some(inner) { inner }
+        | None { 0 }
+}
+"#,
+    );
+
+    let table = Resolver::new().resolve_program(&program).expect("resolve");
+    let value = table
+        .lookup_scoped(Namespace::Local, "value")
+        .expect("parameter local symbol");
+    let inner = table
+        .lookup_scoped(Namespace::Local, "inner")
+        .expect("pattern local symbol");
+
+    assert_ne!(value.scope_id, inner.scope_id);
+    assert_eq!(inner.is_mutable, Some(false));
+    assert!(inner.scope_id > value.scope_id);
+}


### PR DESCRIPTION
## Summary
- Move closure-local resolver tests into `tests/resolver_phase2/expr_locals/closures.rs`.
- Move pattern-local resolver tests into `tests/resolver_phase2/expr_locals/patterns.rs`.
- Keep `expr_locals.rs` focused on core local symbol and enum variant expression diagnostics.
- Lower the tracked Rust cleanup threshold from 305 to 300 lines after reducing the only file above that cap.

## Result
- `tests/resolver_phase2/expr_locals.rs`: 303 -> 224 lines.
- New focused modules: 56 and 30 lines.
- Largest tracked Rust file after the split is 300 lines.

## Validation
- TDD guard first: `cargo test --test docs_truth production_rust_files_stay_below_cleanup_threshold -- --nocapture` failed on `tests/resolver_phase2/expr_locals.rs` at 303 lines before the split.
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --lib`
- `cargo test --tests`
- Push workflow guard: `gh run list --repo lantos1618/zenlang --branch codex/split-resolver-expr-local-tests --event push --limit 10 --json databaseId,status,conclusion,workflowName,headSha,createdAt,url` returned `[]`.