### PR TITLE
[codex] Block-scope transitive worklist proof

### DIFF
--- a/tests/docs_truth.rs
+++ b/tests/docs_truth.rs
@@ -9,6 +9,19 @@ fn read(path: impl AsRef<Path>) -> String {
     std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {}", path.display(), e))
 }
 
+fn generated_c_fixture_block<'a>(source: &'a str, fixture: &str) -> &'a str {
+    let start = source
+        .find(fixture)
+        .unwrap_or_else(|| panic!("missing generated-C fixture block: {fixture}"));
+    let tail = &source[start..];
+    let next_block = tail[fixture.len()..]
+        .find("let c_source = compile_to_c_with_generated_call_check")
+        .map(|offset| fixture.len() + offset)
+        .unwrap_or(tail.len());
+
+    &tail[..next_block]
+}
+
 #[path = "docs_truth/contributor_docs.rs"]
 mod contributor_docs;
 #[path = "docs_truth/phase_audit.rs"]

--- a/tests/docs_truth/phase_audit/phase_plan.rs
+++ b/tests/docs_truth/phase_audit/phase_plan.rs
@@ -147,15 +147,18 @@ fn local_nested_generic_method_generated_c_pins_definition_counts() {
 fn imported_transitive_worklist_generated_c_pins_definition_counts() {
     let method_worklist =
         read("tests/integration/generic_specializations/multifile_generated_c/method_worklist_dependencies.rs");
+    let transitive_block = generated_c_fixture_block(
+        &method_worklist,
+        "multi_file_generic_imported_transitive_dependency/main.zen",
+    );
 
     for required in [
-        "multi_file_generic_imported_transitive_dependency/main.zen",
         r#"assert_c_call_resolves_to_single_definition(&c_source, "inner_i32")"#,
         r#"assert_c_call_resolves_to_single_definition(&c_source, "middle_i32")"#,
         r#"assert_c_call_resolves_to_single_definition(&c_source, "outer_i32")"#,
     ] {
         assert!(
-            method_worklist.contains(required),
+            transitive_block.contains(required),
             "imported transitive generic worklist tests should pin exact definition counts: {required}"
         );
     }

--- a/tests/docs_truth/repo_hygiene/codegen_c.rs
+++ b/tests/docs_truth/repo_hygiene/codegen_c.rs
@@ -81,6 +81,10 @@ fn generated_c_tests_use_single_definition_assertion_helper() {
         read("tests/integration/generic_specializations/method_worklist_generated_c.rs");
     let multi_file_worklist =
         read("tests/integration/generic_specializations/multifile_generated_c/method_worklist_dependencies.rs");
+    let transitive_worklist_block = generated_c_fixture_block(
+        &multi_file_worklist,
+        "multi_file_generic_imported_transitive_dependency/main.zen",
+    );
     let enum_generated_c = read("tests/integration/generic_specializations/enum_generated_c.rs");
     let behavior_bounds =
         read("tests/integration/generic_specializations/behavior_bounds/local_and_defaults.rs");
@@ -107,11 +111,11 @@ fn generated_c_tests_use_single_definition_assertion_helper() {
             r#"assert_c_call_resolves_to_single_definition(&c_source, "unwrap_result_Option_i32_StaticString")"#,
         ),
         (
-            multi_file_worklist.as_str(),
+            transitive_worklist_block,
             r#"assert_c_call_resolves_to_single_definition(&c_source, "inner_i32")"#,
         ),
         (
-            multi_file_worklist.as_str(),
+            transitive_worklist_block,
             r#"assert_c_call_resolves_to_single_definition(&c_source, "outer_i32")"#,
         ),
     ] {

--- a/tests/integration/generic_specializations/multifile_generated_c/method_worklist_dependencies.rs
+++ b/tests/integration/generic_specializations/multifile_generated_c/method_worklist_dependencies.rs
@@ -50,9 +50,9 @@ fn multi_file_generic_method_and_worklist_specializations_do_not_emit_unspeciali
     assert!(c_source.contains("inner_i32(value)"));
     assert!(c_source.contains("middle_i32(value)"));
     assert!(c_source.contains("outer_i32(89LL)"));
-    assert_c_call_resolves_to_definition(&c_source, "inner_i32");
-    assert_c_call_resolves_to_definition(&c_source, "middle_i32");
-    assert_c_call_resolves_to_definition(&c_source, "outer_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "inner_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "middle_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "outer_i32");
     assert!(!c_source.contains("T inner"));
     assert!(!c_source.contains("T middle"));
 


### PR DESCRIPTION
## Summary

- Add a docs-truth helper for checking generated-C fixture blocks instead of whole files.
- Scope the imported transitive worklist guards to the `multi_file_generic_imported_transitive_dependency` block.
- Upgrade that transitive block to use `assert_c_call_resolves_to_single_definition` for `inner_i32`, `middle_i32`, and `outer_i32`.

## Validation

- `cargo test --test docs_truth imported_transitive_worklist_generated_c_pins_definition_counts --quiet`
- `cargo test --test docs_truth generated_c_tests_use_single_definition_assertion_helper --quiet`
- `cargo test --test integration multi_file_generic_method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols --quiet`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth --quiet`
- `cargo test --lib --quiet`
- `cargo clippy -- -D warnings`
- `cargo test --tests --quiet`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`