### PR TITLE
[codex] Split core assignment tests

### DIFF
--- a/src/typechecker/tests/core_semantics/enum_assignment_and_modules.rs
+++ b/src/typechecker/tests/core_semantics/enum_assignment_and_modules.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod assignments;
+
 #[test]
 fn enum_variant_unknown_variant_is_error() {
     let program = parse_program(
@@ -45,70 +47,6 @@ main = () void {
             .message
             .contains("payload for enum variant `Maybe.Some` expects `i32`, found `StaticString`")),
         "expected payload type diagnostic, got {errors:?}"
-    );
-}
-
-#[test]
-fn assignment_to_immutable_binding_is_error() {
-    let program = parse_program(
-        r#"
-main = () void {
-    x = 1
-    x = 2
-}
-"#,
-    );
-
-    let mut tc = TypeChecker::new();
-    let errors = tc
-        .check_program(&program)
-        .expect_err("immutable assignment should fail");
-    assert!(
-        errors.iter().any(|d| d
-            .message
-            .contains("cannot assign to immutable variable `x`")),
-        "expected immutable assignment diagnostic, got {errors:?}"
-    );
-}
-
-#[test]
-fn assignment_to_mutable_closure_parameter_is_allowed() {
-    let program = parse_program(
-        r#"
-main = () void {
-    mapper = (mut input: i32) i32 {
-        input = input + 1
-        input
-    }
-}
-"#,
-    );
-
-    let mut tc = TypeChecker::new();
-    tc.check_program(&program)
-        .expect("mutable closure parameter assignment should pass");
-}
-
-#[test]
-fn assignment_type_mismatch_is_error() {
-    let program = parse_program(
-        r#"
-main = () void {
-    x ::= 1
-    x = "bad"
-}
-"#,
-    );
-
-    let mut tc = TypeChecker::new();
-    let errors = tc
-        .check_program(&program)
-        .expect_err("assignment type mismatch should fail");
-    assert!(
-        errors.iter().any(|d| d
-            .message
-            .contains("assignment to `x` expects `i32`, found `StaticString`")),
-        "expected assignment type diagnostic, got {errors:?}"
     );
 }
 

--- a/src/typechecker/tests/core_semantics/enum_assignment_and_modules/assignments.rs
+++ b/src/typechecker/tests/core_semantics/enum_assignment_and_modules/assignments.rs
@@ -1,0 +1,65 @@
+use super::*;
+
+#[test]
+fn assignment_to_immutable_binding_is_error() {
+    let program = parse_program(
+        r#"
+main = () void {
+    x = 1
+    x = 2
+}
+"#,
+    );
+
+    let mut tc = TypeChecker::new();
+    let errors = tc
+        .check_program(&program)
+        .expect_err("immutable assignment should fail");
+    assert!(
+        errors.iter().any(|d| d
+            .message
+            .contains("cannot assign to immutable variable `x`")),
+        "expected immutable assignment diagnostic, got {errors:?}"
+    );
+}
+
+#[test]
+fn assignment_to_mutable_closure_parameter_is_allowed() {
+    let program = parse_program(
+        r#"
+main = () void {
+    mapper = (mut input: i32) i32 {
+        input = input + 1
+        input
+    }
+}
+"#,
+    );
+
+    let mut tc = TypeChecker::new();
+    tc.check_program(&program)
+        .expect("mutable closure parameter assignment should pass");
+}
+
+#[test]
+fn assignment_type_mismatch_is_error() {
+    let program = parse_program(
+        r#"
+main = () void {
+    x ::= 1
+    x = "bad"
+}
+"#,
+    );
+
+    let mut tc = TypeChecker::new();
+    let errors = tc
+        .check_program(&program)
+        .expect_err("assignment type mismatch should fail");
+    assert!(
+        errors.iter().any(|d| d
+            .message
+            .contains("assignment to `x` expects `i32`, found `StaticString`")),
+        "expected assignment type diagnostic, got {errors:?}"
+    );
+}

--- a/tests/docs_truth/repo_hygiene/file_size/core_semantics_splits.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/core_semantics_splits.rs
@@ -37,3 +37,34 @@ fn core_feature_gate_type_tests_live_in_focused_helper() {
         "core_semantics.rs should include feature gate tests"
     );
 }
+
+#[test]
+fn core_assignment_tests_live_in_focused_helper() {
+    let root = read("src/typechecker/tests/core_semantics/enum_assignment_and_modules.rs");
+    let assignments =
+        read("src/typechecker/tests/core_semantics/enum_assignment_and_modules/assignments.rs");
+
+    for test_name in [
+        "assignment_to_immutable_binding_is_error",
+        "assignment_to_mutable_closure_parameter_is_allowed",
+        "assignment_type_mismatch_is_error",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "enum_assignment_and_modules.rs should not own assignment test: {test_name}"
+        );
+        assert!(
+            assignments.contains(&format!("fn {test_name}")),
+            "assignment tests should live in focused module: {test_name}"
+        );
+    }
+
+    assert!(
+        root.lines().count() < 200,
+        "enum_assignment_and_modules.rs should stay focused on enum, module, field, conversion, and fallthrough checks"
+    );
+    assert!(
+        root.contains("mod assignments;"),
+        "enum_assignment_and_modules.rs should include the focused assignments module"
+    );
+}


### PR DESCRIPTION
## What changed

- Moved assignment and mutability typechecker tests into `enum_assignment_and_modules/assignments.rs`.
- Kept `enum_assignment_and_modules.rs` focused on enum variants, field access, conversions, module calls, and non-void fallthrough checks.
- Added a docs-truth guard proving assignment tests stay in the focused helper.

## Validation

- `cargo test --test docs_truth core_assignment_tests_live_in_focused_helper --quiet`
- `cargo test assignment_to_immutable_binding_is_error --quiet`
- `cargo test assignment_type_mismatch_is_error --quiet`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --tests --quiet`