### PR TITLE
[codex] Split generic function mutability tests

### DIFF
--- a/src/typechecker/tests/resolver_collection/function_method_templates/generic_functions.rs
+++ b/src/typechecker/tests/resolver_collection/function_method_templates/generic_functions.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod param_mutability;
+
 #[test]
 fn collect_declarations_with_symbols_uses_resolver_generic_function_template_metadata() {
     let mut program = parse_program(
@@ -186,68 +188,4 @@ choose<T> = (left: T, right: T) T {
     assert_eq!(template.params[1].name, "right");
     assert_eq!(template.params[0].ty, AstType::Named("T".to_string()));
     assert_eq!(template.params[1].ty, AstType::Named("T".to_string()));
-}
-
-#[test]
-fn collect_declarations_with_symbols_preserves_generic_template_param_mutability_by_position() {
-    let mut program = parse_program(
-        r#"
-keep<T> = (mut value: T) T {
-    value = value
-    value
-}
-"#,
-    );
-    let symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    if let Declaration::Function { params, .. } = &mut program.declarations[0] {
-        params[0].name = "stale".to_string();
-    }
-    let mut tc = TypeChecker::new();
-
-    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
-
-    let template = tc.generic_functions.get("keep").expect("generic template");
-    assert_eq!(template.params[0].name, "value");
-    assert!(
-        template.params[0].mutable,
-        "resolver-restored parameter name should preserve positional mutability"
-    );
-}
-
-#[test]
-fn collect_declarations_with_symbols_ignores_stale_generic_template_param_names_for_mutability() {
-    let mut program = parse_program(
-        r#"
-choose<T> = (left: T, mut right: T) T {
-    right = right
-    right
-}
-"#,
-    );
-    let symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    if let Declaration::Function { params, .. } = &mut program.declarations[0] {
-        params.swap(0, 1);
-    }
-    let mut tc = TypeChecker::new();
-
-    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
-
-    let template = tc
-        .generic_functions
-        .get("choose")
-        .expect("generic template");
-    assert_eq!(template.params[0].name, "left");
-    assert_eq!(template.params[1].name, "right");
-    assert!(
-        template.params[0].mutable,
-        "resolver-restored first parameter should keep first AST position mutability"
-    );
-    assert!(
-        !template.params[1].mutable,
-        "resolver-restored second parameter should keep second AST position mutability"
-    );
 }

--- a/src/typechecker/tests/resolver_collection/function_method_templates/generic_functions/param_mutability.rs
+++ b/src/typechecker/tests/resolver_collection/function_method_templates/generic_functions/param_mutability.rs
@@ -1,0 +1,65 @@
+use super::*;
+
+#[test]
+fn collect_declarations_with_symbols_preserves_generic_template_param_mutability_by_position() {
+    let mut program = parse_program(
+        r#"
+keep<T> = (mut value: T) T {
+    value = value
+    value
+}
+"#,
+    );
+    let symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    if let Declaration::Function { params, .. } = &mut program.declarations[0] {
+        params[0].name = "stale".to_string();
+    }
+    let mut tc = TypeChecker::new();
+
+    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
+
+    let template = tc.generic_functions.get("keep").expect("generic template");
+    assert_eq!(template.params[0].name, "value");
+    assert!(
+        template.params[0].mutable,
+        "resolver-restored parameter name should preserve positional mutability"
+    );
+}
+
+#[test]
+fn collect_declarations_with_symbols_ignores_stale_generic_template_param_names_for_mutability() {
+    let mut program = parse_program(
+        r#"
+choose<T> = (left: T, mut right: T) T {
+    right = right
+    right
+}
+"#,
+    );
+    let symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    if let Declaration::Function { params, .. } = &mut program.declarations[0] {
+        params.swap(0, 1);
+    }
+    let mut tc = TypeChecker::new();
+
+    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
+
+    let template = tc
+        .generic_functions
+        .get("choose")
+        .expect("generic template");
+    assert_eq!(template.params[0].name, "left");
+    assert_eq!(template.params[1].name, "right");
+    assert!(
+        template.params[0].mutable,
+        "resolver-restored first parameter should keep first AST position mutability"
+    );
+    assert!(
+        !template.params[1].mutable,
+        "resolver-restored second parameter should keep second AST position mutability"
+    );
+}

--- a/tests/docs_truth/repo_hygiene/file_size/function_method_template_splits.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/function_method_template_splits.rs
@@ -33,3 +33,36 @@ fn type_impl_generic_method_mutability_tests_live_in_focused_helper() {
         "type_impl_generic_methods.rs should include the focused parameter mutability module"
     );
 }
+
+#[test]
+fn generic_function_mutability_tests_live_in_focused_helper() {
+    let root = read(
+        "src/typechecker/tests/resolver_collection/function_method_templates/generic_functions.rs",
+    );
+    let mutability = read(
+        "src/typechecker/tests/resolver_collection/function_method_templates/generic_functions/param_mutability.rs",
+    );
+
+    for test_name in [
+        "collect_declarations_with_symbols_preserves_generic_template_param_mutability_by_position",
+        "collect_declarations_with_symbols_ignores_stale_generic_template_param_names_for_mutability",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "generic_functions.rs should not own parameter mutability replay test: {test_name}"
+        );
+        assert!(
+            mutability.contains(&format!("fn {test_name}")),
+            "generic function parameter mutability replay should live in focused module: {test_name}"
+        );
+    }
+
+    assert!(
+        root.lines().count() < 210,
+        "generic_functions.rs should stay focused on generic function template shape metadata"
+    );
+    assert!(
+        root.contains("mod param_mutability;"),
+        "generic_functions.rs should include the focused parameter mutability module"
+    );
+}


### PR DESCRIPTION
## What changed

- Moved generic function parameter-mutability replay tests into `generic_functions/param_mutability.rs`.
- Kept `generic_functions.rs` focused on resolver-backed generic function template shape metadata.
- Added a docs-truth guard that keeps those mutability tests in the focused helper.

## Why

The generic function template test file was carrying a separate mutability replay concern. This mirrors the existing type-impl generic method split and keeps the Phase 5 generic evidence files focused.

## Validation

- `cargo test --test docs_truth generic_function_mutability_tests_live_in_focused_helper --quiet`
- `cargo test --lib resolver_collection::function_method_templates::generic_functions --quiet`
- `cargo test --test docs_truth production_rust_files_stay_below_cleanup_threshold --quiet`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --tests --quiet`
