### PR TITLE
[codex] Complete multifile nested result proof

### DIFF
--- a/tests/docs_truth/phase_audit/phase_plan.rs
+++ b/tests/docs_truth/phase_audit/phase_plan.rs
@@ -113,13 +113,18 @@ fn nested_generic_result_generated_c_pins_definition_counts() {
 fn multi_file_nested_generic_method_generated_c_pins_definition_counts() {
     let method_worklist =
         read("tests/integration/generic_specializations/multifile_generated_c/method_worklist_dependencies.rs");
+    let nested_method_block = generated_c_fixture_block(
+        &method_worklist,
+        "multi_file_type_method_nested_result_dependency/main.zen",
+    );
 
     for required in [
-        "multi_file_type_method_nested_result_dependency",
         r#"assert_c_call_resolves_to_single_definition(&c_source, "Box_wrap_result_i32")"#,
+        r#"assert_c_call_resolves_to_single_definition(&c_source, "unwrap_result_Option_i32_StaticString")"#,
+        r#"assert_c_call_resolves_to_single_definition(&c_source, "unwrap_option_i32")"#,
     ] {
         assert!(
-            method_worklist.contains(required),
+            nested_method_block.contains(required),
             "multi-file nested generic method generated-C tests should pin exact definition counts: {required}"
         );
     }

--- a/tests/docs_truth/repo_hygiene/codegen_c.rs
+++ b/tests/docs_truth/repo_hygiene/codegen_c.rs
@@ -85,6 +85,10 @@ fn generated_c_tests_use_single_definition_assertion_helper() {
         &multi_file_worklist,
         "multi_file_generic_imported_transitive_dependency/main.zen",
     );
+    let multi_file_nested_method_block = generated_c_fixture_block(
+        &multi_file_worklist,
+        "multi_file_type_method_nested_result_dependency/main.zen",
+    );
     let enum_generated_c = read("tests/integration/generic_specializations/enum_generated_c.rs");
     let behavior_bounds =
         read("tests/integration/generic_specializations/behavior_bounds/local_and_defaults.rs");
@@ -109,6 +113,14 @@ fn generated_c_tests_use_single_definition_assertion_helper() {
         (
             local_worklist.as_str(),
             r#"assert_c_call_resolves_to_single_definition(&c_source, "unwrap_result_Option_i32_StaticString")"#,
+        ),
+        (
+            multi_file_nested_method_block,
+            r#"assert_c_call_resolves_to_single_definition(&c_source, "unwrap_result_Option_i32_StaticString")"#,
+        ),
+        (
+            multi_file_nested_method_block,
+            r#"assert_c_call_resolves_to_single_definition(&c_source, "unwrap_option_i32")"#,
         ),
         (
             transitive_worklist_block,

--- a/tests/integration/generic_specializations/multifile_generated_c/method_worklist_dependencies.rs
+++ b/tests/integration/generic_specializations/multifile_generated_c/method_worklist_dependencies.rs
@@ -154,7 +154,11 @@ fn multi_file_generic_method_and_worklist_specializations_do_not_emit_unspeciali
         .contains("typedef struct Result_Option_i32_StaticString Result_Option_i32_StaticString;"));
     assert!(c_source.contains("Result_Option_i32_StaticString Box_wrap_result_i32(Box_i32 self)"));
     assert!(c_source.contains("Box_wrap_result_i32(box)"));
+    assert!(c_source.contains("unwrap_result_Option_i32_StaticString(wrapped,"));
+    assert!(c_source.contains("unwrap_option_i32(some, 0LL)"));
     assert_c_call_resolves_to_single_definition(&c_source, "Box_wrap_result_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "unwrap_result_Option_i32_StaticString");
+    assert_c_call_resolves_to_single_definition(&c_source, "unwrap_option_i32");
     assert!(!c_source.contains("Option_T"));
     assert!(!c_source.contains("Result_Option_T"));
     assert!(!c_source.contains("T Box_wrap_result"));


### PR DESCRIPTION
## Summary

- Scope the multi-file nested result method generated-C docs guard to the exact fixture block.
- Require `unwrap_result_Option_i32_StaticString` and `unwrap_option_i32` single-definition assertions alongside `Box_wrap_result_i32`.
- Add generated-C presence checks for the imported unwrap helper calls in the multi-file nested result test.

## Validation

- `cargo test --test docs_truth multi_file_nested_generic_method_generated_c_pins_definition_counts --quiet`
- `cargo test --test docs_truth generated_c_tests_use_single_definition_assertion_helper --quiet`
- `cargo test --test integration multi_file_generic_method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols --quiet`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth --quiet`
- `cargo test --lib --quiet`
- `cargo clippy -- -D warnings`
- `cargo test --tests --quiet`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`