### PR TITLE
[codex] Restore parser state during generic lookahead

### DIFF
--- a/src/parser/block_helpers.rs
+++ b/src/parser/block_helpers.rs
@@ -128,8 +128,18 @@ impl Parser {
                 break;
             }
             args.push(self.parse_type()?);
-            if matches!(self.peek(), Token::Comma) {
-                self.advance();
+            self.skip_newlines();
+            match self.peek() {
+                Token::Comma => {
+                    self.advance();
+                }
+                Token::Gt | Token::ShiftRight => break,
+                other => {
+                    return Err(CompileError::Syntax(
+                        format!("expected `,` or `>` in type argument list, found {other:?}"),
+                        Some(self.peek_span()),
+                    ));
+                }
             }
         }
         self.expect_gt()?;

--- a/src/parser/core.rs
+++ b/src/parser/core.rs
@@ -10,6 +10,11 @@ pub(super) struct Parser {
     next_loop_control_id: usize,
 }
 
+pub(super) struct ParserCheckpoint {
+    pos: usize,
+    tokens: Vec<(Token, Span)>,
+}
+
 impl Parser {
     pub(super) fn new(tokens: Vec<(Token, Span)>, file_id: FileId) -> Self {
         Self {
@@ -34,6 +39,54 @@ impl Parser {
         let id = self.next_loop_control_id;
         self.next_loop_control_id += 1;
         format!("__zen_loop_{}", id)
+    }
+
+    pub(super) fn checkpoint(&self) -> ParserCheckpoint {
+        ParserCheckpoint {
+            pos: self.pos,
+            tokens: self.tokens.clone(),
+        }
+    }
+
+    pub(super) fn restore(&mut self, checkpoint: ParserCheckpoint) {
+        self.pos = checkpoint.pos;
+        self.tokens = checkpoint.tokens;
+    }
+
+    pub(super) fn generic_close_has_attached_suffix_from(&self, start: usize) -> bool {
+        let mut depth = 0usize;
+        for index in start..self.tokens.len() {
+            let (token, span) = &self.tokens[index];
+            match token {
+                Token::Lt => depth += 1,
+                Token::Gt => {
+                    depth = depth.saturating_sub(1);
+                    if depth == 0 {
+                        return self.token_has_attached_generic_suffix(index, *span);
+                    }
+                }
+                Token::ShiftRight => {
+                    depth = depth.saturating_sub(2);
+                    if depth == 0 {
+                        return self.token_has_attached_generic_suffix(index, *span);
+                    }
+                }
+                Token::EOF | Token::Newline | Token::RParen | Token::RBrace => return false,
+                _ => {}
+            }
+        }
+        false
+    }
+
+    fn token_has_attached_generic_suffix(&self, index: usize, close_span: Span) -> bool {
+        let Some((next, next_span)) = self.tokens.get(index + 1) else {
+            return false;
+        };
+        match next {
+            Token::LParen | Token::Dot => next_span.start == close_span.end,
+            Token::LBrace => true,
+            _ => false,
+        }
     }
 
     /// Skip tokens until we find something that looks like a new declaration.

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -113,36 +113,57 @@ impl Parser {
                             break;
                         }
 
-                        let saved = self.pos;
-                        if let Ok(type_args) = self.parse_type_arg_list() {
-                            if matches!(self.peek(), Token::LParen) {
-                                let name = name.clone();
-                                self.advance(); // consume (
-                                let args = self.parse_arg_list()?;
-                                let end = self.expect(&Token::RParen)?;
-                                let span = id_span.merge(end);
-                                lhs = Expression::FunctionCall {
-                                    name,
-                                    module: None,
-                                    type_args,
-                                    args,
-                                    span,
-                                };
-                                continue;
+                        if self.peek_span().start == id_span.end {
+                            let type_args_start = self.pos;
+                            let checkpoint = self.checkpoint();
+                            match self.parse_type_arg_list() {
+                                Ok(type_args) => {
+                                    let type_args_end = self.prev_span();
+                                    if matches!(self.peek(), Token::LParen)
+                                        && self.peek_span().start == type_args_end.end
+                                    {
+                                        let name = name.clone();
+                                        self.advance(); // consume (
+                                        let args = self.parse_arg_list()?;
+                                        let end = self.expect(&Token::RParen)?;
+                                        let span = id_span.merge(end);
+                                        lhs = Expression::FunctionCall {
+                                            name,
+                                            module: None,
+                                            type_args,
+                                            args,
+                                            span,
+                                        };
+                                        continue;
+                                    }
+                                    if matches!(self.peek(), Token::Dot)
+                                        && self.peek_span().start == type_args_end.end
+                                        && first_char_is_upper(name)
+                                    {
+                                        let enum_name = name.clone();
+                                        lhs = self.parse_generic_enum_variant(
+                                            enum_name, type_args, id_span,
+                                        )?;
+                                        continue;
+                                    }
+                                    if matches!(self.peek(), Token::LBrace)
+                                        && first_char_is_upper(name)
+                                    {
+                                        let name = name.clone();
+                                        lhs =
+                                            self.parse_struct_literal(name, type_args, id_span)?;
+                                        continue;
+                                    }
+                                }
+                                Err(err) => {
+                                    if self.generic_close_has_attached_suffix_from(type_args_start)
+                                    {
+                                        return Err(err);
+                                    }
+                                }
                             }
-                            if matches!(self.peek(), Token::Dot) && first_char_is_upper(name) {
-                                let enum_name = name.clone();
-                                lhs =
-                                    self.parse_generic_enum_variant(enum_name, type_args, id_span)?;
-                                continue;
-                            }
-                            if matches!(self.peek(), Token::LBrace) && first_char_is_upper(name) {
-                                let name = name.clone();
-                                lhs = self.parse_struct_literal(name, type_args, id_span)?;
-                                continue;
-                            }
+                            self.restore(checkpoint);
                         }
-                        self.pos = saved;
                     }
                 }
 

--- a/src/parser/expressions/suffixes.rs
+++ b/src/parser/expressions/suffixes.rs
@@ -31,18 +31,28 @@ impl Parser {
             }
         }
 
-        let type_args = if matches!(self.peek(), Token::Lt) {
-            let saved = self.pos;
-            match self.parse_type_arg_list() {
-                Ok(type_args) if matches!(self.peek(), Token::LParen) => type_args,
-                _ => {
-                    self.pos = saved;
-                    Vec::new()
+        let type_args =
+            if matches!(self.peek(), Token::Lt) && self.peek_span().start == name_span.end {
+                let type_args_start = self.pos;
+                let checkpoint = self.checkpoint();
+                match self.parse_type_arg_list() {
+                    Ok(type_args)
+                        if matches!(self.peek(), Token::LParen)
+                            && self.peek_span().start == self.prev_span().end =>
+                    {
+                        type_args
+                    }
+                    Err(err) if self.generic_close_has_attached_suffix_from(type_args_start) => {
+                        return Err(err);
+                    }
+                    _ => {
+                        self.restore(checkpoint);
+                        Vec::new()
+                    }
                 }
-            }
-        } else {
-            Vec::new()
-        };
+            } else {
+                Vec::new()
+            };
 
         if matches!(self.peek(), Token::LParen) {
             self.advance();

--- a/src/parser/tests/expressions.rs
+++ b/src/parser/tests/expressions.rs
@@ -1,5 +1,19 @@
 use super::*;
 
+fn final_expr(src: &str) -> Expression {
+    let prog = parse_ok(src);
+    let Declaration::Function { body, .. } = &prog.declarations[0] else {
+        panic!("expected function declaration");
+    };
+    let Expression::Block {
+        expr: Some(expr), ..
+    } = body
+    else {
+        panic!("expected final block expression");
+    };
+    expr.as_ref().clone()
+}
+
 #[test]
 fn parse_pattern_match() {
     let prog = parse_ok(
@@ -175,4 +189,53 @@ fn parse_nested_conditionals() {
 }"#,
     );
     assert_eq!(prog.declarations.len(), 1);
+}
+
+#[test]
+fn speculative_generic_lookahead_preserves_shift_right_tokens() {
+    let expr = final_expr("f = (x: i32, y: i32, z: i32) bool { x < y >> z }");
+    let Expression::BinaryOp {
+        op: BinaryOp::Lt,
+        right,
+        ..
+    } = expr
+    else {
+        panic!("expected top-level less-than expression");
+    };
+    let Expression::BinaryOp {
+        op: BinaryOp::ShiftRight,
+        ..
+    } = right.as_ref()
+    else {
+        panic!("expected right side to keep shift-right expression, got {right:?}");
+    };
+}
+
+#[test]
+fn spaced_comparison_is_not_parsed_as_generic_function_call() {
+    let expr = final_expr("f = (x: i32, y: i32, z: i32) bool { x < y > (z) }");
+    let Expression::BinaryOp {
+        op: BinaryOp::Gt,
+        left,
+        ..
+    } = expr
+    else {
+        panic!("expected top-level greater-than expression");
+    };
+    let Expression::BinaryOp {
+        op: BinaryOp::Lt, ..
+    } = left.as_ref()
+    else {
+        panic!("expected left side to be less-than expression, got {left:?}");
+    };
+}
+
+#[test]
+fn type_argument_lists_require_commas_between_args() {
+    let errs = parse_err("f = () i32 { identity<i32 f64>(1) }");
+    assert!(
+        errs.iter()
+            .any(|err| format!("{err:?}").contains("expected `,` or `>`")),
+        "expected missing type-argument comma diagnostic, got {errs:?}"
+    );
 }

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -79,8 +79,17 @@ impl Parser {
             }
             type_args.push(self.parse_type()?);
             self.skip_newlines();
-            if matches!(self.peek(), Token::Comma) {
-                self.advance();
+            match self.peek() {
+                Token::Comma => {
+                    self.advance();
+                }
+                Token::Gt | Token::ShiftRight => break,
+                other => {
+                    return Err(CompileError::Syntax(
+                        format!("expected `,` or `>` in type argument list, found {other:?}"),
+                        Some(self.peek_span()),
+                    ));
+                }
             }
         }
         self.expect_gt()?;


### PR DESCRIPTION
## What changed
- Added a parser checkpoint/restore path for speculative generic lookahead so failed `name<T>` probes restore token mutations as well as position.
- Required generic call/enum lookahead to use attached `<...>(...)` or `<...>.Variant` syntax, which prevents spaced comparisons from being parsed as generic calls.
- Tightened type-argument parsing to require commas between adjacent type arguments.
- Added regressions for `x < y >> z`, spaced `x < y > (z)`, and missing type-argument commas.

## Why
`expect_gt()` splits `>>` while parsing nested generics. The old speculative generic path only restored `self.pos`, so failed lookahead could leave the token stream mutated and parse comparisons incorrectly.

## Validation
- `cargo test parser::tests::expressions --quiet`
- `cargo test parser::tests --quiet`
- `cargo test generic --quiet`
- `cargo test --test generic_diagnostics --quiet`
- `cargo test --lib --quiet`
- `cargo test --tests --quiet`
- `cargo clippy -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
