### PR TITLE
[codex] Split specialized type-name recovery

### DIFF
--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -32,6 +32,7 @@ mod monomorphize;
 mod monomorphize_dependencies;
 mod monomorphize_inference;
 mod monomorphize_names;
+mod monomorphize_specialized_type_names;
 mod monomorphize_specialized_types;
 mod monomorphize_substitution;
 mod monomorphize_types;

--- a/src/typechecker/monomorphize_specialized_type_names.rs
+++ b/src/typechecker/monomorphize_specialized_type_names.rs
@@ -1,0 +1,83 @@
+//! Recover source generic names and arguments from specialized concrete types.
+
+use std::collections::HashMap;
+
+use crate::ast::typed::Type;
+use crate::ast::AstType;
+
+use super::monomorphize_types::{concrete_name_matches_generic, type_to_ast};
+use super::TypeChecker;
+
+impl TypeChecker {
+    pub(super) fn generic_type_args_from_type(
+        &self,
+        concrete_name: &str,
+        ty: &Type,
+    ) -> Option<(String, Vec<AstType>)> {
+        if let Some((name, params)) = self
+            .structs
+            .iter()
+            .find(|(name, info)| {
+                concrete_name != name.as_str()
+                    && concrete_name_matches_generic(concrete_name, name)
+                    && !info.type_params.is_empty()
+            })
+            .map(|(name, info)| (name.clone(), info.type_params.clone()))
+        {
+            let type_args = self.infer_specialized_type_args(&name, ty, &params);
+            if type_args.len() == params.len() {
+                return Some((name, type_args));
+            }
+        }
+
+        if let Some((name, params)) = self
+            .enums
+            .iter()
+            .find(|(name, info)| {
+                concrete_name != name.as_str()
+                    && concrete_name_matches_generic(concrete_name, name)
+                    && !info.type_params.is_empty()
+            })
+            .map(|(name, info)| (name.clone(), info.type_params.clone()))
+        {
+            let type_args = self.infer_specialized_type_args(&name, ty, &params);
+            if type_args.len() == params.len() {
+                return Some((name, type_args));
+            }
+        }
+
+        None
+    }
+
+    fn infer_specialized_type_args(
+        &self,
+        generic_name: &str,
+        ty: &Type,
+        params: &[String],
+    ) -> Vec<AstType> {
+        let mut inferred = HashMap::new();
+        let mut conflicts = Vec::new();
+        self.match_generic_type_params(generic_name, ty, params, &mut inferred, &mut conflicts);
+        params
+            .iter()
+            .filter_map(|param| inferred.get(param).map(|ty| self.type_to_ast_ref(ty)))
+            .collect()
+    }
+
+    pub(crate) fn type_to_ast_ref(&self, ty: &Type) -> AstType {
+        match ty {
+            Type::Struct { name, .. } | Type::Enum { name, .. } => {
+                if let Some((generic_name, type_args)) = self.generic_type_args_from_type(name, ty)
+                {
+                    AstType::Generic {
+                        name: generic_name,
+                        type_args,
+                    }
+                } else {
+                    type_to_ast(ty)
+                }
+            }
+            _ => type_to_ast(ty),
+        }
+    }
+}

--- a/src/typechecker/monomorphize_specialized_types.rs
+++ b/src/typechecker/monomorphize_specialized_types.rs
@@ -6,7 +6,7 @@ use crate::ast::typed::{Type, TypeDefKind, TypedTypeDef};
 use crate::ast::AstType;
 use crate::error::Span;
 
-use super::monomorphize_types::{concrete_name_matches_generic, substitute_ast_type, type_to_ast};
+use super::monomorphize_types::substitute_ast_type;
 use super::TypeChecker;
 
 impl TypeChecker {
@@ -181,75 +181,6 @@ impl TypeChecker {
                 self.ensure_specialized_type_refs_for_type(ret, span);
             }
             _ => {}
-        }
-    }
-
-    fn generic_type_args_from_type(
-        &self,
-        concrete_name: &str,
-        ty: &Type,
-    ) -> Option<(String, Vec<AstType>)> {
-        if let Some((name, params)) = self
-            .structs
-            .iter()
-            .find(|(name, info)| {
-                concrete_name != name.as_str()
-                    && concrete_name_matches_generic(concrete_name, name)
-                    && !info.type_params.is_empty()
-            })
-            .map(|(name, info)| (name.clone(), info.type_params.clone()))
-        {
-            let mut inferred = HashMap::new();
-            let mut conflicts = Vec::new();
-            self.match_generic_type_params(&name, ty, &params, &mut inferred, &mut conflicts);
-            let type_args = params
-                .iter()
-                .filter_map(|param| inferred.get(param).map(|ty| self.type_to_ast_ref(ty)))
-                .collect::<Vec<_>>();
-            if type_args.len() == params.len() {
-                return Some((name, type_args));
-            }
-        }
-
-        if let Some((name, params)) = self
-            .enums
-            .iter()
-            .find(|(name, info)| {
-                concrete_name != name.as_str()
-                    && concrete_name_matches_generic(concrete_name, name)
-                    && !info.type_params.is_empty()
-            })
-            .map(|(name, info)| (name.clone(), info.type_params.clone()))
-        {
-            let mut inferred = HashMap::new();
-            let mut conflicts = Vec::new();
-            self.match_generic_type_params(&name, ty, &params, &mut inferred, &mut conflicts);
-            let type_args = params
-                .iter()
-                .filter_map(|param| inferred.get(param).map(|ty| self.type_to_ast_ref(ty)))
-                .collect::<Vec<_>>();
-            if type_args.len() == params.len() {
-                return Some((name, type_args));
-            }
-        }
-
-        None
-    }
-
-    pub(crate) fn type_to_ast_ref(&self, ty: &Type) -> AstType {
-        match ty {
-            Type::Struct { name, .. } | Type::Enum { name, .. } => {
-                if let Some((generic_name, type_args)) = self.generic_type_args_from_type(name, ty)
-                {
-                    AstType::Generic {
-                        name: generic_name,
-                        type_args,
-                    }
-                } else {
-                    type_to_ast(ty)
-                }
-            }
-            _ => type_to_ast(ty),
         }
     }
 }

--- a/tests/docs_truth/repo_hygiene/file_size/lexer_and_monomorphize.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/lexer_and_monomorphize.rs
@@ -96,3 +96,31 @@ fn monomorphize_type_substitution_lives_in_focused_helper() {
         "typechecker module should include the focused monomorphize_names helper"
     );
 }
+
+#[test]
+fn monomorphize_specialized_type_name_recovery_lives_in_focused_helper() {
+    let specialized_types = read("src/typechecker/monomorphize_specialized_types.rs");
+    let specialized_type_names = read("src/typechecker/monomorphize_specialized_type_names.rs");
+    let module = read("src/typechecker/mod.rs");
+
+    assert!(
+        specialized_types.lines().count() < 210,
+        "monomorphize_specialized_types.rs should stay focused on emitting specialized definitions"
+    );
+    assert!(
+        !specialized_types.contains("fn generic_type_args_from_type"),
+        "specialized type-name recovery should live in monomorphize_specialized_type_names.rs"
+    );
+    assert!(
+        specialized_type_names.contains("fn generic_type_args_from_type"),
+        "monomorphize_specialized_type_names.rs should recover generic args from specialized type names"
+    );
+    assert!(
+        specialized_type_names.contains("pub(crate) fn type_to_ast_ref"),
+        "monomorphize_specialized_type_names.rs should own Type-to-AstType recovery for monomorphization"
+    );
+    assert!(
+        module.contains("mod monomorphize_specialized_type_names;"),
+        "typechecker module should include the focused specialized type-name helper"
+    );
+}


### PR DESCRIPTION
## Summary
- move generic type-name/argument recovery out of `monomorphize_specialized_types.rs` into `monomorphize_specialized_type_names.rs`
- keep specialized type emission focused on emitting specialized definitions
- add a repo-hygiene guard that prevents this responsibility from drifting back

## Verification
- cargo test --test docs_truth monomorphize_specialized_type_name_recovery_lives_in_focused_helper --quiet
- cargo test --test integration emit_json_typed_multi_file_generic_method_nested_result_schema_matches_golden --quiet
- cargo test --lib monomorph --quiet
- cargo fmt --check
- git diff --check
- cargo clippy -- -D warnings
- cargo test --lib --quiet
- cargo test --tests --quiet