### PR TITLE
[codex] Split resolver entry behavior validation

### DIFF
--- a/src/typechecker/resolver_validation.rs
+++ b/src/typechecker/resolver_validation.rs
@@ -5,6 +5,7 @@
 use super::*;
 
 include!("resolver_validation/entry_symbols.rs");
+include!("resolver_validation/entry_behavior_associations.rs");
 include!("resolver_validation/entry_locals.rs");
 include!("resolver_validation/post_pass.rs");
 include!("resolver_validation/replay_tasks.rs");

--- a/src/typechecker/resolver_validation/entry_behavior_associations.rs
+++ b/src/typechecker/resolver_validation/entry_behavior_associations.rs
@@ -1,0 +1,105 @@
+struct ResolverImplBlockEntry<'a> {
+    type_name: &'a str,
+    behavior: &'a Option<String>,
+    behavior_type_args: &'a [AstType],
+    methods: &'a [Declaration],
+    span: Span,
+}
+
+impl TypeChecker {
+    fn validate_resolver_impl_block_entry_symbols(
+        &mut self,
+        symbols: &SymbolTable,
+        entry: ResolverImplBlockEntry<'_>,
+        scope_cursor: &mut ResolverScopeCursor,
+    ) {
+        let type_symbol = symbols.lookup(Namespace::Type, entry.type_name);
+        if type_symbol.is_none() {
+            self.require_resolver_symbol(symbols, Namespace::Type, entry.type_name, entry.span);
+        }
+        if let Some(behavior) = entry.behavior {
+            self.require_resolver_symbol(symbols, Namespace::Behavior, behavior, entry.span);
+            if let Some(symbol) = type_symbol {
+                self.validate_resolver_behavior_impl_names(
+                    symbol,
+                    entry.type_name,
+                    expected_behavior_edge(behavior, entry.behavior_type_args),
+                    entry.span,
+                );
+            }
+        }
+        self.validate_generic_type_arg_refs_allow_unknowns(entry.behavior_type_args, entry.span);
+        for method in entry.methods {
+            if let Declaration::Function {
+                name,
+                params,
+                return_type,
+                type_params,
+                public,
+                span,
+                body,
+                ..
+            } = method
+            {
+                let method_key = Self::behavior_impl_method_key(
+                    entry.type_name,
+                    name,
+                    entry.behavior.as_deref(),
+                    entry.behavior_type_args,
+                );
+                self.require_resolver_value_symbol(
+                    symbols,
+                    &method_key,
+                    expected_value_symbol(params, return_type, type_params, *public),
+                    *span,
+                );
+                self.require_resolver_callable_locals(symbols, params, body, scope_cursor);
+            }
+        }
+    }
+
+    fn validate_resolver_requires_entry_symbols(
+        &mut self,
+        symbols: &SymbolTable,
+        type_name: &str,
+        behavior: &str,
+        behavior_type_args: &[AstType],
+        span: Span,
+    ) {
+        let type_symbol = symbols.lookup(Namespace::Type, type_name);
+        if type_symbol.is_none() {
+            self.require_resolver_symbol(symbols, Namespace::Type, type_name, span);
+        }
+        self.require_resolver_symbol(symbols, Namespace::Behavior, behavior, span);
+        if let Some(symbol) = type_symbol {
+            self.validate_resolver_behavior_required_names(
+                symbol,
+                type_name,
+                expected_behavior_edge(behavior, behavior_type_args),
+                span,
+            );
+        }
+        self.validate_generic_type_arg_refs_allow_unknowns(behavior_type_args, span);
+    }
+
+    fn validate_resolver_behavior_extends_entry_symbols(
+        &mut self,
+        symbols: &SymbolTable,
+        behavior: &str,
+        parent: &str,
+        parent_type_args: &[AstType],
+        span: Span,
+    ) {
+        self.require_resolver_symbol(symbols, Namespace::Behavior, behavior, span);
+        self.require_resolver_symbol(symbols, Namespace::Behavior, parent, span);
+        self.validate_generic_type_arg_refs_allow_unknowns(parent_type_args, span);
+        if let Some(symbol) = symbols.lookup(Namespace::Behavior, behavior) {
+            self.validate_resolver_behavior_parent_names(
+                symbol,
+                behavior,
+                expected_behavior_edge(parent, parent_type_args),
+                span,
+            );
+        }
+    }
+}

--- a/src/typechecker/resolver_validation/entry_symbols.rs
+++ b/src/typechecker/resolver_validation/entry_symbols.rs
@@ -154,54 +154,17 @@ impl TypeChecker {
                     span,
                     ..
                 } => {
-                    let type_symbol = symbols.lookup(Namespace::Type, type_name);
-                    if type_symbol.is_none() {
-                        self.require_resolver_symbol(symbols, Namespace::Type, type_name, *span);
-                    }
-                    if let Some(behavior) = behavior {
-                        self.require_resolver_symbol(symbols, Namespace::Behavior, behavior, *span);
-                        if let Some(symbol) = type_symbol {
-                            self.validate_resolver_behavior_impl_names(
-                                symbol,
-                                type_name,
-                                expected_behavior_edge(behavior, behavior_type_args),
-                                *span,
-                            );
-                        }
-                    }
-                    self.validate_generic_type_arg_refs_allow_unknowns(behavior_type_args, *span);
-                    for method in methods {
-                        if let Declaration::Function {
-                            name,
-                            params,
-                            return_type,
-                            type_params,
-                            public,
-                            span,
-                            body,
-                            ..
-                        } = method
-                        {
-                            let method_key = Self::behavior_impl_method_key(
-                                type_name,
-                                name,
-                                behavior.as_deref(),
-                                behavior_type_args,
-                            );
-                            self.require_resolver_value_symbol(
-                                symbols,
-                                &method_key,
-                                expected_value_symbol(params, return_type, type_params, *public),
-                                *span,
-                            );
-                            self.require_resolver_callable_locals(
-                                symbols,
-                                params,
-                                body,
-                                &mut scope_cursor,
-                            );
-                        }
-                    }
+                    self.validate_resolver_impl_block_entry_symbols(
+                        symbols,
+                        ResolverImplBlockEntry {
+                            type_name,
+                            behavior,
+                            behavior_type_args,
+                            methods,
+                            span: *span,
+                        },
+                        &mut scope_cursor,
+                    );
                 }
                 Declaration::Requires {
                     type_name,
@@ -209,20 +172,13 @@ impl TypeChecker {
                     behavior_type_args,
                     span,
                 } => {
-                    let type_symbol = symbols.lookup(Namespace::Type, type_name);
-                    if type_symbol.is_none() {
-                        self.require_resolver_symbol(symbols, Namespace::Type, type_name, *span);
-                    }
-                    self.require_resolver_symbol(symbols, Namespace::Behavior, behavior, *span);
-                    if let Some(symbol) = type_symbol {
-                        self.validate_resolver_behavior_required_names(
-                            symbol,
-                            type_name,
-                            expected_behavior_edge(behavior, behavior_type_args),
-                            *span,
-                        );
-                    }
-                    self.validate_generic_type_arg_refs_allow_unknowns(behavior_type_args, *span);
+                    self.validate_resolver_requires_entry_symbols(
+                        symbols,
+                        type_name,
+                        behavior,
+                        behavior_type_args,
+                        *span,
+                    );
                 }
                 Declaration::BehaviorExtends {
                     behavior,
@@ -230,17 +186,13 @@ impl TypeChecker {
                     parent_type_args,
                     span,
                 } => {
-                    self.require_resolver_symbol(symbols, Namespace::Behavior, behavior, *span);
-                    self.require_resolver_symbol(symbols, Namespace::Behavior, parent, *span);
-                    self.validate_generic_type_arg_refs_allow_unknowns(parent_type_args, *span);
-                    if let Some(symbol) = symbols.lookup(Namespace::Behavior, behavior) {
-                        self.validate_resolver_behavior_parent_names(
-                            symbol,
-                            behavior,
-                            expected_behavior_edge(parent, parent_type_args),
-                            *span,
-                        );
-                    }
+                    self.validate_resolver_behavior_extends_entry_symbols(
+                        symbols,
+                        behavior,
+                        parent,
+                        parent_type_args,
+                        *span,
+                    );
                 }
                 Declaration::TopLevelExpr { expr, .. } => {
                     self.require_resolver_scoped_expr_locals(symbols, expr, &mut scope_cursor);

--- a/tests/docs_truth/repo_hygiene/typechecker_resolver_validation.rs
+++ b/tests/docs_truth/repo_hygiene/typechecker_resolver_validation.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+mod entry_symbols;
 mod focused_modules;
 mod local_traversal;
 mod support_helpers;
@@ -28,36 +29,6 @@ fn typechecker_resolver_validation_post_pass_lives_in_focused_helper() {
     assert!(
         root.contains("include!(\"resolver_validation/post_pass.rs\");"),
         "resolver validation should include focused post-pass validation"
-    );
-}
-
-#[test]
-fn typechecker_resolver_entry_local_helpers_live_in_focused_helper() {
-    let root = read("src/typechecker/resolver_validation.rs");
-    let entry = read("src/typechecker/resolver_validation/entry_symbols.rs");
-    let locals = read("src/typechecker/resolver_validation/entry_locals.rs");
-
-    for helper in [
-        "require_resolver_callable_locals",
-        "require_resolver_scoped_expr_locals",
-    ] {
-        assert!(
-            !entry.contains(&format!("fn {helper}")),
-            "resolver entry traversal should not own local helper: {helper}"
-        );
-        assert!(
-            locals.contains(&format!("fn {helper}")),
-            "resolver entry local helper should live in focused helper: {helper}"
-        );
-    }
-
-    assert!(
-        entry.lines().count() < 260,
-        "resolver entry traversal should stay focused on declaration dispatch"
-    );
-    assert!(
-        root.contains("include!(\"resolver_validation/entry_locals.rs\");"),
-        "resolver validation should include focused entry-local helpers"
     );
 }
 

--- a/tests/docs_truth/repo_hygiene/typechecker_resolver_validation/entry_symbols.rs
+++ b/tests/docs_truth/repo_hygiene/typechecker_resolver_validation/entry_symbols.rs
@@ -1,0 +1,63 @@
+use super::*;
+
+#[test]
+fn typechecker_resolver_entry_local_helpers_live_in_focused_helper() {
+    let root = read("src/typechecker/resolver_validation.rs");
+    let entry = read("src/typechecker/resolver_validation/entry_symbols.rs");
+    let locals = read("src/typechecker/resolver_validation/entry_locals.rs");
+
+    for helper in [
+        "require_resolver_callable_locals",
+        "require_resolver_scoped_expr_locals",
+    ] {
+        assert!(
+            !entry.contains(&format!("fn {helper}")),
+            "resolver entry traversal should not own local helper: {helper}"
+        );
+        assert!(
+            locals.contains(&format!("fn {helper}")),
+            "resolver entry local helper should live in focused helper: {helper}"
+        );
+    }
+
+    assert!(
+        entry.lines().count() < 260,
+        "resolver entry traversal should stay focused on declaration dispatch"
+    );
+    assert!(
+        root.contains("include!(\"resolver_validation/entry_locals.rs\");"),
+        "resolver validation should include focused entry-local helpers"
+    );
+}
+
+#[test]
+fn typechecker_resolver_behavior_association_entries_live_in_focused_helper() {
+    let root = read("src/typechecker/resolver_validation.rs");
+    let entry = read("src/typechecker/resolver_validation/entry_symbols.rs");
+    let behavior_entries =
+        read("src/typechecker/resolver_validation/entry_behavior_associations.rs");
+
+    for helper in [
+        "validate_resolver_impl_block_entry_symbols",
+        "validate_resolver_requires_entry_symbols",
+        "validate_resolver_behavior_extends_entry_symbols",
+    ] {
+        assert!(
+            !entry.contains(&format!("fn {helper}")),
+            "resolver entry traversal should not own behavior-association helper: {helper}"
+        );
+        assert!(
+            behavior_entries.contains(&format!("fn {helper}")),
+            "resolver behavior-association entry helper should live in focused helper: {helper}"
+        );
+    }
+
+    assert!(
+        entry.lines().count() < 220,
+        "resolver entry traversal should stay focused on declaration dispatch"
+    );
+    assert!(
+        root.contains("include!(\"resolver_validation/entry_behavior_associations.rs\");"),
+        "resolver validation should include focused behavior-association entry helpers"
+    );
+}


### PR DESCRIPTION
## What changed

- Moved resolver entry validation for impl blocks, requires declarations, and behavior extends declarations into `entry_behavior_associations.rs`.
- Left `entry_symbols.rs` focused on declaration dispatch.
- Moved resolver-entry docs-truth guards into a focused `typechecker_resolver_validation/entry_symbols.rs` helper so the docs-truth root stays below its own cleanup pressure.

## Validation

- `cargo test --test docs_truth typechecker_resolver_behavior_association_entries_live_in_focused_helper --quiet`
- `cargo test --test docs_truth typechecker_resolver_entry_local_helpers_live_in_focused_helper --quiet`
- `cargo test --lib resolver_validation --quiet`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --tests --quiet`