### PR TITLE
[codex] Guard runtime fixture coverage

### DIFF
--- a/tests/integration/discovery.rs
+++ b/tests/integration/discovery.rs
@@ -21,3 +21,40 @@ fn all_zen_files_have_expected_output() {
         missing
     );
 }
+
+#[test]
+fn all_expected_outputs_are_exercised_by_runtime_tests() {
+    let dir = test_dir();
+    let expected_dir = dir.join("expected");
+    let single_file_tests = std::fs::read_to_string("tests/integration/single_file_fixtures.rs")
+        .expect("read single-file runtime tests");
+    let runtime_tests = std::fs::read_to_string("tests/integration/runtime_fixtures.rs")
+        .expect("read runtime tests");
+    let multi_file_tests = std::fs::read_to_string("tests/integration/multi_file_fixtures.rs")
+        .expect("read multi-file runtime tests");
+
+    let mut uncovered = Vec::new();
+    for entry in std::fs::read_dir(&expected_dir).expect("read tests/zen/expected") {
+        let entry = entry.expect("expected dir entry");
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("expected") {
+            continue;
+        }
+
+        let stem = path.file_stem().unwrap().to_str().unwrap();
+        let run_test_call = format!("run_test(\"{stem}\")");
+        let multi_file_path = format!("{stem}/main.zen");
+        if !single_file_tests.contains(&run_test_call)
+            && !runtime_tests.contains(&run_test_call)
+            && !multi_file_tests.contains(&multi_file_path)
+        {
+            uncovered.push(stem.to_string());
+        }
+    }
+
+    uncovered.sort();
+    assert!(
+        uncovered.is_empty(),
+        "expected fixtures without runtime coverage: {uncovered:?}"
+    );
+}

--- a/tests/integration/single_file_fixtures.rs
+++ b/tests/integration/single_file_fixtures.rs
@@ -41,6 +41,11 @@ fn test_loops() {
 }
 
 #[test]
+fn test_loop_control() {
+    run_test("loop_control");
+}
+
+#[test]
 fn test_strings() {
     run_test("strings");
 }


### PR DESCRIPTION
## Summary
- add a discovery guard that every `tests/zen/expected/*.expected` fixture is exercised by runtime tests
- add the missing `loop_control` runtime fixture test exposed by the new guard
- prevent future expected-output fixture drift where snapshots exist but no executable test uses them

## Verification
- cargo test --test integration all_expected_outputs_are_exercised_by_runtime_tests --quiet
- cargo test --test integration test_loop_control --quiet
- cargo fmt --check
- git diff --check
- cargo clippy -- -D warnings
- cargo test --lib --quiet
- cargo test --tests --quiet