### PR TITLE
[codex] Pin local method worklist definitions

### DIFF
--- a/tests/docs_truth/repo_hygiene/codegen_c.rs
+++ b/tests/docs_truth/repo_hygiene/codegen_c.rs
@@ -169,4 +169,8 @@ fn generated_c_tests_use_single_definition_assertion_helper() {
         !behavior_bounds.contains("assert_c_call_resolves_to_definition(&c_source"),
         "local behavior-bound generated-C tests should use the single-definition helper for generated call checks"
     );
+    assert!(
+        !local_worklist.contains("assert_c_call_resolves_to_definition(&c_source"),
+        "local method/worklist generated-C tests should use the single-definition helper for generated call checks"
+    );
 }

--- a/tests/integration/generic_specializations/method_worklist_generated_c.rs
+++ b/tests/integration/generic_specializations/method_worklist_generated_c.rs
@@ -5,7 +5,7 @@ fn method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols() {
     let c_source = compile_to_c_with_generated_call_check(&test_dir().join("generic_method.zen"));
     assert!(c_source.contains("int32_t Box_get_i32(Box_i32 self)"));
     assert!(c_source.contains("Box_get_i32(box)"));
-    assert_c_call_resolves_to_definition(&c_source, "Box_get_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Box_get_i32");
     assert!(!c_source.contains("Box_T"));
     assert!(!c_source.contains("T Box_get"));
 
@@ -17,9 +17,9 @@ fn method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols() {
     assert!(c_source.contains("Box_copy_Option_i32(nested)"));
     assert!(c_source.contains("Option_i32 Option_copy_i32(Option_i32 self)"));
     assert!(c_source.contains("Option_copy_i32(option)"));
-    assert_c_call_resolves_to_definition(&c_source, "Box_copy_i32");
-    assert_c_call_resolves_to_definition(&c_source, "Box_copy_Option_i32");
-    assert_c_call_resolves_to_definition(&c_source, "Option_copy_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Box_copy_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Box_copy_Option_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Option_copy_i32");
     assert!(
         c_source
             .find("struct Option_i32")
@@ -37,8 +37,8 @@ fn method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols() {
     assert!(c_source.contains("int32_t Box_get_inner_i32(Box_i32 self)"));
     assert!(c_source.contains("inner_i32(self.value)"));
     assert!(c_source.contains("Box_get_inner_i32(box)"));
-    assert_c_call_resolves_to_definition(&c_source, "inner_i32");
-    assert_c_call_resolves_to_definition(&c_source, "Box_get_inner_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "inner_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Box_get_inner_i32");
     assert!(!c_source.contains("T inner"));
     assert!(!c_source.contains("inner_T"));
 
@@ -75,8 +75,8 @@ fn method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols() {
     assert!(c_source.contains("int32_t Point_keep_i32(Point self, int32_t value)"));
     assert!(c_source.contains("Point_get(point)"));
     assert!(c_source.contains("Point_keep_i32(point, 7LL)"));
-    assert_c_call_resolves_to_definition(&c_source, "Point_get");
-    assert_c_call_resolves_to_definition(&c_source, "Point_keep_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Point_get");
+    assert_c_call_resolves_to_single_definition(&c_source, "Point_keep_i32");
     assert!(!c_source.contains("T Point_keep"));
     assert!(!c_source.contains("Point_keep(point"));
 
@@ -86,8 +86,8 @@ fn method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols() {
     assert!(c_source.contains("Box_i32 Box_replace_i32(Box_i32 self, int32_t value)"));
     assert!(c_source.contains("Box_get_i32(next)"));
     assert!(c_source.contains("Box_replace_i32(box, 42LL)"));
-    assert_c_call_resolves_to_definition(&c_source, "Box_get_i32");
-    assert_c_call_resolves_to_definition(&c_source, "Box_replace_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Box_get_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Box_replace_i32");
     assert!(!c_source.contains("Box_T"));
     assert!(!c_source.contains("T Box_get"));
     assert!(!c_source.contains("T Box_replace"));
@@ -97,8 +97,8 @@ fn method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols() {
     assert!(c_source.contains("int32_t Vec_len_StaticString(Vec_StaticString self)"));
     assert!(c_source.contains("Vec_len_i32(ints)"));
     assert!(c_source.contains("Vec_len_StaticString(words)"));
-    assert_c_call_resolves_to_definition(&c_source, "Vec_len_i32");
-    assert_c_call_resolves_to_definition(&c_source, "Vec_len_StaticString");
+    assert_c_call_resolves_to_single_definition(&c_source, "Vec_len_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Vec_len_StaticString");
     assert!(!c_source.contains("Vec_T"));
     assert!(!c_source.contains("T Vec_len"));
 
@@ -107,7 +107,7 @@ fn method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols() {
     assert!(c_source.contains("int32_t outer_i32(int32_t value)"));
     assert!(c_source.contains("inner_i32(value)"));
     assert_c_call_resolves_to_single_definition(&c_source, "inner_i32");
-    assert_c_call_resolves_to_definition(&c_source, "outer_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "outer_i32");
     assert!(!c_source.contains("T inner"));
     assert!(!c_source.contains("inner_T"));
 
@@ -117,8 +117,8 @@ fn method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols() {
     assert!(c_source.contains("int32_t right_i32(int32_t value)"));
     assert!(c_source.contains("inner_i32(value)"));
     assert_c_call_resolves_to_single_definition(&c_source, "inner_i32");
-    assert_c_call_resolves_to_definition(&c_source, "left_i32");
-    assert_c_call_resolves_to_definition(&c_source, "right_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "left_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "right_i32");
     assert!(!c_source.contains("T inner"));
     assert!(!c_source.contains("inner_T"));
 
@@ -143,7 +143,7 @@ fn method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols() {
         compile_to_c_with_generated_call_check(&test_dir().join("generic_ufc_function.zen"));
     assert!(c_source.contains("int32_t id_i32(int32_t value)"));
     assert!(c_source.contains("id_i32(12LL)"));
-    assert_c_call_resolves_to_definition(&c_source, "id_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "id_i32");
     assert!(!c_source.contains("id(12LL)"));
     assert!(!c_source.contains("T id"));
 


### PR DESCRIPTION
## Summary

- Require local method/worklist generated-C tests to use single-definition call checks.
- Upgrade the local method/worklist generated-C proof assertions to exact single-definition checks.

## Validation

- `cargo test --test docs_truth generated_c_tests_use_single_definition_assertion_helper --quiet`
- `cargo test --test integration method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols --quiet`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth --quiet`
- `cargo test --lib --quiet`
- `cargo clippy -- -D warnings`
- `cargo test --tests --quiet`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`