### PR TITLE
[codex] Pin imported behavior impl definitions

### DIFF
--- a/tests/docs_truth/repo_hygiene/codegen_c.rs
+++ b/tests/docs_truth/repo_hygiene/codegen_c.rs
@@ -95,6 +95,9 @@ fn generated_c_tests_use_single_definition_assertion_helper() {
     let imported_function_behavior_bounds = read(
         "tests/integration/generic_specializations/behavior_bounds/imported_function_dependencies.rs",
     );
+    let imported_behavior_impls = read(
+        "tests/integration/generic_specializations/behavior_bounds/imported_behavior_impls.rs",
+    );
     let multi_file_enums = read(
         "tests/integration/generic_specializations/multifile_generated_c/enum_dependencies.rs",
     );
@@ -157,5 +160,9 @@ fn generated_c_tests_use_single_definition_assertion_helper() {
     assert!(
         !imported_function_behavior_bounds.contains("assert_c_call_resolves_to_definition(&c_source"),
         "imported function behavior-bound generated-C tests should use the single-definition helper for generated call checks"
+    );
+    assert!(
+        !imported_behavior_impls.contains("assert_c_call_resolves_to_definition(&c_source"),
+        "imported behavior-impl generated-C tests should use the single-definition helper for generated call checks"
     );
 }

--- a/tests/integration/generic_specializations/behavior_bounds/imported_behavior_impls.rs
+++ b/tests/integration/generic_specializations/behavior_bounds/imported_behavior_impls.rs
@@ -8,8 +8,8 @@ fn imported_behavior_impl_specializations_do_not_emit_unspecialized_c_symbols() 
     assert!(c_source.contains("zen_str Point_encode__Json_StaticString(Point value)"));
     assert!(c_source.contains("zen_str encode_Point(Point value)"));
     assert!(c_source.contains("Point_encode__Json_StaticString(value)"));
-    assert_c_call_resolves_to_definition(&c_source, "Point_encode__Json_StaticString");
-    assert_c_call_resolves_to_definition(&c_source, "encode_Point");
+    assert_c_call_resolves_to_single_definition(&c_source, "Point_encode__Json_StaticString");
+    assert_c_call_resolves_to_single_definition(&c_source, "encode_Point");
     assert!(!c_source.contains("T_encode"));
 
     let c_source = compile_to_c_with_generated_call_check(
@@ -18,8 +18,8 @@ fn imported_behavior_impl_specializations_do_not_emit_unspecialized_c_symbols() 
     assert!(c_source.contains("zen_str Point_encode(Point value)"));
     assert!(c_source.contains("zen_str encode_Point(Point value)"));
     assert!(c_source.contains("Point_encode(value)"));
-    assert_c_call_resolves_to_definition(&c_source, "Point_encode");
-    assert_c_call_resolves_to_definition(&c_source, "encode_Point");
+    assert_c_call_resolves_to_single_definition(&c_source, "Point_encode");
+    assert_c_call_resolves_to_single_definition(&c_source, "encode_Point");
     assert!(!c_source.contains("T_encode"));
 }
 
@@ -31,8 +31,8 @@ fn imported_behavior_default_and_parent_dispatch_do_not_emit_unspecialized_c_sym
     assert!(c_source.contains("zen_str Point_to_json(Point "));
     assert!(c_source.contains("zen_str render_Point(Point value)"));
     assert!(c_source.contains("Point_to_json(value)"));
-    assert_c_call_resolves_to_definition(&c_source, "Point_to_json");
-    assert_c_call_resolves_to_definition(&c_source, "render_Point");
+    assert_c_call_resolves_to_single_definition(&c_source, "Point_to_json");
+    assert_c_call_resolves_to_single_definition(&c_source, "render_Point");
     assert!(!c_source.contains("T_to_json"));
 
     let c_source = compile_to_c_with_generated_call_check(
@@ -41,8 +41,8 @@ fn imported_behavior_default_and_parent_dispatch_do_not_emit_unspecialized_c_sym
     assert!(c_source.contains("zen_str Point_encode(Point __arg0)"));
     assert!(c_source.contains("zen_str render_Point(Point value)"));
     assert!(c_source.contains("Point_encode(value)"));
-    assert_c_call_resolves_to_definition(&c_source, "Point_encode");
-    assert_c_call_resolves_to_definition(&c_source, "render_Point");
+    assert_c_call_resolves_to_single_definition(&c_source, "Point_encode");
+    assert_c_call_resolves_to_single_definition(&c_source, "render_Point");
     assert!(!c_source.contains("Json_T"));
     assert!(!c_source.contains("T_encode"));
 
@@ -52,8 +52,8 @@ fn imported_behavior_default_and_parent_dispatch_do_not_emit_unspecialized_c_sym
     assert!(c_source.contains("zen_str Point_encode(Point value)"));
     assert!(c_source.contains("zen_str render_Point(Point value)"));
     assert!(c_source.contains("Point_encode(value)"));
-    assert_c_call_resolves_to_definition(&c_source, "Point_encode");
-    assert_c_call_resolves_to_definition(&c_source, "render_Point");
+    assert_c_call_resolves_to_single_definition(&c_source, "Point_encode");
+    assert_c_call_resolves_to_single_definition(&c_source, "render_Point");
     assert!(!c_source.contains("T_encode"));
 }
 
@@ -65,8 +65,8 @@ fn imported_behavior_requires_do_not_emit_unspecialized_c_symbols() {
     assert!(c_source.contains("zen_str Point_encode__Json_StaticString(Point value)"));
     assert!(c_source.contains("zen_str encode_Point(Point value)"));
     assert!(c_source.contains("Point_encode__Json_StaticString(value)"));
-    assert_c_call_resolves_to_definition(&c_source, "Point_encode__Json_StaticString");
-    assert_c_call_resolves_to_definition(&c_source, "encode_Point");
+    assert_c_call_resolves_to_single_definition(&c_source, "Point_encode__Json_StaticString");
+    assert_c_call_resolves_to_single_definition(&c_source, "encode_Point");
     assert!(!c_source.contains("T_encode"));
 
     let c_source = compile_to_c_with_generated_call_check(
@@ -75,7 +75,7 @@ fn imported_behavior_requires_do_not_emit_unspecialized_c_symbols() {
     assert!(c_source.contains("zen_str Point_encode(Point value)"));
     assert!(c_source.contains("zen_str encode_Point(Point value)"));
     assert!(c_source.contains("Point_encode(value)"));
-    assert_c_call_resolves_to_definition(&c_source, "Point_encode");
-    assert_c_call_resolves_to_definition(&c_source, "encode_Point");
+    assert_c_call_resolves_to_single_definition(&c_source, "Point_encode");
+    assert_c_call_resolves_to_single_definition(&c_source, "encode_Point");
     assert!(!c_source.contains("T_encode"));
 }


### PR DESCRIPTION
## Summary

- Require imported behavior-impl generated-C tests to use single-definition call checks.
- Upgrade imported behavior impl/default/requires dispatch assertions to exact single-definition checks.

## Validation

- `cargo test --test docs_truth generated_c_tests_use_single_definition_assertion_helper --quiet`
- `cargo test --test integration imported_behavior_impl_specializations_do_not_emit_unspecialized_c_symbols --quiet`
- `cargo test --test integration imported_behavior_default_and_parent_dispatch_do_not_emit_unspecialized_c_symbols --quiet`
- `cargo test --test integration imported_behavior_requires_do_not_emit_unspecialized_c_symbols --quiet`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth --quiet`
- `cargo test --lib --quiet`
- `cargo clippy -- -D warnings`
- `cargo test --tests --quiet`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`