### PR TITLE
[codex] Split resolver core method signature tests

### DIFF
--- a/tests/docs_truth/repo_hygiene/file_size.rs
+++ b/tests/docs_truth/repo_hygiene/file_size.rs
@@ -2,5 +2,6 @@ mod core_semantics_splits;
 mod focused_tests;
 mod function_method_template_splits;
 mod lexer_and_monomorphize;
+mod resolver_phase2_splits;
 mod thresholds;
 mod typechecker_test_splits;

--- a/tests/docs_truth/repo_hygiene/file_size/resolver_phase2_splits.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/resolver_phase2_splits.rs
@@ -1,0 +1,32 @@
+use super::super::*;
+
+#[test]
+fn resolver_phase2_method_signature_tests_live_in_focused_helper() {
+    let root = read("tests/resolver_phase2/core_symbols.rs");
+    let methods = read("tests/resolver_phase2/core_symbols/method_signatures.rs");
+
+    for test_name in [
+        "resolver_rejects_method_on_unknown_type",
+        "resolver_records_method_signatures_as_value_symbols",
+        "resolver_records_method_function_type_signatures",
+        "resolver_rejects_self_type_outside_method_or_behavior",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "core_symbols.rs should not own resolver method signature test: {test_name}"
+        );
+        assert!(
+            methods.contains(&format!("fn {test_name}")),
+            "resolver method signature tests should live in focused module: {test_name}"
+        );
+    }
+
+    assert!(
+        root.lines().count() < 180,
+        "core_symbols.rs should stay focused on core namespace, visibility, type, and import symbols"
+    );
+    assert!(
+        root.contains("#[path = \"core_symbols/method_signatures.rs\"]"),
+        "core_symbols.rs should include the focused method signature module by path"
+    );
+}

--- a/tests/resolver_phase2/core_symbols.rs
+++ b/tests/resolver_phase2/core_symbols.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+#[path = "core_symbols/method_signatures.rs"]
+mod method_signatures;
+
 #[test]
 fn resolver_assigns_symbol_ids_in_separate_namespaces() {
     let program = parse_program(
@@ -121,118 +124,6 @@ distance = (point: Point) UnknownReturn { 0 }
         err.iter()
             .any(|d| d.message.contains("unknown type symbol 'UnknownReturn'")),
         "expected missing return type diagnostic, got {err:?}"
-    );
-}
-
-#[test]
-fn resolver_rejects_method_on_unknown_type() {
-    let program = parse_program(
-        r#"
-Missing.label = () StaticString { "missing" }
-"#,
-    );
-
-    let err = Resolver::new()
-        .resolve_program(&program)
-        .expect_err("method receiver type should be known");
-
-    assert!(
-        err.iter()
-            .any(|d| d.message.contains("unknown type symbol 'Missing'")),
-        "expected unknown method receiver type diagnostic, got {err:?}"
-    );
-}
-
-#[test]
-fn resolver_records_method_signatures_as_value_symbols() {
-    let program = parse_program(
-        r#"
-Box<T>: {
-    value: T
-}
-
-Box.get<T> = (self: Box<T>) T {
-    self.value
-}
-"#,
-    );
-
-    let table = Resolver::new().resolve_program(&program).expect("resolve");
-    let method = table
-        .lookup(Namespace::Value, "Box.get")
-        .expect("method symbol");
-
-    assert_eq!(method.parameter_count, Some(1));
-    assert_eq!(
-        method.parameter_names.as_deref(),
-        Some(&["self".to_string()][..])
-    );
-    assert_eq!(
-        method.parameter_type_names.as_deref(),
-        Some(&["Box<T>".to_string()][..])
-    );
-    assert_eq!(method.return_type_name.as_deref(), Some("T"));
-    assert_eq!(method.type_parameter_count, Some(1));
-    assert_eq!(
-        method.type_parameter_names.as_deref(),
-        Some(&["T".to_string()][..])
-    );
-    assert_eq!(method.type_parameter_bounds.as_deref(), Some(&[][..]));
-}
-
-#[test]
-fn resolver_records_method_function_type_signatures() {
-    let program = parse_program(
-        r#"
-Box<T>: {
-    value: T
-}
-
-Box.map<T> = (self: Box<T>, callback: (T) T) (T) T {
-    callback
-}
-"#,
-    );
-
-    let table = Resolver::new().resolve_program(&program).expect("resolve");
-    let method = table
-        .lookup(Namespace::Value, "Box.map")
-        .expect("method symbol");
-
-    assert_eq!(method.parameter_count, Some(2));
-    assert_eq!(
-        method.parameter_names.as_deref(),
-        Some(&["self".to_string(), "callback".to_string()][..])
-    );
-    assert_eq!(
-        method.parameter_type_names.as_deref(),
-        Some(&["Box<T>".to_string(), "(T) T".to_string()][..])
-    );
-    assert_eq!(method.return_type_name.as_deref(), Some("(T) T"));
-    assert_eq!(method.type_parameter_count, Some(1));
-    assert_eq!(
-        method.type_parameter_names.as_deref(),
-        Some(&["T".to_string()][..])
-    );
-    assert_eq!(method.type_parameter_bounds.as_deref(), Some(&[][..]));
-}
-
-#[test]
-fn resolver_rejects_self_type_outside_method_or_behavior() {
-    let program = parse_program(
-        r#"
-main = (value: Self) i32 { 0 }
-"#,
-    );
-
-    let err = Resolver::new()
-        .resolve_program(&program)
-        .expect_err("Self should require a method or behavior context");
-
-    assert!(
-        err.iter()
-            .any(|d| d.message.contains("Self type is only valid")),
-        "expected invalid Self type diagnostic, got {err:?}"
     );
 }
 

--- a/tests/resolver_phase2/core_symbols/method_signatures.rs
+++ b/tests/resolver_phase2/core_symbols/method_signatures.rs
@@ -1,0 +1,113 @@
+use super::*;
+
+#[test]
+fn resolver_rejects_method_on_unknown_type() {
+    let program = parse_program(
+        r#"
+Missing.label = () StaticString { "missing" }
+"#,
+    );
+
+    let err = Resolver::new()
+        .resolve_program(&program)
+        .expect_err("method receiver type should be known");
+
+    assert!(
+        err.iter()
+            .any(|d| d.message.contains("unknown type symbol 'Missing'")),
+        "expected unknown method receiver type diagnostic, got {err:?}"
+    );
+}
+
+#[test]
+fn resolver_records_method_signatures_as_value_symbols() {
+    let program = parse_program(
+        r#"
+Box<T>: {
+    value: T
+}
+
+Box.get<T> = (self: Box<T>) T {
+    self.value
+}
+"#,
+    );
+
+    let table = Resolver::new().resolve_program(&program).expect("resolve");
+    let method = table
+        .lookup(Namespace::Value, "Box.get")
+        .expect("method symbol");
+
+    assert_eq!(method.parameter_count, Some(1));
+    assert_eq!(
+        method.parameter_names.as_deref(),
+        Some(&["self".to_string()][..])
+    );
+    assert_eq!(
+        method.parameter_type_names.as_deref(),
+        Some(&["Box<T>".to_string()][..])
+    );
+    assert_eq!(method.return_type_name.as_deref(), Some("T"));
+    assert_eq!(method.type_parameter_count, Some(1));
+    assert_eq!(
+        method.type_parameter_names.as_deref(),
+        Some(&["T".to_string()][..])
+    );
+    assert_eq!(method.type_parameter_bounds.as_deref(), Some(&[][..]));
+}
+
+#[test]
+fn resolver_records_method_function_type_signatures() {
+    let program = parse_program(
+        r#"
+Box<T>: {
+    value: T
+}
+
+Box.map<T> = (self: Box<T>, callback: (T) T) (T) T {
+    callback
+}
+"#,
+    );
+
+    let table = Resolver::new().resolve_program(&program).expect("resolve");
+    let method = table
+        .lookup(Namespace::Value, "Box.map")
+        .expect("method symbol");
+
+    assert_eq!(method.parameter_count, Some(2));
+    assert_eq!(
+        method.parameter_names.as_deref(),
+        Some(&["self".to_string(), "callback".to_string()][..])
+    );
+    assert_eq!(
+        method.parameter_type_names.as_deref(),
+        Some(&["Box<T>".to_string(), "(T) T".to_string()][..])
+    );
+    assert_eq!(method.return_type_name.as_deref(), Some("(T) T"));
+    assert_eq!(method.type_parameter_count, Some(1));
+    assert_eq!(
+        method.type_parameter_names.as_deref(),
+        Some(&["T".to_string()][..])
+    );
+    assert_eq!(method.type_parameter_bounds.as_deref(), Some(&[][..]));
+}
+
+#[test]
+fn resolver_rejects_self_type_outside_method_or_behavior() {
+    let program = parse_program(
+        r#"
+main = (value: Self) i32 { 0 }
+"#,
+    );
+
+    let err = Resolver::new()
+        .resolve_program(&program)
+        .expect_err("Self should require a method or behavior context");
+
+    assert!(
+        err.iter()
+            .any(|d| d.message.contains("Self type is only valid")),
+        "expected invalid Self type diagnostic, got {err:?}"
+    );
+}


### PR DESCRIPTION
## What changed

- Moved resolver core method signature and invalid `Self` tests into `tests/resolver_phase2/core_symbols/method_signatures.rs`.
- Kept `core_symbols.rs` focused on core namespaces, visibility, type references, and import binding symbols.
- Added a docs-truth guard proving method signature tests stay in the focused resolver Phase 2 helper.

## Validation

- `cargo test --test docs_truth resolver_phase2_method_signature_tests_live_in_focused_helper --quiet`
- `cargo test --test resolver_phase2 resolver_records_method_signatures_as_value_symbols --quiet`
- `cargo test --test resolver_phase2 resolver_rejects_self_type_outside_method_or_behavior --quiet`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --tests --quiet`