### PR TITLE
[codex] Pin imported behavior function definitions

### DIFF
--- a/tests/docs_truth/repo_hygiene/codegen_c.rs
+++ b/tests/docs_truth/repo_hygiene/codegen_c.rs
@@ -92,6 +92,9 @@ fn generated_c_tests_use_single_definition_assertion_helper() {
     let enum_generated_c = read("tests/integration/generic_specializations/enum_generated_c.rs");
     let behavior_bounds =
         read("tests/integration/generic_specializations/behavior_bounds/local_and_defaults.rs");
+    let imported_function_behavior_bounds = read(
+        "tests/integration/generic_specializations/behavior_bounds/imported_function_dependencies.rs",
+    );
     let multi_file_enums = read(
         "tests/integration/generic_specializations/multifile_generated_c/enum_dependencies.rs",
     );
@@ -150,4 +153,9 @@ fn generated_c_tests_use_single_definition_assertion_helper() {
             "enum generated-C tests should use the single-definition helper for generated call checks"
         );
     }
+
+    assert!(
+        !imported_function_behavior_bounds.contains("assert_c_call_resolves_to_definition(&c_source"),
+        "imported function behavior-bound generated-C tests should use the single-definition helper for generated call checks"
+    );
 }

--- a/tests/integration/generic_specializations/behavior_bounds/imported_function_dependencies.rs
+++ b/tests/integration/generic_specializations/behavior_bounds/imported_function_dependencies.rs
@@ -8,8 +8,8 @@ fn imported_function_behavior_bound_dependencies_do_not_emit_unspecialized_c_sym
     assert!(c_source.contains("int32_t Point_encode__Json_i32(Point value)"));
     assert!(c_source.contains("int32_t encode_Point(Point value)"));
     assert!(c_source.contains("Point_encode__Json_i32(value)"));
-    assert_c_call_resolves_to_definition(&c_source, "Point_encode__Json_i32");
-    assert_c_call_resolves_to_definition(&c_source, "encode_Point");
+    assert_c_call_resolves_to_single_definition(&c_source, "Point_encode__Json_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "encode_Point");
     assert!(!c_source.contains("T_encode"));
 }
 
@@ -23,9 +23,9 @@ fn imported_function_signature_type_dependencies_do_not_emit_unspecialized_c_sym
     assert!(c_source.contains("int32_t Point_encode__Json_i32(Point value)"));
     assert!(c_source.contains("int32_t encode_Point(Point value)"));
     assert!(c_source.contains("Point_encode__Json_i32(value)"));
-    assert_c_call_resolves_to_definition(&c_source, "make_point");
-    assert_c_call_resolves_to_definition(&c_source, "Point_encode__Json_i32");
-    assert_c_call_resolves_to_definition(&c_source, "encode_Point");
+    assert_c_call_resolves_to_single_definition(&c_source, "make_point");
+    assert_c_call_resolves_to_single_definition(&c_source, "Point_encode__Json_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "encode_Point");
     assert!(!c_source.contains("T_encode"));
 
     let c_source = compile_to_c_with_generated_call_check(
@@ -37,9 +37,9 @@ fn imported_function_signature_type_dependencies_do_not_emit_unspecialized_c_sym
     assert!(c_source.contains("int32_t encode_point(Point value)"));
     assert!(c_source.contains("Point_encode__Json_i32(value)"));
     assert!(c_source.contains("encode_point(point)"));
-    assert_c_call_resolves_to_definition(&c_source, "make_point");
-    assert_c_call_resolves_to_definition(&c_source, "Point_encode__Json_i32");
-    assert_c_call_resolves_to_definition(&c_source, "encode_point");
+    assert_c_call_resolves_to_single_definition(&c_source, "make_point");
+    assert_c_call_resolves_to_single_definition(&c_source, "Point_encode__Json_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "encode_point");
     assert!(!c_source.contains("T_encode"));
 
     let c_source = compile_to_c_with_generated_call_check(
@@ -50,8 +50,8 @@ fn imported_function_signature_type_dependencies_do_not_emit_unspecialized_c_sym
     assert!(c_source.contains("int32_t Point_encode__Json_i32(Point value)"));
     assert!(c_source.contains("int32_t encode_Point(Point value)"));
     assert!(c_source.contains("Point_encode__Json_i32(value)"));
-    assert_c_call_resolves_to_definition(&c_source, "make_point");
-    assert_c_call_resolves_to_definition(&c_source, "Point_encode__Json_i32");
-    assert_c_call_resolves_to_definition(&c_source, "encode_Point");
+    assert_c_call_resolves_to_single_definition(&c_source, "make_point");
+    assert_c_call_resolves_to_single_definition(&c_source, "Point_encode__Json_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "encode_Point");
     assert!(!c_source.contains("T_encode"));
 }


### PR DESCRIPTION
## Summary

- Require imported function behavior-bound generated-C tests to use single-definition call checks.
- Upgrade imported behavior function dependency assertions for `make_point`, `Point_encode__Json_i32`, and dispatch helpers to exact single-definition checks.

## Validation

- `cargo test --test docs_truth generated_c_tests_use_single_definition_assertion_helper --quiet`
- `cargo test --test integration imported_function_behavior_bound_dependencies_do_not_emit_unspecialized_c_symbols --quiet`
- `cargo test --test integration imported_function_signature_type_dependencies_do_not_emit_unspecialized_c_symbols --quiet`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth --quiet`
- `cargo test --lib --quiet`
- `cargo clippy -- -D warnings`
- `cargo test --tests --quiet`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`