### PR TITLE
[codex] Split semantic bundle task tests

### DIFF
--- a/src/typechecker/tests/declaration_validation/resolver_replay/semantic_bundles.rs
+++ b/src/typechecker/tests/declaration_validation/resolver_replay/semantic_bundles.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod task_collection;
+
 #[test]
 fn resolver_declaration_semantic_bundle_replays_validation_passes() {
     let program = parse_program(
@@ -139,87 +141,6 @@ main = (value: Point) i32 { 1 }
         "resolver collection bundle should validate resolver struct defaults, got {:?}",
         checker.diagnostics()
     );
-}
-
-#[test]
-fn declaration_collection_replay_bundle_collects_ast_and_resolver_tasks_together() {
-    let program = parse_program(
-        r#"
-{ io } = std
-
-Point: { x: i32 }
-
-Json: behavior {
-    encode: (Self) StaticString
-}
-
-Point.implements(Json) {
-    encode = (self: Point) StaticString { "point" }
-}
-
-Point.requires(Json)
-
-main = () i32 { 1 }
-"#,
-    );
-
-    let tasks = TypeChecker::collect_declaration_collection_replay_tasks(&program.declarations);
-
-    assert_eq!(tasks.ast.imports.len(), 1);
-    assert_eq!(tasks.ast.types.len(), 1);
-    assert_eq!(tasks.ast.behaviors.len(), 1);
-    assert_eq!(tasks.ast.callable.len(), 1);
-    assert_eq!(tasks.ast.impl_blocks.len(), 1);
-    assert_eq!(tasks.resolver.types.len(), 1);
-    assert_eq!(tasks.resolver.behaviors.len(), 1);
-    assert_eq!(tasks.resolver.callable.len(), 1);
-    assert_eq!(tasks.resolver.behavior_associations.impls.len(), 1);
-    assert_eq!(tasks.resolver.behavior_associations.requires.len(), 1);
-    assert_eq!(tasks.resolver.type_references.len(), 4);
-    assert_eq!(
-        tasks.resolver_semantics.behavior_associations.impls.len(),
-        1
-    );
-    assert_eq!(
-        tasks
-            .resolver_semantics
-            .behavior_associations
-            .requires
-            .len(),
-        1
-    );
-    assert_eq!(tasks.resolver_semantics.struct_defaults.len(), 1);
-    assert_eq!(tasks.resolver_semantics.type_references.len(), 4);
-}
-
-#[test]
-fn resolver_declaration_semantic_tasks_collect_only_semantic_work() {
-    let program = parse_program(
-        r#"
-Point: { x: i32 = true }
-
-Json: behavior {
-    encode: (Self) StaticString
-}
-
-Point.implements(Json) {
-    encode = (self: Point) StaticString { "point" }
-}
-
-Point.requires(Json)
-
-main = (value: Point) i32 { 1 }
-"#,
-    );
-
-    let tasks =
-        TypeChecker::collect_resolver_declaration_semantic_validation_tasks(&program.declarations);
-
-    assert_eq!(tasks.behavior_associations.impls.len(), 1);
-    assert_eq!(tasks.behavior_associations.requires.len(), 1);
-    assert_eq!(tasks.struct_defaults.len(), 1);
-    assert_eq!(tasks.struct_defaults[0].name, "Point");
-    assert_eq!(tasks.type_references.len(), 4);
 }
 
 #[test]

--- a/src/typechecker/tests/declaration_validation/resolver_replay/semantic_bundles/task_collection.rs
+++ b/src/typechecker/tests/declaration_validation/resolver_replay/semantic_bundles/task_collection.rs
@@ -1,0 +1,82 @@
+use super::*;
+
+#[test]
+fn declaration_collection_replay_bundle_collects_ast_and_resolver_tasks_together() {
+    let program = parse_program(
+        r#"
+{ io } = std
+
+Point: { x: i32 }
+
+Json: behavior {
+    encode: (Self) StaticString
+}
+
+Point.implements(Json) {
+    encode = (self: Point) StaticString { "point" }
+}
+
+Point.requires(Json)
+
+main = () i32 { 1 }
+"#,
+    );
+
+    let tasks = TypeChecker::collect_declaration_collection_replay_tasks(&program.declarations);
+
+    assert_eq!(tasks.ast.imports.len(), 1);
+    assert_eq!(tasks.ast.types.len(), 1);
+    assert_eq!(tasks.ast.behaviors.len(), 1);
+    assert_eq!(tasks.ast.callable.len(), 1);
+    assert_eq!(tasks.ast.impl_blocks.len(), 1);
+    assert_eq!(tasks.resolver.types.len(), 1);
+    assert_eq!(tasks.resolver.behaviors.len(), 1);
+    assert_eq!(tasks.resolver.callable.len(), 1);
+    assert_eq!(tasks.resolver.behavior_associations.impls.len(), 1);
+    assert_eq!(tasks.resolver.behavior_associations.requires.len(), 1);
+    assert_eq!(tasks.resolver.type_references.len(), 4);
+    assert_eq!(
+        tasks.resolver_semantics.behavior_associations.impls.len(),
+        1
+    );
+    assert_eq!(
+        tasks
+            .resolver_semantics
+            .behavior_associations
+            .requires
+            .len(),
+        1
+    );
+    assert_eq!(tasks.resolver_semantics.struct_defaults.len(), 1);
+    assert_eq!(tasks.resolver_semantics.type_references.len(), 4);
+}
+
+#[test]
+fn resolver_declaration_semantic_tasks_collect_only_semantic_work() {
+    let program = parse_program(
+        r#"
+Point: { x: i32 = true }
+
+Json: behavior {
+    encode: (Self) StaticString
+}
+
+Point.implements(Json) {
+    encode = (self: Point) StaticString { "point" }
+}
+
+Point.requires(Json)
+
+main = (value: Point) i32 { 1 }
+"#,
+    );
+
+    let tasks =
+        TypeChecker::collect_resolver_declaration_semantic_validation_tasks(&program.declarations);
+
+    assert_eq!(tasks.behavior_associations.impls.len(), 1);
+    assert_eq!(tasks.behavior_associations.requires.len(), 1);
+    assert_eq!(tasks.struct_defaults.len(), 1);
+    assert_eq!(tasks.struct_defaults[0].name, "Point");
+    assert_eq!(tasks.type_references.len(), 4);
+}

--- a/tests/docs_truth/repo_hygiene/file_size.rs
+++ b/tests/docs_truth/repo_hygiene/file_size.rs
@@ -1,4 +1,5 @@
 mod core_semantics_splits;
+mod declaration_validation_splits;
 mod focused_tests;
 mod function_method_template_splits;
 mod generic_behavior_splits;

--- a/tests/docs_truth/repo_hygiene/file_size/declaration_validation_splits.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/declaration_validation_splits.rs
@@ -1,0 +1,33 @@
+use super::super::*;
+
+#[test]
+fn resolver_semantic_bundle_task_tests_live_in_focused_helper() {
+    let root =
+        read("src/typechecker/tests/declaration_validation/resolver_replay/semantic_bundles.rs");
+    let task_collection = read(
+        "src/typechecker/tests/declaration_validation/resolver_replay/semantic_bundles/task_collection.rs",
+    );
+
+    for test_name in [
+        "declaration_collection_replay_bundle_collects_ast_and_resolver_tasks_together",
+        "resolver_declaration_semantic_tasks_collect_only_semantic_work",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "semantic_bundles.rs should not own task collection assertion: {test_name}"
+        );
+        assert!(
+            task_collection.contains(&format!("fn {test_name}")),
+            "resolver semantic bundle task assertions should live in focused module: {test_name}"
+        );
+    }
+
+    assert!(
+        root.lines().count() < 190,
+        "semantic_bundles.rs should stay focused on resolver-backed replay execution"
+    );
+    assert!(
+        root.contains("mod task_collection;"),
+        "semantic_bundles.rs should include the focused task_collection module"
+    );
+}


### PR DESCRIPTION
## What changed

- Moved resolver declaration replay task-shape assertions into `semantic_bundles/task_collection.rs`.
- Kept `semantic_bundles.rs` focused on resolver-backed semantic replay execution.
- Added a docs-truth guard proving task collection assertions stay in the focused helper.

## Validation

- `cargo test --test docs_truth resolver_semantic_bundle_task_tests_live_in_focused_helper --quiet`
- `cargo test declaration_collection_replay_bundle_collects_ast_and_resolver_tasks_together --quiet`
- `cargo test resolver_declaration_semantic_tasks_collect_only_semantic_work --quiet`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --tests --quiet`