### PR TITLE
[codex] Add generated C single-definition helper

### DIFF
--- a/tests/docs_truth/phase_audit/phase_plan.rs
+++ b/tests/docs_truth/phase_audit/phase_plan.rs
@@ -115,7 +115,7 @@ fn multi_file_nested_generic_method_generated_c_pins_definition_counts() {
 
     for required in [
         "multi_file_type_method_nested_result_dependency",
-        r#"assert_c_function_definition_count(&c_source, "Box_wrap_result_i32", 1)"#,
+        r#"assert_c_call_resolves_to_single_definition(&c_source, "Box_wrap_result_i32")"#,
     ] {
         assert!(
             method_worklist.contains(required),
@@ -131,9 +131,9 @@ fn local_nested_generic_method_generated_c_pins_definition_counts() {
 
     for required in [
         "generic_method_nested_result.zen",
-        r#"assert_c_function_definition_count(&c_source, "Box_wrap_result_i32", 1)"#,
-        r#"assert_c_function_definition_count(&c_source, "unwrap_result_Option_i32_StaticString", 1)"#,
-        r#"assert_c_function_definition_count(&c_source, "unwrap_option_i32", 1)"#,
+        r#"assert_c_call_resolves_to_single_definition(&c_source, "Box_wrap_result_i32")"#,
+        r#"assert_c_call_resolves_to_single_definition(&c_source, "unwrap_result_Option_i32_StaticString")"#,
+        r#"assert_c_call_resolves_to_single_definition(&c_source, "unwrap_option_i32")"#,
     ] {
         assert!(
             method_worklist.contains(required),
@@ -149,9 +149,9 @@ fn imported_transitive_worklist_generated_c_pins_definition_counts() {
 
     for required in [
         "multi_file_generic_imported_transitive_dependency/main.zen",
-        r#"assert_c_function_definition_count(&c_source, "inner_i32", 1)"#,
-        r#"assert_c_function_definition_count(&c_source, "middle_i32", 1)"#,
-        r#"assert_c_function_definition_count(&c_source, "outer_i32", 1)"#,
+        r#"assert_c_call_resolves_to_single_definition(&c_source, "inner_i32")"#,
+        r#"assert_c_call_resolves_to_single_definition(&c_source, "middle_i32")"#,
+        r#"assert_c_call_resolves_to_single_definition(&c_source, "outer_i32")"#,
     ] {
         assert!(
             method_worklist.contains(required),

--- a/tests/docs_truth/repo_hygiene/codegen_c.rs
+++ b/tests/docs_truth/repo_hygiene/codegen_c.rs
@@ -72,3 +72,46 @@ fn codegen_c_expression_operator_spelling_lives_in_focused_helper() {
         "C codegen should load focused aggregate literal helper"
     );
 }
+
+#[test]
+fn generated_c_tests_use_single_definition_assertion_helper() {
+    let support = read("tests/integration/support.rs");
+    let generated_c = read("tests/integration/support/generated_c.rs");
+    let local_worklist =
+        read("tests/integration/generic_specializations/method_worklist_generated_c.rs");
+    let multi_file_worklist =
+        read("tests/integration/generic_specializations/multifile_generated_c/method_worklist_dependencies.rs");
+
+    assert!(
+        generated_c.contains("fn assert_c_call_resolves_to_single_definition("),
+        "generated-C support should expose a helper for call resolution plus exactly-one definition"
+    );
+    assert!(
+        support.contains("assert_c_call_resolves_to_single_definition"),
+        "integration support should re-export the generated-C single-definition helper"
+    );
+
+    for (fixture, helper_call) in [
+        (
+            local_worklist.as_str(),
+            r#"assert_c_call_resolves_to_single_definition(&c_source, "Box_wrap_result_i32")"#,
+        ),
+        (
+            local_worklist.as_str(),
+            r#"assert_c_call_resolves_to_single_definition(&c_source, "unwrap_result_Option_i32_StaticString")"#,
+        ),
+        (
+            multi_file_worklist.as_str(),
+            r#"assert_c_call_resolves_to_single_definition(&c_source, "inner_i32")"#,
+        ),
+        (
+            multi_file_worklist.as_str(),
+            r#"assert_c_call_resolves_to_single_definition(&c_source, "outer_i32")"#,
+        ),
+    ] {
+        assert!(
+            fixture.contains(helper_call),
+            "Phase 5 generated-C evidence should use the single-definition helper: {helper_call}"
+        );
+    }
+}

--- a/tests/integration/generic_specializations/method_worklist_generated_c.rs
+++ b/tests/integration/generic_specializations/method_worklist_generated_c.rs
@@ -49,10 +49,8 @@ fn method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols() {
     assert!(c_source.contains("int32_t Box_get_inner_i32(Box_i32 self)"));
     assert!(c_source.contains("Box_inner_i32(self)"));
     assert!(c_source.contains("Box_get_inner_i32(box)"));
-    assert_c_call_resolves_to_definition(&c_source, "Box_inner_i32");
-    assert_c_call_resolves_to_definition(&c_source, "Box_get_inner_i32");
-    assert_c_function_definition_count(&c_source, "Box_inner_i32", 1);
-    assert_c_function_definition_count(&c_source, "Box_get_inner_i32", 1);
+    assert_c_call_resolves_to_single_definition(&c_source, "Box_inner_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Box_get_inner_i32");
     assert!(!c_source.contains("T Box_inner"));
 
     let c_source = compile_to_c_with_generated_call_check(
@@ -64,12 +62,9 @@ fn method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols() {
     assert!(c_source.contains("Box_wrap_result_i32(box)"));
     assert!(c_source.contains("unwrap_result_Option_i32_StaticString(wrapped,"));
     assert!(c_source.contains("unwrap_option_i32(some, 0LL)"));
-    assert_c_call_resolves_to_definition(&c_source, "Box_wrap_result_i32");
-    assert_c_call_resolves_to_definition(&c_source, "unwrap_result_Option_i32_StaticString");
-    assert_c_call_resolves_to_definition(&c_source, "unwrap_option_i32");
-    assert_c_function_definition_count(&c_source, "Box_wrap_result_i32", 1);
-    assert_c_function_definition_count(&c_source, "unwrap_result_Option_i32_StaticString", 1);
-    assert_c_function_definition_count(&c_source, "unwrap_option_i32", 1);
+    assert_c_call_resolves_to_single_definition(&c_source, "Box_wrap_result_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "unwrap_result_Option_i32_StaticString");
+    assert_c_call_resolves_to_single_definition(&c_source, "unwrap_option_i32");
     assert!(!c_source.contains("Result_T"));
     assert!(!c_source.contains("Option_T"));
     assert!(!c_source.contains("T Box_wrap_result"));
@@ -111,9 +106,8 @@ fn method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols() {
     assert!(c_source.contains("int32_t inner_i32(int32_t value)"));
     assert!(c_source.contains("int32_t outer_i32(int32_t value)"));
     assert!(c_source.contains("inner_i32(value)"));
-    assert_c_call_resolves_to_definition(&c_source, "inner_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "inner_i32");
     assert_c_call_resolves_to_definition(&c_source, "outer_i32");
-    assert_c_function_definition_count(&c_source, "inner_i32", 1);
     assert!(!c_source.contains("T inner"));
     assert!(!c_source.contains("inner_T"));
 
@@ -122,10 +116,9 @@ fn method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols() {
     assert!(c_source.contains("int32_t left_i32(int32_t value)"));
     assert!(c_source.contains("int32_t right_i32(int32_t value)"));
     assert!(c_source.contains("inner_i32(value)"));
-    assert_c_call_resolves_to_definition(&c_source, "inner_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "inner_i32");
     assert_c_call_resolves_to_definition(&c_source, "left_i32");
     assert_c_call_resolves_to_definition(&c_source, "right_i32");
-    assert_c_function_definition_count(&c_source, "inner_i32", 1);
     assert!(!c_source.contains("T inner"));
     assert!(!c_source.contains("inner_T"));
 
@@ -134,8 +127,7 @@ fn method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols() {
     assert!(c_source.contains("int32_t repeat_i32(int32_t value, int32_t remaining)"));
     assert!(c_source.contains("repeat_i32(value, (remaining - 1LL))"));
     assert!(c_source.contains("repeat_i32(41LL, 3LL)"));
-    assert_c_call_resolves_to_definition(&c_source, "repeat_i32");
-    assert_c_function_definition_count(&c_source, "repeat_i32", 1);
+    assert_c_call_resolves_to_single_definition(&c_source, "repeat_i32");
     assert!(!c_source.contains("T repeat"));
     assert!(!c_source.contains("repeat_T"));
 
@@ -144,8 +136,7 @@ fn method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols() {
     assert!(c_source.contains("int32_t Box_repeat_i32(Box_i32 self, int32_t remaining)"));
     assert!(c_source.contains("Box_repeat_i32(self, (remaining - 1LL))"));
     assert!(c_source.contains("Box_repeat_i32(box, 3LL)"));
-    assert_c_call_resolves_to_definition(&c_source, "Box_repeat_i32");
-    assert_c_function_definition_count(&c_source, "Box_repeat_i32", 1);
+    assert_c_call_resolves_to_single_definition(&c_source, "Box_repeat_i32");
     assert!(!c_source.contains("T Box_repeat"));
 
     let c_source =
@@ -161,8 +152,7 @@ fn method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols() {
     assert!(c_source.contains("int32_t id_i32(int32_t value)"));
     assert!(c_source.contains("id_i32(12LL)"));
     assert!(c_source.contains("id_i32(30LL)"));
-    assert_c_call_resolves_to_definition(&c_source, "id_i32");
-    assert_c_function_definition_count(&c_source, "id_i32", 1);
+    assert_c_call_resolves_to_single_definition(&c_source, "id_i32");
     assert!(!c_source.contains("id(12LL)"));
     assert!(!c_source.contains("id(30LL)"));
     assert!(!c_source.contains("T id"));

--- a/tests/integration/generic_specializations/multifile_generated_c/method_worklist_dependencies.rs
+++ b/tests/integration/generic_specializations/multifile_generated_c/method_worklist_dependencies.rs
@@ -25,12 +25,9 @@ fn multi_file_generic_method_and_worklist_specializations_do_not_emit_unspeciali
     assert!(c_source.contains("inner_i32(value)"));
     assert!(c_source.contains("middle_i32(value)"));
     assert!(c_source.contains("outer_i32(83LL)"));
-    assert_c_call_resolves_to_definition(&c_source, "inner_i32");
-    assert_c_call_resolves_to_definition(&c_source, "middle_i32");
-    assert_c_call_resolves_to_definition(&c_source, "outer_i32");
-    assert_c_function_definition_count(&c_source, "inner_i32", 1);
-    assert_c_function_definition_count(&c_source, "middle_i32", 1);
-    assert_c_function_definition_count(&c_source, "outer_i32", 1);
+    assert_c_call_resolves_to_single_definition(&c_source, "inner_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "middle_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "outer_i32");
     assert!(!c_source.contains("T inner"));
     assert!(!c_source.contains("T middle"));
 
@@ -40,8 +37,7 @@ fn multi_file_generic_method_and_worklist_specializations_do_not_emit_unspeciali
     assert!(c_source.contains("int32_t repeat_i32(int32_t value, int32_t remaining)"));
     assert!(c_source.contains("repeat_i32(value, (remaining - 1LL))"));
     assert!(c_source.contains("repeat_i32(97LL, 4LL)"));
-    assert_c_call_resolves_to_definition(&c_source, "repeat_i32");
-    assert_c_function_definition_count(&c_source, "repeat_i32", 1);
+    assert_c_call_resolves_to_single_definition(&c_source, "repeat_i32");
     assert!(!c_source.contains("T repeat"));
     assert!(!c_source.contains("repeat_T"));
 
@@ -158,8 +154,7 @@ fn multi_file_generic_method_and_worklist_specializations_do_not_emit_unspeciali
         .contains("typedef struct Result_Option_i32_StaticString Result_Option_i32_StaticString;"));
     assert!(c_source.contains("Result_Option_i32_StaticString Box_wrap_result_i32(Box_i32 self)"));
     assert!(c_source.contains("Box_wrap_result_i32(box)"));
-    assert_c_call_resolves_to_definition(&c_source, "Box_wrap_result_i32");
-    assert_c_function_definition_count(&c_source, "Box_wrap_result_i32", 1);
+    assert_c_call_resolves_to_single_definition(&c_source, "Box_wrap_result_i32");
     assert!(!c_source.contains("Option_T"));
     assert!(!c_source.contains("Result_Option_T"));
     assert!(!c_source.contains("T Box_wrap_result"));

--- a/tests/integration/support.rs
+++ b/tests/integration/support.rs
@@ -11,8 +11,8 @@ use zen::typechecker::TypeChecker;
 mod generated_c;
 
 pub use generated_c::{
-    assert_c_call_resolves_to_definition, assert_c_function_definition_count,
-    assert_generated_c_calls_resolve_to_definitions,
+    assert_c_call_resolves_to_definition, assert_c_call_resolves_to_single_definition,
+    assert_c_function_definition_count, assert_generated_c_calls_resolve_to_definitions,
     assert_generated_c_function_definitions_are_unique, has_c_call_outside_signature,
     undefined_generated_c_calls,
 };

--- a/tests/integration/support/generated_c.rs
+++ b/tests/integration/support/generated_c.rs
@@ -49,6 +49,11 @@ pub fn assert_c_call_resolves_to_definition(c_source: &str, name: &str) {
     );
 }
 
+pub fn assert_c_call_resolves_to_single_definition(c_source: &str, name: &str) {
+    assert_c_call_resolves_to_definition(c_source, name);
+    assert_c_function_definition_count(c_source, name, 1);
+}
+
 pub fn assert_generated_c_calls_resolve_to_definitions(c_source: &str) {
     let undefined = undefined_generated_c_calls(c_source);
     assert!(


### PR DESCRIPTION
## Summary

Add `assert_c_call_resolves_to_single_definition` to integration generated-C test support and use it in focused generic worklist generated-C assertions.

## Why

Phase 5 generated-C evidence repeatedly checks two parts of the same invariant: a generated call resolves to a definition, and that definition is emitted exactly once. The helper makes that invariant explicit and reduces duplicated assertion pairs in the local and multi-file generic worklist tests.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth --quiet`
- `cargo test --lib --quiet`
- `cargo clippy -- -D warnings`
- `cargo test --tests --quiet`
- `cargo test --test integration method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols --quiet`
- `cargo test --test integration multi_file_generic_method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols --quiet`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`
