### PR TITLE
[codex] Split module graph stdlib gate tests

### DIFF
--- a/src/module_system/tests/graph_loading.rs
+++ b/src/module_system/tests/graph_loading.rs
@@ -1,45 +1,6 @@
 use super::*;
 
-fn assert_graph_stdlib_import_is_gated_before_loading_sketch(
-    sketch_dir: &str,
-    sketch_file: &str,
-    import_source: &str,
-    expected_gate: &str,
-    gate_name: &str,
-) {
-    let tmp = setup_temp_dir();
-    let sketch_dir = tmp.path().join("stdlib").join(sketch_dir);
-    fs::create_dir_all(&sketch_dir).unwrap();
-    fs::write(sketch_dir.join(sketch_file), "this is not valid zen\n").unwrap();
-
-    let main_path = tmp.path().join("main.zen");
-    fs::write(
-        &main_path,
-        format!("{import_source}\n\nmain = () i32 {{ 0 }}\n"),
-    )
-    .unwrap();
-
-    let mut files = FileTable::new();
-    let mut ms = ModuleSystem::with_stdlib_root(tmp.path().join("stdlib"));
-
-    let errors = ms
-        .load_module_graph(&main_path, &mut files)
-        .expect_err("stdlib import should be gated before graph loading sketches");
-    let messages = errors
-        .iter()
-        .map(ToString::to_string)
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    assert!(
-        messages.contains(expected_gate),
-        "expected {gate_name} stdlib gate diagnostic, got {messages}"
-    );
-    assert!(
-        !messages.contains("expected") && !messages.contains("unexpected token"),
-        "{gate_name} stdlib gate should not leak parser diagnostics from sketches, got {messages}"
-    );
-}
+mod stdlib_gates;
 
 #[test]
 fn module_graph_records_imports_without_merging_declarations() {
@@ -188,50 +149,6 @@ fn module_graph_reuses_export_visibility_errors() {
     assert!(
         msg.contains("not exported"),
         "error should mention export visibility, got: {msg}"
-    );
-}
-
-#[test]
-fn module_graph_gates_stdlib_actor_framework_import_before_loading_sketch() {
-    assert_graph_stdlib_import_is_gated_before_loading_sketch(
-        "concurrency/actor",
-        "actor.zen",
-        "{ Actor } = @std.concurrency.actor.actor",
-        "std actor framework modules are gated",
-        "actor",
-    );
-}
-
-#[test]
-fn module_graph_gates_stdlib_allocator_import_before_loading_sketch() {
-    assert_graph_stdlib_import_is_gated_before_loading_sketch(
-        "memory",
-        "allocator.zen",
-        "{ Allocator } = @std.memory.allocator",
-        "std allocator modules are gated",
-        "allocator",
-    );
-}
-
-#[test]
-fn module_graph_gates_stdlib_async_runtime_import_before_loading_sketch() {
-    assert_graph_stdlib_import_is_gated_before_loading_sketch(
-        "concurrency/async",
-        "scheduler.zen",
-        "{ Scheduler } = @std.concurrency.async.scheduler",
-        "std async runtime modules are gated",
-        "async",
-    );
-}
-
-#[test]
-fn module_graph_gates_stdlib_sync_runtime_import_before_loading_sketch() {
-    assert_graph_stdlib_import_is_gated_before_loading_sketch(
-        "concurrency/sync",
-        "channel.zen",
-        "{ Channel } = @std.concurrency.sync.channel",
-        "std sync runtime modules are gated",
-        "sync",
     );
 }
 

--- a/src/module_system/tests/graph_loading/stdlib_gates.rs
+++ b/src/module_system/tests/graph_loading/stdlib_gates.rs
@@ -1,0 +1,86 @@
+use super::*;
+
+fn assert_graph_stdlib_import_is_gated_before_loading_sketch(
+    sketch_dir: &str,
+    sketch_file: &str,
+    import_source: &str,
+    expected_gate: &str,
+    gate_name: &str,
+) {
+    let tmp = setup_temp_dir();
+    let sketch_dir = tmp.path().join("stdlib").join(sketch_dir);
+    fs::create_dir_all(&sketch_dir).unwrap();
+    fs::write(sketch_dir.join(sketch_file), "this is not valid zen\n").unwrap();
+
+    let main_path = tmp.path().join("main.zen");
+    fs::write(
+        &main_path,
+        format!("{import_source}\n\nmain = () i32 {{ 0 }}\n"),
+    )
+    .unwrap();
+
+    let mut files = FileTable::new();
+    let mut ms = ModuleSystem::with_stdlib_root(tmp.path().join("stdlib"));
+
+    let errors = ms
+        .load_module_graph(&main_path, &mut files)
+        .expect_err("stdlib import should be gated before graph loading sketches");
+    let messages = errors
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(
+        messages.contains(expected_gate),
+        "expected {gate_name} stdlib gate diagnostic, got {messages}"
+    );
+    assert!(
+        !messages.contains("expected") && !messages.contains("unexpected token"),
+        "{gate_name} stdlib gate should not leak parser diagnostics from sketches, got {messages}"
+    );
+}
+
+#[test]
+fn module_graph_gates_stdlib_actor_framework_import_before_loading_sketch() {
+    assert_graph_stdlib_import_is_gated_before_loading_sketch(
+        "concurrency/actor",
+        "actor.zen",
+        "{ Actor } = @std.concurrency.actor.actor",
+        "std actor framework modules are gated",
+        "actor",
+    );
+}
+
+#[test]
+fn module_graph_gates_stdlib_allocator_import_before_loading_sketch() {
+    assert_graph_stdlib_import_is_gated_before_loading_sketch(
+        "memory",
+        "allocator.zen",
+        "{ Allocator } = @std.memory.allocator",
+        "std allocator modules are gated",
+        "allocator",
+    );
+}
+
+#[test]
+fn module_graph_gates_stdlib_async_runtime_import_before_loading_sketch() {
+    assert_graph_stdlib_import_is_gated_before_loading_sketch(
+        "concurrency/async",
+        "scheduler.zen",
+        "{ Scheduler } = @std.concurrency.async.scheduler",
+        "std async runtime modules are gated",
+        "async",
+    );
+}
+
+#[test]
+fn module_graph_gates_stdlib_sync_runtime_import_before_loading_sketch() {
+    assert_graph_stdlib_import_is_gated_before_loading_sketch(
+        "concurrency/sync",
+        "channel.zen",
+        "{ Channel } = @std.concurrency.sync.channel",
+        "std sync runtime modules are gated",
+        "sync",
+    );
+}

--- a/tests/docs_truth/repo_hygiene/file_size.rs
+++ b/tests/docs_truth/repo_hygiene/file_size.rs
@@ -4,6 +4,7 @@ mod focused_tests;
 mod function_method_template_splits;
 mod generic_behavior_splits;
 mod lexer_and_monomorphize;
+mod module_system_splits;
 mod resolver_phase2_splits;
 mod thresholds;
 mod typechecker_test_splits;

--- a/tests/docs_truth/repo_hygiene/file_size/module_system_splits.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/module_system_splits.rs
@@ -1,0 +1,32 @@
+use super::super::*;
+
+#[test]
+fn module_graph_stdlib_gate_tests_live_in_focused_helper() {
+    let root = read("src/module_system/tests/graph_loading.rs");
+    let stdlib_gates = read("src/module_system/tests/graph_loading/stdlib_gates.rs");
+
+    for test_name in [
+        "module_graph_gates_stdlib_actor_framework_import_before_loading_sketch",
+        "module_graph_gates_stdlib_allocator_import_before_loading_sketch",
+        "module_graph_gates_stdlib_async_runtime_import_before_loading_sketch",
+        "module_graph_gates_stdlib_sync_runtime_import_before_loading_sketch",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "graph_loading.rs should not own graph stdlib gate test: {test_name}"
+        );
+        assert!(
+            stdlib_gates.contains(&format!("fn {test_name}")),
+            "module graph stdlib gate tests should live in focused module: {test_name}"
+        );
+    }
+
+    assert!(
+        root.lines().count() < 210,
+        "module graph loading tests should stay focused on graph loading, resolver symbols, visibility, and cycles"
+    );
+    assert!(
+        root.contains("mod stdlib_gates;"),
+        "graph_loading.rs should include the focused stdlib_gates module"
+    );
+}


### PR DESCRIPTION
## What changed

- Moved graph-loading stdlib gate tests into `src/module_system/tests/graph_loading/stdlib_gates.rs`.
- Kept `graph_loading.rs` focused on graph loading behavior, resolver symbols, visibility, and circular imports.
- Added a docs-truth guard proving graph stdlib gate tests stay in the focused helper.

## Validation

- `cargo test --test docs_truth module_graph_stdlib_gate_tests_live_in_focused_helper --quiet`
- `cargo test module_graph_gates_stdlib_actor_framework_import_before_loading_sketch --quiet`
- `cargo test module_graph_detects_circular_imports --quiet`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --tests --quiet`