### PR TITLE
[codex] Compact learn guide

### DIFF
--- a/docs/learn_zen_in_y_minutes.md
+++ b/docs/learn_zen_in_y_minutes.md
@@ -1,13 +1,13 @@
 # Learn Zen In Y Minutes
-Zen is a systems language for explicit programs: declarations are prefix-first,
-blocks produce their final expression, pattern matching is the branch form,
-loops use explicit control handles, and ownership/effects stay visible in types.
+Zen is a systems language for explicit programs: prefix-first declarations,
+final-expression blocks, pattern matching, explicit loop handles, and visible
+ownership/effects.
 Use this page as the quick language tour. Stable examples can be copied today.
 Preview examples cover gated surfaces: allocator-backed strings, sync/async
 effects, raw memory, actors, and comptime type matching.
 
 ## The Shape
-Declarations are prefix-first. The name being introduced or changed comes first:
+Declarations are prefix-first; names come first:
 
 | Need | Spell it like this |
 | --- | --- |
@@ -32,7 +32,6 @@ Local bindings are immutable by default. Use `::=` for mutable inferred locals;
 plain `=` then assigns a new value. Zen does not use a `return` keyword.
 Function bodies, match arms, and nested blocks produce their final expression.
 Numeric conversions are explicit and prefix-first: `cast(value, Type)`.
-
 String literals are `StaticString`, not allocator-backed strings.
 `StaticString` is baked into the program: static bytes plus a fixed byte count
 known after compilation. Passing it around copies a pointer-and-length view into
@@ -49,21 +48,19 @@ fields explicitly; field access uses dot syntax.
 ```zen
 Option<T>: None, Some(T)
 Result<T, E>: Ok(T), Err(E)
-
 unwrap_or<T> = (value: Option<T>, fallback: T) T {
     value ?
         | Some(inner) { inner }
         | None { fallback }
 }
 ```
-The `?` operator is the pattern-match form for bools, enums, `Option`, and `Result`.
-
+The `?` operator matches bools, enums, `Option`, and `Result`.
 ## Result And Error Handling
 Zen models failure with data. There are no exceptions and no null.
 Nested generic types are written directly, such as `Result<Option<i32>, StaticString>`.
 
 ## Behaviors
-Behaviors describe required methods. Generic functions use behavior bounds when they need a capability.
+Behaviors describe required methods; generic bounds name capabilities.
 
 ```zen
 Display: behavior { display: (Self) StaticString }
@@ -74,7 +71,7 @@ show<T: Display> = (value: T) StaticString {
     value.display()
 }
 ```
-Relationship declarations keep the changed type or behavior on the left:
+Relationships keep the changed type or behavior on the left:
 `Point.implements(Display)`, `Point.requires(Display)`, and
 `PrettyDisplay.extends(Display)`. There is no `impl Type for Behavior` spelling.
 
@@ -100,7 +97,6 @@ sum_to = (limit: i32) i32 {
 }
 ```
 Nested loop exit:
-
 ```zen
 loop((outer) {
     loop((inner) {
@@ -112,7 +108,6 @@ loop((outer) {
 })
 ```
 UFC loop control:
-
 ```zen
 loop((l) {
     done(l)
@@ -120,21 +115,20 @@ loop((l) {
 })
 ```
 There is no `while`, `for`, `break`, `continue`, suffix loop, or hidden result
-channel. Accumulated values live in explicit mutable bindings outside the loop.
+channel. State lives in mutable bindings outside the loop.
 
 ## Defer
 `defer` runs cleanup expressions before leaving the current scope.
 
 ## Imports And Modules
-Imports use destructuring-style binding from a module path; local files import by module name, and dotted paths resolve through subdirectories.
+Imports destructure from module paths; dotted paths resolve through subdirectories.
 
 ## Memory And Ownership
-Stable Zen does not hide heap allocation behind literals, interpolation, method calls, or generic containers. Heap APIs show the owner and allocator path.
-
+Stable Zen does not hide heap allocation behind literals, interpolation, calls, or containers. Heap APIs show the owner and allocator path.
 ```zen
 OwnedBytes<T, A>: { ptr: RawPtr<T>, len: usize, capacity: usize, allocator: A }
 ```
-Pointer, length, capacity, and allocator travel together; a pointer alone is just an address.
+Pointer, length, capacity, and allocator travel together.
 
 ## Sync, Async, And Allocator Preview
 `Sync` and `Async` are effect modes in type surfaces, not source keywords; there
@@ -155,23 +149,15 @@ Read the outer type first:
 | `Allocator<T, Async>` | allocation returns as task-shaped work |
 | `String<A>` | owned dynamic bytes plus allocator ownership |
 
-There is no hidden conversion between sync and async allocation. `Result<...>` is complete now; `Task<Result<...>>` completes later at a scheduler boundary.
-
-```zen
-Buffer<T, A: Allocator<T, Sync>>: { ptr: RawPtr<T>, len: usize, capacity: usize, allocator: A }
-make_buffer<T, A: Allocator<T, Sync>> = (allocator: A, len: usize) Result<Buffer<T, A>, AllocError> {
-    allocator.alloc(len) ?
-        | Ok(ptr) { Result<Buffer<T, A>, AllocError>.Ok(Buffer<T, A> { ptr: ptr, len: len, capacity: len, allocator: allocator }) }
-        | Err(error) { Result<Buffer<T, A>, AllocError>.Err(error) }
-}
-```
-Raw allocation intrinsics such as `@builtin.raw_allocate`, `@builtin.raw_deallocate`, and `@builtin.raw_reallocate` are compiler-owned preview names; stable source should not call them directly.
+There is no hidden conversion between sync and async allocation. `Result<...>` is complete now; `Task<Result<...>>` completes at a scheduler boundary.
+`make_buffer<T, A: Allocator<T, Sync>>` returns checked buffer data after matching `allocator.alloc(len)`.
+Raw allocation intrinsics (`@builtin.raw_allocate`, `@builtin.raw_deallocate`, `@builtin.raw_reallocate`) are compiler-owned preview names; stable source does not call them directly.
 
 ## Pointer, Slice, Array, Actor, And Comptime Preview
-`RawPtr<T>` is the raw-memory spelling used in allocator previews. `Ptr<T>`,
+`RawPtr<T>` is raw-memory spelling for allocator previews. `Ptr<T>`,
 `MutPtr<T>`, `Slice<T>`, and `[T; N]` name pointer, mutable pointer, slice, and
 fixed-array shapes. Raw pointer offset, casts, integer conversion, load, store,
-atomics, raw syscalls, comptime type matching, actor framework types, and scheduler operations stay gated until layout, ownership, effects, and runtime contracts are promoted.
+atomics, raw syscalls, comptime type matching, actor framework types, and scheduler operations stay gated.
 
 ## Translation Cheat Sheet
 | If you reach for | Use |
@@ -179,14 +165,10 @@ atomics, raw syscalls, comptime type matching, actor framework types, and schedu
 | keyword exit value | final expression |
 | `while condition { ... }` | `loop((l) { condition ? | true { ... l.next() } | false { l.done() } })` |
 | `for item in items { ... }` | explicit state plus `loop((l) { ... })` |
-| `break` | `l.done()` or `done(l)` |
-| `continue` | `l.next()` or `next(l)` |
 | `impl Type for Behavior` | `Type.implements(Behavior) { ... }` |
-| `extends Parent` keyword block | `Child.extends(Parent)` |
-| `requires Behavior` keyword block | `Type.requires(Behavior)` |
-| `async fn` | a function returning `Task<Result<T, E>>` or another task-shaped type |
+| `async fn` | function returning `Task<Result<T, E>>` |
 | string literal text | `StaticString` |
-| growable owned text | `String<A>` or another owner that carries allocator ownership |
+| growable owned text | `String<A>` |
 
 ## One Page Example
 ```zen
@@ -194,9 +176,7 @@ atomics, raw syscalls, comptime type matching, actor framework types, and schedu
 Display: behavior { display: (Self) StaticString }
 Point: { x: i32, y: i32 }
 Point.sum = (self: Point) i32 { self.x + self.y }
-Point.implements(Display) {
-    display = (self: Point) StaticString { "Point" }
-}
+Point.implements(Display) { display = (self: Point) StaticString { "Point" } }
 show<T: Display> = (value: T) StaticString { value.display() }
 main = () i32 {
     point = Point { x: 20, y: 22 }
@@ -207,5 +187,4 @@ main = () i32 {
 That example shows prefix declarations, typed data, attached methods, behavior
 implementations, bounded generics, expression-oriented control flow, static text,
 and explicit loop control.
-
 More to read: `README.md`, `examples/README.md`, and `docs/V1_SPEC.md`.

--- a/tests/docs_truth/public_docs/learn_zen.rs
+++ b/tests/docs_truth/public_docs/learn_zen.rs
@@ -108,7 +108,12 @@ fn learn_zen_guide_covers_core_tour_and_gated_previews() {
     }
 
     assert!(
-        guide.lines().count() <= 215,
+        guide.lines().count() <= 190,
         "Learn guide should stay compact; move detailed status or evidence to phase docs and tests"
+    );
+
+    assert!(
+        guide.split_whitespace().count() <= 1150,
+        "Learn guide should stay concise enough to paste into model context"
     );
 }


### PR DESCRIPTION
## Summary

- Compressed `docs/learn_zen_in_y_minutes.md` while keeping the language tour coverage for static strings, allocator-backed strings, loops, behaviors, sync/async surfaces, raw memory, actors, and comptime previews.
- Reduced the guide from 211 lines / 1275 words to 190 lines / 1122 words.
- Tightened docs-truth coverage with both line-count and word-count guards so the guide remains pasteable into model context.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth -- public_docs::learn_zen::learn_zen_guide_covers_core_tour_and_gated_previews --nocapture`
- `cargo test --test docs_truth -- --nocapture`
- Verified branch push did not trigger push-event Actions: `gh run list --event push --branch codex/compact-learn-guide --limit 5 --json databaseId,status,conclusion,headSha,workflowName,createdAt` returned `[]`.