### PR TITLE
[codex] Split resolver expected-local pattern tests

### DIFF
--- a/src/typechecker/tests/resolver_validation/expected_locals.rs
+++ b/src/typechecker/tests/resolver_validation/expected_locals.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod patterns;
+
 #[test]
 fn expected_resolver_impl_method_symbols_collect_value_symbols_and_locals() {
     let program = parse_program(
@@ -110,88 +112,6 @@ main = () i32 {
     expected_resolver_child_expr_locals(body, &mut scope_cursor, &locals, &mut expected);
 
     assert!(expected.iter().any(|(name, _)| name == "value"));
-}
-
-#[test]
-fn expected_resolver_pattern_expr_locals_collects_pattern_and_body_bindings() {
-    let program = parse_program(
-        r#"
-Option:
-    None,
-    Some(i32)
-
-main = (value: Option) i32 {
-    value ?
-        | Some(inner) {
-            doubled := inner
-            doubled
-        }
-        | None { 0 }
-}
-"#,
-    );
-    let Declaration::Function { body, .. } = &program.declarations[1] else {
-        panic!("expected function");
-    };
-    let Expression::Block {
-        expr: Some(expr), ..
-    } = body
-    else {
-        panic!("expected block");
-    };
-    let Expression::Match { arms, .. } = expr.as_ref() else {
-        panic!("expected match expression");
-    };
-    let arm = arms.first().expect("first match arm");
-    let mut scope_cursor = ResolverScopeCursor::default();
-    let locals = scope_cursor.new_scope();
-    let mut expected = HashSet::new();
-
-    expected_resolver_pattern_expr_locals(
-        &arm.pattern,
-        &arm.body,
-        &mut scope_cursor,
-        &locals,
-        &mut expected,
-    );
-
-    assert!(expected.iter().any(|(name, _)| name == "inner"));
-    assert!(expected.iter().any(|(name, _)| name == "doubled"));
-}
-
-#[test]
-fn expected_resolver_pattern_locals_collects_struct_shorthand_bindings() {
-    let program = parse_program(
-        r#"
-Point: { x: i32, y: i32 }
-
-main = (point: Point) i32 {
-    point ?
-        | Point { x, y } { x + y }
-}
-"#,
-    );
-    let Declaration::Function { body, .. } = &program.declarations[1] else {
-        panic!("expected function");
-    };
-    let Expression::Block {
-        expr: Some(expr), ..
-    } = body
-    else {
-        panic!("expected block");
-    };
-    let Expression::Match { arms, .. } = expr.as_ref() else {
-        panic!("expected match expression");
-    };
-    let arm = arms.first().expect("first match arm");
-    let mut scope_cursor = ResolverScopeCursor::default();
-    let mut locals = scope_cursor.new_scope();
-    let mut expected = HashSet::new();
-
-    expected_resolver_pattern_locals(&arm.pattern, &mut scope_cursor, &mut locals, &mut expected);
-
-    assert!(expected.iter().any(|(name, _)| name == "x"));
-    assert!(expected.iter().any(|(name, _)| name == "y"));
 }
 
 #[test]

--- a/src/typechecker/tests/resolver_validation/expected_locals/patterns.rs
+++ b/src/typechecker/tests/resolver_validation/expected_locals/patterns.rs
@@ -1,0 +1,83 @@
+use super::*;
+
+#[test]
+fn expected_resolver_pattern_expr_locals_collects_pattern_and_body_bindings() {
+    let program = parse_program(
+        r#"
+Option:
+    None,
+    Some(i32)
+
+main = (value: Option) i32 {
+    value ?
+        | Some(inner) {
+            doubled := inner
+            doubled
+        }
+        | None { 0 }
+}
+"#,
+    );
+    let Declaration::Function { body, .. } = &program.declarations[1] else {
+        panic!("expected function");
+    };
+    let Expression::Block {
+        expr: Some(expr), ..
+    } = body
+    else {
+        panic!("expected block");
+    };
+    let Expression::Match { arms, .. } = expr.as_ref() else {
+        panic!("expected match expression");
+    };
+    let arm = arms.first().expect("first match arm");
+    let mut scope_cursor = ResolverScopeCursor::default();
+    let locals = scope_cursor.new_scope();
+    let mut expected = HashSet::new();
+
+    expected_resolver_pattern_expr_locals(
+        &arm.pattern,
+        &arm.body,
+        &mut scope_cursor,
+        &locals,
+        &mut expected,
+    );
+
+    assert!(expected.iter().any(|(name, _)| name == "inner"));
+    assert!(expected.iter().any(|(name, _)| name == "doubled"));
+}
+
+#[test]
+fn expected_resolver_pattern_locals_collects_struct_shorthand_bindings() {
+    let program = parse_program(
+        r#"
+Point: { x: i32, y: i32 }
+
+main = (point: Point) i32 {
+    point ?
+        | Point { x, y } { x + y }
+}
+"#,
+    );
+    let Declaration::Function { body, .. } = &program.declarations[1] else {
+        panic!("expected function");
+    };
+    let Expression::Block {
+        expr: Some(expr), ..
+    } = body
+    else {
+        panic!("expected block");
+    };
+    let Expression::Match { arms, .. } = expr.as_ref() else {
+        panic!("expected match expression");
+    };
+    let arm = arms.first().expect("first match arm");
+    let mut scope_cursor = ResolverScopeCursor::default();
+    let mut locals = scope_cursor.new_scope();
+    let mut expected = HashSet::new();
+
+    expected_resolver_pattern_locals(&arm.pattern, &mut scope_cursor, &mut locals, &mut expected);
+
+    assert!(expected.iter().any(|(name, _)| name == "x"));
+    assert!(expected.iter().any(|(name, _)| name == "y"));
+}

--- a/tests/docs_truth/repo_hygiene/file_size.rs
+++ b/tests/docs_truth/repo_hygiene/file_size.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[test]
 fn production_rust_files_stay_below_cleanup_threshold() {
-    const MAX_LINES: usize = 299;
+    const MAX_LINES: usize = 295;
 
     let output = std::process::Command::new("git")
         .args(["ls-files", "*.rs"])


### PR DESCRIPTION
## Summary
- split resolver expected-local pattern tests into a focused `expected_locals::patterns` module
- reduced `expected_locals.rs` from 296 lines to 216 lines
- tightened the tracked Rust file-size guard from 299 lines to 295 lines

## Result
- new focused pattern-local module is 83 lines
- largest tracked Rust files are now 294 lines

## Validation
- TDD guard failed before the split: `src/typechecker/tests/resolver_validation/expected_locals.rs has 296 lines; split focused helpers before growing past 295`
- `cargo test --lib expected_resolver_pattern -- --nocapture`
- `cargo test --test docs_truth production_rust_files_stay_below_cleanup_threshold -- --nocapture`
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- branch push Actions check returned `[]`