### PR TITLE
[codex] Pin multi-file nested method count

### DIFF
--- a/tests/docs_truth/phase_audit/phase_plan.rs
+++ b/tests/docs_truth/phase_audit/phase_plan.rs
@@ -107,3 +107,19 @@ fn nested_generic_result_generated_c_pins_definition_counts() {
         );
     }
 }
+
+#[test]
+fn multi_file_nested_generic_method_generated_c_pins_definition_counts() {
+    let method_worklist =
+        read("tests/integration/generic_specializations/multifile_generated_c/method_worklist_dependencies.rs");
+
+    for required in [
+        "multi_file_type_method_nested_result_dependency",
+        r#"assert_c_function_definition_count(&c_source, "Box_wrap_result_i32", 1)"#,
+    ] {
+        assert!(
+            method_worklist.contains(required),
+            "multi-file nested generic method generated-C tests should pin exact definition counts: {required}"
+        );
+    }
+}

--- a/tests/integration/generic_specializations/multifile_generated_c/method_worklist_dependencies.rs
+++ b/tests/integration/generic_specializations/multifile_generated_c/method_worklist_dependencies.rs
@@ -156,6 +156,7 @@ fn multi_file_generic_method_and_worklist_specializations_do_not_emit_unspeciali
     assert!(c_source.contains("Result_Option_i32_StaticString Box_wrap_result_i32(Box_i32 self)"));
     assert!(c_source.contains("Box_wrap_result_i32(box)"));
     assert_c_call_resolves_to_definition(&c_source, "Box_wrap_result_i32");
+    assert_c_function_definition_count(&c_source, "Box_wrap_result_i32", 1);
     assert!(!c_source.contains("Option_T"));
     assert!(!c_source.contains("Result_Option_T"));
     assert!(!c_source.contains("T Box_wrap_result"));


### PR DESCRIPTION
## Summary

Pin the generated-C definition count for the multi-file nested generic method dependency case.

## Why

The fixture already proves `Box_wrap_result_i32` resolves to an emitted definition. This strengthens the Phase 5 worklist evidence by asserting the multi-file nested specialization is emitted exactly once, with a docs-truth guard to keep the count assertion present.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth --quiet`
- `cargo test --lib --quiet`
- `cargo clippy -- -D warnings`
- `cargo test --tests --quiet`
- `cargo test --test integration multi_file_generic_method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols --quiet`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`
