### PR TITLE
[codex] Add embedding semantic overlap guard

### DIFF
--- a/tests/docs_truth/repo_hygiene/mod.rs
+++ b/tests/docs_truth/repo_hygiene/mod.rs
@@ -19,6 +19,7 @@ mod removed_syntax;
 mod resolver_expression_validation;
 mod resolver_symbol_table;
 mod resolver_validation;
+mod semantic_overlap;
 mod source_truth;
 mod typechecker_aggregate_constructors;
 mod typechecker_behavior_impls;

--- a/tests/docs_truth/repo_hygiene/semantic_overlap.rs
+++ b/tests/docs_truth/repo_hygiene/semantic_overlap.rs
@@ -1,0 +1,50 @@
+use super::*;
+
+#[test]
+fn semantic_overlap_tool_uses_embedding_model_not_lexical_fallback() {
+    let script = read("tools/semantic_overlap.py");
+
+    assert!(
+        script.contains(r#"DEFAULT_MODEL = "Qwen/Qwen3-Embedding-0.6B""#),
+        "semantic overlap audit should default to the local open-source Qwen3 embedding model"
+    );
+    assert!(
+        script.contains("No lexical fallback is provided; this audit uses embeddings only."),
+        "semantic overlap audit should stay embedding-only"
+    );
+    assert!(
+        !script.contains("TfidfVectorizer") && !script.contains("sklearn"),
+        "semantic overlap audit should not regress to TF-IDF or sklearn lexical similarity"
+    );
+}
+
+#[test]
+fn semantic_overlap_outputs_and_model_caches_stay_ignored() {
+    let script = read("tools/semantic_overlap.py");
+    let gitignore = read(".gitignore");
+
+    for expected in [
+        r#"DEFAULT_CACHE_DIR = ".cache/huggingface""#,
+        r#"default="target/tmp/semantic-overlap-report.md""#,
+        r#"default="target/tmp/semantic-overlap-report.json""#,
+    ] {
+        assert!(
+            script.contains(expected),
+            "semantic overlap tool should keep local caches and reports in ignored paths: {expected}"
+        );
+    }
+
+    for expected in [
+        "/target/",
+        "/.cache/huggingface/",
+        "/.cache/torch/",
+        "/hf-cache/",
+        "/model-cache/",
+        "/models/",
+    ] {
+        assert!(
+            gitignore.contains(expected),
+            "semantic overlap artifacts should be ignored by git: {expected}"
+        );
+    }
+}

--- a/tools/semantic_overlap.py
+++ b/tools/semantic_overlap.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 
 DEFAULT_MODEL = "Qwen/Qwen3-Embedding-0.6B"
+DEFAULT_CACHE_DIR = ".cache/huggingface"
 DEFAULT_EXTS = ".json,.md,.rs,.toml,.yaml,.yml,.zen"
 DEFAULT_EXCLUDES = (".git/", ".vscode/", "target/", "vscode-extension/out/")
 DEFAULT_INCLUDES = (
@@ -38,7 +39,11 @@ def args() -> argparse.Namespace:
     )
     add = p.add_argument
     add("--model", default=DEFAULT_MODEL, help=f"SentenceTransformers model (default: {DEFAULT_MODEL})")
-    add("--cache-dir", help="Optional Hugging Face cache dir, e.g. ~/.cache/huggingface")
+    add(
+        "--cache-dir",
+        default=DEFAULT_CACHE_DIR,
+        help=f"Hugging Face cache dir; keep this ignored (default: {DEFAULT_CACHE_DIR})",
+    )
     add("--device", help="Torch device override such as cpu, cuda, or mps")
     add("--batch-size", type=int, default=16)
     add("--max-seq-length", type=int, default=128)
@@ -166,15 +171,18 @@ def load_model(opts: argparse.Namespace):
     except ModuleNotFoundError as exc:
         raise SystemExit(
             "Missing dependency: sentence-transformers. Install locally with:\n"
-            "  uv pip install sentence-transformers torch\n"
+            "  uv pip install 'sentence-transformers>=2.7.0' 'transformers>=4.51.0' torch\n"
             "or run through uv:\n"
-            "  uv run --with sentence-transformers tools/semantic_overlap.py\n"
+            "  uv run --with 'sentence-transformers>=2.7.0' "
+            "--with 'transformers>=4.51.0' --with torch tools/semantic_overlap.py\n"
             "No lexical fallback is provided; this audit uses embeddings only."
         ) from exc
 
     kwargs: dict[str, object] = {}
     if opts.cache_dir:
-        kwargs["cache_folder"] = opts.cache_dir
+        cache_dir = Path(opts.cache_dir).expanduser()
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        kwargs["cache_folder"] = str(cache_dir)
     if opts.device:
         kwargs["device"] = opts.device
     model = SentenceTransformer(opts.model, **kwargs)
@@ -270,6 +278,7 @@ def write_reports(
         "# Semantic Overlap Report",
         "",
         f"- Model: `{opts.model}`",
+        f"- Cache dir: `{opts.cache_dir}`",
         f"- Files embedded: {len(files)}",
         f"- Scope: {scope}",
         f"- Tests included: {'yes' if opts.include_tests else 'no'}",
@@ -298,6 +307,7 @@ def write_reports(
         json.dumps(
             {
                 "model": opts.model,
+                "cache_dir": opts.cache_dir,
                 "file_count": len(files),
                 "scope": "all_tracked" if opts.all_tracked else "default",
                 "include_tests": opts.include_tests,


### PR DESCRIPTION
## What changed

- Tightened `tools/semantic_overlap.py` so the default Hugging Face cache is the ignored `.cache/huggingface` path.
- Updated the dependency hint for Qwen3 embeddings to include the required `sentence-transformers`, `transformers`, and `torch` packages.
- Added docs-truth guards proving the audit stays embedding-only and that cache/report artifacts remain ignored.

## Why

This gives us a real semantic overlap/slop audit path without falling back to TF-IDF or accidentally committing model caches/reports.

## Validation

- `python3 -m py_compile tools/semantic_overlap.py`
- `python3 tools/semantic_overlap.py --plan-only`
- Qwen3 embedding smoke run over 8 files
- Full Qwen3 embedding run over 352 files / 1250 chunks
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth semantic_overlap --quiet`
- `cargo test --test docs_truth --quiet`
