### PR TITLE
[codex] Pin imported transitive worklist counts

### DIFF
--- a/tests/docs_truth/phase_audit/phase_plan.rs
+++ b/tests/docs_truth/phase_audit/phase_plan.rs
@@ -141,3 +141,21 @@ fn local_nested_generic_method_generated_c_pins_definition_counts() {
         );
     }
 }
+
+#[test]
+fn imported_transitive_worklist_generated_c_pins_definition_counts() {
+    let method_worklist =
+        read("tests/integration/generic_specializations/multifile_generated_c/method_worklist_dependencies.rs");
+
+    for required in [
+        "multi_file_generic_imported_transitive_dependency/main.zen",
+        r#"assert_c_function_definition_count(&c_source, "inner_i32", 1)"#,
+        r#"assert_c_function_definition_count(&c_source, "middle_i32", 1)"#,
+        r#"assert_c_function_definition_count(&c_source, "outer_i32", 1)"#,
+    ] {
+        assert!(
+            method_worklist.contains(required),
+            "imported transitive generic worklist tests should pin exact definition counts: {required}"
+        );
+    }
+}

--- a/tests/integration/generic_specializations/multifile_generated_c/method_worklist_dependencies.rs
+++ b/tests/integration/generic_specializations/multifile_generated_c/method_worklist_dependencies.rs
@@ -28,6 +28,9 @@ fn multi_file_generic_method_and_worklist_specializations_do_not_emit_unspeciali
     assert_c_call_resolves_to_definition(&c_source, "inner_i32");
     assert_c_call_resolves_to_definition(&c_source, "middle_i32");
     assert_c_call_resolves_to_definition(&c_source, "outer_i32");
+    assert_c_function_definition_count(&c_source, "inner_i32", 1);
+    assert_c_function_definition_count(&c_source, "middle_i32", 1);
+    assert_c_function_definition_count(&c_source, "outer_i32", 1);
     assert!(!c_source.contains("T inner"));
     assert!(!c_source.contains("T middle"));
 


### PR DESCRIPTION
## Summary

Pin generated-C definition counts for imported transitive generic worklist specializations.

## Why

The `multi_file_generic_imported_transitive_dependency` fixture already proved the generated calls resolve. This strengthens the Phase 5 imported worklist evidence by asserting `inner_i32`, `middle_i32`, and `outer_i32` are each emitted exactly once.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth --quiet`
- `cargo test --lib --quiet`
- `cargo clippy -- -D warnings`
- `cargo test --tests --quiet`
- `cargo test --test integration multi_file_generic_method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols --quiet`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`
