### PR TITLE
[codex] Remove split generated C count assertions

### DIFF
--- a/tests/docs_truth/repo_hygiene/codegen_c.rs
+++ b/tests/docs_truth/repo_hygiene/codegen_c.rs
@@ -81,6 +81,12 @@ fn generated_c_tests_use_single_definition_assertion_helper() {
         read("tests/integration/generic_specializations/method_worklist_generated_c.rs");
     let multi_file_worklist =
         read("tests/integration/generic_specializations/multifile_generated_c/method_worklist_dependencies.rs");
+    let enum_generated_c = read("tests/integration/generic_specializations/enum_generated_c.rs");
+    let behavior_bounds =
+        read("tests/integration/generic_specializations/behavior_bounds/local_and_defaults.rs");
+    let multi_file_enums = read(
+        "tests/integration/generic_specializations/multifile_generated_c/enum_dependencies.rs",
+    );
 
     assert!(
         generated_c.contains("fn assert_c_call_resolves_to_single_definition("),
@@ -112,6 +118,13 @@ fn generated_c_tests_use_single_definition_assertion_helper() {
         assert!(
             fixture.contains(helper_call),
             "Phase 5 generated-C evidence should use the single-definition helper: {helper_call}"
+        );
+    }
+
+    for source in [enum_generated_c, behavior_bounds, multi_file_enums] {
+        assert!(
+            !source.contains("assert_c_function_definition_count"),
+            "Phase 5 generated-C tests should use the single-definition helper instead of split call/count assertions"
         );
     }
 }

--- a/tests/integration/generic_specializations/behavior_bounds/local_and_defaults.rs
+++ b/tests/integration/generic_specializations/behavior_bounds/local_and_defaults.rs
@@ -27,12 +27,10 @@ fn local_behavior_bound_specializations_do_not_emit_unspecialized_c_symbols() {
     assert!(c_source.contains("int32_t encode_i32_Point(Point value)"));
     assert!(c_source.contains("Point_encode__Json_StaticString(value)"));
     assert!(c_source.contains("Point_encode__Json_i32(value)"));
-    assert_c_call_resolves_to_definition(&c_source, "Point_encode__Json_StaticString");
-    assert_c_call_resolves_to_definition(&c_source, "Point_encode__Json_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Point_encode__Json_StaticString");
+    assert_c_call_resolves_to_single_definition(&c_source, "Point_encode__Json_i32");
     assert_c_call_resolves_to_definition(&c_source, "encode_str_Point");
     assert_c_call_resolves_to_definition(&c_source, "encode_i32_Point");
-    assert_c_function_definition_count(&c_source, "Point_encode__Json_StaticString", 1);
-    assert_c_function_definition_count(&c_source, "Point_encode__Json_i32", 1);
     assert!(!c_source.contains("Json_T"));
     assert!(!c_source.contains("T_encode"));
 }

--- a/tests/integration/generic_specializations/enum_generated_c.rs
+++ b/tests/integration/generic_specializations/enum_generated_c.rs
@@ -35,10 +35,8 @@ fn enum_specializations_do_not_emit_unspecialized_c_symbols() {
     assert!(c_source.contains("Option_unwrap_or_i32(none_int, 55LL)"));
     assert!(c_source.contains("Option_unwrap_or_bool(some_bool, false)"));
     assert!(c_source.contains("Option_unwrap_or_bool(none_bool, true)"));
-    assert_c_call_resolves_to_definition(&c_source, "Option_unwrap_or_i32");
-    assert_c_call_resolves_to_definition(&c_source, "Option_unwrap_or_bool");
-    assert_c_function_definition_count(&c_source, "Option_unwrap_or_i32", 1);
-    assert_c_function_definition_count(&c_source, "Option_unwrap_or_bool", 1);
+    assert_c_call_resolves_to_single_definition(&c_source, "Option_unwrap_or_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Option_unwrap_or_bool");
     assert!(!c_source.contains("Option_T"));
     assert!(!c_source.contains("T Option_unwrap_or"));
     assert!(!c_source.contains("Option_unwrap_or(some"));
@@ -92,10 +90,8 @@ fn enum_specializations_do_not_emit_unspecialized_c_symbols() {
     assert!(c_source.contains("Result_unwrap_or_i32_StaticString(err_int, 34LL)"));
     assert!(c_source.contains("Result_unwrap_or_bool_StaticString(ok_bool, true)"));
     assert!(c_source.contains("Result_unwrap_or_bool_StaticString(err_bool, true)"));
-    assert_c_call_resolves_to_definition(&c_source, "Result_unwrap_or_i32_StaticString");
-    assert_c_call_resolves_to_definition(&c_source, "Result_unwrap_or_bool_StaticString");
-    assert_c_function_definition_count(&c_source, "Result_unwrap_or_i32_StaticString", 1);
-    assert_c_function_definition_count(&c_source, "Result_unwrap_or_bool_StaticString", 1);
+    assert_c_call_resolves_to_single_definition(&c_source, "Result_unwrap_or_i32_StaticString");
+    assert_c_call_resolves_to_single_definition(&c_source, "Result_unwrap_or_bool_StaticString");
     assert!(!c_source.contains("Result_T"));
     assert!(!c_source.contains("T Result_unwrap_or"));
     assert!(!c_source.contains("Result_unwrap_or(err"));

--- a/tests/integration/generic_specializations/multifile_generated_c/enum_dependencies.rs
+++ b/tests/integration/generic_specializations/multifile_generated_c/enum_dependencies.rs
@@ -62,10 +62,8 @@ fn multi_file_generic_enum_specializations_do_not_emit_unspecialized_c_symbols()
     assert!(c_source.contains("Result_unwrap_or_i32_StaticString(err_int, 144LL)"));
     assert!(c_source.contains("Result_unwrap_or_bool_StaticString(ok_bool, true)"));
     assert!(c_source.contains("Result_unwrap_or_bool_StaticString(err_bool, true)"));
-    assert_c_call_resolves_to_definition(&c_source, "Result_unwrap_or_i32_StaticString");
-    assert_c_call_resolves_to_definition(&c_source, "Result_unwrap_or_bool_StaticString");
-    assert_c_function_definition_count(&c_source, "Result_unwrap_or_i32_StaticString", 1);
-    assert_c_function_definition_count(&c_source, "Result_unwrap_or_bool_StaticString", 1);
+    assert_c_call_resolves_to_single_definition(&c_source, "Result_unwrap_or_i32_StaticString");
+    assert_c_call_resolves_to_single_definition(&c_source, "Result_unwrap_or_bool_StaticString");
     assert!(!c_source.contains("Result_T"));
     assert!(!c_source.contains("T Result_unwrap_or"));
     assert!(!c_source.contains("Result_unwrap_or(err"));


### PR DESCRIPTION
## Summary

- Replace remaining generated-C call/count assertion pairs in enum, behavior-bound, and multi-file enum specialization tests with `assert_c_call_resolves_to_single_definition`.
- Add a repo-hygiene guard so those Phase 5 generated-C tests do not reintroduce split count assertions.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth generated_c_tests_use_single_definition_assertion_helper --quiet`
- `cargo test --test integration enum_specializations_do_not_emit_unspecialized_c_symbols --quiet`
- `cargo test --test integration multi_file_generic_enum_specializations_do_not_emit_unspecialized_c_symbols --quiet`
- `cargo test --test integration local_behavior_bound_specializations_do_not_emit_unspecialized_c_symbols --quiet`
- `cargo test --test docs_truth --quiet`
- `cargo test --lib --quiet`
- `cargo clippy -- -D warnings`
- `cargo test --tests --quiet`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`