### PR TITLE
[codex] Split resolver type metadata default tests

### DIFF
--- a/src/typechecker/tests/resolver_collection/type_metadata.rs
+++ b/src/typechecker/tests/resolver_collection/type_metadata.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 mod enum_metadata;
+mod struct_defaults;
 
 #[test]
 fn collect_declarations_with_symbols_uses_resolver_struct_field_metadata() {
@@ -68,141 +69,6 @@ Point: { x: i32 }
 
     assert!(tc.structs.contains_key("Point"));
     assert!(!tc.structs.contains_key("Missing"));
-}
-
-#[test]
-fn collect_declarations_with_symbols_uses_resolver_struct_field_names_for_defaults() {
-    let mut program = parse_program(
-        r#"
-Point: { x: i32 = true }
-"#,
-    );
-    let symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    if let Declaration::Struct { fields, .. } = &mut program.declarations[0] {
-        fields[0].name = "stale".to_string();
-    }
-    let mut tc = TypeChecker::new();
-
-    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
-
-    assert!(
-        tc.diagnostics.iter().any(|diag| {
-            diag.code == "E3073"
-                && diag
-                    .message
-                    .contains("field `x` default expects `i32`, found `bool`")
-        }),
-        "resolver-backed default validation should use resolver-restored field names: {:?}",
-        tc.diagnostics
-    );
-}
-
-#[test]
-fn resolver_struct_field_defaults_validate_from_semantic_tasks() {
-    let program = parse_program(
-        r#"
-Point: { x: i32 = true }
-"#,
-    );
-    let symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    let tasks =
-        TypeChecker::collect_resolver_declaration_semantic_validation_tasks(&program.declarations);
-    let mut stale_declarations = program.declarations.clone();
-    if let Declaration::Struct { fields, .. } = &mut stale_declarations[0] {
-        fields.clear();
-    }
-    let mut tc = TypeChecker::new();
-    tc.with_resolver_backed_collection(|checker| checker.collect_declarations(&stale_declarations));
-    let metadata_tasks =
-        TypeChecker::collect_resolver_declaration_metadata_tasks(&program.declarations);
-    tc.collect_resolver_declaration_metadata(&symbols, &metadata_tasks);
-
-    tc.with_resolver_backed_collection(|checker| {
-        checker.validate_resolver_declaration_semantics_from_semantic_tasks(&tasks, Some(&symbols));
-    });
-
-    assert!(
-        tc.diagnostics.iter().any(|diag| {
-            diag.code == "E3073"
-                && diag
-                    .message
-                    .contains("field `x` default expects `i32`, found `bool`")
-        }),
-        "resolver-backed default validation should use semantic validation tasks: {:?}",
-        tc.diagnostics
-    );
-}
-
-#[test]
-fn resolver_backed_struct_field_defaults_use_semantic_tasks() {
-    let program = parse_program(
-        r#"
-Point: { x: i32 = true }
-"#,
-    );
-    let symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    let mut stale_declarations = program.declarations.clone();
-    if let Declaration::Struct { fields, .. } = &mut stale_declarations[0] {
-        fields.clear();
-    }
-    let mut tc = TypeChecker::new();
-    tc.with_resolver_backed_collection(|checker| checker.collect_declarations(&stale_declarations));
-    let tasks = TypeChecker::collect_resolver_declaration_metadata_tasks(&program.declarations);
-    tc.collect_resolver_declaration_metadata(&symbols, &tasks);
-
-    tc.with_resolver_backed_collection(|checker| {
-        checker.validate_struct_field_defaults(&program.declarations, Some(&symbols));
-    });
-
-    assert!(
-        tc.diagnostics.iter().any(|diag| {
-            diag.code == "E3073"
-                && diag
-                    .message
-                    .contains("field `x` default expects `i32`, found `bool`")
-        }),
-        "resolver-backed default validation should use focused semantic tasks: {:?}",
-        tc.diagnostics
-    );
-}
-
-#[test]
-fn resolver_backed_semantic_validation_uses_semantic_tasks() {
-    let program = parse_program(
-        r#"
-Point: { x: i32 = true }
-"#,
-    );
-    let symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    let tasks = TypeChecker::collect_resolver_declaration_metadata_tasks(&program.declarations);
-    let mut tc = TypeChecker::new();
-    tc.with_resolver_backed_collection(|checker| {
-        checker.collect_declarations(&program.declarations)
-    });
-    tc.collect_resolver_declaration_metadata(&symbols, &tasks);
-
-    tc.with_resolver_backed_collection(|checker| {
-        checker.validate_collected_declaration_semantics(&program.declarations, Some(&symbols));
-    });
-
-    assert!(
-        tc.diagnostics.iter().any(|diag| {
-            diag.code == "E3073"
-                && diag
-                    .message
-                    .contains("field `x` default expects `i32`, found `bool`")
-        }),
-        "resolver-backed semantic validation should use resolver semantic tasks: {:?}",
-        tc.diagnostics
-    );
 }
 
 #[test]

--- a/src/typechecker/tests/resolver_collection/type_metadata/struct_defaults.rs
+++ b/src/typechecker/tests/resolver_collection/type_metadata/struct_defaults.rs
@@ -1,0 +1,136 @@
+use super::*;
+
+#[test]
+fn collect_declarations_with_symbols_uses_resolver_struct_field_names_for_defaults() {
+    let mut program = parse_program(
+        r#"
+Point: { x: i32 = true }
+"#,
+    );
+    let symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    if let Declaration::Struct { fields, .. } = &mut program.declarations[0] {
+        fields[0].name = "stale".to_string();
+    }
+    let mut tc = TypeChecker::new();
+
+    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
+
+    assert!(
+        tc.diagnostics.iter().any(|diag| {
+            diag.code == "E3073"
+                && diag
+                    .message
+                    .contains("field `x` default expects `i32`, found `bool`")
+        }),
+        "resolver-backed default validation should use resolver-restored field names: {:?}",
+        tc.diagnostics
+    );
+}
+
+#[test]
+fn resolver_struct_field_defaults_validate_from_semantic_tasks() {
+    let program = parse_program(
+        r#"
+Point: { x: i32 = true }
+"#,
+    );
+    let symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    let tasks =
+        TypeChecker::collect_resolver_declaration_semantic_validation_tasks(&program.declarations);
+    let mut stale_declarations = program.declarations.clone();
+    if let Declaration::Struct { fields, .. } = &mut stale_declarations[0] {
+        fields.clear();
+    }
+    let mut tc = TypeChecker::new();
+    tc.with_resolver_backed_collection(|checker| checker.collect_declarations(&stale_declarations));
+    let metadata_tasks =
+        TypeChecker::collect_resolver_declaration_metadata_tasks(&program.declarations);
+    tc.collect_resolver_declaration_metadata(&symbols, &metadata_tasks);
+
+    tc.with_resolver_backed_collection(|checker| {
+        checker.validate_resolver_declaration_semantics_from_semantic_tasks(&tasks, Some(&symbols));
+    });
+
+    assert!(
+        tc.diagnostics.iter().any(|diag| {
+            diag.code == "E3073"
+                && diag
+                    .message
+                    .contains("field `x` default expects `i32`, found `bool`")
+        }),
+        "resolver-backed default validation should use semantic validation tasks: {:?}",
+        tc.diagnostics
+    );
+}
+
+#[test]
+fn resolver_backed_struct_field_defaults_use_semantic_tasks() {
+    let program = parse_program(
+        r#"
+Point: { x: i32 = true }
+"#,
+    );
+    let symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    let mut stale_declarations = program.declarations.clone();
+    if let Declaration::Struct { fields, .. } = &mut stale_declarations[0] {
+        fields.clear();
+    }
+    let mut tc = TypeChecker::new();
+    tc.with_resolver_backed_collection(|checker| checker.collect_declarations(&stale_declarations));
+    let tasks = TypeChecker::collect_resolver_declaration_metadata_tasks(&program.declarations);
+    tc.collect_resolver_declaration_metadata(&symbols, &tasks);
+
+    tc.with_resolver_backed_collection(|checker| {
+        checker.validate_struct_field_defaults(&program.declarations, Some(&symbols));
+    });
+
+    assert!(
+        tc.diagnostics.iter().any(|diag| {
+            diag.code == "E3073"
+                && diag
+                    .message
+                    .contains("field `x` default expects `i32`, found `bool`")
+        }),
+        "resolver-backed default validation should use focused semantic tasks: {:?}",
+        tc.diagnostics
+    );
+}
+
+#[test]
+fn resolver_backed_semantic_validation_uses_semantic_tasks() {
+    let program = parse_program(
+        r#"
+Point: { x: i32 = true }
+"#,
+    );
+    let symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    let tasks = TypeChecker::collect_resolver_declaration_metadata_tasks(&program.declarations);
+    let mut tc = TypeChecker::new();
+    tc.with_resolver_backed_collection(|checker| {
+        checker.collect_declarations(&program.declarations)
+    });
+    tc.collect_resolver_declaration_metadata(&symbols, &tasks);
+
+    tc.with_resolver_backed_collection(|checker| {
+        checker.validate_collected_declaration_semantics(&program.declarations, Some(&symbols));
+    });
+
+    assert!(
+        tc.diagnostics.iter().any(|diag| {
+            diag.code == "E3073"
+                && diag
+                    .message
+                    .contains("field `x` default expects `i32`, found `bool`")
+        }),
+        "resolver-backed semantic validation should use resolver semantic tasks: {:?}",
+        tc.diagnostics
+    );
+}

--- a/tests/docs_truth/repo_hygiene/file_size.rs
+++ b/tests/docs_truth/repo_hygiene/file_size.rs
@@ -73,6 +73,16 @@ fn resolver_validation_docs_truth_stays_split_across_focused_modules() {
 }
 
 #[test]
+fn resolver_collection_type_metadata_tests_stay_split_by_responsibility() {
+    let root = read("src/typechecker/tests/resolver_collection/type_metadata.rs");
+
+    assert!(
+        root.lines().count() < 260,
+        "resolver collection type metadata tests should stay split by focused responsibility"
+    );
+}
+
+#[test]
 fn resolver_metadata_queue_selection_tests_live_in_focused_helper() {
     let helper = read("src/typechecker/tests/resolver_metadata/impl_and_method_helpers.rs");
     let queue_helper = read("src/typechecker/tests/resolver_metadata/queue_selection.rs");


### PR DESCRIPTION
## Summary
- moved resolver-backed struct field default metadata tests into a focused `type_metadata::struct_defaults` module
- reduced `type_metadata.rs` from 294 lines to 160 lines
- added a docs-truth guard requiring the resolver collection type metadata root to stay split by responsibility

## Validation
- TDD guard failed before the split: `resolver collection type metadata tests should stay split by focused responsibility`
- `cargo test --lib resolver_backed_struct_field_defaults -- --nocapture`
- `cargo test --lib type_metadata::struct_defaults -- --nocapture`
- `cargo test --test docs_truth resolver_collection_type_metadata_tests_stay_split_by_responsibility -- --nocapture`
- `cargo fmt --check && git diff --check && cargo test --test docs_truth -- --nocapture && cargo clippy -- -D warnings && cargo test --lib && cargo test --tests`
- branch push Actions check returned `[]`