### PR TITLE
[codex] Discover generic generated-C fixtures

### DIFF
--- a/tests/docs_truth/v1_spec/implementation_evidence.rs
+++ b/tests/docs_truth/v1_spec/implementation_evidence.rs
@@ -68,3 +68,17 @@ fn v1_spec_records_resolver_generic_and_behavior_evidence() {
         "docs/V1_SPEC.md should stay compact; move exhaustive evidence to tests, golden fixtures, or git history"
     );
 }
+
+#[test]
+fn generic_generated_c_definition_checks_discover_fixtures() {
+    let tests = read("tests/integration/generic_specializations.rs");
+
+    assert!(
+        tests.contains("generic_specialization_fixture_paths"),
+        "generic generated-C definition checks should discover generic fixtures instead of relying on a hand-maintained list"
+    );
+    assert!(
+        !tests.contains("let fixtures = ["),
+        "generic generated-C definition checks should not use a hard-coded fixture table"
+    );
+}

--- a/tests/integration/generic_specializations.rs
+++ b/tests/integration/generic_specializations.rs
@@ -1,4 +1,5 @@
 use super::support::*;
+use std::path::PathBuf;
 
 #[path = "generic_specializations/behavior_bounds.rs"]
 mod behavior_bounds;
@@ -11,42 +12,60 @@ mod multifile_generated_c;
 
 #[test]
 fn generic_specializations_emit_each_generated_c_definition_once() {
-    let fixtures = [
-        "generic_enum_method.zen",
-        "generic_enum_multi_specialization.zen",
-        "generic_enum_option.zen",
-        "generic_identity.zen",
-        "generic_method.zen",
-        "generic_method_nested_result.zen",
-        "generic_method_self.zen",
-        "generic_method_worklist.zen",
-        "generic_type_impl_methods.zen",
-        "generic_nested_result_enum.zen",
-        "generic_result_enum.zen",
-        "generic_result_enum_method.zen",
-        "generic_result_enum_multi_specialization.zen",
-        "generic_struct.zen",
-        "generic_ufc_dedup.zen",
-        "generic_ufc_function.zen",
-        "generic_vec.zen",
-        "generic_worklist.zen",
-        "generic_worklist_dedup.zen",
-        "multi_file_generic/main.zen",
-        "multi_file_generic_enum_method/main.zen",
-        "multi_file_generic_imported_transitive_dependency/main.zen",
-        "multi_file_generic_imported_type_dependency/main.zen",
-        "multi_file_generic_imported_worklist_chain/main.zen",
-        "multi_file_generic_result_enum_method/main.zen",
-        "multi_file_generic_result_enum_multi_specialization/main.zen",
-        "multi_file_imported_generic_function_return_enum_dependency/main.zen",
-        "multi_file_type_impl_return_enum_dependency/main.zen",
-        "multi_file_type_method_nested_result_dependency/main.zen",
-        "multi_file_type_method_return_enum_dependency/main.zen",
-        "multi_file_type_method_worklist/main.zen",
-    ];
-
-    for fixture in fixtures {
-        let c_source = compile_to_c_with_generated_call_check(&test_dir().join(fixture));
+    for fixture in generic_specialization_fixture_paths() {
+        let c_source = compile_to_c_with_generated_call_check(&test_dir().join(&fixture));
         assert_generated_c_function_definitions_are_unique(&c_source);
     }
+}
+
+fn generic_specialization_fixture_paths() -> Vec<PathBuf> {
+    let root = test_dir();
+    let mut fixtures = Vec::new();
+
+    for entry in std::fs::read_dir(&root).expect("read tests/zen fixtures") {
+        let entry = entry.expect("read tests/zen fixture entry");
+        let path = entry.path();
+        if !path.is_file() || path.extension().is_none_or(|ext| ext != "zen") {
+            continue;
+        }
+
+        let stem = path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .unwrap_or("");
+        if stem.contains("generic") || stem == "type_impl_methods" {
+            fixtures.push(relative_fixture_path(&root, path));
+        }
+    }
+
+    for entry in std::fs::read_dir(&root).expect("read tests/zen fixture directories") {
+        let entry = entry.expect("read tests/zen fixture directory entry");
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+
+        let dir_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("");
+        if dir_name.contains("generic")
+            || dir_name.starts_with("multi_file_type_impl")
+            || dir_name.starts_with("multi_file_type_method")
+        {
+            let main = path.join("main.zen");
+            if main.exists() {
+                fixtures.push(relative_fixture_path(&root, main));
+            }
+        }
+    }
+
+    fixtures.sort();
+    fixtures
+}
+
+fn relative_fixture_path(root: &std::path::Path, path: PathBuf) -> PathBuf {
+    path.strip_prefix(root)
+        .expect("fixture path should be under tests/zen")
+        .to_path_buf()
 }


### PR DESCRIPTION
## Summary
- Replace the hand-maintained generic generated-C duplicate-definition fixture table with filesystem discovery.
- Cover all generic root fixtures plus multi-file generic/type-method/type-impl fixtures that have `main.zen`.
- Add a docs-truth guard so generated-C definition checks keep using fixture discovery instead of drifting back to a literal table.

## Validation
- `cargo test --test docs_truth generic_generated_c_definition_checks_discover_fixtures --quiet`
- `cargo test --test integration generic_specializations_emit_each_generated_c_definition_once --quiet`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --tests --quiet`
