### PR TITLE
[codex] Split resolver validation doc guards

### DIFF
--- a/tests/docs_truth/repo_hygiene/file_size.rs
+++ b/tests/docs_truth/repo_hygiene/file_size.rs
@@ -63,6 +63,16 @@ fn zen_source_files_stay_below_cleanup_threshold() {
 }
 
 #[test]
+fn resolver_validation_docs_truth_stays_split_across_focused_modules() {
+    let root = read("tests/docs_truth/repo_hygiene/typechecker_resolver_validation.rs");
+
+    assert!(
+        root.lines().count() < 260,
+        "typechecker resolver-validation docs-truth guards should stay split across focused modules"
+    );
+}
+
+#[test]
 fn resolver_metadata_queue_selection_tests_live_in_focused_helper() {
     let helper = read("src/typechecker/tests/resolver_metadata/impl_and_method_helpers.rs");
     let queue_helper = read("src/typechecker/tests/resolver_metadata/queue_selection.rs");

--- a/tests/docs_truth/repo_hygiene/typechecker_resolver_validation.rs
+++ b/tests/docs_truth/repo_hygiene/typechecker_resolver_validation.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 mod focused_modules;
+mod support_helpers;
 
 #[test]
 fn typechecker_resolver_validation_post_pass_lives_in_focused_helper() {
@@ -147,57 +148,6 @@ fn typechecker_resolver_type_parameter_helpers_live_in_focused_helper() {
     assert!(
         root.contains("include!(\"resolver_validation_support/resolver_type_parameters.rs\");"),
         "resolver validation support should include focused resolver type-parameter helpers"
-    );
-}
-
-#[test]
-fn typechecker_resolver_expected_formatting_lives_in_focused_helper() {
-    let root = read("src/typechecker/resolver_validation_support.rs");
-    let helpers = read("src/typechecker/resolver_validation_support/expected_helpers.rs");
-    let formatting = read("src/typechecker/resolver_validation_support/expected_formatting.rs");
-
-    for helper in [
-        "visibility_name",
-        "mutability_name",
-        "resolver_count_display",
-        "resolver_metadata_display",
-        "resolver_ast_type_metadata_display",
-        "optional_ast_type_display",
-        "format_type_parameter_names",
-        "format_type_parameter_bounds",
-        "format_type_parameter_bound_refs",
-        "format_parameter_type_names",
-        "format_ast_type_list",
-        "format_parameter_names",
-        "format_field_types",
-        "format_field_type_names",
-        "format_variant_names",
-        "format_resolver_string_list",
-        "format_resolver_display_list",
-        "join_resolver_strings",
-        "join_resolver_display_values",
-        "format_resolver_named_list",
-        "format_behavior_method_signatures",
-        "format_behavior_method_types",
-        "format_behavior_ref_names",
-        "format_behavior_refs",
-        "format_resolver_nonempty_joined_list",
-        "behavior_ref_names_match",
-        "behavior_refs_match",
-    ] {
-        assert!(
-            !helpers.contains(&format!("fn {helper}")),
-            "expected_helpers.rs should not own resolver formatting helper: {helper}"
-        );
-        assert!(
-            formatting.contains(&format!("fn {helper}")),
-            "resolver expected formatting should live in focused helper: {helper}"
-        );
-    }
-
-    assert!(
-        root.contains("include!(\"resolver_validation_support/expected_formatting.rs\");"),
-        "resolver validation support should include focused expected formatting helper"
     );
 }
 

--- a/tests/docs_truth/repo_hygiene/typechecker_resolver_validation/support_helpers.rs
+++ b/tests/docs_truth/repo_hygiene/typechecker_resolver_validation/support_helpers.rs
@@ -1,0 +1,52 @@
+use super::*;
+
+#[test]
+fn typechecker_resolver_expected_formatting_lives_in_focused_helper() {
+    let root = read("src/typechecker/resolver_validation_support.rs");
+    let helpers = read("src/typechecker/resolver_validation_support/expected_helpers.rs");
+    let formatting = read("src/typechecker/resolver_validation_support/expected_formatting.rs");
+
+    for helper in [
+        "visibility_name",
+        "mutability_name",
+        "resolver_count_display",
+        "resolver_metadata_display",
+        "resolver_ast_type_metadata_display",
+        "optional_ast_type_display",
+        "format_type_parameter_names",
+        "format_type_parameter_bounds",
+        "format_type_parameter_bound_refs",
+        "format_parameter_type_names",
+        "format_ast_type_list",
+        "format_parameter_names",
+        "format_field_types",
+        "format_field_type_names",
+        "format_variant_names",
+        "format_resolver_string_list",
+        "format_resolver_display_list",
+        "join_resolver_strings",
+        "join_resolver_display_values",
+        "format_resolver_named_list",
+        "format_behavior_method_signatures",
+        "format_behavior_method_types",
+        "format_behavior_ref_names",
+        "format_behavior_refs",
+        "format_resolver_nonempty_joined_list",
+        "behavior_ref_names_match",
+        "behavior_refs_match",
+    ] {
+        assert!(
+            !helpers.contains(&format!("fn {helper}")),
+            "expected_helpers.rs should not own resolver formatting helper: {helper}"
+        );
+        assert!(
+            formatting.contains(&format!("fn {helper}")),
+            "resolver expected formatting should live in focused helper: {helper}"
+        );
+    }
+
+    assert!(
+        root.contains("include!(\"resolver_validation_support/expected_formatting.rs\");"),
+        "resolver validation support should include focused expected formatting helper"
+    );
+}


### PR DESCRIPTION
## Summary
- moved the resolver expected-formatting docs-truth guard into a focused `support_helpers` module
- reduced `tests/docs_truth/repo_hygiene/typechecker_resolver_validation.rs` from 294 lines to 244 lines
- added a focused guard requiring the resolver-validation docs-truth root to stay under 260 lines

## Validation
- TDD guard failed before the split: `typechecker resolver-validation docs-truth guards should stay split across focused modules`
- `cargo test --test docs_truth typechecker_resolver_expected_formatting_lives_in_focused_helper -- --nocapture`
- `cargo test --test docs_truth resolver_validation_docs_truth_stays_split_across_focused_modules -- --nocapture`
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- branch push Actions check returned `[]`