### PR TITLE
[codex] Add recursive generic JSON goldens

### DIFF
--- a/tests/fixtures/ir_json/hir_generic_recursive_function.golden.json
+++ b/tests/fixtures/ir_json/hir_generic_recursive_function.golden.json
@@ -1,0 +1,30 @@
+{
+  "format": "zen.hir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "declarations": {
+    "types": [],
+    "functions": [
+      {
+        "name": "main",
+        "params": [],
+        "return_type": "i32"
+      },
+      {
+        "name": "repeat_i32",
+        "params": [
+          {
+            "name": "value",
+            "type": "i32"
+          },
+          {
+            "name": "remaining",
+            "type": "i32"
+          }
+        ],
+        "return_type": "i32"
+      }
+    ],
+    "globals": []
+  }
+}

--- a/tests/fixtures/ir_json/hir_generic_recursive_method.golden.json
+++ b/tests/fixtures/ir_json/hir_generic_recursive_method.golden.json
@@ -1,0 +1,42 @@
+{
+  "format": "zen.hir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "declarations": {
+    "types": [
+      {
+        "name": "Box_i32",
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "value",
+            "type": "i32"
+          }
+        ],
+        "variants": []
+      }
+    ],
+    "functions": [
+      {
+        "name": "main",
+        "params": [],
+        "return_type": "i32"
+      },
+      {
+        "name": "Box.repeat_i32",
+        "params": [
+          {
+            "name": "self",
+            "type": "Box_i32"
+          },
+          {
+            "name": "remaining",
+            "type": "i32"
+          }
+        ],
+        "return_type": "i32"
+      }
+    ],
+    "globals": []
+  }
+}

--- a/tests/fixtures/ir_json/mir_generic_recursive_function.golden.json
+++ b/tests/fixtures/ir_json/mir_generic_recursive_function.golden.json
@@ -1,0 +1,166 @@
+{
+  "format": "zen.mir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "lowering_status": "minimal",
+  "functions": [
+    {
+      "name": "main",
+      "params": [],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [
+            {
+              "kind": "expr",
+              "value": {
+                "kind": "call",
+                "type": "void",
+                "function": "io_println",
+                "args": [
+                  {
+                    "kind": "string_interpolation",
+                    "type": "StaticString",
+                    "value": {
+                      "parts": 1
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "int",
+              "type": "i32",
+              "value": 0
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "repeat_i32",
+      "params": [
+        {
+          "name": "value",
+          "type": "i32"
+        },
+        {
+          "name": "remaining",
+          "type": "i32"
+        }
+      ],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "match",
+              "type": "i32",
+              "target": {
+                "kind": "binary",
+                "type": "bool",
+                "op": ">",
+                "left": {
+                  "kind": "local",
+                  "type": "i32",
+                  "name": "remaining"
+                },
+                "right": {
+                  "kind": "int",
+                  "type": "i32",
+                  "value": 0
+                }
+              },
+              "match_kind": "conditional_else",
+              "arms": [
+                {
+                  "pattern": {
+                    "kind": "bool",
+                    "value": true,
+                    "bindings": []
+                  },
+                  "body": {
+                    "label": "entry",
+                    "statements": [],
+                    "terminator": {
+                      "kind": "return",
+                      "value": {
+                        "kind": "block",
+                        "type": "i32",
+                        "value": {
+                          "has_result": true,
+                          "result": {
+                            "args": [
+                              {
+                                "kind": "local",
+                                "name": "value",
+                                "type": "i32"
+                              },
+                              {
+                                "kind": "binary",
+                                "left": {
+                                  "kind": "local",
+                                  "name": "remaining",
+                                  "type": "i32"
+                                },
+                                "op": "-",
+                                "right": {
+                                  "kind": "int",
+                                  "type": "i32",
+                                  "value": 1
+                                },
+                                "type": "i32"
+                              }
+                            ],
+                            "function": "repeat_i32",
+                            "kind": "call",
+                            "type": "i32"
+                          },
+                          "statement_count": 0
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "pattern": {
+                    "kind": "bool",
+                    "value": false,
+                    "bindings": []
+                  },
+                  "body": {
+                    "label": "entry",
+                    "statements": [],
+                    "terminator": {
+                      "kind": "return",
+                      "value": {
+                        "kind": "block",
+                        "type": "i32",
+                        "value": {
+                          "has_result": true,
+                          "result": {
+                            "kind": "local",
+                            "name": "value",
+                            "type": "i32"
+                          },
+                          "statement_count": 0
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/ir_json/mir_generic_recursive_method.golden.json
+++ b/tests/fixtures/ir_json/mir_generic_recursive_method.golden.json
@@ -1,0 +1,189 @@
+{
+  "format": "zen.mir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "lowering_status": "minimal",
+  "functions": [
+    {
+      "name": "main",
+      "params": [],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [
+            {
+              "kind": "let",
+              "name": "box",
+              "type": "Box_i32",
+              "mutable": false,
+              "value": {
+                "kind": "struct",
+                "type": "Box_i32",
+                "name": "Box_i32",
+                "args": [
+                  {
+                    "kind": "int",
+                    "type": "i32",
+                    "value": 43
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "expr",
+              "value": {
+                "kind": "call",
+                "type": "void",
+                "function": "io_println",
+                "args": [
+                  {
+                    "kind": "string_interpolation",
+                    "type": "StaticString",
+                    "value": {
+                      "parts": 1
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "int",
+              "type": "i32",
+              "value": 0
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Box.repeat_i32",
+      "params": [
+        {
+          "name": "self",
+          "type": "Box_i32"
+        },
+        {
+          "name": "remaining",
+          "type": "i32"
+        }
+      ],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "match",
+              "type": "i32",
+              "target": {
+                "kind": "binary",
+                "type": "bool",
+                "op": ">",
+                "left": {
+                  "kind": "local",
+                  "type": "i32",
+                  "name": "remaining"
+                },
+                "right": {
+                  "kind": "int",
+                  "type": "i32",
+                  "value": 0
+                }
+              },
+              "match_kind": "conditional_else",
+              "arms": [
+                {
+                  "pattern": {
+                    "kind": "bool",
+                    "value": true,
+                    "bindings": []
+                  },
+                  "body": {
+                    "label": "entry",
+                    "statements": [],
+                    "terminator": {
+                      "kind": "return",
+                      "value": {
+                        "kind": "block",
+                        "type": "i32",
+                        "value": {
+                          "has_result": true,
+                          "result": {
+                            "args": [
+                              {
+                                "kind": "local",
+                                "name": "self",
+                                "type": "Box_i32"
+                              },
+                              {
+                                "kind": "binary",
+                                "left": {
+                                  "kind": "local",
+                                  "name": "remaining",
+                                  "type": "i32"
+                                },
+                                "op": "-",
+                                "right": {
+                                  "kind": "int",
+                                  "type": "i32",
+                                  "value": 1
+                                },
+                                "type": "i32"
+                              }
+                            ],
+                            "function": "Box.repeat_i32",
+                            "kind": "call",
+                            "type": "i32"
+                          },
+                          "statement_count": 0
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "pattern": {
+                    "kind": "bool",
+                    "value": false,
+                    "bindings": []
+                  },
+                  "body": {
+                    "label": "entry",
+                    "statements": [],
+                    "terminator": {
+                      "kind": "return",
+                      "value": {
+                        "kind": "block",
+                        "type": "i32",
+                        "value": {
+                          "has_result": true,
+                          "result": {
+                            "field": "value",
+                            "kind": "field",
+                            "target": {
+                              "kind": "local",
+                              "name": "self",
+                              "type": "Box_i32"
+                            },
+                            "type": "i32"
+                          },
+                          "statement_count": 0
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/ir_json/typed_generic_recursive_function.golden.json
+++ b/tests/fixtures/ir_json/typed_generic_recursive_function.golden.json
@@ -1,0 +1,357 @@
+{
+  "format": "zen.typed.v0",
+  "semantic_status": "checked",
+  "program": {
+    "functions": [
+      {
+        "name": "main",
+        "params": [],
+        "return_type": "I32",
+        "body": {
+          "statements": [
+            {
+              "kind": {
+                "Expression": {
+                  "kind": {
+                    "FunctionCall": {
+                      "function": "io_println",
+                      "args": [
+                        {
+                          "kind": {
+                            "StringInterpolation": {
+                              "parts": [
+                                {
+                                  "Expr": {
+                                    "kind": {
+                                      "FunctionCall": {
+                                        "function": "repeat_i32",
+                                        "args": [
+                                          {
+                                            "kind": {
+                                              "IntLiteral": 41
+                                            },
+                                            "ty": "I32",
+                                            "span": {
+                                              "file_id": 0,
+                                              "start": 195,
+                                              "end": 197
+                                            }
+                                          },
+                                          {
+                                            "kind": {
+                                              "IntLiteral": 3
+                                            },
+                                            "ty": "I32",
+                                            "span": {
+                                              "file_id": 0,
+                                              "start": 199,
+                                              "end": 200
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "ty": "I32",
+                                    "span": {
+                                      "file_id": 0,
+                                      "start": 188,
+                                      "end": 201
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "ty": "Str",
+                          "span": {
+                            "file_id": 0,
+                            "start": 186,
+                            "end": 202
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "ty": "Void",
+                  "span": {
+                    "file_id": 0,
+                    "start": 174,
+                    "end": 204
+                  }
+                }
+              },
+              "span": {
+                "file_id": 0,
+                "start": 174,
+                "end": 204
+              }
+            }
+          ],
+          "expr": {
+            "kind": {
+              "IntLiteral": 0
+            },
+            "ty": "I32",
+            "span": {
+              "file_id": 0,
+              "start": 209,
+              "end": 210
+            }
+          },
+          "ty": "I32",
+          "span": {
+            "file_id": 0,
+            "start": 168,
+            "end": 212
+          }
+        },
+        "defers": [],
+        "span": {
+          "file_id": 0,
+          "start": 154,
+          "end": 212
+        }
+      },
+      {
+        "name": "repeat_i32",
+        "params": [
+          {
+            "name": "value",
+            "ty": "I32",
+            "span": {
+              "file_id": 0,
+              "start": 27,
+              "end": 35
+            }
+          },
+          {
+            "name": "remaining",
+            "ty": "I32",
+            "span": {
+              "file_id": 0,
+              "start": 37,
+              "end": 51
+            }
+          }
+        ],
+        "return_type": "I32",
+        "body": {
+          "statements": [],
+          "expr": {
+            "kind": {
+              "Match": {
+                "scrutinee": {
+                  "kind": {
+                    "BinaryOp": {
+                      "op": "Gt",
+                      "left": {
+                        "kind": {
+                          "Variable": "remaining"
+                        },
+                        "ty": "I32",
+                        "span": {
+                          "file_id": 0,
+                          "start": 61,
+                          "end": 70
+                        }
+                      },
+                      "right": {
+                        "kind": {
+                          "IntLiteral": 0
+                        },
+                        "ty": "I32",
+                        "span": {
+                          "file_id": 0,
+                          "start": 73,
+                          "end": 74
+                        }
+                      }
+                    }
+                  },
+                  "ty": "Bool",
+                  "span": {
+                    "file_id": 0,
+                    "start": 61,
+                    "end": 74
+                  }
+                },
+                "arms": [
+                  {
+                    "pattern": {
+                      "Bool": true
+                    },
+                    "body": {
+                      "statements": [],
+                      "expr": {
+                        "kind": {
+                          "Block": {
+                            "statements": [],
+                            "expr": {
+                              "kind": {
+                                "FunctionCall": {
+                                  "function": "repeat_i32",
+                                  "args": [
+                                    {
+                                      "kind": {
+                                        "Variable": "value"
+                                      },
+                                      "ty": "I32",
+                                      "span": {
+                                        "file_id": 0,
+                                        "start": 101,
+                                        "end": 106
+                                      }
+                                    },
+                                    {
+                                      "kind": {
+                                        "BinaryOp": {
+                                          "op": "Sub",
+                                          "left": {
+                                            "kind": {
+                                              "Variable": "remaining"
+                                            },
+                                            "ty": "I32",
+                                            "span": {
+                                              "file_id": 0,
+                                              "start": 108,
+                                              "end": 117
+                                            }
+                                          },
+                                          "right": {
+                                            "kind": {
+                                              "IntLiteral": 1
+                                            },
+                                            "ty": "I32",
+                                            "span": {
+                                              "file_id": 0,
+                                              "start": 120,
+                                              "end": 121
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "ty": "I32",
+                                      "span": {
+                                        "file_id": 0,
+                                        "start": 108,
+                                        "end": 121
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              "ty": "I32",
+                              "span": {
+                                "file_id": 0,
+                                "start": 94,
+                                "end": 122
+                              }
+                            },
+                            "ty": "I32",
+                            "span": {
+                              "file_id": 0,
+                              "start": 92,
+                              "end": 124
+                            }
+                          }
+                        },
+                        "ty": "I32",
+                        "span": {
+                          "file_id": 0,
+                          "start": 92,
+                          "end": 124
+                        }
+                      },
+                      "ty": "I32",
+                      "span": {
+                        "file_id": 0,
+                        "start": 92,
+                        "end": 124
+                      }
+                    },
+                    "span": {
+                      "file_id": 0,
+                      "start": 87,
+                      "end": 124
+                    }
+                  },
+                  {
+                    "pattern": {
+                      "Bool": false
+                    },
+                    "body": {
+                      "statements": [],
+                      "expr": {
+                        "kind": {
+                          "Block": {
+                            "statements": [],
+                            "expr": {
+                              "kind": {
+                                "Variable": "value"
+                              },
+                              "ty": "I32",
+                              "span": {
+                                "file_id": 0,
+                                "start": 143,
+                                "end": 148
+                              }
+                            },
+                            "ty": "I32",
+                            "span": {
+                              "file_id": 0,
+                              "start": 141,
+                              "end": 150
+                            }
+                          }
+                        },
+                        "ty": "I32",
+                        "span": {
+                          "file_id": 0,
+                          "start": 141,
+                          "end": 150
+                        }
+                      },
+                      "ty": "I32",
+                      "span": {
+                        "file_id": 0,
+                        "start": 141,
+                        "end": 150
+                      }
+                    },
+                    "span": {
+                      "file_id": 0,
+                      "start": 135,
+                      "end": 150
+                    }
+                  }
+                ],
+                "kind": "ConditionalElse"
+              }
+            },
+            "ty": "I32",
+            "span": {
+              "file_id": 0,
+              "start": 61,
+              "end": 150
+            }
+          },
+          "ty": "I32",
+          "span": {
+            "file_id": 0,
+            "start": 55,
+            "end": 152
+          }
+        },
+        "defers": [],
+        "span": {
+          "file_id": 0,
+          "start": 14,
+          "end": 152
+        }
+      }
+    ],
+    "types": [],
+    "globals": [],
+    "entry_point": "main"
+  }
+}

--- a/tests/fixtures/ir_json/typed_generic_recursive_method.golden.json
+++ b/tests/fixtures/ir_json/typed_generic_recursive_method.golden.json
@@ -1,0 +1,493 @@
+{
+  "format": "zen.typed.v0",
+  "semantic_status": "checked",
+  "program": {
+    "functions": [
+      {
+        "name": "main",
+        "params": [],
+        "return_type": "I32",
+        "body": {
+          "statements": [
+            {
+              "kind": {
+                "VarDecl": {
+                  "name": "box",
+                  "ty": {
+                    "Struct": {
+                      "name": "Box_i32",
+                      "fields": [
+                        [
+                          "value",
+                          "I32"
+                        ]
+                      ]
+                    }
+                  },
+                  "value": {
+                    "kind": {
+                      "StructLiteral": {
+                        "type_name": "Box_i32",
+                        "fields": [
+                          [
+                            "value",
+                            {
+                              "kind": {
+                                "IntLiteral": 43
+                              },
+                              "ty": "I32",
+                              "span": {
+                                "file_id": 0,
+                                "start": 235,
+                                "end": 237
+                              }
+                            }
+                          ]
+                        ]
+                      }
+                    },
+                    "ty": {
+                      "Struct": {
+                        "name": "Box_i32",
+                        "fields": [
+                          [
+                            "value",
+                            "I32"
+                          ]
+                        ]
+                      }
+                    },
+                    "span": {
+                      "file_id": 0,
+                      "start": 217,
+                      "end": 239
+                    }
+                  },
+                  "mutable": false
+                }
+              },
+              "span": {
+                "file_id": 0,
+                "start": 211,
+                "end": 239
+              }
+            },
+            {
+              "kind": {
+                "Expression": {
+                  "kind": {
+                    "FunctionCall": {
+                      "function": "io_println",
+                      "args": [
+                        {
+                          "kind": {
+                            "StringInterpolation": {
+                              "parts": [
+                                {
+                                  "Expr": {
+                                    "kind": {
+                                      "FunctionCall": {
+                                        "function": "Box.repeat_i32",
+                                        "args": [
+                                          {
+                                            "kind": {
+                                              "Variable": "box"
+                                            },
+                                            "ty": {
+                                              "Struct": {
+                                                "name": "Box_i32",
+                                                "fields": [
+                                                  [
+                                                    "value",
+                                                    "I32"
+                                                  ]
+                                                ]
+                                              }
+                                            },
+                                            "span": {
+                                              "file_id": 0,
+                                              "start": 258,
+                                              "end": 261
+                                            }
+                                          },
+                                          {
+                                            "kind": {
+                                              "IntLiteral": 3
+                                            },
+                                            "ty": "I32",
+                                            "span": {
+                                              "file_id": 0,
+                                              "start": 269,
+                                              "end": 270
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "ty": "I32",
+                                    "span": {
+                                      "file_id": 0,
+                                      "start": 258,
+                                      "end": 271
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "ty": "Str",
+                          "span": {
+                            "file_id": 0,
+                            "start": 256,
+                            "end": 272
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "ty": "Void",
+                  "span": {
+                    "file_id": 0,
+                    "start": 244,
+                    "end": 274
+                  }
+                }
+              },
+              "span": {
+                "file_id": 0,
+                "start": 244,
+                "end": 274
+              }
+            }
+          ],
+          "expr": {
+            "kind": {
+              "IntLiteral": 0
+            },
+            "ty": "I32",
+            "span": {
+              "file_id": 0,
+              "start": 279,
+              "end": 280
+            }
+          },
+          "ty": "I32",
+          "span": {
+            "file_id": 0,
+            "start": 205,
+            "end": 282
+          }
+        },
+        "defers": [],
+        "span": {
+          "file_id": 0,
+          "start": 191,
+          "end": 282
+        }
+      },
+      {
+        "name": "Box.repeat_i32",
+        "params": [
+          {
+            "name": "self",
+            "ty": {
+              "Struct": {
+                "name": "Box_i32",
+                "fields": [
+                  [
+                    "value",
+                    "I32"
+                  ]
+                ]
+              }
+            },
+            "span": {
+              "file_id": 0,
+              "start": 57,
+              "end": 69
+            }
+          },
+          {
+            "name": "remaining",
+            "ty": "I32",
+            "span": {
+              "file_id": 0,
+              "start": 71,
+              "end": 85
+            }
+          }
+        ],
+        "return_type": "I32",
+        "body": {
+          "statements": [],
+          "expr": {
+            "kind": {
+              "Match": {
+                "scrutinee": {
+                  "kind": {
+                    "BinaryOp": {
+                      "op": "Gt",
+                      "left": {
+                        "kind": {
+                          "Variable": "remaining"
+                        },
+                        "ty": "I32",
+                        "span": {
+                          "file_id": 0,
+                          "start": 95,
+                          "end": 104
+                        }
+                      },
+                      "right": {
+                        "kind": {
+                          "IntLiteral": 0
+                        },
+                        "ty": "I32",
+                        "span": {
+                          "file_id": 0,
+                          "start": 107,
+                          "end": 108
+                        }
+                      }
+                    }
+                  },
+                  "ty": "Bool",
+                  "span": {
+                    "file_id": 0,
+                    "start": 95,
+                    "end": 108
+                  }
+                },
+                "arms": [
+                  {
+                    "pattern": {
+                      "Bool": true
+                    },
+                    "body": {
+                      "statements": [],
+                      "expr": {
+                        "kind": {
+                          "Block": {
+                            "statements": [],
+                            "expr": {
+                              "kind": {
+                                "FunctionCall": {
+                                  "function": "Box.repeat_i32",
+                                  "args": [
+                                    {
+                                      "kind": {
+                                        "Variable": "self"
+                                      },
+                                      "ty": {
+                                        "Struct": {
+                                          "name": "Box_i32",
+                                          "fields": [
+                                            [
+                                              "value",
+                                              "I32"
+                                            ]
+                                          ]
+                                        }
+                                      },
+                                      "span": {
+                                        "file_id": 0,
+                                        "start": 128,
+                                        "end": 132
+                                      }
+                                    },
+                                    {
+                                      "kind": {
+                                        "BinaryOp": {
+                                          "op": "Sub",
+                                          "left": {
+                                            "kind": {
+                                              "Variable": "remaining"
+                                            },
+                                            "ty": "I32",
+                                            "span": {
+                                              "file_id": 0,
+                                              "start": 140,
+                                              "end": 149
+                                            }
+                                          },
+                                          "right": {
+                                            "kind": {
+                                              "IntLiteral": 1
+                                            },
+                                            "ty": "I32",
+                                            "span": {
+                                              "file_id": 0,
+                                              "start": 152,
+                                              "end": 153
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "ty": "I32",
+                                      "span": {
+                                        "file_id": 0,
+                                        "start": 140,
+                                        "end": 153
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              "ty": "I32",
+                              "span": {
+                                "file_id": 0,
+                                "start": 128,
+                                "end": 154
+                              }
+                            },
+                            "ty": "I32",
+                            "span": {
+                              "file_id": 0,
+                              "start": 126,
+                              "end": 156
+                            }
+                          }
+                        },
+                        "ty": "I32",
+                        "span": {
+                          "file_id": 0,
+                          "start": 126,
+                          "end": 156
+                        }
+                      },
+                      "ty": "I32",
+                      "span": {
+                        "file_id": 0,
+                        "start": 126,
+                        "end": 156
+                      }
+                    },
+                    "span": {
+                      "file_id": 0,
+                      "start": 121,
+                      "end": 156
+                    }
+                  },
+                  {
+                    "pattern": {
+                      "Bool": false
+                    },
+                    "body": {
+                      "statements": [],
+                      "expr": {
+                        "kind": {
+                          "Block": {
+                            "statements": [],
+                            "expr": {
+                              "kind": {
+                                "FieldAccess": {
+                                  "object": {
+                                    "kind": {
+                                      "Variable": "self"
+                                    },
+                                    "ty": {
+                                      "Struct": {
+                                        "name": "Box_i32",
+                                        "fields": [
+                                          [
+                                            "value",
+                                            "I32"
+                                          ]
+                                        ]
+                                      }
+                                    },
+                                    "span": {
+                                      "file_id": 0,
+                                      "start": 175,
+                                      "end": 179
+                                    }
+                                  },
+                                  "field": "value"
+                                }
+                              },
+                              "ty": "I32",
+                              "span": {
+                                "file_id": 0,
+                                "start": 175,
+                                "end": 185
+                              }
+                            },
+                            "ty": "I32",
+                            "span": {
+                              "file_id": 0,
+                              "start": 173,
+                              "end": 187
+                            }
+                          }
+                        },
+                        "ty": "I32",
+                        "span": {
+                          "file_id": 0,
+                          "start": 173,
+                          "end": 187
+                        }
+                      },
+                      "ty": "I32",
+                      "span": {
+                        "file_id": 0,
+                        "start": 173,
+                        "end": 187
+                      }
+                    },
+                    "span": {
+                      "file_id": 0,
+                      "start": 167,
+                      "end": 187
+                    }
+                  }
+                ],
+                "kind": "ConditionalElse"
+              }
+            },
+            "ty": "I32",
+            "span": {
+              "file_id": 0,
+              "start": 95,
+              "end": 187
+            }
+          },
+          "ty": "I32",
+          "span": {
+            "file_id": 0,
+            "start": 89,
+            "end": 189
+          }
+        },
+        "defers": [],
+        "span": {
+          "file_id": 0,
+          "start": 40,
+          "end": 189
+        }
+      }
+    ],
+    "types": [
+      {
+        "name": "Box_i32",
+        "kind": {
+          "Struct": {
+            "fields": [
+              [
+                "value",
+                "I32"
+              ]
+            ]
+          }
+        },
+        "methods": [],
+        "span": {
+          "file_id": 0,
+          "start": 217,
+          "end": 239
+        }
+      }
+    ],
+    "globals": [],
+    "entry_point": "main"
+  }
+}

--- a/tests/integration/cli_build/frontend_json/hir_golden/generic_methods.rs
+++ b/tests/integration/cli_build/frontend_json/hir_golden/generic_methods.rs
@@ -46,6 +46,15 @@ fn emit_json_hir_generic_method_method_worklist_schema_matches_golden() {
 }
 
 #[test]
+fn emit_json_hir_generic_recursive_method_schema_matches_golden() {
+    assert_hir_golden(
+        "tests/zen/generic_recursive_method.zen",
+        "tests/fixtures/ir_json/hir_generic_recursive_method.golden.json",
+        "generic recursive method input",
+    );
+}
+
+#[test]
 fn emit_json_hir_generic_method_nested_result_schema_matches_golden() {
     assert_hir_golden(
         "tests/zen/generic_method_nested_result.zen",

--- a/tests/integration/cli_build/frontend_json/hir_golden/generic_values.rs
+++ b/tests/integration/cli_build/frontend_json/hir_golden/generic_values.rs
@@ -28,6 +28,15 @@ fn emit_json_hir_generic_worklist_dedup_schema_matches_golden() {
 }
 
 #[test]
+fn emit_json_hir_generic_recursive_function_schema_matches_golden() {
+    assert_hir_golden(
+        "tests/zen/generic_recursive_function.zen",
+        "tests/fixtures/ir_json/hir_generic_recursive_function.golden.json",
+        "generic recursive function input",
+    );
+}
+
+#[test]
 fn emit_json_hir_generic_ufc_dedup_schema_matches_golden() {
     assert_hir_golden(
         "tests/zen/generic_ufc_dedup.zen",

--- a/tests/integration/cli_build/frontend_json/mir_golden/generic_methods.rs
+++ b/tests/integration/cli_build/frontend_json/mir_golden/generic_methods.rs
@@ -46,6 +46,15 @@ fn emit_json_mir_generic_method_method_worklist_schema_matches_golden() {
 }
 
 #[test]
+fn emit_json_mir_generic_recursive_method_schema_matches_golden() {
+    assert_mir_golden(
+        "tests/zen/generic_recursive_method.zen",
+        "tests/fixtures/ir_json/mir_generic_recursive_method.golden.json",
+        "generic recursive method input",
+    );
+}
+
+#[test]
 fn emit_json_mir_generic_method_nested_result_schema_matches_golden() {
     assert_mir_golden(
         "tests/zen/generic_method_nested_result.zen",

--- a/tests/integration/cli_build/frontend_json/mir_golden/generic_values.rs
+++ b/tests/integration/cli_build/frontend_json/mir_golden/generic_values.rs
@@ -28,6 +28,15 @@ fn emit_json_mir_generic_worklist_dedup_schema_matches_golden() {
 }
 
 #[test]
+fn emit_json_mir_generic_recursive_function_schema_matches_golden() {
+    assert_mir_golden(
+        "tests/zen/generic_recursive_function.zen",
+        "tests/fixtures/ir_json/mir_generic_recursive_function.golden.json",
+        "generic recursive function input",
+    );
+}
+
+#[test]
 fn emit_json_mir_generic_ufc_dedup_schema_matches_golden() {
     assert_mir_golden(
         "tests/zen/generic_ufc_dedup.zen",

--- a/tests/integration/cli_build/frontend_json/typed_golden/generic_values.rs
+++ b/tests/integration/cli_build/frontend_json/typed_golden/generic_values.rs
@@ -28,6 +28,15 @@ fn emit_json_typed_generic_worklist_dedup_schema_matches_golden() {
 }
 
 #[test]
+fn emit_json_typed_generic_recursive_function_schema_matches_golden() {
+    assert_typed_golden(
+        "generic_recursive_function.zen",
+        "tests/fixtures/ir_json/typed_generic_recursive_function.golden.json",
+        "generic recursive function",
+    );
+}
+
+#[test]
 fn emit_json_typed_generic_vec_schema_matches_golden() {
     assert_typed_golden(
         "generic_vec.zen",

--- a/tests/integration/cli_build/frontend_json/typed_golden/methods.rs
+++ b/tests/integration/cli_build/frontend_json/typed_golden/methods.rs
@@ -46,6 +46,15 @@ fn emit_json_typed_generic_method_method_worklist_schema_matches_golden() {
 }
 
 #[test]
+fn emit_json_typed_generic_recursive_method_schema_matches_golden() {
+    assert_typed_golden(
+        "generic_recursive_method.zen",
+        "tests/fixtures/ir_json/typed_generic_recursive_method.golden.json",
+        "generic recursive method",
+    );
+}
+
+#[test]
 fn emit_json_typed_generic_method_nested_result_schema_matches_golden() {
     assert_typed_golden(
         "generic_method_nested_result.zen",


### PR DESCRIPTION
## Summary
- add typed, HIR, and MIR golden coverage for recursive generic function specialization
- add typed, HIR, and MIR golden coverage for recursive generic method specialization
- pin recursive specialized names and call sites in JSON, complementing the generated-C/runtime fixtures

## Verification
- cargo test --test integration emit_json_typed_generic_recursive --quiet
- cargo test --test integration emit_json_hir_generic_recursive --quiet
- cargo test --test integration emit_json_mir_generic_recursive --quiet
- cargo fmt --check
- git diff --check
- cargo clippy -- -D warnings
- cargo test --lib --quiet
- cargo test --tests --quiet