### PR TITLE
[codex] Normalize enum generated C proofs

### DIFF
--- a/tests/docs_truth/repo_hygiene/codegen_c.rs
+++ b/tests/docs_truth/repo_hygiene/codegen_c.rs
@@ -137,10 +137,17 @@ fn generated_c_tests_use_single_definition_assertion_helper() {
         );
     }
 
-    for source in [enum_generated_c, behavior_bounds, multi_file_enums] {
+    for source in [&enum_generated_c, &behavior_bounds, &multi_file_enums] {
         assert!(
             !source.contains("assert_c_function_definition_count"),
             "Phase 5 generated-C tests should use the single-definition helper instead of split call/count assertions"
+        );
+    }
+
+    for source in [&enum_generated_c, &multi_file_enums] {
+        assert!(
+            !source.contains("assert_c_call_resolves_to_definition(&c_source"),
+            "enum generated-C tests should use the single-definition helper for generated call checks"
         );
     }
 }

--- a/tests/integration/generic_specializations/enum_generated_c.rs
+++ b/tests/integration/generic_specializations/enum_generated_c.rs
@@ -8,7 +8,7 @@ fn enum_specializations_do_not_emit_unspecialized_c_symbols() {
     assert!(c_source.contains("int32_t unwrap_or_i32(Option_i32 value, int32_t fallback)"));
     assert!(c_source.contains("Option_i32_Some"));
     assert!(c_source.contains("unwrap_or_i32(x, 0LL)"));
-    assert_c_call_resolves_to_definition(&c_source, "unwrap_or_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "unwrap_or_i32");
     assert!(!c_source.contains("Option_T"));
     assert!(!c_source.contains("T unwrap_or"));
     assert!(!c_source.contains("unwrap_or(x"));
@@ -19,7 +19,7 @@ fn enum_specializations_do_not_emit_unspecialized_c_symbols() {
     assert!(c_source.contains("int32_t Option_unwrap_or_i32(Option_i32 self, int32_t fallback)"));
     assert!(c_source.contains("Option_unwrap_or_i32(some, 0LL)"));
     assert!(c_source.contains("Option_unwrap_or_i32(none, 55LL)"));
-    assert_c_call_resolves_to_definition(&c_source, "Option_unwrap_or_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Option_unwrap_or_i32");
     assert!(!c_source.contains("Option_T"));
     assert!(!c_source.contains("T Option_unwrap_or"));
     assert!(!c_source.contains("Option_unwrap_or(some"));
@@ -57,7 +57,7 @@ fn enum_specializations_do_not_emit_unspecialized_c_symbols() {
     ));
     assert!(c_source.contains("Result_i32_StaticString_Err"));
     assert!(c_source.contains("unwrap_or_i32_StaticString(err, 9LL)"));
-    assert_c_call_resolves_to_definition(&c_source, "unwrap_or_i32_StaticString");
+    assert_c_call_resolves_to_single_definition(&c_source, "unwrap_or_i32_StaticString");
     assert!(!c_source.contains("Result_T"));
     assert!(!c_source.contains("T unwrap_or"));
     assert!(!c_source.contains("unwrap_or(err"));
@@ -70,7 +70,7 @@ fn enum_specializations_do_not_emit_unspecialized_c_symbols() {
     ));
     assert!(c_source.contains("Result_unwrap_or_i32_StaticString(ok, 0LL)"));
     assert!(c_source.contains("Result_unwrap_or_i32_StaticString(err, 34LL)"));
-    assert_c_call_resolves_to_definition(&c_source, "Result_unwrap_or_i32_StaticString");
+    assert_c_call_resolves_to_single_definition(&c_source, "Result_unwrap_or_i32_StaticString");
     assert!(!c_source.contains("Result_T"));
     assert!(!c_source.contains("T Result_unwrap_or"));
     assert!(!c_source.contains("Result_unwrap_or(err"));

--- a/tests/integration/generic_specializations/multifile_generated_c/enum_dependencies.rs
+++ b/tests/integration/generic_specializations/multifile_generated_c/enum_dependencies.rs
@@ -12,8 +12,8 @@ fn multi_file_generic_enum_specializations_do_not_emit_unspecialized_c_symbols()
     ));
     assert!(c_source.contains("unwrap_option_i32(some, 0LL)"));
     assert!(c_source.contains("unwrap_result_i32_StaticString(err, 9LL)"));
-    assert_c_call_resolves_to_definition(&c_source, "unwrap_option_i32");
-    assert_c_call_resolves_to_definition(&c_source, "unwrap_result_i32_StaticString");
+    assert_c_call_resolves_to_single_definition(&c_source, "unwrap_option_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "unwrap_result_i32_StaticString");
     assert!(!c_source.contains("Option_T"));
     assert!(!c_source.contains("Result_T"));
     assert!(!c_source.contains("T unwrap_option"));
@@ -28,7 +28,7 @@ fn multi_file_generic_enum_specializations_do_not_emit_unspecialized_c_symbols()
     assert!(c_source.contains("int32_t Option_unwrap_or_i32(Option_i32 self, int32_t fallback)"));
     assert!(c_source.contains("Option_unwrap_or_i32(some, 0LL)"));
     assert!(c_source.contains("Option_unwrap_or_i32(none, 89LL)"));
-    assert_c_call_resolves_to_definition(&c_source, "Option_unwrap_or_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Option_unwrap_or_i32");
     assert!(!c_source.contains("Option_T"));
     assert!(!c_source.contains("T Option_unwrap_or"));
     assert!(!c_source.contains("Option_unwrap_or(some"));
@@ -42,7 +42,7 @@ fn multi_file_generic_enum_specializations_do_not_emit_unspecialized_c_symbols()
     ));
     assert!(c_source.contains("Result_unwrap_or_i32_StaticString(ok, 0LL)"));
     assert!(c_source.contains("Result_unwrap_or_i32_StaticString(err, 144LL)"));
-    assert_c_call_resolves_to_definition(&c_source, "Result_unwrap_or_i32_StaticString");
+    assert_c_call_resolves_to_single_definition(&c_source, "Result_unwrap_or_i32_StaticString");
     assert!(!c_source.contains("Result_T"));
     assert!(!c_source.contains("T Result_unwrap_or"));
     assert!(!c_source.contains("Result_unwrap_or(err"));
@@ -76,8 +76,8 @@ fn multi_file_generic_enum_specializations_do_not_emit_unspecialized_c_symbols()
     assert!(c_source.contains("int32_t unwrap_i32(Option_i32 value, int32_t fallback)"));
     assert!(c_source.contains("wrap_i32(107LL)"));
     assert!(c_source.contains("unwrap_i32(value, 0LL)"));
-    assert_c_call_resolves_to_definition(&c_source, "wrap_i32");
-    assert_c_call_resolves_to_definition(&c_source, "unwrap_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "wrap_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "unwrap_i32");
     assert!(!c_source.contains("T wrap"));
     assert!(!c_source.contains("T unwrap"));
 }


### PR DESCRIPTION
## Summary

- Require enum generated-C proof files to use `assert_c_call_resolves_to_single_definition` for generated call checks.
- Upgrade local and multi-file enum generated-C assertions from plain call-resolution to exact single-definition checks.

## Validation

- `cargo test --test docs_truth generated_c_tests_use_single_definition_assertion_helper --quiet`
- `cargo test --test integration enum_specializations_do_not_emit_unspecialized_c_symbols --quiet`
- `cargo test --test integration multi_file_generic_enum_specializations_do_not_emit_unspecialized_c_symbols --quiet`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth --quiet`
- `cargo test --lib --quiet`
- `cargo clippy -- -D warnings`
- `cargo test --tests --quiet`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`