### PR TITLE
[codex] Use single-definition helper for nested enum

### DIFF
--- a/tests/docs_truth/phase_audit/phase_plan.rs
+++ b/tests/docs_truth/phase_audit/phase_plan.rs
@@ -96,13 +96,14 @@ fn phase_plan_records_recovered_progress_and_next_slice() {
 #[test]
 fn nested_generic_result_generated_c_pins_definition_counts() {
     let enum_generated_c = read("tests/integration/generic_specializations/enum_generated_c.rs");
+    let normalized_enum_generated_c = enum_generated_c.split_whitespace().collect::<String>();
 
     for required in [
-        r#"assert_c_function_definition_count(&c_source, "unwrap_result_Option_i32_StaticString", 1)"#,
-        r#"assert_c_function_definition_count(&c_source, "unwrap_option_i32", 1)"#,
+        "assert_c_call_resolves_to_single_definition(&c_source,\"unwrap_result_Option_i32_StaticString\"",
+        "assert_c_call_resolves_to_single_definition(&c_source,\"unwrap_option_i32\"",
     ] {
         assert!(
-            enum_generated_c.contains(required),
+            normalized_enum_generated_c.contains(required),
             "nested generic Result<Option<T>, E> generated-C tests should pin exact definition counts: {required}"
         );
     }

--- a/tests/integration/generic_specializations/enum_generated_c.rs
+++ b/tests/integration/generic_specializations/enum_generated_c.rs
@@ -110,10 +110,8 @@ fn enum_specializations_do_not_emit_unspecialized_c_symbols() {
     ));
     assert!(c_source.contains("unwrap_result_Option_i32_StaticString(ok,"));
     assert!(c_source.contains("unwrap_option_i32(some, 0LL)"));
-    assert_c_call_resolves_to_definition(&c_source, "unwrap_result_Option_i32_StaticString");
-    assert_c_call_resolves_to_definition(&c_source, "unwrap_option_i32");
-    assert_c_function_definition_count(&c_source, "unwrap_result_Option_i32_StaticString", 1);
-    assert_c_function_definition_count(&c_source, "unwrap_option_i32", 1);
+    assert_c_call_resolves_to_single_definition(&c_source, "unwrap_result_Option_i32_StaticString");
+    assert_c_call_resolves_to_single_definition(&c_source, "unwrap_option_i32");
     assert!(!c_source.contains("Result_T"));
     assert!(!c_source.contains("Option_T"));
     assert!(!c_source.contains("T unwrap_result"));


### PR DESCRIPTION
## Summary

- Replace the nested generic enum generated-C call/count assertion pair with `assert_c_call_resolves_to_single_definition`.
- Update the docs-truth guard to require the combined helper while tolerating rustfmt line wrapping.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth nested_generic_result_generated_c_pins_definition_counts --quiet`
- `cargo test --test integration enum_specializations_do_not_emit_unspecialized_c_symbols --quiet`
- `cargo test --test docs_truth --quiet`
- `cargo test --lib --quiet`
- `cargo clippy -- -D warnings`
- `cargo test --tests --quiet`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`