### PR TITLE
[codex] Scan bare generated C calls

### DIFF
--- a/tests/integration/generated_c_assertions.rs
+++ b/tests/integration/generated_c_assertions.rs
@@ -28,13 +28,17 @@ int32_t inner_i32(int32_t value) {
 int32_t outer_i32(int32_t value) {
     printf("%d", value);
     missing_stmt_i32(value);
-    return missing_i32(value) + inner_i32(value);
+    return missing_i32(value) + inner_i32(value) + id(12LL);
 }
 "#;
 
     assert_eq!(
         undefined_generated_c_calls(c_source),
-        vec!["missing_stmt_i32".to_string(), "missing_i32".to_string()]
+        vec![
+            "missing_stmt_i32".to_string(),
+            "missing_i32".to_string(),
+            "id".to_string()
+        ]
     );
 }
 

--- a/tests/integration/support/generated_c.rs
+++ b/tests/integration/support/generated_c.rs
@@ -105,7 +105,7 @@ fn c_function_definition_name(trimmed: &str) -> Option<String> {
         .map_or(0, |idx| idx + 1);
     let name = &before[name_start..];
 
-    if is_generated_c_function_name(name) {
+    if is_tracked_c_function_name(name) {
         Some(name.to_string())
     } else {
         None
@@ -129,7 +129,7 @@ fn is_any_c_function_signature_line(trimmed: &str) -> bool {
     let name = before[name_start..].trim();
 
     !return_type.is_empty()
-        && is_generated_c_function_name(name)
+        && is_tracked_c_function_name(name)
         && !before.contains('=')
         && !before.contains("return")
 }
@@ -152,7 +152,7 @@ fn generated_c_calls_on_line(trimmed: &str) -> Vec<String> {
         }
 
         let name = &trimmed[start..paren];
-        if is_generated_c_function_name(name) && !calls.iter().any(|call| call == name) {
+        if is_tracked_c_function_name(name) && !calls.iter().any(|call| call == name) {
             calls.push(name.to_string());
         }
 
@@ -162,15 +162,39 @@ fn generated_c_calls_on_line(trimmed: &str) -> Vec<String> {
     calls
 }
 
-fn is_generated_c_function_name(name: &str) -> bool {
-    name.contains('_')
-        && name
-            .chars()
-            .next()
-            .is_some_and(|ch| ch.is_ascii_alphabetic())
+fn is_tracked_c_function_name(name: &str) -> bool {
+    name.chars()
+        .next()
+        .is_some_and(|ch| ch.is_ascii_alphabetic() || ch == '_')
         && name
             .chars()
             .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+        && !is_untracked_c_call_name(name)
+}
+
+fn is_untracked_c_call_name(name: &str) -> bool {
+    matches!(
+        name,
+        "abort"
+            | "ceil"
+            | "floor"
+            | "for"
+            | "fprintf"
+            | "fputc"
+            | "free"
+            | "fwrite"
+            | "if"
+            | "malloc"
+            | "memcpy"
+            | "pow"
+            | "printf"
+            | "snprintf"
+            | "sizeof"
+            | "sqrt"
+            | "strlen"
+            | "switch"
+            | "while"
+    )
 }
 
 pub fn has_c_call_outside_signature(c_source: &str, name: &str) -> bool {


### PR DESCRIPTION
## What changed
- Broadened the generated-C undefined-call scanner so it tracks plain identifiers as well as names containing underscores.
- Added a regression that catches an undefined bare call like `id(12LL)` while still ignoring C library/runtime calls such as `printf`, `fwrite`, and `sizeof`.

## Why
The scanner previously missed unspecialized bare generated calls because it only considered names with underscores. Some generic proof tests compensated with fixture-specific negative substring checks; this makes the shared helper catch that class directly.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth --quiet`
- `cargo test --lib --quiet`
- `cargo clippy -- -D warnings`
- `cargo test --tests --quiet`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`
