### PR TITLE
[codex] Split codegen expression literal tests

### DIFF
--- a/src/codegen/c/tests/expression_emission.rs
+++ b/src/codegen/c/tests/expression_emission.rs
@@ -1,49 +1,8 @@
 use super::*;
 use crate::ast::expressions::BinaryOp;
 
-#[test]
-fn emit_int_literal() {
-    let mut e = CEmitter::new();
-    let expr = texpr(TypedExprKind::IntLiteral(42), Type::I32);
-    assert_eq!(e.emit_expr_inline(&expr), "42LL");
-}
-
-#[test]
-fn emit_float_literal() {
-    let mut e = CEmitter::new();
-    let expr = texpr(TypedExprKind::FloatLiteral(3.14), Type::F64);
-    assert_eq!(e.emit_expr_inline(&expr), "3.14");
-}
-
-#[test]
-fn emit_bool_literal() {
-    let mut e = CEmitter::new();
-    assert_eq!(
-        e.emit_expr_inline(&texpr(TypedExprKind::BoolLiteral(true), Type::Bool)),
-        "true"
-    );
-    assert_eq!(
-        e.emit_expr_inline(&texpr(TypedExprKind::BoolLiteral(false), Type::Bool)),
-        "false"
-    );
-}
-
-#[test]
-fn emit_string_literal() {
-    let mut e = CEmitter::new();
-    let expr = texpr(TypedExprKind::StringLiteral("hi".into()), Type::Str);
-    assert_eq!(
-        e.emit_expr_inline(&expr),
-        "(zen_str){ .ptr = \"hi\", .len = sizeof(\"hi\") - 1 }"
-    );
-}
-
-#[test]
-fn emit_variable() {
-    let mut e = CEmitter::new();
-    let expr = texpr(TypedExprKind::Variable("count".into()), Type::I32);
-    assert_eq!(e.emit_expr_inline(&expr), "count");
-}
+#[path = "expression_emission/literals.rs"]
+mod literals;
 
 #[test]
 fn emit_binary_ops() {

--- a/src/codegen/c/tests/expression_emission/literals.rs
+++ b/src/codegen/c/tests/expression_emission/literals.rs
@@ -1,0 +1,45 @@
+use super::*;
+
+#[test]
+fn emit_int_literal() {
+    let mut e = CEmitter::new();
+    let expr = texpr(TypedExprKind::IntLiteral(42), Type::I32);
+    assert_eq!(e.emit_expr_inline(&expr), "42LL");
+}
+
+#[test]
+fn emit_float_literal() {
+    let mut e = CEmitter::new();
+    let expr = texpr(TypedExprKind::FloatLiteral(3.14), Type::F64);
+    assert_eq!(e.emit_expr_inline(&expr), "3.14");
+}
+
+#[test]
+fn emit_bool_literal() {
+    let mut e = CEmitter::new();
+    assert_eq!(
+        e.emit_expr_inline(&texpr(TypedExprKind::BoolLiteral(true), Type::Bool)),
+        "true"
+    );
+    assert_eq!(
+        e.emit_expr_inline(&texpr(TypedExprKind::BoolLiteral(false), Type::Bool)),
+        "false"
+    );
+}
+
+#[test]
+fn emit_string_literal() {
+    let mut e = CEmitter::new();
+    let expr = texpr(TypedExprKind::StringLiteral("hi".into()), Type::Str);
+    assert_eq!(
+        e.emit_expr_inline(&expr),
+        "(zen_str){ .ptr = \"hi\", .len = sizeof(\"hi\") - 1 }"
+    );
+}
+
+#[test]
+fn emit_variable() {
+    let mut e = CEmitter::new();
+    let expr = texpr(TypedExprKind::Variable("count".into()), Type::I32);
+    assert_eq!(e.emit_expr_inline(&expr), "count");
+}

--- a/tests/docs_truth/repo_hygiene/file_size.rs
+++ b/tests/docs_truth/repo_hygiene/file_size.rs
@@ -1,5 +1,6 @@
 mod behavior_impl_method_splits;
 mod build_graph_splits;
+mod codegen_test_splits;
 mod core_semantics_splits;
 mod declaration_validation_splits;
 mod focused_tests;

--- a/tests/docs_truth/repo_hygiene/file_size/codegen_test_splits.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/codegen_test_splits.rs
@@ -1,0 +1,33 @@
+use super::super::*;
+
+#[test]
+fn codegen_c_expression_literal_tests_live_in_focused_helper() {
+    let root = read("src/codegen/c/tests/expression_emission.rs");
+    let literals = read("src/codegen/c/tests/expression_emission/literals.rs");
+
+    for test_name in [
+        "emit_int_literal",
+        "emit_float_literal",
+        "emit_bool_literal",
+        "emit_string_literal",
+        "emit_variable",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "expression_emission.rs should not own primitive expression test: {test_name}"
+        );
+        assert!(
+            literals.contains(&format!("fn {test_name}")),
+            "primitive expression emission tests should live in focused helper: {test_name}"
+        );
+    }
+
+    assert!(
+        root.lines().count() < 210,
+        "expression_emission.rs should stay focused on compound expression and statement emission"
+    );
+    assert!(
+        root.contains("#[path = \"expression_emission/literals.rs\"]"),
+        "expression_emission.rs should include the focused literal emission module by path"
+    );
+}


### PR DESCRIPTION
## Summary

Split primitive C expression emission tests out of the root expression emission test file into a focused literal helper module.

## Why

This keeps the root codegen expression emission test file below the cleanup threshold and makes future expression-emission additions easier to place without growing another large catch-all test file.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth --quiet`
- `cargo test --lib --quiet`
- `cargo clippy -- -D warnings`
- `cargo test --tests --quiet`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`
