### PR TITLE
[codex] Split behavior impl generic signature tests

### DIFF
--- a/src/typechecker/tests/resolver_collection/behavior_impl_methods/restored_signatures.rs
+++ b/src/typechecker/tests/resolver_collection/behavior_impl_methods/restored_signatures.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod generic_templates;
+
 #[test]
 fn collect_declarations_with_symbols_does_not_fallback_to_stale_ast_behavior_impl_method_signature()
 {
@@ -139,111 +141,4 @@ Point.implements(Json) {
         "resolver-restored behavior impl method signature should avoid stale AST diagnostics: {:?}",
         tc.diagnostics
     );
-}
-
-#[test]
-fn collect_declarations_with_symbols_uses_resolver_behavior_impl_generic_method_template_target_and_name_metadata(
-) {
-    let mut program = parse_program(
-        r#"
-Point: { x: i32 }
-Json: behavior {
-    encode: (Self) StaticString
-}
-
-Point.implements(Json) {
-    encode<T> = (value: Point) StaticString { "point" }
-}
-"#,
-    );
-    let symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    if let Declaration::ImplBlock {
-        type_name, methods, ..
-    } = &mut program.declarations[2]
-    {
-        *type_name = "Missing".to_string();
-        if let Declaration::Function {
-            name,
-            params,
-            return_type,
-            ..
-        } = &mut methods[0]
-        {
-            *name = "missing".to_string();
-            params.pop();
-            *return_type = None;
-        }
-    }
-    let mut tc = TypeChecker::new();
-
-    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
-
-    let template = tc
-        .generic_methods
-        .get("Point.encode")
-        .expect("generic behavior impl method template");
-    assert!(!tc.generic_methods.contains_key("Missing.missing"));
-    assert!(!tc.generic_methods.contains_key("Point.missing"));
-    assert_eq!(template.type_params, vec!["T".to_string()]);
-    assert_eq!(template.params.len(), 1);
-    assert_eq!(template.params[0].name, "value");
-    assert_eq!(template.params[0].ty, AstType::Named("Point".to_string()));
-    assert_eq!(template.return_type, Some(AstType::Str));
-    assert!(
-        tc.diagnostics.is_empty(),
-        "resolver-restored behavior impl generic template should avoid stale AST diagnostics: {:?}",
-        tc.diagnostics
-    );
-}
-
-#[test]
-fn collect_declarations_with_symbols_clears_stale_behavior_impl_generic_method_template_after_key_restore(
-) {
-    let mut program = parse_program(
-        r#"
-Point: { x: i32 }
-Json: behavior {
-    encode: (Self) StaticString
-}
-
-Point.implements(Json) {
-    encode<T> = (value: Point) StaticString { "point" }
-}
-"#,
-    );
-    let mut symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    symbols.set_return_type_for_test(Namespace::Value, "Point.encode", None);
-    if let Declaration::ImplBlock {
-        type_name, methods, ..
-    } = &mut program.declarations[2]
-    {
-        *type_name = "Missing".to_string();
-        if let Declaration::Function {
-            name,
-            params,
-            return_type,
-            ..
-        } = &mut methods[0]
-        {
-            *name = "missing".to_string();
-            params[0].ty = AstType::Named("Stale".to_string());
-            *return_type = Some(AstType::Named("AlsoStale".to_string()));
-        }
-    }
-    let mut tc = TypeChecker::new();
-
-    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
-
-    assert!(
-        !tc.generic_methods.contains_key("Missing.missing"),
-        "resolver-backed behavior impl collection should clear stale AST generic method templates"
-    );
-    assert!(
-            !tc.generic_methods.contains_key("Point.encode"),
-            "resolver-backed behavior impl collection should clear restored generic method templates when resolver signature metadata is incomplete"
-        );
 }

--- a/src/typechecker/tests/resolver_collection/behavior_impl_methods/restored_signatures/generic_templates.rs
+++ b/src/typechecker/tests/resolver_collection/behavior_impl_methods/restored_signatures/generic_templates.rs
@@ -1,0 +1,108 @@
+use super::*;
+
+#[test]
+fn collect_declarations_with_symbols_uses_resolver_behavior_impl_generic_method_template_target_and_name_metadata(
+) {
+    let mut program = parse_program(
+        r#"
+Point: { x: i32 }
+Json: behavior {
+    encode: (Self) StaticString
+}
+
+Point.implements(Json) {
+    encode<T> = (value: Point) StaticString { "point" }
+}
+"#,
+    );
+    let symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    if let Declaration::ImplBlock {
+        type_name, methods, ..
+    } = &mut program.declarations[2]
+    {
+        *type_name = "Missing".to_string();
+        if let Declaration::Function {
+            name,
+            params,
+            return_type,
+            ..
+        } = &mut methods[0]
+        {
+            *name = "missing".to_string();
+            params.pop();
+            *return_type = None;
+        }
+    }
+    let mut tc = TypeChecker::new();
+
+    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
+
+    let template = tc
+        .generic_methods
+        .get("Point.encode")
+        .expect("generic behavior impl method template");
+    assert!(!tc.generic_methods.contains_key("Missing.missing"));
+    assert!(!tc.generic_methods.contains_key("Point.missing"));
+    assert_eq!(template.type_params, vec!["T".to_string()]);
+    assert_eq!(template.params.len(), 1);
+    assert_eq!(template.params[0].name, "value");
+    assert_eq!(template.params[0].ty, AstType::Named("Point".to_string()));
+    assert_eq!(template.return_type, Some(AstType::Str));
+    assert!(
+        tc.diagnostics.is_empty(),
+        "resolver-restored behavior impl generic template should avoid stale AST diagnostics: {:?}",
+        tc.diagnostics
+    );
+}
+
+#[test]
+fn collect_declarations_with_symbols_clears_stale_behavior_impl_generic_method_template_after_key_restore(
+) {
+    let mut program = parse_program(
+        r#"
+Point: { x: i32 }
+Json: behavior {
+    encode: (Self) StaticString
+}
+
+Point.implements(Json) {
+    encode<T> = (value: Point) StaticString { "point" }
+}
+"#,
+    );
+    let mut symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    symbols.set_return_type_for_test(Namespace::Value, "Point.encode", None);
+    if let Declaration::ImplBlock {
+        type_name, methods, ..
+    } = &mut program.declarations[2]
+    {
+        *type_name = "Missing".to_string();
+        if let Declaration::Function {
+            name,
+            params,
+            return_type,
+            ..
+        } = &mut methods[0]
+        {
+            *name = "missing".to_string();
+            params[0].ty = AstType::Named("Stale".to_string());
+            *return_type = Some(AstType::Named("AlsoStale".to_string()));
+        }
+    }
+    let mut tc = TypeChecker::new();
+
+    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
+
+    assert!(
+        !tc.generic_methods.contains_key("Missing.missing"),
+        "resolver-backed behavior impl collection should clear stale AST generic method templates"
+    );
+    assert!(
+            !tc.generic_methods.contains_key("Point.encode"),
+            "resolver-backed behavior impl collection should clear restored generic method templates when resolver signature metadata is incomplete"
+        );
+}

--- a/tests/docs_truth/repo_hygiene/file_size.rs
+++ b/tests/docs_truth/repo_hygiene/file_size.rs
@@ -1,3 +1,4 @@
+mod behavior_impl_method_splits;
 mod build_graph_splits;
 mod core_semantics_splits;
 mod declaration_validation_splits;

--- a/tests/docs_truth/repo_hygiene/file_size/behavior_impl_method_splits.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/behavior_impl_method_splits.rs
@@ -1,0 +1,39 @@
+use super::super::*;
+
+#[test]
+fn resolver_behavior_impl_restored_generic_signature_tests_live_in_focused_helper() {
+    let root = read(
+        "src/typechecker/tests/resolver_collection/behavior_impl_methods/restored_signatures.rs",
+    );
+    let generic = read(
+        "src/typechecker/tests/resolver_collection/behavior_impl_methods/restored_signatures/generic_templates.rs",
+    );
+    let includes = read("tests/docs_truth/repo_hygiene/file_size.rs");
+
+    for test_name in [
+        "collect_declarations_with_symbols_uses_resolver_behavior_impl_generic_method_template_target_and_name_metadata",
+        "collect_declarations_with_symbols_clears_stale_behavior_impl_generic_method_template_after_key_restore",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "restored_signatures.rs should not own generic restored-signature test: {test_name}"
+        );
+        assert!(
+            generic.contains(&format!("fn {test_name}")),
+            "generic restored-signature tests should live in focused module: {test_name}"
+        );
+    }
+
+    assert!(
+        root.lines().count() < 170,
+        "restored_signatures.rs should stay focused on non-generic behavior impl restored signatures"
+    );
+    assert!(
+        root.contains("mod generic_templates;"),
+        "restored_signatures.rs should include the focused generic restored-signature tests"
+    );
+    assert!(
+        includes.contains("mod behavior_impl_method_splits;"),
+        "file_size.rs should include focused behavior impl method split guards"
+    );
+}


### PR DESCRIPTION
## What changed

- Moved the generic behavior impl restored-signature tests into `restored_signatures/generic_templates.rs`.
- Kept `restored_signatures.rs` focused on non-generic behavior impl signature restoration.
- Added a focused docs-truth guard to prevent the generic tests moving back into the root file.

## Why

The restored-signature test file was the highest tracked Rust file at 249 lines. This keeps resolver-backed behavior impl tests split by responsibility while preserving the same coverage.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth resolver_behavior_impl_restored_generic_signature_tests_live_in_focused_helper --quiet`
- `cargo test --lib resolver_collection::behavior_impl_methods --quiet`
- `cargo test --test docs_truth --quiet`
- `cargo test --lib --quiet`
- `cargo clippy -- -D warnings`
- `cargo test --tests --quiet`
