### PR TITLE
[codex] Split required stale diagnostic tests

### DIFF
--- a/src/typechecker/tests/resolver_collection/behavior_impls/required_diagnostics.rs
+++ b/src/typechecker/tests/resolver_collection/behavior_impls/required_diagnostics.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod stale_requires;
+
 #[test]
 fn collect_declarations_with_symbols_reports_resolver_restored_required_target_and_name() {
     let mut program = parse_program(
@@ -159,119 +161,4 @@ Point.requires(Json<i32>)
         "resolver-restored impl refs should keep both required specializations available: {:?}",
         tc.behavior_impls
     );
-}
-
-#[test]
-fn collect_declarations_with_symbols_does_not_fallback_to_stale_ast_behavior_required_metadata() {
-    let mut program = parse_program(
-        r#"
-Json<T>: behavior {
-    encode: (Self) T
-}
-
-Point: { x: i32 }
-
-Point.implements(Json<StaticString>) {
-    encode = (value: Point) StaticString { "point" }
-}
-
-Point.requires(Json<StaticString>)
-"#,
-    );
-    let mut symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    symbols.set_behavior_required_refs_for_test(Namespace::Type, "Point", None);
-    if let Declaration::Requires {
-        behavior_type_args, ..
-    } = &mut program.declarations[3]
-    {
-        behavior_type_args[0] = AstType::I32;
-    }
-    let mut tc = TypeChecker::new();
-
-    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
-
-    assert!(
-            tc.diagnostics.is_empty(),
-            "resolver-backed collection should not validate stale AST-only requires refs when resolver required metadata is incomplete: {:?}",
-            tc.diagnostics
-        );
-}
-
-#[test]
-fn collect_declarations_with_symbols_does_not_validate_stale_requires_after_target_restore() {
-    let mut program = parse_program(
-        r#"
-Json<T>: behavior {
-    encode: (Self) T
-}
-
-Point: { x: i32 }
-
-Point.implements(Json<StaticString>) {
-    encode = (value: Point) StaticString { "point" }
-}
-
-Point.requires(Json<StaticString>)
-"#,
-    );
-    let mut symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    symbols.set_behavior_required_refs_for_test(Namespace::Type, "Point", None);
-    if let Declaration::Requires {
-        type_name,
-        behavior,
-        behavior_type_args,
-        ..
-    } = &mut program.declarations[3]
-    {
-        *type_name = "Missing".to_string();
-        *behavior = "AlsoMissing".to_string();
-        behavior_type_args[0] = AstType::I32;
-    }
-    let mut tc = TypeChecker::new();
-
-    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
-
-    assert!(
-            tc.diagnostics.is_empty(),
-            "resolver-backed collection should not validate stale AST-only requires refs after target restoration when resolver required metadata is incomplete: {:?}",
-            tc.diagnostics
-        );
-}
-
-#[test]
-fn collect_declarations_with_symbols_uses_resolver_behavior_required_name_metadata() {
-    let mut program = parse_program(
-        r#"
-Json<T>: behavior {
-    encode: (Self) T
-}
-
-Point: { x: i32 }
-
-Point.implements(Json<StaticString>) {
-    encode = (value: Point) StaticString { "point" }
-}
-
-Point.requires(Json<StaticString>)
-"#,
-    );
-    let symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    if let Declaration::Requires { behavior, .. } = &mut program.declarations[3] {
-        *behavior = "Missing".to_string();
-    }
-    let mut tc = TypeChecker::new();
-
-    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
-
-    assert!(
-            tc.diagnostics.is_empty(),
-            "resolver-restored requires name metadata should avoid stale AST requires diagnostics: {:?}",
-            tc.diagnostics
-        );
 }

--- a/src/typechecker/tests/resolver_collection/behavior_impls/required_diagnostics/stale_requires.rs
+++ b/src/typechecker/tests/resolver_collection/behavior_impls/required_diagnostics/stale_requires.rs
@@ -1,0 +1,116 @@
+use super::*;
+
+#[test]
+fn collect_declarations_with_symbols_does_not_fallback_to_stale_ast_behavior_required_metadata() {
+    let mut program = parse_program(
+        r#"
+Json<T>: behavior {
+    encode: (Self) T
+}
+
+Point: { x: i32 }
+
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
+}
+
+Point.requires(Json<StaticString>)
+"#,
+    );
+    let mut symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    symbols.set_behavior_required_refs_for_test(Namespace::Type, "Point", None);
+    if let Declaration::Requires {
+        behavior_type_args, ..
+    } = &mut program.declarations[3]
+    {
+        behavior_type_args[0] = AstType::I32;
+    }
+    let mut tc = TypeChecker::new();
+
+    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
+
+    assert!(
+        tc.diagnostics.is_empty(),
+        "resolver-backed collection should not validate stale AST-only requires refs when resolver required metadata is incomplete: {:?}",
+        tc.diagnostics
+    );
+}
+
+#[test]
+fn collect_declarations_with_symbols_does_not_validate_stale_requires_after_target_restore() {
+    let mut program = parse_program(
+        r#"
+Json<T>: behavior {
+    encode: (Self) T
+}
+
+Point: { x: i32 }
+
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
+}
+
+Point.requires(Json<StaticString>)
+"#,
+    );
+    let mut symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    symbols.set_behavior_required_refs_for_test(Namespace::Type, "Point", None);
+    if let Declaration::Requires {
+        type_name,
+        behavior,
+        behavior_type_args,
+        ..
+    } = &mut program.declarations[3]
+    {
+        *type_name = "Missing".to_string();
+        *behavior = "AlsoMissing".to_string();
+        behavior_type_args[0] = AstType::I32;
+    }
+    let mut tc = TypeChecker::new();
+
+    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
+
+    assert!(
+        tc.diagnostics.is_empty(),
+        "resolver-backed collection should not validate stale AST-only requires refs after target restoration when resolver required metadata is incomplete: {:?}",
+        tc.diagnostics
+    );
+}
+
+#[test]
+fn collect_declarations_with_symbols_uses_resolver_behavior_required_name_metadata() {
+    let mut program = parse_program(
+        r#"
+Json<T>: behavior {
+    encode: (Self) T
+}
+
+Point: { x: i32 }
+
+Point.implements(Json<StaticString>) {
+    encode = (value: Point) StaticString { "point" }
+}
+
+Point.requires(Json<StaticString>)
+"#,
+    );
+    let symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    if let Declaration::Requires { behavior, .. } = &mut program.declarations[3] {
+        *behavior = "Missing".to_string();
+    }
+    let mut tc = TypeChecker::new();
+
+    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
+
+    assert!(
+        tc.diagnostics.is_empty(),
+        "resolver-restored requires name metadata should avoid stale AST requires diagnostics: {:?}",
+        tc.diagnostics
+    );
+}

--- a/tests/docs_truth/repo_hygiene/file_size/focused_tests.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/focused_tests.rs
@@ -146,6 +146,39 @@ fn resolver_function_value_tests_live_in_focused_helper() {
 }
 
 #[test]
+fn resolver_required_stale_diagnostic_tests_live_in_focused_helper() {
+    let root =
+        read("src/typechecker/tests/resolver_collection/behavior_impls/required_diagnostics.rs");
+    let stale_requires = read(
+        "src/typechecker/tests/resolver_collection/behavior_impls/required_diagnostics/stale_requires.rs",
+    );
+
+    for test_name in [
+        "collect_declarations_with_symbols_does_not_fallback_to_stale_ast_behavior_required_metadata",
+        "collect_declarations_with_symbols_does_not_validate_stale_requires_after_target_restore",
+        "collect_declarations_with_symbols_uses_resolver_behavior_required_name_metadata",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "required_diagnostics.rs should not own stale requires diagnostic test: {test_name}"
+        );
+        assert!(
+            stale_requires.contains(&format!("fn {test_name}")),
+            "stale requires diagnostic tests should live in focused module: {test_name}"
+        );
+    }
+
+    assert!(
+        root.lines().count() < 190,
+        "required_diagnostics.rs should stay focused on resolver-restored requires diagnostics"
+    );
+    assert!(
+        root.contains("mod stale_requires;"),
+        "required_diagnostics.rs should include the focused stale_requires module"
+    );
+}
+
+#[test]
 fn declaration_validation_precollection_tasks_live_in_focused_helper() {
     let tasks = read("src/typechecker/tests/declaration_validation/tasks.rs");
     let precollection = read("src/typechecker/tests/declaration_validation/precollection_tasks.rs");


### PR DESCRIPTION
## What changed

- Moved stale-AST required-behavior diagnostic tests into `required_diagnostics/stale_requires.rs`.
- Kept `required_diagnostics.rs` focused on resolver-restored requires diagnostics and specialization cases.
- Added a docs-truth guard requiring the focused stale requires module and capping the root required diagnostics test file.

## Validation

- `cargo test --test docs_truth resolver_required_stale_diagnostic_tests_live_in_focused_helper --quiet`
- `cargo test --lib required_diagnostics --quiet`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --tests --quiet`