### PR TITLE
[codex] Split comptime intrinsic gate tests

### DIFF
--- a/src/typechecker/tests/core_semantics/intrinsic_gates.rs
+++ b/src/typechecker/tests/core_semantics/intrinsic_gates.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod type_match;
+
 #[test]
 fn async_scheduler_intrinsics_are_rejected_as_gated_not_unknown() {
     let program = parse_program(
@@ -232,69 +234,5 @@ main = () void {
         err.iter()
             .all(|d| !d.message.contains("unknown function `@builtin.syscall")),
         "syscall gates should not be reported as ordinary unknown builtins, got {err:?}"
-    );
-}
-
-#[test]
-fn comptime_type_match_intrinsic_is_rejected_as_gated_not_unknown() {
-    let program = parse_program(
-        r#"
-Point: { x: i32 }
-
-main = () void {
-    @builtin.type_match<Point>()
-}
-"#,
-    );
-    let mut tc = TypeChecker::new();
-
-    let err = tc.check_program(&program).expect_err(
-        "comptime type matching should stay gated until typed metadata lowering exists",
-    );
-
-    assert!(
-        err.iter()
-            .any(|d| d.message.contains("comptime type matching is gated")),
-        "expected type-match gate diagnostic, got {err:?}"
-    );
-    assert!(
-        err.iter()
-            .all(|d| !d.message.contains("unknown function `@builtin.type_match`")),
-        "type-match gate should not be reported as an ordinary unknown builtin, got {err:?}"
-    );
-}
-
-#[test]
-fn primitive_and_enum_type_match_intrinsics_are_rejected_as_gated_not_unknown() {
-    let program = parse_program(
-        r#"
-Choice:
-    First,
-    Second
-
-main = () void {
-    @builtin.type_match<i32>()
-    @builtin.type_match<Choice>()
-}
-"#,
-    );
-    let mut tc = TypeChecker::new();
-
-    let err = tc.check_program(&program).expect_err(
-        "primitive and enum comptime type matching should stay gated until typed metadata lowering exists",
-    );
-
-    let type_match_gate_count = err
-        .iter()
-        .filter(|d| d.message.contains("comptime type matching is gated"))
-        .count();
-    assert_eq!(
-        type_match_gate_count, 2,
-        "expected primitive and enum type-match calls to both report gates, got {err:?}"
-    );
-    assert!(
-        err.iter()
-            .all(|d| !d.message.contains("unknown function `@builtin.type_match`")),
-        "primitive/enum type-match gates should not be reported as ordinary unknown builtins, got {err:?}"
     );
 }

--- a/src/typechecker/tests/core_semantics/intrinsic_gates/type_match.rs
+++ b/src/typechecker/tests/core_semantics/intrinsic_gates/type_match.rs
@@ -1,0 +1,65 @@
+use super::*;
+
+#[test]
+fn comptime_type_match_intrinsic_is_rejected_as_gated_not_unknown() {
+    let program = parse_program(
+        r#"
+Point: { x: i32 }
+
+main = () void {
+    @builtin.type_match<Point>()
+}
+"#,
+    );
+    let mut tc = TypeChecker::new();
+
+    let err = tc.check_program(&program).expect_err(
+        "comptime type matching should stay gated until typed metadata lowering exists",
+    );
+
+    assert!(
+        err.iter()
+            .any(|d| d.message.contains("comptime type matching is gated")),
+        "expected type-match gate diagnostic, got {err:?}"
+    );
+    assert!(
+        err.iter()
+            .all(|d| !d.message.contains("unknown function `@builtin.type_match`")),
+        "type-match gate should not be reported as an ordinary unknown builtin, got {err:?}"
+    );
+}
+
+#[test]
+fn primitive_and_enum_type_match_intrinsics_are_rejected_as_gated_not_unknown() {
+    let program = parse_program(
+        r#"
+Choice:
+    First,
+    Second
+
+main = () void {
+    @builtin.type_match<i32>()
+    @builtin.type_match<Choice>()
+}
+"#,
+    );
+    let mut tc = TypeChecker::new();
+
+    let err = tc.check_program(&program).expect_err(
+        "primitive and enum comptime type matching should stay gated until typed metadata lowering exists",
+    );
+
+    let type_match_gate_count = err
+        .iter()
+        .filter(|d| d.message.contains("comptime type matching is gated"))
+        .count();
+    assert_eq!(
+        type_match_gate_count, 2,
+        "expected primitive and enum type-match calls to both report gates, got {err:?}"
+    );
+    assert!(
+        err.iter()
+            .all(|d| !d.message.contains("unknown function `@builtin.type_match`")),
+        "primitive/enum type-match gates should not be reported as ordinary unknown builtins, got {err:?}"
+    );
+}

--- a/tests/docs_truth/repo_hygiene/file_size.rs
+++ b/tests/docs_truth/repo_hygiene/file_size.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[test]
 fn production_rust_files_stay_below_cleanup_threshold() {
-    const MAX_LINES: usize = 300;
+    const MAX_LINES: usize = 299;
 
     let output = std::process::Command::new("git")
         .args(["ls-files", "*.rs"])


### PR DESCRIPTION
## Summary
- split comptime `@builtin.type_match` intrinsic gate tests into a focused `type_match` module
- lowered the tracked Rust file-size guard from 300 lines to 299 lines
- kept the former 300-line intrinsic gate test file at 238 lines; largest tracked Rust file is now 296 lines

## Validation
- TDD guard failed before the split: `src/typechecker/tests/core_semantics/intrinsic_gates.rs has 300 lines; split focused helpers before growing past 299`
- `cargo test --lib comptime_type_match_intrinsic_is_rejected_as_gated_not_unknown -- --nocapture`
- `cargo test --lib type_match_intrinsics -- --nocapture`
- `cargo test --test docs_truth production_rust_files_stay_below_cleanup_threshold -- --nocapture`
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- branch push Actions check: `gh run list --repo lantos1618/zenlang --branch codex/split-comptime-intrinsic-gates --event push ...` returned `[]`