### PR TITLE
[codex] Split resolver non-behavior impl tests

### DIFF
--- a/tests/docs_truth/repo_hygiene/file_size/resolver_phase2_splits.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/resolver_phase2_splits.rs
@@ -30,3 +30,33 @@ fn resolver_phase2_method_signature_tests_live_in_focused_helper() {
         "core_symbols.rs should include the focused method signature module by path"
     );
 }
+
+#[test]
+fn resolver_phase2_non_behavior_impl_tests_live_in_focused_helper() {
+    let root = read("tests/resolver_phase2/impls.rs");
+    let non_behavior = read("tests/resolver_phase2/impls/non_behavior.rs");
+
+    for test_name in [
+        "resolver_accepts_non_behavior_impl_blocks_as_method_symbols",
+        "resolver_rejects_duplicate_non_behavior_impl_method_names",
+        "resolver_rejects_non_behavior_impl_method_colliding_with_top_level_method",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "impls.rs should not own non-behavior impl test: {test_name}"
+        );
+        assert!(
+            non_behavior.contains(&format!("fn {test_name}")),
+            "non-behavior impl tests should live in focused helper: {test_name}"
+        );
+    }
+
+    assert!(
+        root.lines().count() < 190,
+        "impls.rs should stay focused on behavior impl resolver metadata"
+    );
+    assert!(
+        root.contains("#[path = \"impls/non_behavior.rs\"]"),
+        "impls.rs should include the focused non-behavior impl module by path"
+    );
+}

--- a/tests/resolver_phase2/impls.rs
+++ b/tests/resolver_phase2/impls.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+#[path = "impls/non_behavior.rs"]
+mod non_behavior;
+
 #[test]
 fn resolver_records_behavior_impl_methods_as_value_symbols() {
     let program = parse_program(
@@ -97,81 +100,6 @@ Point.implements(Json<StaticString>) {
             .message
             .contains("duplicate behavior implementation `Json<StaticString>`")),
         "expected duplicate behavior implementation diagnostic, got {err:?}"
-    );
-}
-
-#[test]
-fn resolver_accepts_non_behavior_impl_blocks_as_method_symbols() {
-    let program = parse_program(
-        r#"
-Point: { x: i32 }
-
-Point.impl = {
-    get = (self: Point) i32 { self.x }
-}
-"#,
-    );
-
-    let symbols = Resolver::new()
-        .resolve_program(&program)
-        .expect("non-behavior impl blocks should resolve");
-
-    let get = symbols
-        .lookup(Namespace::Value, "Point.get")
-        .expect("impl method symbol");
-    assert_eq!(get.parameter_count, Some(1));
-    assert_eq!(
-        get.parameter_type_names.as_deref(),
-        Some(&["Point".to_string()][..])
-    );
-}
-
-#[test]
-fn resolver_rejects_duplicate_non_behavior_impl_method_names() {
-    let program = parse_program(
-        r#"
-Point: { x: i32 }
-
-Point.impl = {
-    get = (self: Point) i32 { self.x }
-    get = (self: Point) i32 { self.x }
-}
-"#,
-    );
-
-    let err = Resolver::new()
-        .resolve_program(&program)
-        .expect_err("duplicate non-behavior impl methods should fail in resolver");
-
-    assert!(
-        err.iter()
-            .any(|d| d.message.contains("duplicate value symbol 'Point.get'")),
-        "expected duplicate impl method symbol diagnostic, got {err:?}"
-    );
-}
-
-#[test]
-fn resolver_rejects_non_behavior_impl_method_colliding_with_top_level_method() {
-    let program = parse_program(
-        r#"
-Point: { x: i32 }
-
-Point.get = (self: Point) i32 { self.x }
-
-Point.impl = {
-    get = (self: Point) i32 { self.x }
-}
-"#,
-    );
-
-    let err = Resolver::new()
-        .resolve_program(&program)
-        .expect_err("impl method colliding with top-level method should fail in resolver");
-
-    assert!(
-        err.iter()
-            .any(|d| d.message.contains("duplicate value symbol 'Point.get'")),
-        "expected duplicate method symbol diagnostic, got {err:?}"
     );
 }
 

--- a/tests/resolver_phase2/impls/non_behavior.rs
+++ b/tests/resolver_phase2/impls/non_behavior.rs
@@ -1,0 +1,76 @@
+use super::*;
+
+#[test]
+fn resolver_accepts_non_behavior_impl_blocks_as_method_symbols() {
+    let program = parse_program(
+        r#"
+Point: { x: i32 }
+
+Point.impl = {
+    get = (self: Point) i32 { self.x }
+}
+"#,
+    );
+
+    let symbols = Resolver::new()
+        .resolve_program(&program)
+        .expect("non-behavior impl blocks should resolve");
+
+    let get = symbols
+        .lookup(Namespace::Value, "Point.get")
+        .expect("impl method symbol");
+    assert_eq!(get.parameter_count, Some(1));
+    assert_eq!(
+        get.parameter_type_names.as_deref(),
+        Some(&["Point".to_string()][..])
+    );
+}
+
+#[test]
+fn resolver_rejects_duplicate_non_behavior_impl_method_names() {
+    let program = parse_program(
+        r#"
+Point: { x: i32 }
+
+Point.impl = {
+    get = (self: Point) i32 { self.x }
+    get = (self: Point) i32 { self.x }
+}
+"#,
+    );
+
+    let err = Resolver::new()
+        .resolve_program(&program)
+        .expect_err("duplicate non-behavior impl methods should fail in resolver");
+
+    assert!(
+        err.iter()
+            .any(|d| d.message.contains("duplicate value symbol 'Point.get'")),
+        "expected duplicate impl method symbol diagnostic, got {err:?}"
+    );
+}
+
+#[test]
+fn resolver_rejects_non_behavior_impl_method_colliding_with_top_level_method() {
+    let program = parse_program(
+        r#"
+Point: { x: i32 }
+
+Point.get = (self: Point) i32 { self.x }
+
+Point.impl = {
+    get = (self: Point) i32 { self.x }
+}
+"#,
+    );
+
+    let err = Resolver::new()
+        .resolve_program(&program)
+        .expect_err("impl method colliding with top-level method should fail in resolver");
+
+    assert!(
+        err.iter()
+            .any(|d| d.message.contains("duplicate value symbol 'Point.get'")),
+        "expected duplicate method symbol diagnostic, got {err:?}"
+    );
+}


### PR DESCRIPTION
## What changed

- Moved non-behavior impl block resolver tests into `tests/resolver_phase2/impls/non_behavior.rs`.
- Kept `tests/resolver_phase2/impls.rs` focused on behavior impl resolver metadata.
- Added docs-truth coverage to prevent the non-behavior impl tests moving back into the root file.

## Why

`tests/resolver_phase2/impls.rs` was the largest tracked Rust file at 248 lines. This split keeps resolver Phase 2 impl coverage focused without changing behavior.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth resolver_phase2_non_behavior_impl_tests_live_in_focused_helper --quiet`
- `cargo test --test resolver_phase2 impls --quiet`
- `cargo test --test docs_truth --quiet`
- `cargo test --lib --quiet`
- `cargo clippy -- -D warnings`
- `cargo test --tests --quiet`
