### PR TITLE
[codex] Remove stale LLVM wording from live sources

### DIFF
--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -1,7 +1,7 @@
 //! Compiler Intrinsics
 //!
 //! This is the SINGLE SOURCE OF TRUTH for all compiler intrinsic type information.
-//! These are low-level primitives that map directly to LLVM IR or syscalls.
+//! These are low-level primitives that map directly to backend code or host calls.
 //!
 //! Everything else (io, math, collections, etc.) should be written in Zen
 //! using these intrinsics.

--- a/stdlib/compiler.zen
+++ b/stdlib/compiler.zen
@@ -3,7 +3,7 @@
 // All other stdlib modules should import from here
 //
 // Architecture:
-//   @builtin.*          - Raw Rust/LLVM intrinsics (only used in this file)
+//   @builtin.*          - Raw compiler intrinsics (only used in this file)
 //   @std.compiler.*     - This module (safe wrappers for other stdlib)
 //   { compiler } = @std - User-facing import
 

--- a/stdlib/concurrency/primitives/atomic.zen
+++ b/stdlib/concurrency/primitives/atomic.zen
@@ -8,7 +8,7 @@
 // ============================================================================
 // Memory Ordering
 // ============================================================================
-// These map to LLVM atomics ordering semantics
+// These map to compiler atomic ordering semantics
 
 ORDERING_RELAXED = 0    // No synchronization
 ORDERING_ACQUIRE = 1    // Acquire semantics (loads)

--- a/tests/docs_truth/repo_hygiene/source_truth.rs
+++ b/tests/docs_truth/repo_hygiene/source_truth.rs
@@ -77,3 +77,31 @@ fn generated_vscode_packages_are_not_tracked() {
         ".gitignore should keep generated VSIX packages out of source control"
     );
 }
+
+#[test]
+fn live_compiler_and_stdlib_sources_do_not_claim_llvm_intrinsics() {
+    let output = std::process::Command::new("git")
+        .args(["ls-files", "src", "stdlib"])
+        .current_dir(repo_root())
+        .output()
+        .expect("list live compiler and stdlib sources");
+    assert!(
+        output.status.success(),
+        "git ls-files failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let tracked = String::from_utf8(output.stdout).expect("git ls-files output is utf-8");
+    for path in tracked
+        .lines()
+        .filter(|path| path.ends_with(".rs") || path.ends_with(".zen") || path.ends_with(".md"))
+    {
+        let source = std::fs::read_to_string(repo_root().join(path)).expect("read tracked file");
+        for stale in ["LLVM IR", "Raw Rust/LLVM", "LLVM atomics"] {
+            assert!(
+                !source.contains(stale),
+                "{path} should not claim live compiler or stdlib intrinsics are LLVM-specific: {stale}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## What changed
- Reworded three live compiler/stdlib comments that still described intrinsics or atomics as LLVM-specific.
- Added a docs-truth guard that scans tracked `src/` and `stdlib/` files for stale live-source claims like `LLVM IR`, `Raw Rust/LLVM`, and `LLVM atomics`.

## Why
The active backend path is C-oriented, and the compiler/stdlib boundary should not imply allocator, async, or atomic APIs are LLVM-owned. Unsupported LLVM references remain allowed in negative tests and forbidden-claim guards outside live source.

## Validation
- `cargo test --test docs_truth live_compiler_and_stdlib_sources_do_not_claim_llvm_intrinsics --quiet`
- `cargo test --test docs_truth source_truth --quiet`
- `cargo test --test docs_truth --quiet`
- `cargo test --lib --quiet`
- `cargo clippy -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
