### PR TITLE
[codex] Split program type definition lowering

### DIFF
--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -40,6 +40,7 @@ mod patterns;
 mod program_checking;
 mod program_globals;
 mod program_module_graph;
+mod program_type_defs;
 mod resolve;
 mod resolve_binary_ops;
 mod resolver_backed_collection;

--- a/src/typechecker/program_checking.rs
+++ b/src/typechecker/program_checking.rs
@@ -77,18 +77,7 @@ impl TypeChecker {
                     if !type_params.is_empty() {
                         continue;
                     }
-                    let resolved_fields: Vec<(String, Type)> = fields
-                        .iter()
-                        .map(|f| (f.name.clone(), self.resolve_type(&f.ty)))
-                        .collect();
-                    types.push(TypedTypeDef {
-                        name: name.clone(),
-                        kind: TypeDefKind::Struct {
-                            fields: resolved_fields,
-                        },
-                        methods: Vec::new(),
-                        span: *span,
-                    });
+                    types.push(self.typed_struct_def(name, fields, *span));
                 }
                 Declaration::Enum {
                     name,
@@ -100,26 +89,7 @@ impl TypeChecker {
                     if !type_params.is_empty() {
                         continue;
                     }
-                    let typed_variants: Vec<TypedVariant> = variants
-                        .iter()
-                        .enumerate()
-                        .map(|(i, v)| TypedVariant {
-                            name: v.name.clone(),
-                            tag: i as u32,
-                            payload: v
-                                .payload
-                                .as_ref()
-                                .map(|ty| vec![("payload".to_string(), self.resolve_type(ty))]),
-                        })
-                        .collect();
-                    types.push(TypedTypeDef {
-                        name: name.clone(),
-                        kind: TypeDefKind::Enum {
-                            variants: typed_variants,
-                        },
-                        methods: Vec::new(),
-                        span: *span,
-                    });
+                    types.push(self.typed_enum_def(name, variants, *span));
                 }
                 Declaration::TopLevelExpr { expr, span } => {
                     // Top-level expressions like main() call

--- a/src/typechecker/program_type_defs.rs
+++ b/src/typechecker/program_type_defs.rs
@@ -1,0 +1,53 @@
+use super::*;
+
+impl TypeChecker {
+    pub(super) fn typed_struct_def(
+        &mut self,
+        name: &str,
+        fields: &[StructField],
+        span: Span,
+    ) -> TypedTypeDef {
+        let resolved_fields = fields
+            .iter()
+            .map(|field| (field.name.clone(), self.resolve_type(&field.ty)))
+            .collect();
+
+        TypedTypeDef {
+            name: name.to_string(),
+            kind: TypeDefKind::Struct {
+                fields: resolved_fields,
+            },
+            methods: Vec::new(),
+            span,
+        }
+    }
+
+    pub(super) fn typed_enum_def(
+        &mut self,
+        name: &str,
+        variants: &[EnumVariant],
+        span: Span,
+    ) -> TypedTypeDef {
+        let typed_variants = variants
+            .iter()
+            .enumerate()
+            .map(|(index, variant)| TypedVariant {
+                name: variant.name.clone(),
+                tag: index as u32,
+                payload: variant
+                    .payload
+                    .as_ref()
+                    .map(|ty| vec![("payload".to_string(), self.resolve_type(ty))]),
+            })
+            .collect();
+
+        TypedTypeDef {
+            name: name.to_string(),
+            kind: TypeDefKind::Enum {
+                variants: typed_variants,
+            },
+            methods: Vec::new(),
+            span,
+        }
+    }
+}

--- a/tests/docs_truth/repo_hygiene/typechecker_program_checking.rs
+++ b/tests/docs_truth/repo_hygiene/typechecker_program_checking.rs
@@ -46,3 +46,30 @@ fn typechecker_program_global_lowering_lives_in_focused_helper() {
         "typechecker root should include focused program global helper"
     );
 }
+
+#[test]
+fn typechecker_program_type_def_lowering_lives_in_focused_helper() {
+    let root = read("src/typechecker/mod.rs");
+    let program_checking = read("src/typechecker/program_checking.rs");
+    let type_defs = read("src/typechecker/program_type_defs.rs");
+
+    for helper in ["fn typed_struct_def(", "fn typed_enum_def("] {
+        assert!(
+            !program_checking.contains(helper),
+            "program_checking.rs should not own typed type-definition lowering helper: {helper}"
+        );
+        assert!(
+            type_defs.contains(helper),
+            "typed type-definition lowering helper should live in focused module: {helper}"
+        );
+    }
+
+    assert!(
+        program_checking.lines().count() < 220,
+        "program_checking.rs should stay focused on program declaration checking"
+    );
+    assert!(
+        root.contains("mod program_type_defs;"),
+        "typechecker root should include focused program type-definition helper"
+    );
+}


### PR DESCRIPTION
## Summary

Move typed struct and enum definition construction out of `program_checking.rs` into `program_type_defs.rs`.

## Why

`program_checking.rs` should focus on the program declaration checking loop. Struct and enum type-definition lowering is a distinct responsibility and now has a docs-truth guard to keep it split.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth --quiet`
- `cargo test --lib --quiet`
- `cargo clippy -- -D warnings`
- `cargo test --tests --quiet`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`
