### PR TITLE
[codex] Split resolver local-scope helpers

### DIFF
--- a/src/typechecker/resolver_validation.rs
+++ b/src/typechecker/resolver_validation.rs
@@ -14,6 +14,7 @@ include!("resolver_validation/imports_behavior_dependencies.rs");
 include!("resolver_validation/imports_source_dependencies.rs");
 include!("resolver_validation/imported_method_seeding.rs");
 include!("resolver_validation/symbols_locals.rs");
+include!("resolver_validation/local_scope_helpers.rs");
 include!("resolver_validation/local_traversal.rs");
 include!("resolver_validation/pattern_locals.rs");
 include!("resolver_validation/metadata_core.rs");

--- a/src/typechecker/resolver_validation/local_scope_helpers.rs
+++ b/src/typechecker/resolver_validation/local_scope_helpers.rs
@@ -1,0 +1,81 @@
+impl TypeChecker {
+    fn require_resolver_parameter_locals(
+        &mut self,
+        symbols: &SymbolTable,
+        params: &[Param],
+        locals: &mut ResolverLocalScope,
+    ) {
+        for param in params {
+            self.require_resolver_local_symbol(
+                symbols,
+                &param.name,
+                expected_local_symbol(param.mutable, locals.current_scope_id),
+                param.span,
+            );
+            locals.insert(param.name.clone(), param.mutable);
+        }
+    }
+
+    fn require_resolver_child_expr_locals(
+        &mut self,
+        symbols: &SymbolTable,
+        expr: &Expression,
+        scope_cursor: &mut ResolverScopeCursor,
+        locals: &ResolverLocalScope,
+    ) {
+        let mut child_locals = scope_cursor.child_scope(locals);
+        self.require_resolver_expr_locals(symbols, expr, scope_cursor, &mut child_locals);
+    }
+
+    fn require_resolver_block_locals(
+        &mut self,
+        symbols: &SymbolTable,
+        statements: &[ast::Statement],
+        expr: Option<&Expression>,
+        scope_cursor: &mut ResolverScopeCursor,
+        locals: &ResolverLocalScope,
+    ) {
+        let mut block_locals = scope_cursor.child_scope(locals);
+        for statement in statements {
+            self.require_resolver_statement_locals(
+                symbols,
+                statement,
+                scope_cursor,
+                &mut block_locals,
+            );
+        }
+        if let Some(expr) = expr {
+            self.require_resolver_expr_locals(symbols, expr, scope_cursor, &mut block_locals);
+        }
+    }
+
+    fn require_resolver_closure_locals(
+        &mut self,
+        symbols: &SymbolTable,
+        params: &[Param],
+        body: &Expression,
+        scope_cursor: &mut ResolverScopeCursor,
+        locals: &ResolverLocalScope,
+    ) {
+        let mut closure_locals = scope_cursor.child_scope(locals);
+        self.require_resolver_parameter_locals(symbols, params, &mut closure_locals);
+        self.require_resolver_expr_locals(symbols, body, scope_cursor, &mut closure_locals);
+    }
+
+    fn require_resolver_var_decl_local(
+        &mut self,
+        symbols: &SymbolTable,
+        name: &str,
+        mutable: bool,
+        span: Span,
+        locals: &mut ResolverLocalScope,
+    ) {
+        self.require_resolver_local_symbol(
+            symbols,
+            name,
+            expected_local_symbol(mutable, locals.current_scope_id),
+            span,
+        );
+        locals.insert(name.to_string(), mutable);
+    }
+}

--- a/src/typechecker/resolver_validation/local_traversal.rs
+++ b/src/typechecker/resolver_validation/local_traversal.rs
@@ -1,67 +1,4 @@
 impl TypeChecker {
-    fn require_resolver_parameter_locals(
-        &mut self,
-        symbols: &SymbolTable,
-        params: &[Param],
-        locals: &mut ResolverLocalScope,
-    ) {
-        for param in params {
-            self.require_resolver_local_symbol(
-                symbols,
-                &param.name,
-                expected_local_symbol(param.mutable, locals.current_scope_id),
-                param.span,
-            );
-            locals.insert(param.name.clone(), param.mutable);
-        }
-    }
-
-    fn require_resolver_child_expr_locals(
-        &mut self,
-        symbols: &SymbolTable,
-        expr: &Expression,
-        scope_cursor: &mut ResolverScopeCursor,
-        locals: &ResolverLocalScope,
-    ) {
-        let mut child_locals = scope_cursor.child_scope(locals);
-        self.require_resolver_expr_locals(symbols, expr, scope_cursor, &mut child_locals);
-    }
-
-    fn require_resolver_block_locals(
-        &mut self,
-        symbols: &SymbolTable,
-        statements: &[ast::Statement],
-        expr: Option<&Expression>,
-        scope_cursor: &mut ResolverScopeCursor,
-        locals: &ResolverLocalScope,
-    ) {
-        let mut block_locals = scope_cursor.child_scope(locals);
-        for statement in statements {
-            self.require_resolver_statement_locals(
-                symbols,
-                statement,
-                scope_cursor,
-                &mut block_locals,
-            );
-        }
-        if let Some(expr) = expr {
-            self.require_resolver_expr_locals(symbols, expr, scope_cursor, &mut block_locals);
-        }
-    }
-
-    fn require_resolver_closure_locals(
-        &mut self,
-        symbols: &SymbolTable,
-        params: &[Param],
-        body: &Expression,
-        scope_cursor: &mut ResolverScopeCursor,
-        locals: &ResolverLocalScope,
-    ) {
-        let mut closure_locals = scope_cursor.child_scope(locals);
-        self.require_resolver_parameter_locals(symbols, params, &mut closure_locals);
-        self.require_resolver_expr_locals(symbols, body, scope_cursor, &mut closure_locals);
-    }
-
     fn require_resolver_expr_locals(
         &mut self,
         symbols: &SymbolTable,
@@ -232,22 +169,4 @@ impl TypeChecker {
             }
         }
     }
-
-    fn require_resolver_var_decl_local(
-        &mut self,
-        symbols: &SymbolTable,
-        name: &str,
-        mutable: bool,
-        span: Span,
-        locals: &mut ResolverLocalScope,
-    ) {
-        self.require_resolver_local_symbol(
-            symbols,
-            name,
-            expected_local_symbol(mutable, locals.current_scope_id),
-            span,
-        );
-        locals.insert(name.to_string(), mutable);
-    }
-
 }

--- a/tests/docs_truth/repo_hygiene/typechecker_resolver_validation.rs
+++ b/tests/docs_truth/repo_hygiene/typechecker_resolver_validation.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 mod focused_modules;
+mod local_traversal;
 mod support_helpers;
 
 #[test]
@@ -148,33 +149,6 @@ fn typechecker_resolver_type_parameter_helpers_live_in_focused_helper() {
     assert!(
         root.contains("include!(\"resolver_validation_support/resolver_type_parameters.rs\");"),
         "resolver validation support should include focused resolver type-parameter helpers"
-    );
-}
-
-#[test]
-fn typechecker_resolver_pattern_local_traversal_lives_in_focused_helper() {
-    let traversal = read("src/typechecker/resolver_validation/local_traversal.rs");
-    let patterns = read("src/typechecker/resolver_validation/pattern_locals.rs");
-
-    for helper in [
-        "require_resolver_pattern_expr_locals",
-        "require_resolver_pattern_locals",
-        "require_resolver_pattern_binding",
-    ] {
-        assert!(
-            !traversal.contains(&format!("fn {helper}")),
-            "resolver local traversal should not own pattern-local helper: {helper}"
-        );
-        assert!(
-            patterns.contains(&format!("fn {helper}")),
-            "resolver pattern-local traversal should live in focused helper: {helper}"
-        );
-    }
-
-    let root = read("src/typechecker/resolver_validation.rs");
-    assert!(
-        root.contains("include!(\"resolver_validation/pattern_locals.rs\");"),
-        "resolver validation should include focused pattern-local traversal"
     );
 }
 

--- a/tests/docs_truth/repo_hygiene/typechecker_resolver_validation/local_traversal.rs
+++ b/tests/docs_truth/repo_hygiene/typechecker_resolver_validation/local_traversal.rs
@@ -1,0 +1,61 @@
+use super::*;
+
+#[test]
+fn typechecker_resolver_pattern_local_traversal_lives_in_focused_helper() {
+    let traversal = read("src/typechecker/resolver_validation/local_traversal.rs");
+    let patterns = read("src/typechecker/resolver_validation/pattern_locals.rs");
+
+    for helper in [
+        "require_resolver_pattern_expr_locals",
+        "require_resolver_pattern_locals",
+        "require_resolver_pattern_binding",
+    ] {
+        assert!(
+            !traversal.contains(&format!("fn {helper}")),
+            "resolver local traversal should not own pattern-local helper: {helper}"
+        );
+        assert!(
+            patterns.contains(&format!("fn {helper}")),
+            "resolver pattern-local traversal should live in focused helper: {helper}"
+        );
+    }
+
+    let root = read("src/typechecker/resolver_validation.rs");
+    assert!(
+        root.contains("include!(\"resolver_validation/pattern_locals.rs\");"),
+        "resolver validation should include focused pattern-local traversal"
+    );
+}
+
+#[test]
+fn typechecker_resolver_local_scope_helpers_live_in_focused_helper() {
+    let root = read("src/typechecker/resolver_validation.rs");
+    let traversal = read("src/typechecker/resolver_validation/local_traversal.rs");
+    let helpers = read("src/typechecker/resolver_validation/local_scope_helpers.rs");
+
+    for helper in [
+        "require_resolver_parameter_locals",
+        "require_resolver_child_expr_locals",
+        "require_resolver_block_locals",
+        "require_resolver_closure_locals",
+        "require_resolver_var_decl_local",
+    ] {
+        assert!(
+            !traversal.contains(&format!("fn {helper}")),
+            "resolver local traversal should not own local-scope helper: {helper}"
+        );
+        assert!(
+            helpers.contains(&format!("fn {helper}")),
+            "resolver local-scope helper should live in focused helper: {helper}"
+        );
+    }
+
+    assert!(
+        traversal.lines().count() < 190,
+        "resolver local traversal should stay focused on expression and statement dispatch"
+    );
+    assert!(
+        root.contains("include!(\"resolver_validation/local_scope_helpers.rs\");"),
+        "resolver validation should include focused local-scope helpers"
+    );
+}


### PR DESCRIPTION
## What changed

- Moved resolver local-scope construction helpers into `resolver_validation/local_scope_helpers.rs`.
- Kept `resolver_validation/local_traversal.rs` focused on expression and statement traversal.
- Added a docs-truth guard for the helper split.
- Moved the local-traversal docs-truth guard pair into its own focused docs-truth module so the guard file remains under the repo-hygiene cap.

## Validation

- `cargo test --test docs_truth typechecker_resolver_local_scope_helpers_live_in_focused_helper --quiet`
- `cargo test --test docs_truth typechecker_resolver_pattern_local_traversal_lives_in_focused_helper --quiet`
- `cargo test --test docs_truth resolver_validation_docs_truth_stays_split_across_focused_modules --quiet`
- `cargo test --lib resolver_type_reference_validation_tasks_collect_only_type_reference_work --quiet`
- `cargo test --lib resolver_declaration_metadata_tasks_collect_top_level_type_reference_tasks --quiet`
- `cargo test --lib for_type_refs --quiet`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --tests --quiet`