### PR TITLE
[codex] Split build graph core impl

### DIFF
--- a/src/build_graph.rs
+++ b/src/build_graph.rs
@@ -4,6 +4,7 @@ use std::fmt;
 use serde::Serialize;
 
 mod dependency_order;
+mod graph;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BuildGraphInput {
@@ -99,74 +100,8 @@ pub enum BuildGraphError {
 }
 
 impl BuildGraph {
-    pub fn from_input(input: BuildGraphInput) -> Result<Self, BuildGraphError> {
-        if input.targets.is_empty() {
-            return Err(BuildGraphError::MissingTargets);
-        }
-
-        let declared_host_effects = sorted_unique(input.declared_host_effects);
-        let used_host_effects = sorted_unique(input.used_host_effects);
-        let declared_set: BTreeSet<_> = declared_host_effects.iter().cloned().collect();
-        for effect in &used_host_effects {
-            if !declared_set.contains(effect) {
-                return Err(BuildGraphError::UndeclaredHostEffect(effect.clone()));
-            }
-        }
-
-        let mut target_names = BTreeSet::new();
-        let mut targets = Vec::with_capacity(input.targets.len());
-        for target in input.targets {
-            if target.name.is_empty() {
-                return Err(BuildGraphError::EmptyTargetName);
-            }
-            if !target_names.insert(target.name.clone()) {
-                return Err(BuildGraphError::DuplicateTargetName(target.name));
-            }
-            targets.push(BuildTarget {
-                name: target.name,
-                kind: target.kind,
-                sources: sorted_unique(target.sources),
-                dependencies: sorted_unique(target.dependencies),
-                features: sorted_unique(target.features),
-            });
-        }
-        for target in &targets {
-            for dependency in &target.dependencies {
-                if dependency == &target.name {
-                    return Err(BuildGraphError::SelfTargetDependency(target.name.clone()));
-                }
-                if !target_names.contains(dependency) {
-                    return Err(BuildGraphError::UnknownTargetDependency {
-                        target: target.name.clone(),
-                        dependency: dependency.clone(),
-                    });
-                }
-            }
-        }
-        targets.sort_by(|left, right| left.name.cmp(&right.name));
-
-        let graph = Self {
-            targets,
-            declared_host_effects,
-            used_host_effects,
-        };
-        graph.targets_in_dependency_order()?;
-        Ok(graph)
-    }
-
     pub fn targets(&self) -> &[BuildTarget] {
         &self.targets
-    }
-
-    pub fn canonical_json(&self) -> Result<String, serde_json::Error> {
-        serde_json::to_string(&BuildGraphJson {
-            format: "zen.build_graph.v0",
-            schema_version: 0,
-            semantic_status: "deterministic",
-            targets: &self.targets,
-            declared_host_effects: &self.declared_host_effects,
-            used_host_effects: &self.used_host_effects,
-        })
     }
 }
 

--- a/src/build_graph/graph.rs
+++ b/src/build_graph/graph.rs
@@ -1,0 +1,71 @@
+use std::collections::BTreeSet;
+
+use super::*;
+
+impl BuildGraph {
+    pub fn from_input(input: BuildGraphInput) -> Result<Self, BuildGraphError> {
+        if input.targets.is_empty() {
+            return Err(BuildGraphError::MissingTargets);
+        }
+
+        let declared_host_effects = sorted_unique(input.declared_host_effects);
+        let used_host_effects = sorted_unique(input.used_host_effects);
+        let declared_set: BTreeSet<_> = declared_host_effects.iter().cloned().collect();
+        for effect in &used_host_effects {
+            if !declared_set.contains(effect) {
+                return Err(BuildGraphError::UndeclaredHostEffect(effect.clone()));
+            }
+        }
+
+        let mut target_names = BTreeSet::new();
+        let mut targets = Vec::with_capacity(input.targets.len());
+        for target in input.targets {
+            if target.name.is_empty() {
+                return Err(BuildGraphError::EmptyTargetName);
+            }
+            if !target_names.insert(target.name.clone()) {
+                return Err(BuildGraphError::DuplicateTargetName(target.name));
+            }
+            targets.push(BuildTarget {
+                name: target.name,
+                kind: target.kind,
+                sources: sorted_unique(target.sources),
+                dependencies: sorted_unique(target.dependencies),
+                features: sorted_unique(target.features),
+            });
+        }
+        for target in &targets {
+            for dependency in &target.dependencies {
+                if dependency == &target.name {
+                    return Err(BuildGraphError::SelfTargetDependency(target.name.clone()));
+                }
+                if !target_names.contains(dependency) {
+                    return Err(BuildGraphError::UnknownTargetDependency {
+                        target: target.name.clone(),
+                        dependency: dependency.clone(),
+                    });
+                }
+            }
+        }
+        targets.sort_by(|left, right| left.name.cmp(&right.name));
+
+        let graph = Self {
+            targets,
+            declared_host_effects,
+            used_host_effects,
+        };
+        graph.targets_in_dependency_order()?;
+        Ok(graph)
+    }
+
+    pub fn canonical_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(&BuildGraphJson {
+            format: "zen.build_graph.v0",
+            schema_version: 0,
+            semantic_status: "deterministic",
+            targets: &self.targets,
+            declared_host_effects: &self.declared_host_effects,
+            used_host_effects: &self.used_host_effects,
+        })
+    }
+}

--- a/tests/docs_truth/repo_hygiene/file_size.rs
+++ b/tests/docs_truth/repo_hygiene/file_size.rs
@@ -1,3 +1,4 @@
+mod build_graph_splits;
 mod core_semantics_splits;
 mod declaration_validation_splits;
 mod focused_tests;

--- a/tests/docs_truth/repo_hygiene/file_size/build_graph_splits.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/build_graph_splits.rs
@@ -1,0 +1,27 @@
+use super::super::*;
+
+#[test]
+fn build_graph_core_methods_live_in_focused_module() {
+    let root = read("src/build_graph.rs");
+    let graph = read("src/build_graph/graph.rs");
+
+    for method in ["pub fn from_input(", "pub fn canonical_json("] {
+        assert!(
+            !root.contains(method),
+            "build_graph.rs should not own BuildGraph core method `{method}`"
+        );
+        assert!(
+            graph.contains(method),
+            "BuildGraph core method should live in graph.rs: {method}"
+        );
+    }
+
+    assert!(
+        root.lines().count() < 210,
+        "build_graph.rs should stay focused on public build graph data types"
+    );
+    assert!(
+        root.contains("mod graph;"),
+        "build_graph.rs should include the focused graph implementation module"
+    );
+}


### PR DESCRIPTION
## What changed

- Moved `BuildGraph::from_input` and `BuildGraph::canonical_json` into `src/build_graph/graph.rs`.
- Kept public build graph data types and lightweight accessors in `src/build_graph.rs`.
- Added a docs-truth guard that keeps core graph methods out of the root type-definition file.

## Why

`build_graph.rs` was mixing public data type declarations with graph construction and serialization behavior. The split keeps the root focused on data types and puts core graph implementation in a focused module.

## Validation

- `cargo test --test docs_truth build_graph_core_methods_live_in_focused_module --quiet`
- `cargo test --test build_graph --quiet`
- `cargo test --test docs_truth production_rust_files_stay_below_cleanup_threshold --quiet`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --tests --quiet`
