### PR TITLE
[codex] Split resolver replay association tasks

### DIFF
--- a/src/typechecker/resolver_validation.rs
+++ b/src/typechecker/resolver_validation.rs
@@ -9,6 +9,7 @@ include!("resolver_validation/entry_behavior_associations.rs");
 include!("resolver_validation/entry_locals.rs");
 include!("resolver_validation/post_pass.rs");
 include!("resolver_validation/replay_tasks.rs");
+include!("resolver_validation/replay_task_association_lists.rs");
 include!("resolver_validation/imports_modules.rs");
 include!("resolver_validation/imports_dependencies.rs");
 include!("resolver_validation/imports_behavior_dependencies.rs");

--- a/src/typechecker/resolver_validation/replay_task_association_lists.rs
+++ b/src/typechecker/resolver_validation/replay_task_association_lists.rs
@@ -1,0 +1,59 @@
+impl TypeChecker {
+    #[cfg(test)]
+    pub(super) fn collect_resolver_behavior_association_list_tasks<'a>(
+        program: &'a ast::Program,
+        symbols: &'a SymbolTable,
+    ) -> ResolverBehaviorAssociationListTasks<'a> {
+        Self::collect_resolver_validation_replay_tasks(program, symbols).behavior_associations
+    }
+
+    pub(super) fn collect_resolver_behavior_association_list_tasks_from_declaration_tasks<'a>(
+        declaration_tasks: &ResolverValidationReplayDeclarationTasks<'a>,
+    ) -> ResolverBehaviorAssociationListTasks<'a> {
+        let mut tasks = ResolverBehaviorAssociationListTasks::default();
+
+        for source in &declaration_tasks.type_declarations {
+            Self::push_resolver_type_behavior_association_list_task(
+                source,
+                &declaration_tasks.expected_associations,
+                &mut tasks.type_associations,
+            );
+        }
+        for source in &declaration_tasks.behavior_declarations {
+            Self::push_resolver_behavior_parent_list_task(
+                source,
+                &declaration_tasks.expected_parents,
+                &mut tasks.behavior_parents,
+            );
+        }
+
+        tasks
+    }
+
+    fn push_resolver_type_behavior_association_list_task<'a>(
+        source: &ResolverValidationBehaviorAssociationSource<'a>,
+        expected: &ExpectedBehaviorAssociations,
+        tasks: &mut Vec<ResolverTypeBehaviorAssociationListTask<'a>>,
+    ) {
+        tasks.push(ResolverTypeBehaviorAssociationListTask {
+            symbol: source.symbol,
+            name: source.name,
+            impl_edges: expected.impls.owned_edges_for(source.name),
+            required_edges: expected.required.owned_edges_for(source.name),
+            span: source.span,
+        });
+    }
+
+    fn push_resolver_behavior_parent_list_task<'a>(
+        source: &ResolverValidationBehaviorAssociationSource<'a>,
+        expected: &ExpectedBehaviorEdges,
+        tasks: &mut Vec<ResolverBehaviorParentListTask<'a>>,
+    ) {
+        tasks.push(ResolverBehaviorParentListTask {
+            symbol: source.symbol,
+            name: source.name,
+            parent_edges: expected.owned_edges_for(source.name),
+            span: source.span,
+        });
+    }
+}

--- a/src/typechecker/resolver_validation/replay_tasks.rs
+++ b/src/typechecker/resolver_validation/replay_tasks.rs
@@ -1,12 +1,4 @@
 impl TypeChecker {
-    #[cfg(test)]
-    pub(super) fn collect_resolver_behavior_association_list_tasks<'a>(
-        program: &'a ast::Program,
-        symbols: &'a SymbolTable,
-    ) -> ResolverBehaviorAssociationListTasks<'a> {
-        Self::collect_resolver_validation_replay_tasks(program, symbols).behavior_associations
-    }
-
     pub(super) fn collect_resolver_validation_replay_tasks<'a>(
         program: &'a ast::Program,
         symbols: &'a SymbolTable,
@@ -22,56 +14,6 @@ impl TypeChecker {
             expected_symbols: declaration_tasks.expected_symbols,
             behavior_associations,
         }
-    }
-
-    pub(super) fn collect_resolver_behavior_association_list_tasks_from_declaration_tasks<'a>(
-        declaration_tasks: &ResolverValidationReplayDeclarationTasks<'a>,
-    ) -> ResolverBehaviorAssociationListTasks<'a> {
-        let mut tasks = ResolverBehaviorAssociationListTasks::default();
-
-        for source in &declaration_tasks.type_declarations {
-            Self::push_resolver_type_behavior_association_list_task(
-                source,
-                &declaration_tasks.expected_associations,
-                &mut tasks.type_associations,
-            );
-        }
-        for source in &declaration_tasks.behavior_declarations {
-            Self::push_resolver_behavior_parent_list_task(
-                source,
-                &declaration_tasks.expected_parents,
-                &mut tasks.behavior_parents,
-            );
-        }
-
-        tasks
-    }
-
-    fn push_resolver_type_behavior_association_list_task<'a>(
-        source: &ResolverValidationBehaviorAssociationSource<'a>,
-        expected: &ExpectedBehaviorAssociations,
-        tasks: &mut Vec<ResolverTypeBehaviorAssociationListTask<'a>>,
-    ) {
-        tasks.push(ResolverTypeBehaviorAssociationListTask {
-            symbol: source.symbol,
-            name: source.name,
-            impl_edges: expected.impls.owned_edges_for(source.name),
-            required_edges: expected.required.owned_edges_for(source.name),
-            span: source.span,
-        });
-    }
-
-    fn push_resolver_behavior_parent_list_task<'a>(
-        source: &ResolverValidationBehaviorAssociationSource<'a>,
-        expected: &ExpectedBehaviorEdges,
-        tasks: &mut Vec<ResolverBehaviorParentListTask<'a>>,
-    ) {
-        tasks.push(ResolverBehaviorParentListTask {
-            symbol: source.symbol,
-            name: source.name,
-            parent_edges: expected.owned_edges_for(source.name),
-            span: source.span,
-        });
     }
 
     pub(super) fn collect_resolver_validation_replay_declaration_tasks<'a>(

--- a/tests/docs_truth/repo_hygiene/file_size/resolver_validation_splits.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/resolver_validation_splits.rs
@@ -34,3 +34,35 @@ fn source_dependency_callable_helpers_live_in_focused_module() {
         "resolver_validation.rs should include focused callable dependency helpers"
     );
 }
+
+#[test]
+fn replay_behavior_association_tasks_live_in_focused_module() {
+    let root = read("src/typechecker/resolver_validation/replay_tasks.rs");
+    let associations = read("src/typechecker/resolver_validation/replay_task_association_lists.rs");
+    let includes = read("src/typechecker/resolver_validation.rs");
+
+    for helper in [
+        "fn collect_resolver_behavior_association_list_tasks",
+        "fn collect_resolver_behavior_association_list_tasks_from_declaration_tasks",
+        "fn push_resolver_type_behavior_association_list_task",
+        "fn push_resolver_behavior_parent_list_task",
+    ] {
+        assert!(
+            !root.contains(helper),
+            "replay_tasks.rs should not own behavior association helper `{helper}`"
+        );
+        assert!(
+            associations.contains(helper),
+            "behavior association replay helper should live in focused module: {helper}"
+        );
+    }
+
+    assert!(
+        root.lines().count() < 200,
+        "replay_tasks.rs should stay focused on declaration replay collection"
+    );
+    assert!(
+        includes.contains("include!(\"resolver_validation/replay_task_association_lists.rs\");"),
+        "resolver_validation.rs should include focused behavior association replay helpers"
+    );
+}


### PR DESCRIPTION
## What changed

- Split behavior-association replay task assembly out of `replay_tasks.rs` into `replay_task_association_lists.rs`.
- Added a docs-truth guard that keeps declaration replay collection and behavior-association replay assembly in separate focused modules.

## Why

`replay_tasks.rs` was carrying both declaration replay collection and association-list assembly. This keeps it focused on declaration replay while preserving the resolver validation replay behavior.

## Validation

- `cargo test --test docs_truth replay_behavior_association_tasks_live_in_focused_module --quiet`
- `cargo test --test docs_truth source_dependency_callable_helpers_live_in_focused_module --quiet`
- `cargo test --lib resolver_validation::replay_tasks --quiet`
- `cargo test --test docs_truth production_rust_files_stay_below_cleanup_threshold --quiet`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --tests --quiet`
