### PR TITLE
[codex] Split struct literal resolver tests

### DIFF
--- a/tests/docs_truth/repo_hygiene/file_size/resolver_phase2_splits.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/resolver_phase2_splits.rs
@@ -60,3 +60,34 @@ fn resolver_phase2_non_behavior_impl_tests_live_in_focused_helper() {
         "impls.rs should include the focused non-behavior impl module by path"
     );
 }
+
+#[test]
+fn resolver_phase2_struct_literal_tests_live_in_focused_helper() {
+    let root = read("tests/resolver_phase2/struct_metadata.rs");
+    let literals = read("tests/resolver_phase2/struct_metadata/literals.rs");
+
+    for test_name in [
+        "resolver_rejects_duplicate_struct_literal_fields",
+        "resolver_rejects_unknown_struct_literal_fields",
+        "resolver_rejects_missing_struct_literal_fields",
+        "resolver_rejects_unknown_struct_literal_types",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "struct_metadata.rs should not own struct-literal resolver test: {test_name}"
+        );
+        assert!(
+            literals.contains(&format!("fn {test_name}")),
+            "struct literal resolver tests should live in focused helper: {test_name}"
+        );
+    }
+
+    assert!(
+        root.lines().count() < 170,
+        "struct_metadata.rs should stay focused on struct declaration metadata"
+    );
+    assert!(
+        root.contains("#[path = \"struct_metadata/literals.rs\"]"),
+        "struct_metadata.rs should include the focused struct literal module by path"
+    );
+}

--- a/tests/resolver_phase2/struct_metadata.rs
+++ b/tests/resolver_phase2/struct_metadata.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+#[path = "struct_metadata/literals.rs"]
+mod literals;
+
 #[test]
 fn resolver_records_struct_field_counts() {
     let program = parse_program(
@@ -147,98 +150,4 @@ Point: {
 
     assert_eq!(value.is_mutable, Some(false));
     assert!(value.scope_id > 0);
-}
-
-#[test]
-fn resolver_rejects_duplicate_struct_literal_fields() {
-    let program = parse_program(
-        r#"
-Point: { x: i32 }
-
-main = () i32 {
-    point = Point { x: 1, x: 2 }
-    0
-}
-"#,
-    );
-
-    let err = Resolver::new()
-        .resolve_program(&program)
-        .expect_err("duplicate struct literal field should fail in resolver");
-
-    assert!(
-        err.iter()
-            .any(|d| d.message.contains("duplicate field `x` for struct `Point`")),
-        "expected duplicate struct literal field diagnostic, got {err:?}"
-    );
-}
-
-#[test]
-fn resolver_rejects_unknown_struct_literal_fields() {
-    let program = parse_program(
-        r#"
-Point: { x: i32 }
-
-main = () i32 {
-    point = Point { x: 1, y: 2 }
-    0
-}
-"#,
-    );
-
-    let err = Resolver::new()
-        .resolve_program(&program)
-        .expect_err("unknown struct literal field should fail in resolver");
-
-    assert!(
-        err.iter()
-            .any(|d| d.message.contains("unknown field `y` for struct `Point`")),
-        "expected unknown struct literal field diagnostic, got {err:?}"
-    );
-}
-
-#[test]
-fn resolver_rejects_missing_struct_literal_fields() {
-    let program = parse_program(
-        r#"
-Point: { x: i32, y: i32 }
-
-main = () i32 {
-    point = Point { x: 1 }
-    0
-}
-"#,
-    );
-
-    let err = Resolver::new()
-        .resolve_program(&program)
-        .expect_err("missing struct literal field should fail in resolver");
-
-    assert!(
-        err.iter()
-            .any(|d| d.message.contains("missing field `y` for struct `Point`")),
-        "expected missing struct literal field diagnostic, got {err:?}"
-    );
-}
-
-#[test]
-fn resolver_rejects_unknown_struct_literal_types() {
-    let program = parse_program(
-        r#"
-main = () i32 {
-    point = Point { x: 1 }
-    0
-}
-"#,
-    );
-
-    let err = Resolver::new()
-        .resolve_program(&program)
-        .expect_err("unknown struct literal type should fail in resolver");
-
-    assert!(
-        err.iter()
-            .any(|d| d.message.contains("unknown type symbol 'Point'")),
-        "expected unknown struct literal type diagnostic, got {err:?}"
-    );
 }

--- a/tests/resolver_phase2/struct_metadata/literals.rs
+++ b/tests/resolver_phase2/struct_metadata/literals.rs
@@ -1,0 +1,95 @@
+use super::*;
+
+#[test]
+fn resolver_rejects_duplicate_struct_literal_fields() {
+    let program = parse_program(
+        r#"
+Point: { x: i32 }
+
+main = () i32 {
+    point = Point { x: 1, x: 2 }
+    0
+}
+"#,
+    );
+
+    let err = Resolver::new()
+        .resolve_program(&program)
+        .expect_err("duplicate struct literal field should fail in resolver");
+
+    assert!(
+        err.iter()
+            .any(|d| d.message.contains("duplicate field `x` for struct `Point`")),
+        "expected duplicate struct literal field diagnostic, got {err:?}"
+    );
+}
+
+#[test]
+fn resolver_rejects_unknown_struct_literal_fields() {
+    let program = parse_program(
+        r#"
+Point: { x: i32 }
+
+main = () i32 {
+    point = Point { x: 1, y: 2 }
+    0
+}
+"#,
+    );
+
+    let err = Resolver::new()
+        .resolve_program(&program)
+        .expect_err("unknown struct literal field should fail in resolver");
+
+    assert!(
+        err.iter()
+            .any(|d| d.message.contains("unknown field `y` for struct `Point`")),
+        "expected unknown struct literal field diagnostic, got {err:?}"
+    );
+}
+
+#[test]
+fn resolver_rejects_missing_struct_literal_fields() {
+    let program = parse_program(
+        r#"
+Point: { x: i32, y: i32 }
+
+main = () i32 {
+    point = Point { x: 1 }
+    0
+}
+"#,
+    );
+
+    let err = Resolver::new()
+        .resolve_program(&program)
+        .expect_err("missing struct literal field should fail in resolver");
+
+    assert!(
+        err.iter()
+            .any(|d| d.message.contains("missing field `y` for struct `Point`")),
+        "expected missing struct literal field diagnostic, got {err:?}"
+    );
+}
+
+#[test]
+fn resolver_rejects_unknown_struct_literal_types() {
+    let program = parse_program(
+        r#"
+main = () i32 {
+    point = Point { x: 1 }
+    0
+}
+"#,
+    );
+
+    let err = Resolver::new()
+        .resolve_program(&program)
+        .expect_err("unknown struct literal type should fail in resolver");
+
+    assert!(
+        err.iter()
+            .any(|d| d.message.contains("unknown type symbol 'Point'")),
+        "expected unknown struct literal type diagnostic, got {err:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Move struct-literal resolver validation tests into `tests/resolver_phase2/struct_metadata/literals.rs`.
- Add a docs-truth file-size guard so `struct_metadata.rs` stays focused on struct declaration metadata.

## Validation

- `cargo test --test docs_truth resolver_phase2_struct_literal_tests_live_in_focused_helper --quiet`
- `cargo test --test resolver_phase2 struct_metadata --quiet`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth --quiet`
- `cargo test --lib --quiet`
- `cargo clippy -- -D warnings`
- `cargo test --tests --quiet`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`