### PR TITLE
[codex] Add duplicate generic enum JSON goldens

### DIFF
--- a/tests/fixtures/ir_json/hir_duplicate_generic_enum_variant_names.golden.json
+++ b/tests/fixtures/ir_json/hir_duplicate_generic_enum_variant_names.golden.json
@@ -1,0 +1,81 @@
+{
+  "format": "zen.hir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "declarations": {
+    "types": [
+      {
+        "name": "First_i32",
+        "kind": "enum",
+        "fields": [],
+        "variants": [
+          {
+            "name": "None",
+            "tag": 0,
+            "payload": []
+          },
+          {
+            "name": "Some",
+            "tag": 1,
+            "payload": [
+              {
+                "name": "payload",
+                "type": "i32"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Second_bool",
+        "kind": "enum",
+        "fields": [],
+        "variants": [
+          {
+            "name": "None",
+            "tag": 0,
+            "payload": []
+          },
+          {
+            "name": "Some",
+            "tag": 1,
+            "payload": [
+              {
+                "name": "payload",
+                "type": "bool"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "functions": [
+      {
+        "name": "describe_first",
+        "params": [
+          {
+            "name": "value",
+            "type": "First_i32"
+          }
+        ],
+        "return_type": "StaticString"
+      },
+      {
+        "name": "describe_second",
+        "params": [
+          {
+            "name": "value",
+            "type": "Second_bool"
+          }
+        ],
+        "return_type": "StaticString"
+      },
+      {
+        "name": "main",
+        "params": [],
+        "return_type": "i32"
+      }
+    ],
+    "globals": []
+  }
+}

--- a/tests/fixtures/ir_json/mir_duplicate_generic_enum_variant_names.golden.json
+++ b/tests/fixtures/ir_json/mir_duplicate_generic_enum_variant_names.golden.json
@@ -1,0 +1,281 @@
+{
+  "format": "zen.mir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "lowering_status": "minimal",
+  "functions": [
+    {
+      "name": "describe_first",
+      "params": [
+        {
+          "name": "value",
+          "type": "First_i32"
+        }
+      ],
+      "return_type": "StaticString",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "match",
+              "type": "StaticString",
+              "target": {
+                "kind": "local",
+                "type": "First_i32",
+                "name": "value"
+              },
+              "match_kind": "enum",
+              "arms": [
+                {
+                  "pattern": {
+                    "kind": "enum_variant",
+                    "name": "First_i32.Some",
+                    "bindings": [
+                      {
+                        "name": "inner",
+                        "type": "i32"
+                      }
+                    ]
+                  },
+                  "body": {
+                    "label": "entry",
+                    "statements": [],
+                    "terminator": {
+                      "kind": "return",
+                      "value": {
+                        "kind": "block",
+                        "type": "StaticString",
+                        "value": {
+                          "has_result": true,
+                          "result": {
+                            "kind": "static_string",
+                            "type": "StaticString",
+                            "value": "first-some"
+                          },
+                          "statement_count": 0
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "pattern": {
+                    "kind": "enum_variant",
+                    "name": "First_i32.None",
+                    "bindings": []
+                  },
+                  "body": {
+                    "label": "entry",
+                    "statements": [],
+                    "terminator": {
+                      "kind": "return",
+                      "value": {
+                        "kind": "block",
+                        "type": "StaticString",
+                        "value": {
+                          "has_result": true,
+                          "result": {
+                            "kind": "static_string",
+                            "type": "StaticString",
+                            "value": "first-none"
+                          },
+                          "statement_count": 0
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "describe_second",
+      "params": [
+        {
+          "name": "value",
+          "type": "Second_bool"
+        }
+      ],
+      "return_type": "StaticString",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "match",
+              "type": "StaticString",
+              "target": {
+                "kind": "local",
+                "type": "Second_bool",
+                "name": "value"
+              },
+              "match_kind": "enum",
+              "arms": [
+                {
+                  "pattern": {
+                    "kind": "enum_variant",
+                    "name": "Second_bool.Some",
+                    "bindings": [
+                      {
+                        "name": "inner",
+                        "type": "bool"
+                      }
+                    ]
+                  },
+                  "body": {
+                    "label": "entry",
+                    "statements": [],
+                    "terminator": {
+                      "kind": "return",
+                      "value": {
+                        "kind": "block",
+                        "type": "StaticString",
+                        "value": {
+                          "has_result": true,
+                          "result": {
+                            "kind": "static_string",
+                            "type": "StaticString",
+                            "value": "second-some"
+                          },
+                          "statement_count": 0
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "pattern": {
+                    "kind": "enum_variant",
+                    "name": "Second_bool.None",
+                    "bindings": []
+                  },
+                  "body": {
+                    "label": "entry",
+                    "statements": [],
+                    "terminator": {
+                      "kind": "return",
+                      "value": {
+                        "kind": "block",
+                        "type": "StaticString",
+                        "value": {
+                          "has_result": true,
+                          "result": {
+                            "kind": "static_string",
+                            "type": "StaticString",
+                            "value": "second-none"
+                          },
+                          "statement_count": 0
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "main",
+      "params": [],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [
+            {
+              "kind": "let",
+              "name": "first",
+              "type": "First_i32",
+              "mutable": false,
+              "value": {
+                "kind": "enum_variant",
+                "type": "First_i32",
+                "name": "First_i32.Some",
+                "args": [
+                  {
+                    "kind": "int",
+                    "type": "i32",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "let",
+              "name": "second",
+              "type": "Second_bool",
+              "mutable": false,
+              "value": {
+                "kind": "enum_variant",
+                "type": "Second_bool",
+                "name": "Second_bool.None"
+              }
+            },
+            {
+              "kind": "expr",
+              "value": {
+                "kind": "call",
+                "type": "void",
+                "function": "io_println",
+                "args": [
+                  {
+                    "kind": "call",
+                    "type": "StaticString",
+                    "function": "describe_first",
+                    "args": [
+                      {
+                        "kind": "local",
+                        "type": "First_i32",
+                        "name": "first"
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "expr",
+              "value": {
+                "kind": "call",
+                "type": "void",
+                "function": "io_println",
+                "args": [
+                  {
+                    "kind": "call",
+                    "type": "StaticString",
+                    "function": "describe_second",
+                    "args": [
+                      {
+                        "kind": "local",
+                        "type": "Second_bool",
+                        "name": "second"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "int",
+              "type": "i32",
+              "value": 0
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/ir_json/typed_duplicate_generic_enum_variant_names.golden.json
+++ b/tests/fixtures/ir_json/typed_duplicate_generic_enum_variant_names.golden.json
@@ -1,0 +1,746 @@
+{
+  "format": "zen.typed.v0",
+  "semantic_status": "checked",
+  "program": {
+    "functions": [
+      {
+        "name": "describe_first",
+        "params": [
+          {
+            "name": "value",
+            "ty": {
+              "Enum": {
+                "name": "First_i32",
+                "variants": [
+                  [
+                    "None",
+                    null
+                  ],
+                  [
+                    "Some",
+                    "I32"
+                  ]
+                ]
+              }
+            },
+            "span": {
+              "file_id": 0,
+              "start": 99,
+              "end": 116
+            }
+          }
+        ],
+        "return_type": "Str",
+        "body": {
+          "statements": [],
+          "expr": {
+            "kind": {
+              "Match": {
+                "scrutinee": {
+                  "kind": {
+                    "Variable": "value"
+                  },
+                  "ty": {
+                    "Enum": {
+                      "name": "First_i32",
+                      "variants": [
+                        [
+                          "None",
+                          null
+                        ],
+                        [
+                          "Some",
+                          "I32"
+                        ]
+                      ]
+                    }
+                  },
+                  "span": {
+                    "file_id": 0,
+                    "start": 137,
+                    "end": 142
+                  }
+                },
+                "arms": [
+                  {
+                    "pattern": {
+                      "EnumVariant": {
+                        "type_name": "First_i32",
+                        "variant": "Some",
+                        "bindings": [
+                          [
+                            "inner",
+                            "I32"
+                          ]
+                        ]
+                      }
+                    },
+                    "body": {
+                      "statements": [],
+                      "expr": {
+                        "kind": {
+                          "Block": {
+                            "statements": [],
+                            "expr": {
+                              "kind": {
+                                "StringLiteral": "first-some"
+                              },
+                              "ty": "Str",
+                              "span": {
+                                "file_id": 0,
+                                "start": 169,
+                                "end": 181
+                              }
+                            },
+                            "ty": "Str",
+                            "span": {
+                              "file_id": 0,
+                              "start": 167,
+                              "end": 183
+                            }
+                          }
+                        },
+                        "ty": "Str",
+                        "span": {
+                          "file_id": 0,
+                          "start": 167,
+                          "end": 183
+                        }
+                      },
+                      "ty": "Str",
+                      "span": {
+                        "file_id": 0,
+                        "start": 167,
+                        "end": 183
+                      }
+                    },
+                    "span": {
+                      "file_id": 0,
+                      "start": 155,
+                      "end": 183
+                    }
+                  },
+                  {
+                    "pattern": {
+                      "EnumVariant": {
+                        "type_name": "First_i32",
+                        "variant": "None",
+                        "bindings": []
+                      }
+                    },
+                    "body": {
+                      "statements": [],
+                      "expr": {
+                        "kind": {
+                          "Block": {
+                            "statements": [],
+                            "expr": {
+                              "kind": {
+                                "StringLiteral": "first-none"
+                              },
+                              "ty": "Str",
+                              "span": {
+                                "file_id": 0,
+                                "start": 201,
+                                "end": 213
+                              }
+                            },
+                            "ty": "Str",
+                            "span": {
+                              "file_id": 0,
+                              "start": 199,
+                              "end": 215
+                            }
+                          }
+                        },
+                        "ty": "Str",
+                        "span": {
+                          "file_id": 0,
+                          "start": 199,
+                          "end": 215
+                        }
+                      },
+                      "ty": "Str",
+                      "span": {
+                        "file_id": 0,
+                        "start": 199,
+                        "end": 215
+                      }
+                    },
+                    "span": {
+                      "file_id": 0,
+                      "start": 194,
+                      "end": 215
+                    }
+                  }
+                ],
+                "kind": "EnumMatch"
+              }
+            },
+            "ty": "Str",
+            "span": {
+              "file_id": 0,
+              "start": 137,
+              "end": 215
+            }
+          },
+          "ty": "Str",
+          "span": {
+            "file_id": 0,
+            "start": 131,
+            "end": 217
+          }
+        },
+        "defers": [],
+        "span": {
+          "file_id": 0,
+          "start": 81,
+          "end": 217
+        }
+      },
+      {
+        "name": "describe_second",
+        "params": [
+          {
+            "name": "value",
+            "ty": {
+              "Enum": {
+                "name": "Second_bool",
+                "variants": [
+                  [
+                    "None",
+                    null
+                  ],
+                  [
+                    "Some",
+                    "Bool"
+                  ]
+                ]
+              }
+            },
+            "span": {
+              "file_id": 0,
+              "start": 238,
+              "end": 257
+            }
+          }
+        ],
+        "return_type": "Str",
+        "body": {
+          "statements": [],
+          "expr": {
+            "kind": {
+              "Match": {
+                "scrutinee": {
+                  "kind": {
+                    "Variable": "value"
+                  },
+                  "ty": {
+                    "Enum": {
+                      "name": "Second_bool",
+                      "variants": [
+                        [
+                          "None",
+                          null
+                        ],
+                        [
+                          "Some",
+                          "Bool"
+                        ]
+                      ]
+                    }
+                  },
+                  "span": {
+                    "file_id": 0,
+                    "start": 278,
+                    "end": 283
+                  }
+                },
+                "arms": [
+                  {
+                    "pattern": {
+                      "EnumVariant": {
+                        "type_name": "Second_bool",
+                        "variant": "Some",
+                        "bindings": [
+                          [
+                            "inner",
+                            "Bool"
+                          ]
+                        ]
+                      }
+                    },
+                    "body": {
+                      "statements": [],
+                      "expr": {
+                        "kind": {
+                          "Block": {
+                            "statements": [],
+                            "expr": {
+                              "kind": {
+                                "StringLiteral": "second-some"
+                              },
+                              "ty": "Str",
+                              "span": {
+                                "file_id": 0,
+                                "start": 310,
+                                "end": 323
+                              }
+                            },
+                            "ty": "Str",
+                            "span": {
+                              "file_id": 0,
+                              "start": 308,
+                              "end": 325
+                            }
+                          }
+                        },
+                        "ty": "Str",
+                        "span": {
+                          "file_id": 0,
+                          "start": 308,
+                          "end": 325
+                        }
+                      },
+                      "ty": "Str",
+                      "span": {
+                        "file_id": 0,
+                        "start": 308,
+                        "end": 325
+                      }
+                    },
+                    "span": {
+                      "file_id": 0,
+                      "start": 296,
+                      "end": 325
+                    }
+                  },
+                  {
+                    "pattern": {
+                      "EnumVariant": {
+                        "type_name": "Second_bool",
+                        "variant": "None",
+                        "bindings": []
+                      }
+                    },
+                    "body": {
+                      "statements": [],
+                      "expr": {
+                        "kind": {
+                          "Block": {
+                            "statements": [],
+                            "expr": {
+                              "kind": {
+                                "StringLiteral": "second-none"
+                              },
+                              "ty": "Str",
+                              "span": {
+                                "file_id": 0,
+                                "start": 343,
+                                "end": 356
+                              }
+                            },
+                            "ty": "Str",
+                            "span": {
+                              "file_id": 0,
+                              "start": 341,
+                              "end": 358
+                            }
+                          }
+                        },
+                        "ty": "Str",
+                        "span": {
+                          "file_id": 0,
+                          "start": 341,
+                          "end": 358
+                        }
+                      },
+                      "ty": "Str",
+                      "span": {
+                        "file_id": 0,
+                        "start": 341,
+                        "end": 358
+                      }
+                    },
+                    "span": {
+                      "file_id": 0,
+                      "start": 336,
+                      "end": 358
+                    }
+                  }
+                ],
+                "kind": "EnumMatch"
+              }
+            },
+            "ty": "Str",
+            "span": {
+              "file_id": 0,
+              "start": 278,
+              "end": 358
+            }
+          },
+          "ty": "Str",
+          "span": {
+            "file_id": 0,
+            "start": 272,
+            "end": 360
+          }
+        },
+        "defers": [],
+        "span": {
+          "file_id": 0,
+          "start": 219,
+          "end": 360
+        }
+      },
+      {
+        "name": "main",
+        "params": [],
+        "return_type": "I32",
+        "body": {
+          "statements": [
+            {
+              "kind": {
+                "VarDecl": {
+                  "name": "first",
+                  "ty": {
+                    "Enum": {
+                      "name": "First_i32",
+                      "variants": [
+                        [
+                          "None",
+                          null
+                        ],
+                        [
+                          "Some",
+                          "I32"
+                        ]
+                      ]
+                    }
+                  },
+                  "value": {
+                    "kind": {
+                      "EnumVariant": {
+                        "type_name": "First_i32",
+                        "variant": "Some",
+                        "payload": {
+                          "kind": {
+                            "IntLiteral": 1
+                          },
+                          "ty": "I32",
+                          "span": {
+                            "file_id": 0,
+                            "start": 406,
+                            "end": 407
+                          }
+                        }
+                      }
+                    },
+                    "ty": {
+                      "Enum": {
+                        "name": "First_i32",
+                        "variants": [
+                          [
+                            "None",
+                            null
+                          ],
+                          [
+                            "Some",
+                            "I32"
+                          ]
+                        ]
+                      }
+                    },
+                    "span": {
+                      "file_id": 0,
+                      "start": 390,
+                      "end": 408
+                    }
+                  },
+                  "mutable": false
+                }
+              },
+              "span": {
+                "file_id": 0,
+                "start": 382,
+                "end": 408
+              }
+            },
+            {
+              "kind": {
+                "VarDecl": {
+                  "name": "second",
+                  "ty": {
+                    "Enum": {
+                      "name": "Second_bool",
+                      "variants": [
+                        [
+                          "None",
+                          null
+                        ],
+                        [
+                          "Some",
+                          "Bool"
+                        ]
+                      ]
+                    }
+                  },
+                  "value": {
+                    "kind": {
+                      "EnumVariant": {
+                        "type_name": "Second_bool",
+                        "variant": "None",
+                        "payload": null
+                      }
+                    },
+                    "ty": {
+                      "Enum": {
+                        "name": "Second_bool",
+                        "variants": [
+                          [
+                            "None",
+                            null
+                          ],
+                          [
+                            "Some",
+                            "Bool"
+                          ]
+                        ]
+                      }
+                    },
+                    "span": {
+                      "file_id": 0,
+                      "start": 422,
+                      "end": 439
+                    }
+                  },
+                  "mutable": false
+                }
+              },
+              "span": {
+                "file_id": 0,
+                "start": 413,
+                "end": 439
+              }
+            },
+            {
+              "kind": {
+                "Expression": {
+                  "kind": {
+                    "FunctionCall": {
+                      "function": "io_println",
+                      "args": [
+                        {
+                          "kind": {
+                            "FunctionCall": {
+                              "function": "describe_first",
+                              "args": [
+                                {
+                                  "kind": {
+                                    "Variable": "first"
+                                  },
+                                  "ty": {
+                                    "Enum": {
+                                      "name": "First_i32",
+                                      "variants": [
+                                        [
+                                          "None",
+                                          null
+                                        ],
+                                        [
+                                          "Some",
+                                          "I32"
+                                        ]
+                                      ]
+                                    }
+                                  },
+                                  "span": {
+                                    "file_id": 0,
+                                    "start": 470,
+                                    "end": 475
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "ty": "Str",
+                          "span": {
+                            "file_id": 0,
+                            "start": 455,
+                            "end": 476
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "ty": "Void",
+                  "span": {
+                    "file_id": 0,
+                    "start": 444,
+                    "end": 477
+                  }
+                }
+              },
+              "span": {
+                "file_id": 0,
+                "start": 444,
+                "end": 477
+              }
+            },
+            {
+              "kind": {
+                "Expression": {
+                  "kind": {
+                    "FunctionCall": {
+                      "function": "io_println",
+                      "args": [
+                        {
+                          "kind": {
+                            "FunctionCall": {
+                              "function": "describe_second",
+                              "args": [
+                                {
+                                  "kind": {
+                                    "Variable": "second"
+                                  },
+                                  "ty": {
+                                    "Enum": {
+                                      "name": "Second_bool",
+                                      "variants": [
+                                        [
+                                          "None",
+                                          null
+                                        ],
+                                        [
+                                          "Some",
+                                          "Bool"
+                                        ]
+                                      ]
+                                    }
+                                  },
+                                  "span": {
+                                    "file_id": 0,
+                                    "start": 509,
+                                    "end": 515
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "ty": "Str",
+                          "span": {
+                            "file_id": 0,
+                            "start": 493,
+                            "end": 516
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "ty": "Void",
+                  "span": {
+                    "file_id": 0,
+                    "start": 482,
+                    "end": 517
+                  }
+                }
+              },
+              "span": {
+                "file_id": 0,
+                "start": 482,
+                "end": 517
+              }
+            }
+          ],
+          "expr": {
+            "kind": {
+              "IntLiteral": 0
+            },
+            "ty": "I32",
+            "span": {
+              "file_id": 0,
+              "start": 522,
+              "end": 523
+            }
+          },
+          "ty": "I32",
+          "span": {
+            "file_id": 0,
+            "start": 376,
+            "end": 525
+          }
+        },
+        "defers": [],
+        "span": {
+          "file_id": 0,
+          "start": 362,
+          "end": 525
+        }
+      }
+    ],
+    "types": [
+      {
+        "name": "First_i32",
+        "kind": {
+          "Enum": {
+            "variants": [
+              {
+                "name": "None",
+                "tag": 0,
+                "payload": null
+              },
+              {
+                "name": "Some",
+                "tag": 1,
+                "payload": [
+                  [
+                    "payload",
+                    "I32"
+                  ]
+                ]
+              }
+            ]
+          }
+        },
+        "methods": [],
+        "span": {
+          "file_id": 0,
+          "start": 390,
+          "end": 408
+        }
+      },
+      {
+        "name": "Second_bool",
+        "kind": {
+          "Enum": {
+            "variants": [
+              {
+                "name": "None",
+                "tag": 0,
+                "payload": null
+              },
+              {
+                "name": "Some",
+                "tag": 1,
+                "payload": [
+                  [
+                    "payload",
+                    "Bool"
+                  ]
+                ]
+              }
+            ]
+          }
+        },
+        "methods": [],
+        "span": {
+          "file_id": 0,
+          "start": 422,
+          "end": 439
+        }
+      }
+    ],
+    "globals": [],
+    "entry_point": "main"
+  }
+}

--- a/tests/integration/cli_build/frontend_json/hir_golden/generic_enums.rs
+++ b/tests/integration/cli_build/frontend_json/hir_golden/generic_enums.rs
@@ -28,6 +28,15 @@ fn emit_json_hir_generic_option_multi_schema_matches_golden() {
 }
 
 #[test]
+fn emit_json_hir_duplicate_generic_enum_variant_names_schema_matches_golden() {
+    assert_hir_golden(
+        "tests/zen/duplicate_enum_variant_names.zen",
+        "tests/fixtures/ir_json/hir_duplicate_generic_enum_variant_names.golden.json",
+        "duplicate generic enum variant names",
+    );
+}
+
+#[test]
 fn emit_json_hir_generic_result_multi_schema_matches_golden() {
     assert_hir_golden(
         "tests/zen/generic_result_enum_multi_specialization.zen",

--- a/tests/integration/cli_build/frontend_json/mir_golden/generic_enums.rs
+++ b/tests/integration/cli_build/frontend_json/mir_golden/generic_enums.rs
@@ -28,6 +28,15 @@ fn emit_json_mir_generic_option_multi_schema_matches_golden() {
 }
 
 #[test]
+fn emit_json_mir_duplicate_generic_enum_variant_names_schema_matches_golden() {
+    assert_mir_golden(
+        "tests/zen/duplicate_enum_variant_names.zen",
+        "tests/fixtures/ir_json/mir_duplicate_generic_enum_variant_names.golden.json",
+        "duplicate generic enum variant names",
+    );
+}
+
+#[test]
 fn emit_json_mir_generic_result_multi_schema_matches_golden() {
     assert_mir_golden(
         "tests/zen/generic_result_enum_multi_specialization.zen",

--- a/tests/integration/cli_build/frontend_json/typed_golden/generic_enums.rs
+++ b/tests/integration/cli_build/frontend_json/typed_golden/generic_enums.rs
@@ -19,6 +19,15 @@ fn emit_json_typed_generic_option_multi_schema_matches_golden() {
 }
 
 #[test]
+fn emit_json_typed_duplicate_generic_enum_variant_names_schema_matches_golden() {
+    assert_typed_golden(
+        "duplicate_enum_variant_names.zen",
+        "tests/fixtures/ir_json/typed_duplicate_generic_enum_variant_names.golden.json",
+        "duplicate generic enum variant names",
+    );
+}
+
+#[test]
 fn emit_json_typed_generic_result_schema_matches_golden() {
     assert_typed_golden(
         "generic_result_enum.zen",


### PR DESCRIPTION
## Summary
- add typed, HIR, and MIR golden coverage for duplicate generic enum variant names
- pin distinct specialized enum names (`First_i32`, `Second_bool`) while preserving duplicate variant labels under each type
- complement existing runtime and generated-C coverage for this fixture

## Verification
- cargo test --test integration duplicate_generic_enum_variant_names --quiet
- cargo test --test integration emit_json_typed_duplicate_generic_enum_variant_names_schema_matches_golden --quiet
- cargo test --test integration emit_json_hir_duplicate_generic_enum_variant_names_schema_matches_golden --quiet
- cargo test --test integration emit_json_mir_duplicate_generic_enum_variant_names_schema_matches_golden --quiet
- cargo fmt --check
- git diff --check
- cargo clippy -- -D warnings
- cargo test --lib --quiet
- cargo test --tests --quiet