### PR TITLE
[codex] Split generic type-reference validation

### DIFF
--- a/src/typechecker/generic_type_reference_walker.rs
+++ b/src/typechecker/generic_type_reference_walker.rs
@@ -1,7 +1,7 @@
 use super::*;
-use crate::ast::{gated_builtin_type_name, is_builtin_type_name};
 
 mod expressions;
+mod type_refs;
 
 impl TypeChecker {
     pub(super) fn validate_generic_type_ref_bounds(
@@ -72,130 +72,16 @@ impl TypeChecker {
     ) {
         match ast_type {
             AstType::Named(name) => {
-                if scoped_type_params.contains(name) {
-                    return;
-                }
-
-                if let Some(gated) = gated_builtin_type_name(name) {
-                    self.diagnostics
-                        .push(Diagnostic::error("E0202", gated.gate_message(), span));
-                    return;
-                }
-
-                if !self.is_known_named_type(name) {
-                    if reject_unknown {
-                        self.diagnostics.push(Diagnostic::error(
-                            "E0201",
-                            format!("unknown type symbol '{name}'"),
-                            span,
-                        ));
-                    }
-                    return;
-                }
-
-                let generic = self
-                    .structs
-                    .get(name)
-                    .map(|info| ("struct", info.type_params.len()))
-                    .or_else(|| {
-                        self.enums
-                            .get(name)
-                            .map(|info| ("enum", info.type_params.len()))
-                    });
-                if let Some((kind, type_param_count)) = generic {
-                    if type_param_count > 0 {
-                        self.diagnostics.push(Diagnostic::error(
-                            "E5001",
-                            format!(
-                                "generic {} `{}` expects {} type arguments, found 0",
-                                kind, name, type_param_count
-                            ),
-                            span,
-                        ));
-                    }
-                }
+                self.validate_named_type_ref_bounds(name, scoped_type_params, span, reject_unknown);
             }
             AstType::Generic { name, type_args } => {
-                if let Some(gated) = gated_builtin_type_name(name) {
-                    self.diagnostics
-                        .push(Diagnostic::error("E0202", gated.gate_message(), span));
-                    return;
-                }
-
-                self.validate_generic_type_arg_refs_with_unknowns(
+                self.validate_generic_type_ref_with_args(
+                    name,
                     type_args,
                     scoped_type_params,
                     span,
                     reject_unknown,
                 );
-
-                if scoped_type_params.contains(name) {
-                    return;
-                }
-
-                let (kind, type_params, type_param_bounds) =
-                    if let Some(info) = self.structs.get(name) {
-                        (
-                            "struct",
-                            info.type_params.clone(),
-                            info.type_param_bounds.clone(),
-                        )
-                    } else if let Some(info) = self.enums.get(name) {
-                        (
-                            "enum",
-                            info.type_params.clone(),
-                            info.type_param_bounds.clone(),
-                        )
-                    } else {
-                        if reject_unknown && !self.imports.contains_key(name) {
-                            self.diagnostics.push(Diagnostic::error(
-                                "E0201",
-                                format!("unknown type symbol '{name}'"),
-                                span,
-                            ));
-                        }
-                        return;
-                    };
-
-                if type_params.is_empty() && !type_args.is_empty() {
-                    self.diagnostics.push(Diagnostic::error(
-                        "E5002",
-                        format!(
-                            "non-generic {} `{}` does not accept type arguments",
-                            kind, name
-                        ),
-                        span,
-                    ));
-                    return;
-                }
-
-                if type_params.len() != type_args.len() {
-                    self.diagnostics.push(Diagnostic::error(
-                        "E5001",
-                        format!(
-                            "generic {} `{}` expects {} type arguments, found {}",
-                            kind,
-                            name,
-                            type_params.len(),
-                            type_args.len()
-                        ),
-                        span,
-                    ));
-                    return;
-                }
-
-                let substitutions: HashMap<String, Type> = type_params
-                    .iter()
-                    .zip(type_args.iter())
-                    .filter_map(|(param, arg)| {
-                        if ast_type_references_type_param(arg, scoped_type_params) {
-                            None
-                        } else {
-                            Some((param.clone(), self.resolve_type(arg)))
-                        }
-                    })
-                    .collect();
-                self.check_generic_bounds(&type_param_bounds, &substitutions, span);
             }
             AstType::Ptr(inner)
             | AstType::MutPtr(inner)
@@ -232,14 +118,5 @@ impl TypeChecker {
             }
             _ => {}
         }
-    }
-
-    fn is_known_named_type(&self, name: &str) -> bool {
-        if is_builtin_type_name(name) {
-            return true;
-        }
-        self.structs.contains_key(name)
-            || self.enums.contains_key(name)
-            || self.imports.contains_key(name)
     }
 }

--- a/src/typechecker/generic_type_reference_walker/type_refs.rs
+++ b/src/typechecker/generic_type_reference_walker/type_refs.rs
@@ -1,0 +1,153 @@
+use super::*;
+use crate::ast::{gated_builtin_type_name, is_builtin_type_name};
+
+impl TypeChecker {
+    pub(super) fn validate_named_type_ref_bounds(
+        &mut self,
+        name: &str,
+        scoped_type_params: &HashSet<String>,
+        span: Span,
+        reject_unknown: bool,
+    ) {
+        if scoped_type_params.contains(name) {
+            return;
+        }
+
+        if let Some(gated) = gated_builtin_type_name(name) {
+            self.diagnostics
+                .push(Diagnostic::error("E0202", gated.gate_message(), span));
+            return;
+        }
+
+        if !self.is_known_named_type(name) {
+            if reject_unknown {
+                self.diagnostics.push(Diagnostic::error(
+                    "E0201",
+                    format!("unknown type symbol '{name}'"),
+                    span,
+                ));
+            }
+            return;
+        }
+
+        let generic = self
+            .structs
+            .get(name)
+            .map(|info| ("struct", info.type_params.len()))
+            .or_else(|| {
+                self.enums
+                    .get(name)
+                    .map(|info| ("enum", info.type_params.len()))
+            });
+        if let Some((kind, type_param_count)) = generic {
+            if type_param_count > 0 {
+                self.diagnostics.push(Diagnostic::error(
+                    "E5001",
+                    format!(
+                        "generic {} `{}` expects {} type arguments, found 0",
+                        kind, name, type_param_count
+                    ),
+                    span,
+                ));
+            }
+        }
+    }
+
+    pub(super) fn validate_generic_type_ref_with_args(
+        &mut self,
+        name: &str,
+        type_args: &[AstType],
+        scoped_type_params: &HashSet<String>,
+        span: Span,
+        reject_unknown: bool,
+    ) {
+        if let Some(gated) = gated_builtin_type_name(name) {
+            self.diagnostics
+                .push(Diagnostic::error("E0202", gated.gate_message(), span));
+            return;
+        }
+
+        self.validate_generic_type_arg_refs_with_unknowns(
+            type_args,
+            scoped_type_params,
+            span,
+            reject_unknown,
+        );
+
+        if scoped_type_params.contains(name) {
+            return;
+        }
+
+        let (kind, type_params, type_param_bounds) = if let Some(info) = self.structs.get(name) {
+            (
+                "struct",
+                info.type_params.clone(),
+                info.type_param_bounds.clone(),
+            )
+        } else if let Some(info) = self.enums.get(name) {
+            (
+                "enum",
+                info.type_params.clone(),
+                info.type_param_bounds.clone(),
+            )
+        } else {
+            if reject_unknown && !self.imports.contains_key(name) {
+                self.diagnostics.push(Diagnostic::error(
+                    "E0201",
+                    format!("unknown type symbol '{name}'"),
+                    span,
+                ));
+            }
+            return;
+        };
+
+        if type_params.is_empty() && !type_args.is_empty() {
+            self.diagnostics.push(Diagnostic::error(
+                "E5002",
+                format!(
+                    "non-generic {} `{}` does not accept type arguments",
+                    kind, name
+                ),
+                span,
+            ));
+            return;
+        }
+
+        if type_params.len() != type_args.len() {
+            self.diagnostics.push(Diagnostic::error(
+                "E5001",
+                format!(
+                    "generic {} `{}` expects {} type arguments, found {}",
+                    kind,
+                    name,
+                    type_params.len(),
+                    type_args.len()
+                ),
+                span,
+            ));
+            return;
+        }
+
+        let substitutions: HashMap<String, Type> = type_params
+            .iter()
+            .zip(type_args.iter())
+            .filter_map(|(param, arg)| {
+                if ast_type_references_type_param(arg, scoped_type_params) {
+                    None
+                } else {
+                    Some((param.clone(), self.resolve_type(arg)))
+                }
+            })
+            .collect();
+        self.check_generic_bounds(&type_param_bounds, &substitutions, span);
+    }
+
+    fn is_known_named_type(&self, name: &str) -> bool {
+        if is_builtin_type_name(name) {
+            return true;
+        }
+        self.structs.contains_key(name)
+            || self.enums.contains_key(name)
+            || self.imports.contains_key(name)
+    }
+}

--- a/tests/docs_truth/repo_hygiene/mod.rs
+++ b/tests/docs_truth/repo_hygiene/mod.rs
@@ -24,6 +24,7 @@ mod typechecker_aggregate_constructors;
 mod typechecker_behavior_impls;
 mod typechecker_call_validation;
 mod typechecker_declaration_collection;
+mod typechecker_generic_type_references;
 mod typechecker_imports;
 mod typechecker_patterns;
 mod typechecker_program_checking;

--- a/tests/docs_truth/repo_hygiene/typechecker_generic_type_references.rs
+++ b/tests/docs_truth/repo_hygiene/typechecker_generic_type_references.rs
@@ -1,0 +1,31 @@
+use super::*;
+
+#[test]
+fn generic_type_reference_symbol_validation_lives_in_focused_helper() {
+    let root = read("src/typechecker/generic_type_reference_walker.rs");
+    let type_refs = read("src/typechecker/generic_type_reference_walker/type_refs.rs");
+
+    for helper in [
+        "validate_named_type_ref_bounds",
+        "validate_generic_type_ref_with_args",
+        "is_known_named_type",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {helper}")),
+            "generic_type_reference_walker.rs should not own type-symbol helper: {helper}"
+        );
+        assert!(
+            type_refs.contains(&format!("fn {helper}")),
+            "generic type-symbol validation should live in focused helper: {helper}"
+        );
+    }
+
+    assert!(
+        root.contains("mod type_refs;"),
+        "generic type-reference walker should load the focused type_refs helper"
+    );
+    assert!(
+        root.lines().count() < 170,
+        "generic_type_reference_walker.rs should stay focused on recursive AstType traversal"
+    );
+}


### PR DESCRIPTION
## Summary
- move named/generic type-symbol validation out of `generic_type_reference_walker.rs` into `generic_type_reference_walker/type_refs.rs`
- leave the walker focused on recursive `AstType` traversal while the helper owns arity, non-generic type-arg, gated builtin, and unknown-type diagnostics
- add a repo-hygiene guard for the split

## Verification
- cargo test --test docs_truth generic_type_reference_symbol_validation_lives_in_focused_helper --quiet
- cargo test --test docs_truth semantic_builtin_type_checks_use_shared_spelling_helper --quiet
- cargo test --test integration emit_json_diagnostics_generic_enum_annotation_arity_schema_matches_golden --quiet
- cargo test --lib generic_type --quiet
- cargo fmt --check
- git diff --check
- cargo clippy -- -D warnings
- cargo test --lib --quiet
- cargo test --tests --quiet