### PR TITLE
[codex] Pin multifile method worklist definitions

### DIFF
--- a/tests/docs_truth/repo_hygiene/codegen_c.rs
+++ b/tests/docs_truth/repo_hygiene/codegen_c.rs
@@ -173,4 +173,8 @@ fn generated_c_tests_use_single_definition_assertion_helper() {
         !local_worklist.contains("assert_c_call_resolves_to_definition(&c_source"),
         "local method/worklist generated-C tests should use the single-definition helper for generated call checks"
     );
+    assert!(
+        !multi_file_worklist.contains("assert_c_call_resolves_to_definition(&c_source"),
+        "multi-file method/worklist generated-C tests should use the single-definition helper for generated call checks"
+    );
 }

--- a/tests/integration/generic_specializations/multifile_generated_c/method_worklist_dependencies.rs
+++ b/tests/integration/generic_specializations/multifile_generated_c/method_worklist_dependencies.rs
@@ -11,8 +11,8 @@ fn multi_file_generic_method_and_worklist_specializations_do_not_emit_unspeciali
     assert!(c_source.contains("const Holder_i32 holder = (Holder_i32){ .value = value }"));
     assert!(c_source.contains("Holder_get_i32(holder)"));
     assert!(c_source.contains("get_held_i32(73LL)"));
-    assert_c_call_resolves_to_definition(&c_source, "Holder_get_i32");
-    assert_c_call_resolves_to_definition(&c_source, "get_held_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Holder_get_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "get_held_i32");
     assert!(!c_source.contains("Holder_T"));
     assert!(!c_source.contains("T Holder_get"));
 
@@ -60,7 +60,7 @@ fn multi_file_generic_method_and_worklist_specializations_do_not_emit_unspeciali
         compile_to_c_with_generated_call_check(&test_dir().join("multi_file_type_impl/main.zen"));
     assert!(c_source.contains("int32_t Box_get_i32(Box_i32 self)"));
     assert!(c_source.contains("Box_get_i32(box)"));
-    assert_c_call_resolves_to_definition(&c_source, "Box_get_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Box_get_i32");
     assert!(!c_source.contains("Box_T"));
     assert!(!c_source.contains("T Box_get"));
 
@@ -73,8 +73,8 @@ fn multi_file_generic_method_and_worklist_specializations_do_not_emit_unspeciali
     assert!(c_source.contains("const Holder_i32 holder = (Holder_i32){ .value = self.value }"));
     assert!(c_source.contains("Holder_get_i32(holder)"));
     assert!(c_source.contains("Box_get_held_i32(box)"));
-    assert_c_call_resolves_to_definition(&c_source, "Holder_get_i32");
-    assert_c_call_resolves_to_definition(&c_source, "Box_get_held_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Holder_get_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Box_get_held_i32");
     assert!(!c_source.contains("Holder_T"));
     assert!(!c_source.contains("T Holder_get"));
 
@@ -86,8 +86,8 @@ fn multi_file_generic_method_and_worklist_specializations_do_not_emit_unspeciali
     assert!(c_source.contains("int32_t Box_value_or_i32(Box_i32 self, int32_t fallback)"));
     assert!(c_source.contains("Box_wrap_i32(self)"));
     assert!(c_source.contains("Box_value_or_i32(box, 0LL)"));
-    assert_c_call_resolves_to_definition(&c_source, "Box_wrap_i32");
-    assert_c_call_resolves_to_definition(&c_source, "Box_value_or_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Box_wrap_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Box_value_or_i32");
     assert!(!c_source.contains("Option_T"));
     assert!(!c_source.contains("T Box_wrap"));
 
@@ -95,7 +95,7 @@ fn multi_file_generic_method_and_worklist_specializations_do_not_emit_unspeciali
         compile_to_c_with_generated_call_check(&test_dir().join("multi_file_type_method/main.zen"));
     assert!(c_source.contains("int32_t Point_keep_i32(Point self, int32_t value)"));
     assert!(c_source.contains("Point_keep_i32(point, 13LL)"));
-    assert_c_call_resolves_to_definition(&c_source, "Point_keep_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Point_keep_i32");
     assert!(!c_source.contains("T Point_keep"));
     assert!(!c_source.contains("Point_keep(point"));
 
@@ -106,8 +106,8 @@ fn multi_file_generic_method_and_worklist_specializations_do_not_emit_unspeciali
     assert!(c_source.contains("int32_t Box_get_inner_i32(Box_i32 self)"));
     assert!(c_source.contains("inner_i32(self.value)"));
     assert!(c_source.contains("Box_get_inner_i32(box)"));
-    assert_c_call_resolves_to_definition(&c_source, "inner_i32");
-    assert_c_call_resolves_to_definition(&c_source, "Box_get_inner_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "inner_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Box_get_inner_i32");
     assert!(!c_source.contains("T inner"));
     assert!(!c_source.contains("inner_T"));
 
@@ -118,8 +118,8 @@ fn multi_file_generic_method_and_worklist_specializations_do_not_emit_unspeciali
     assert!(c_source.contains("int32_t Box_get_inner_i32(Box_i32 self)"));
     assert!(c_source.contains("Box_inner_i32(self)"));
     assert!(c_source.contains("Box_get_inner_i32(box)"));
-    assert_c_call_resolves_to_definition(&c_source, "Box_inner_i32");
-    assert_c_call_resolves_to_definition(&c_source, "Box_get_inner_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Box_inner_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Box_get_inner_i32");
     assert!(!c_source.contains("T Box_inner"));
 
     let c_source = compile_to_c_with_generated_call_check(
@@ -129,8 +129,8 @@ fn multi_file_generic_method_and_worklist_specializations_do_not_emit_unspeciali
     assert!(c_source.contains("int32_t Box_get_inner_i32(Box_i32 self)"));
     assert!(c_source.contains("inner_i32(self.value)"));
     assert!(c_source.contains("Box_get_inner_i32(box)"));
-    assert_c_call_resolves_to_definition(&c_source, "inner_i32");
-    assert_c_call_resolves_to_definition(&c_source, "Box_get_inner_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "inner_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Box_get_inner_i32");
     assert!(!c_source.contains("T inner"));
 
     let c_source = compile_to_c_with_generated_call_check(
@@ -141,8 +141,8 @@ fn multi_file_generic_method_and_worklist_specializations_do_not_emit_unspeciali
     assert!(c_source.contains("int32_t Box_value_or_i32(Box_i32 self, int32_t fallback)"));
     assert!(c_source.contains("Box_wrap_i32(self)"));
     assert!(c_source.contains("Box_value_or_i32(box, 0LL)"));
-    assert_c_call_resolves_to_definition(&c_source, "Box_wrap_i32");
-    assert_c_call_resolves_to_definition(&c_source, "Box_value_or_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Box_wrap_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Box_value_or_i32");
     assert!(!c_source.contains("Option_T"));
     assert!(!c_source.contains("T Box_wrap"));
 

--- a/tests/integration/support.rs
+++ b/tests/integration/support.rs
@@ -11,8 +11,8 @@ use zen::typechecker::TypeChecker;
 mod generated_c;
 
 pub use generated_c::{
-    assert_c_call_resolves_to_definition, assert_c_call_resolves_to_single_definition,
-    assert_c_function_definition_count, assert_generated_c_calls_resolve_to_definitions,
+    assert_c_call_resolves_to_single_definition, assert_c_function_definition_count,
+    assert_generated_c_calls_resolve_to_definitions,
     assert_generated_c_function_definitions_are_unique, has_c_call_outside_signature,
     undefined_generated_c_calls,
 };


### PR DESCRIPTION
## What changed
- Upgraded multi-file method/worklist generated-C assertions to require exactly one resolved definition for each generated call.
- Added a docs-truth guard so those tests do not regress back to the weaker call-only helper.
- Removed the now-unused public re-export of the weaker generated-C assertion helper from integration support.

## Why
The existing proof only checked that generated calls had some matching definition. This keeps the Phase 5 generic worklist evidence stricter by proving the relevant multi-file generated symbols are emitted once.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth --quiet`
- `cargo test --lib --quiet`
- `cargo clippy -- -D warnings`
- `cargo test --tests --quiet`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`
