### PR TITLE
[codex] Pin local nested method counts

### DIFF
--- a/tests/docs_truth/phase_audit/phase_plan.rs
+++ b/tests/docs_truth/phase_audit/phase_plan.rs
@@ -123,3 +123,21 @@ fn multi_file_nested_generic_method_generated_c_pins_definition_counts() {
         );
     }
 }
+
+#[test]
+fn local_nested_generic_method_generated_c_pins_definition_counts() {
+    let method_worklist =
+        read("tests/integration/generic_specializations/method_worklist_generated_c.rs");
+
+    for required in [
+        "generic_method_nested_result.zen",
+        r#"assert_c_function_definition_count(&c_source, "Box_wrap_result_i32", 1)"#,
+        r#"assert_c_function_definition_count(&c_source, "unwrap_result_Option_i32_StaticString", 1)"#,
+        r#"assert_c_function_definition_count(&c_source, "unwrap_option_i32", 1)"#,
+    ] {
+        assert!(
+            method_worklist.contains(required),
+            "local nested generic method generated-C tests should pin exact definition counts: {required}"
+        );
+    }
+}

--- a/tests/integration/generic_specializations/method_worklist_generated_c.rs
+++ b/tests/integration/generic_specializations/method_worklist_generated_c.rs
@@ -67,6 +67,9 @@ fn method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols() {
     assert_c_call_resolves_to_definition(&c_source, "Box_wrap_result_i32");
     assert_c_call_resolves_to_definition(&c_source, "unwrap_result_Option_i32_StaticString");
     assert_c_call_resolves_to_definition(&c_source, "unwrap_option_i32");
+    assert_c_function_definition_count(&c_source, "Box_wrap_result_i32", 1);
+    assert_c_function_definition_count(&c_source, "unwrap_result_Option_i32_StaticString", 1);
+    assert_c_function_definition_count(&c_source, "unwrap_option_i32", 1);
     assert!(!c_source.contains("Result_T"));
     assert!(!c_source.contains("Option_T"));
     assert!(!c_source.contains("T Box_wrap_result"));


### PR DESCRIPTION
## Summary

Pin generated-C definition counts for the local nested generic method result fixture.

## Why

The local `generic_method_nested_result.zen` fixture already checked that nested helper calls resolve to emitted definitions. This strengthens Phase 5 worklist evidence by asserting each involved specialization is emitted exactly once.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth --quiet`
- `cargo test --lib --quiet`
- `cargo clippy -- -D warnings`
- `cargo test --tests --quiet`
- `cargo test --test integration method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols --quiet`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`
