### PR TITLE
[codex] Split resolver function value tests

### DIFF
--- a/src/typechecker/tests/resolver_impl_values.rs
+++ b/src/typechecker/tests/resolver_impl_values.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod function_values;
+
 #[test]
 fn check_program_with_symbols_requires_resolver_impl_methods() {
     let program = parse_program(
@@ -162,117 +164,5 @@ Option: Some(i32), None
             .message
             .contains("resolver symbol table missing variant symbol 'Some'")),
         "expected missing enum variant symbol diagnostic, got {err:?}"
-    );
-}
-
-#[test]
-fn check_program_with_symbols_validates_resolver_function_arity() {
-    let program = parse_program(
-        r#"
-add = (a: i32, b: i32) i32 { a + b }
-"#,
-    );
-    let mut symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    symbols.set_parameter_count_for_test(Namespace::Value, "add", Some(1));
-    let mut tc = TypeChecker::new();
-
-    let err = tc
-        .check_program_with_symbols(&program, &symbols)
-        .expect_err("resolver function arity mismatch should fail");
-
-    assert!(
-        err.iter().any(|d| d
-            .message
-            .contains("resolver value symbol 'add' has parameter count 1, expected 2")),
-        "expected resolver function arity diagnostic, got {err:?}"
-    );
-}
-
-#[test]
-fn check_program_with_symbols_validates_resolver_function_parameter_types() {
-    let program = parse_program(
-        r#"
-add = (a: i32, b: f64) f64 { b }
-"#,
-    );
-    let mut symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    symbols.set_parameter_type_names_for_test(
-        Namespace::Value,
-        "add",
-        Some(vec!["i32".to_string(), "i32".to_string()]),
-    );
-    let mut tc = TypeChecker::new();
-
-    let err = tc
-        .check_program_with_symbols(&program, &symbols)
-        .expect_err("resolver function parameter type mismatch should fail");
-
-    assert!(
-        err.iter().any(|d| d.message.contains(
-            "resolver value symbol 'add' has parameter types '(i32, i32)', expected '(i32, f64)'"
-        )),
-        "expected resolver function parameter type diagnostic, got {err:?}"
-    );
-}
-
-#[test]
-fn check_program_with_symbols_validates_resolver_function_type_parameter_metadata() {
-    let program = parse_program(
-        r#"
-apply = (callback: (i32) i32, value: i32) i32 { value }
-"#,
-    );
-    let mut symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    symbols.set_parameter_type_names_for_test(
-        Namespace::Value,
-        "apply",
-        Some(vec!["i32".to_string(), "i32".to_string()]),
-    );
-    let mut tc = TypeChecker::new();
-
-    let err = tc
-        .check_program_with_symbols(&program, &symbols)
-        .expect_err("resolver function type parameter metadata mismatch should fail");
-
-    assert!(
-            err.iter().any(|d| d.message.contains(
-                "resolver value symbol 'apply' has parameter types '(i32, i32)', expected '((i32) i32, i32)'"
-            )),
-            "expected resolver function type parameter metadata diagnostic, got {err:?}"
-        );
-}
-
-#[test]
-fn check_program_with_symbols_validates_resolver_function_parameter_names() {
-    let program = parse_program(
-        r#"
-add = (a: i32, b: f64) f64 { b }
-"#,
-    );
-    let mut symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    symbols.set_parameter_names_for_test(
-        Namespace::Value,
-        "add",
-        Some(vec!["a".to_string(), "other".to_string()]),
-    );
-    let mut tc = TypeChecker::new();
-
-    let err = tc
-        .check_program_with_symbols(&program, &symbols)
-        .expect_err("resolver function parameter name mismatch should fail");
-
-    assert!(
-        err.iter().any(|d| d.message.contains(
-            "resolver value symbol 'add' has parameter names '(a, other)', expected '(a, b)'"
-        )),
-        "expected resolver function parameter name diagnostic, got {err:?}"
     );
 }

--- a/src/typechecker/tests/resolver_impl_values/function_values.rs
+++ b/src/typechecker/tests/resolver_impl_values/function_values.rs
@@ -1,0 +1,113 @@
+use super::*;
+
+#[test]
+fn check_program_with_symbols_validates_resolver_function_arity() {
+    let program = parse_program(
+        r#"
+add = (a: i32, b: i32) i32 { a + b }
+"#,
+    );
+    let mut symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    symbols.set_parameter_count_for_test(Namespace::Value, "add", Some(1));
+    let mut tc = TypeChecker::new();
+
+    let err = tc
+        .check_program_with_symbols(&program, &symbols)
+        .expect_err("resolver function arity mismatch should fail");
+
+    assert!(
+        err.iter().any(|d| d
+            .message
+            .contains("resolver value symbol 'add' has parameter count 1, expected 2")),
+        "expected resolver function arity diagnostic, got {err:?}"
+    );
+}
+
+#[test]
+fn check_program_with_symbols_validates_resolver_function_parameter_types() {
+    let program = parse_program(
+        r#"
+add = (a: i32, b: f64) f64 { b }
+"#,
+    );
+    let mut symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    symbols.set_parameter_type_names_for_test(
+        Namespace::Value,
+        "add",
+        Some(vec!["i32".to_string(), "i32".to_string()]),
+    );
+    let mut tc = TypeChecker::new();
+
+    let err = tc
+        .check_program_with_symbols(&program, &symbols)
+        .expect_err("resolver function parameter type mismatch should fail");
+
+    assert!(
+        err.iter().any(|d| d.message.contains(
+            "resolver value symbol 'add' has parameter types '(i32, i32)', expected '(i32, f64)'"
+        )),
+        "expected resolver function parameter type diagnostic, got {err:?}"
+    );
+}
+
+#[test]
+fn check_program_with_symbols_validates_resolver_function_type_parameter_metadata() {
+    let program = parse_program(
+        r#"
+apply = (callback: (i32) i32, value: i32) i32 { value }
+"#,
+    );
+    let mut symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    symbols.set_parameter_type_names_for_test(
+        Namespace::Value,
+        "apply",
+        Some(vec!["i32".to_string(), "i32".to_string()]),
+    );
+    let mut tc = TypeChecker::new();
+
+    let err = tc
+        .check_program_with_symbols(&program, &symbols)
+        .expect_err("resolver function type parameter metadata mismatch should fail");
+
+    assert!(
+        err.iter().any(|d| d.message.contains(
+            "resolver value symbol 'apply' has parameter types '(i32, i32)', expected '((i32) i32, i32)'"
+        )),
+        "expected resolver function type parameter metadata diagnostic, got {err:?}"
+    );
+}
+
+#[test]
+fn check_program_with_symbols_validates_resolver_function_parameter_names() {
+    let program = parse_program(
+        r#"
+add = (a: i32, b: f64) f64 { b }
+"#,
+    );
+    let mut symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    symbols.set_parameter_names_for_test(
+        Namespace::Value,
+        "add",
+        Some(vec!["a".to_string(), "other".to_string()]),
+    );
+    let mut tc = TypeChecker::new();
+
+    let err = tc
+        .check_program_with_symbols(&program, &symbols)
+        .expect_err("resolver function parameter name mismatch should fail");
+
+    assert!(
+        err.iter().any(|d| d.message.contains(
+            "resolver value symbol 'add' has parameter names '(a, other)', expected '(a, b)'"
+        )),
+        "expected resolver function parameter name diagnostic, got {err:?}"
+    );
+}

--- a/tests/docs_truth/repo_hygiene/file_size/focused_tests.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/focused_tests.rs
@@ -115,6 +115,37 @@ fn resolver_import_absence_tests_live_in_focused_helper() {
 }
 
 #[test]
+fn resolver_function_value_tests_live_in_focused_helper() {
+    let root = read("src/typechecker/tests/resolver_impl_values.rs");
+    let function_values = read("src/typechecker/tests/resolver_impl_values/function_values.rs");
+
+    for test_name in [
+        "check_program_with_symbols_validates_resolver_function_arity",
+        "check_program_with_symbols_validates_resolver_function_parameter_types",
+        "check_program_with_symbols_validates_resolver_function_type_parameter_metadata",
+        "check_program_with_symbols_validates_resolver_function_parameter_names",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "resolver_impl_values.rs should not own function value test: {test_name}"
+        );
+        assert!(
+            function_values.contains(&format!("fn {test_name}")),
+            "resolver function value tests should live in focused module: {test_name}"
+        );
+    }
+
+    assert!(
+        root.lines().count() < 180,
+        "resolver_impl_values.rs should stay focused on impl-method and enum-variant checks"
+    );
+    assert!(
+        root.contains("mod function_values;"),
+        "resolver_impl_values.rs should include the focused function_values module"
+    );
+}
+
+#[test]
 fn declaration_validation_precollection_tasks_live_in_focused_helper() {
     let tasks = read("src/typechecker/tests/declaration_validation/tasks.rs");
     let precollection = read("src/typechecker/tests/declaration_validation/precollection_tasks.rs");


### PR DESCRIPTION
## What changed

- Moved ordinary resolver function value metadata tests into `resolver_impl_values/function_values.rs`.
- Kept `resolver_impl_values.rs` focused on impl-method and enum-variant resolver checks.
- Added a docs-truth guard requiring the focused function value module and capping the root resolver impl/value test file.

## Validation

- `cargo test --test docs_truth resolver_function_value_tests_live_in_focused_helper --quiet`
- `cargo test --lib resolver_impl_values --quiet`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --tests --quiet`