### PR TITLE
[codex] Split resolver type-reference collection validation

### DIFF
--- a/src/typechecker/generic_type_validation/resolver_type_references.rs
+++ b/src/typechecker/generic_type_validation/resolver_type_references.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod collected;
+
 impl TypeChecker {
     pub(in crate::typechecker) fn validate_resolver_type_reference_task_list(
         &mut self,
@@ -146,99 +148,5 @@ impl TypeChecker {
             self.validate_collected_value_type_references(restored_key, &scoped, span);
             self.validate_generic_expr_type_references(body, &scoped);
         }
-    }
-
-    fn collected_value_type_param_scope(&self, name: &str) -> Option<HashSet<String>> {
-        self.functions
-            .get(name)
-            .or_else(|| self.methods.get(name))
-            .map(|info| info.type_params.iter().cloned().collect())
-    }
-
-    fn collected_type_type_param_scope(&self, name: &str) -> Option<HashSet<String>> {
-        self.structs
-            .get(name)
-            .map(|info| info.type_params.iter().cloned().collect())
-            .or_else(|| {
-                self.enums
-                    .get(name)
-                    .map(|info| info.type_params.iter().cloned().collect())
-            })
-    }
-
-    fn collected_behavior_type_param_scope(&self, name: &str) -> Option<HashSet<String>> {
-        self.behaviors
-            .get(name)
-            .map(|info| info.type_params.iter().cloned().collect())
-    }
-
-    fn validate_collected_struct_type_references(
-        &mut self,
-        name: &str,
-        scoped: &HashSet<String>,
-        span: Span,
-    ) {
-        let Some(info) = self.structs.get(name).cloned() else {
-            return;
-        };
-        for (_, ty) in &info.fields {
-            self.validate_generic_type_ref_bounds(ty, scoped, span);
-        }
-    }
-
-    fn validate_collected_enum_type_references(
-        &mut self,
-        name: &str,
-        scoped: &HashSet<String>,
-        span: Span,
-    ) {
-        let Some(info) = self.enums.get(name).cloned() else {
-            return;
-        };
-        for (_, payload) in &info.variants {
-            if let Some(payload) = payload {
-                self.validate_generic_type_ref_bounds(payload, scoped, span);
-            }
-        }
-    }
-
-    fn validate_collected_behavior_type_references(
-        &mut self,
-        name: &str,
-        scoped: &HashSet<String>,
-        span: Span,
-    ) {
-        let Some(info) = self.behaviors.get(name).cloned() else {
-            return;
-        };
-        for method in &info.methods {
-            for param in &method.params {
-                self.validate_generic_type_ref_bounds(&param.ty, scoped, span);
-            }
-            if let Some(return_type) = &method.return_type {
-                self.validate_generic_type_ref_bounds(return_type, scoped, span);
-            }
-        }
-    }
-
-    fn validate_collected_value_type_references(
-        &mut self,
-        name: &str,
-        scoped: &HashSet<String>,
-        span: Span,
-    ) {
-        let info = self
-            .functions
-            .get(name)
-            .or_else(|| self.methods.get(name))
-            .cloned();
-        let Some(info) = info else {
-            return;
-        };
-
-        for (_, ty) in &info.params {
-            self.validate_generic_type_ref_bounds(ty, scoped, span);
-        }
-        self.validate_generic_type_ref_bounds(&info.return_type, scoped, span);
     }
 }

--- a/src/typechecker/generic_type_validation/resolver_type_references/collected.rs
+++ b/src/typechecker/generic_type_validation/resolver_type_references/collected.rs
@@ -1,0 +1,100 @@
+use super::*;
+
+impl TypeChecker {
+    pub(super) fn collected_value_type_param_scope(&self, name: &str) -> Option<HashSet<String>> {
+        self.functions
+            .get(name)
+            .or_else(|| self.methods.get(name))
+            .map(|info| info.type_params.iter().cloned().collect())
+    }
+
+    pub(super) fn collected_type_type_param_scope(&self, name: &str) -> Option<HashSet<String>> {
+        self.structs
+            .get(name)
+            .map(|info| info.type_params.iter().cloned().collect())
+            .or_else(|| {
+                self.enums
+                    .get(name)
+                    .map(|info| info.type_params.iter().cloned().collect())
+            })
+    }
+
+    pub(super) fn collected_behavior_type_param_scope(
+        &self,
+        name: &str,
+    ) -> Option<HashSet<String>> {
+        self.behaviors
+            .get(name)
+            .map(|info| info.type_params.iter().cloned().collect())
+    }
+
+    pub(super) fn validate_collected_struct_type_references(
+        &mut self,
+        name: &str,
+        scoped: &HashSet<String>,
+        span: Span,
+    ) {
+        let Some(info) = self.structs.get(name).cloned() else {
+            return;
+        };
+        for (_, ty) in &info.fields {
+            self.validate_generic_type_ref_bounds(ty, scoped, span);
+        }
+    }
+
+    pub(super) fn validate_collected_enum_type_references(
+        &mut self,
+        name: &str,
+        scoped: &HashSet<String>,
+        span: Span,
+    ) {
+        let Some(info) = self.enums.get(name).cloned() else {
+            return;
+        };
+        for (_, payload) in &info.variants {
+            if let Some(payload) = payload {
+                self.validate_generic_type_ref_bounds(payload, scoped, span);
+            }
+        }
+    }
+
+    pub(super) fn validate_collected_behavior_type_references(
+        &mut self,
+        name: &str,
+        scoped: &HashSet<String>,
+        span: Span,
+    ) {
+        let Some(info) = self.behaviors.get(name).cloned() else {
+            return;
+        };
+        for method in &info.methods {
+            for param in &method.params {
+                self.validate_generic_type_ref_bounds(&param.ty, scoped, span);
+            }
+            if let Some(return_type) = &method.return_type {
+                self.validate_generic_type_ref_bounds(return_type, scoped, span);
+            }
+        }
+    }
+
+    pub(super) fn validate_collected_value_type_references(
+        &mut self,
+        name: &str,
+        scoped: &HashSet<String>,
+        span: Span,
+    ) {
+        let info = self
+            .functions
+            .get(name)
+            .or_else(|| self.methods.get(name))
+            .cloned();
+        let Some(info) = info else {
+            return;
+        };
+
+        for (_, ty) in &info.params {
+            self.validate_generic_type_ref_bounds(ty, scoped, span);
+        }
+        self.validate_generic_type_ref_bounds(&info.return_type, scoped, span);
+    }
+}

--- a/tests/docs_truth/repo_hygiene/typechecker_generic_type_references.rs
+++ b/tests/docs_truth/repo_hygiene/typechecker_generic_type_references.rs
@@ -29,3 +29,38 @@ fn generic_type_reference_symbol_validation_lives_in_focused_helper() {
         "generic_type_reference_walker.rs should stay focused on recursive AstType traversal"
     );
 }
+
+#[test]
+fn resolver_type_reference_collection_validation_lives_in_focused_helper() {
+    let root = read("src/typechecker/generic_type_validation/resolver_type_references.rs");
+    let collected =
+        read("src/typechecker/generic_type_validation/resolver_type_references/collected.rs");
+
+    for helper in [
+        "collected_value_type_param_scope",
+        "collected_type_type_param_scope",
+        "collected_behavior_type_param_scope",
+        "validate_collected_struct_type_references",
+        "validate_collected_enum_type_references",
+        "validate_collected_behavior_type_references",
+        "validate_collected_value_type_references",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {helper}")),
+            "resolver_type_references.rs should not own collected type-reference helper: {helper}"
+        );
+        assert!(
+            collected.contains(&format!("fn {helper}")),
+            "collected type-reference validation should live in focused helper: {helper}"
+        );
+    }
+
+    assert!(
+        root.contains("mod collected;"),
+        "resolver type-reference validation should load the focused collected helper"
+    );
+    assert!(
+        root.lines().count() < 190,
+        "resolver_type_references.rs should stay focused on resolver task dispatch"
+    );
+}


### PR DESCRIPTION
## What changed

- Moved collected resolver type-reference scope and signature validation helpers into `resolver_type_references/collected.rs`.
- Kept `resolver_type_references.rs` focused on resolver validation task dispatch and body/default expression replay.
- Added a docs-truth hygiene guard that requires the split module, verifies helper ownership, and caps the parent module size.

## Validation

- `cargo test --test docs_truth resolver_type_reference_collection_validation_lives_in_focused_helper --quiet`
- `cargo test --lib generic_type --quiet`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --tests --quiet`