### PR TITLE
[codex] Split resolver metadata validation descriptor tests

### DIFF
--- a/src/typechecker/tests/resolver_metadata/validation_descriptors.rs
+++ b/src/typechecker/tests/resolver_metadata/validation_descriptors.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod type_variants;
+
 #[test]
 fn resolver_count_display_formats_known_and_missing_counts() {
     assert_eq!(resolver_count_display(Some(2)), "2");
@@ -192,92 +194,4 @@ fn behavior_method_validation_uses_resolver_codes() {
 
     assert_eq!(validation.display_code, "E0219");
     assert_eq!(validation.typed_code, "E0355");
-}
-
-#[test]
-fn field_validation_formats_messages() {
-    let validation = FieldValidation {
-        display_code: "FIELDS",
-        typed_code: "TYPED_FIELDS",
-    };
-
-    assert_eq!(validation.display_code, "FIELDS");
-    assert_eq!(
-        validation.display_message("type", "Point", "(x: i32)", "(x: f64)"),
-        "resolver type symbol 'Point' has fields '(x: i32)', expected '(x: f64)'"
-    );
-    assert_eq!(
-            validation.typed_message("type", "Pipeline", "(callback: i32)", "(callback: (i32) i32)"),
-            "resolver type symbol 'Pipeline' has typed fields '(callback: i32)', expected '(callback: (i32) i32)'"
-        );
-}
-
-#[test]
-fn field_validation_uses_resolver_codes() {
-    let validation = FieldValidation::resolver_codes();
-
-    assert_eq!(validation.display_code, "E0217");
-    assert_eq!(validation.typed_code, "E0358");
-}
-
-#[test]
-fn variant_payload_validation_formats_messages() {
-    let validation = VariantPayloadValidation {
-        display_code: "PAYLOAD",
-        typed_code: "TYPED_PAYLOAD",
-    };
-
-    assert_eq!(validation.display_code, "PAYLOAD");
-    assert_eq!(
-        validation.display_message("Some", "bool", "i32"),
-        "resolver variant symbol 'Some' has payload type 'bool', expected 'i32'"
-    );
-    assert_eq!(
-        validation.typed_message("Wrap", "i32", "(i32) i32"),
-        "resolver variant symbol 'Wrap' has typed payload type 'i32', expected '(i32) i32'"
-    );
-}
-
-#[test]
-fn variant_payload_validation_uses_resolver_codes() {
-    let validation = VariantPayloadValidation::resolver_codes();
-
-    assert_eq!(validation.display_code, "E0218");
-    assert_eq!(validation.typed_code, "E0359");
-}
-
-#[test]
-fn variant_owner_validation_formats_message() {
-    let validation = VariantOwnerValidation { code: "OWNER" };
-
-    assert_eq!(validation.code, "OWNER");
-    assert_eq!(
-        validation.message("Some", "Result", "Option"),
-        "resolver variant symbol 'Some' has owner 'Result', expected 'Option'"
-    );
-}
-
-#[test]
-fn variant_owner_validation_uses_resolver_code() {
-    let validation = VariantOwnerValidation::resolver_code();
-
-    assert_eq!(validation.code, "E0242");
-}
-
-#[test]
-fn variant_name_validation_formats_message() {
-    let validation = VariantNameValidation { code: "VARIANTS" };
-
-    assert_eq!(validation.code, "VARIANTS");
-    assert_eq!(
-        validation.message("Option", "(Some)", "(Some, None)"),
-        "resolver type symbol 'Option' has variants '(Some)', expected '(Some, None)'"
-    );
-}
-
-#[test]
-fn variant_name_validation_uses_resolver_code() {
-    let validation = VariantNameValidation::resolver_code();
-
-    assert_eq!(validation.code, "E0241");
 }

--- a/src/typechecker/tests/resolver_metadata/validation_descriptors/type_variants.rs
+++ b/src/typechecker/tests/resolver_metadata/validation_descriptors/type_variants.rs
@@ -1,0 +1,94 @@
+use super::*;
+
+#[test]
+fn field_validation_formats_messages() {
+    let validation = FieldValidation {
+        display_code: "FIELDS",
+        typed_code: "TYPED_FIELDS",
+    };
+
+    assert_eq!(validation.display_code, "FIELDS");
+    assert_eq!(
+        validation.display_message("type", "Point", "(x: i32)", "(x: f64)"),
+        "resolver type symbol 'Point' has fields '(x: i32)', expected '(x: f64)'"
+    );
+    assert_eq!(
+        validation.typed_message(
+            "type",
+            "Pipeline",
+            "(callback: i32)",
+            "(callback: (i32) i32)",
+        ),
+        "resolver type symbol 'Pipeline' has typed fields '(callback: i32)', expected '(callback: (i32) i32)'"
+    );
+}
+
+#[test]
+fn field_validation_uses_resolver_codes() {
+    let validation = FieldValidation::resolver_codes();
+
+    assert_eq!(validation.display_code, "E0217");
+    assert_eq!(validation.typed_code, "E0358");
+}
+
+#[test]
+fn variant_payload_validation_formats_messages() {
+    let validation = VariantPayloadValidation {
+        display_code: "PAYLOAD",
+        typed_code: "TYPED_PAYLOAD",
+    };
+
+    assert_eq!(validation.display_code, "PAYLOAD");
+    assert_eq!(
+        validation.display_message("Some", "bool", "i32"),
+        "resolver variant symbol 'Some' has payload type 'bool', expected 'i32'"
+    );
+    assert_eq!(
+        validation.typed_message("Wrap", "i32", "(i32) i32"),
+        "resolver variant symbol 'Wrap' has typed payload type 'i32', expected '(i32) i32'"
+    );
+}
+
+#[test]
+fn variant_payload_validation_uses_resolver_codes() {
+    let validation = VariantPayloadValidation::resolver_codes();
+
+    assert_eq!(validation.display_code, "E0218");
+    assert_eq!(validation.typed_code, "E0359");
+}
+
+#[test]
+fn variant_owner_validation_formats_message() {
+    let validation = VariantOwnerValidation { code: "OWNER" };
+
+    assert_eq!(validation.code, "OWNER");
+    assert_eq!(
+        validation.message("Some", "Result", "Option"),
+        "resolver variant symbol 'Some' has owner 'Result', expected 'Option'"
+    );
+}
+
+#[test]
+fn variant_owner_validation_uses_resolver_code() {
+    let validation = VariantOwnerValidation::resolver_code();
+
+    assert_eq!(validation.code, "E0242");
+}
+
+#[test]
+fn variant_name_validation_formats_message() {
+    let validation = VariantNameValidation { code: "VARIANTS" };
+
+    assert_eq!(validation.code, "VARIANTS");
+    assert_eq!(
+        validation.message("Option", "(Some)", "(Some, None)"),
+        "resolver type symbol 'Option' has variants '(Some)', expected '(Some, None)'"
+    );
+}
+
+#[test]
+fn variant_name_validation_uses_resolver_code() {
+    let validation = VariantNameValidation::resolver_code();
+
+    assert_eq!(validation.code, "E0241");
+}

--- a/tests/docs_truth/repo_hygiene/file_size/focused_tests.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/focused_tests.rs
@@ -49,6 +49,42 @@ fn resolver_metadata_queue_selection_tests_live_in_focused_helper() {
 }
 
 #[test]
+fn resolver_metadata_validation_descriptor_tests_live_in_focused_modules() {
+    let root = read("src/typechecker/tests/resolver_metadata/validation_descriptors.rs");
+    let type_variants =
+        read("src/typechecker/tests/resolver_metadata/validation_descriptors/type_variants.rs");
+
+    for test_name in [
+        "field_validation_formats_messages",
+        "field_validation_uses_resolver_codes",
+        "variant_payload_validation_formats_messages",
+        "variant_payload_validation_uses_resolver_codes",
+        "variant_owner_validation_formats_message",
+        "variant_owner_validation_uses_resolver_code",
+        "variant_name_validation_formats_message",
+        "variant_name_validation_uses_resolver_code",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "validation_descriptors.rs should not own type/variant descriptor test: {test_name}"
+        );
+        assert!(
+            type_variants.contains(&format!("fn {test_name}")),
+            "type/variant descriptor tests should live in focused module: {test_name}"
+        );
+    }
+
+    assert!(
+        root.lines().count() < 230,
+        "validation_descriptors.rs should stay focused on shared/value descriptor tests"
+    );
+    assert!(
+        root.contains("mod type_variants;"),
+        "validation_descriptors.rs should include the focused type_variants module"
+    );
+}
+
+#[test]
 fn declaration_validation_precollection_tasks_live_in_focused_helper() {
     let tasks = read("src/typechecker/tests/declaration_validation/tasks.rs");
     let precollection = read("src/typechecker/tests/declaration_validation/precollection_tasks.rs");


### PR DESCRIPTION
## What changed

- Moved resolver metadata field/variant validation descriptor tests into `resolver_metadata/validation_descriptors/type_variants.rs`.
- Kept `validation_descriptors.rs` focused on common/count/value/return/behavior method descriptor tests.
- Added a docs-truth guard requiring the focused `type_variants` module and keeping the root descriptor test file below a tighter cap.

## Validation

- `cargo test --test docs_truth resolver_metadata_validation_descriptor_tests_live_in_focused_modules --quiet`
- `cargo test --lib validation_descriptors --quiet`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --tests --quiet`