### PR TITLE
[codex] Pin nested generic definition counts

### DIFF
--- a/tests/docs_truth/phase_audit/phase_plan.rs
+++ b/tests/docs_truth/phase_audit/phase_plan.rs
@@ -92,3 +92,18 @@ fn phase_plan_records_recovered_progress_and_next_slice() {
         "docs/PHASE_PLAN.md still claims generic behavior inheritance is gated"
     );
 }
+
+#[test]
+fn nested_generic_result_generated_c_pins_definition_counts() {
+    let enum_generated_c = read("tests/integration/generic_specializations/enum_generated_c.rs");
+
+    for required in [
+        r#"assert_c_function_definition_count(&c_source, "unwrap_result_Option_i32_StaticString", 1)"#,
+        r#"assert_c_function_definition_count(&c_source, "unwrap_option_i32", 1)"#,
+    ] {
+        assert!(
+            enum_generated_c.contains(required),
+            "nested generic Result<Option<T>, E> generated-C tests should pin exact definition counts: {required}"
+        );
+    }
+}

--- a/tests/integration/generic_specializations/enum_generated_c.rs
+++ b/tests/integration/generic_specializations/enum_generated_c.rs
@@ -112,6 +112,8 @@ fn enum_specializations_do_not_emit_unspecialized_c_symbols() {
     assert!(c_source.contains("unwrap_option_i32(some, 0LL)"));
     assert_c_call_resolves_to_definition(&c_source, "unwrap_result_Option_i32_StaticString");
     assert_c_call_resolves_to_definition(&c_source, "unwrap_option_i32");
+    assert_c_function_definition_count(&c_source, "unwrap_result_Option_i32_StaticString", 1);
+    assert_c_function_definition_count(&c_source, "unwrap_option_i32", 1);
     assert!(!c_source.contains("Result_T"));
     assert!(!c_source.contains("Option_T"));
     assert!(!c_source.contains("T unwrap_result"));


### PR DESCRIPTION
## Summary

Pin generated-C definition counts for the nested `Result<Option<T>, E>` specialization case.

## Why

Phase 5 acceptance calls for generated-C call/definition consistency and definition-count checks. The nested generic enum case already checked call resolution; this adds exact count assertions for both nested helper definitions and a docs-truth guard so that evidence stays in place.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth --quiet`
- `cargo test --lib --quiet`
- `cargo clippy -- -D warnings`
- `cargo test --tests --quiet`
- `cargo test --test integration enum_specializations_do_not_emit_unspecialized_c_symbols --quiet`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`
