### PR TITLE
[codex] Narrow generated C assertion surface

### DIFF
--- a/tests/docs_truth/repo_hygiene/codegen_c.rs
+++ b/tests/docs_truth/repo_hygiene/codegen_c.rs
@@ -110,6 +110,18 @@ fn generated_c_tests_use_single_definition_assertion_helper() {
         support.contains("assert_c_call_resolves_to_single_definition"),
         "integration support should re-export the generated-C single-definition helper"
     );
+    assert!(
+        !support.contains("assert_c_function_definition_count"),
+        "integration support should not re-export split generated-C definition-count assertions"
+    );
+    assert!(
+        !generated_c.contains("pub fn assert_c_call_resolves_to_definition("),
+        "generated-C support should keep the weaker call-only helper private"
+    );
+    assert!(
+        !generated_c.contains("pub fn assert_c_function_definition_count("),
+        "generated-C support should keep the split definition-count helper private"
+    );
 
     for (fixture, helper_call) in [
         (

--- a/tests/integration/generated_c_assertions.rs
+++ b/tests/integration/generated_c_assertions.rs
@@ -50,9 +50,13 @@ int32_t inner_i32(int32_t value);
 int32_t inner_i32(int32_t value) {
     return value;
 }
+
+int32_t outer_i32(void) {
+    return inner_i32(1LL);
+}
 "#;
 
-    assert_c_function_definition_count(c_source, "inner_i32", 1);
+    assert_c_call_resolves_to_single_definition(c_source, "inner_i32");
 }
 
 // ── Individual test cases ───────────────────────────────────────────

--- a/tests/integration/support.rs
+++ b/tests/integration/support.rs
@@ -11,8 +11,7 @@ use zen::typechecker::TypeChecker;
 mod generated_c;
 
 pub use generated_c::{
-    assert_c_call_resolves_to_single_definition, assert_c_function_definition_count,
-    assert_generated_c_calls_resolve_to_definitions,
+    assert_c_call_resolves_to_single_definition, assert_generated_c_calls_resolve_to_definitions,
     assert_generated_c_function_definitions_are_unique, has_c_call_outside_signature,
     undefined_generated_c_calls,
 };

--- a/tests/integration/support/generated_c.rs
+++ b/tests/integration/support/generated_c.rs
@@ -8,7 +8,7 @@ fn assert_c_function_definition(c_source: &str, name: &str) {
     );
 }
 
-pub fn assert_c_function_definition_count(c_source: &str, name: &str, expected: usize) {
+fn assert_c_function_definition_count(c_source: &str, name: &str, expected: usize) {
     let actual = c_function_definitions(c_source)
         .iter()
         .filter(|definition| definition.as_str() == name)
@@ -41,7 +41,7 @@ pub fn assert_generated_c_function_definitions_are_unique(c_source: &str) {
     );
 }
 
-pub fn assert_c_call_resolves_to_definition(c_source: &str, name: &str) {
+fn assert_c_call_resolves_to_definition(c_source: &str, name: &str) {
     assert_c_function_definition(c_source, name);
     assert!(
         has_c_call_outside_signature(c_source, name),


### PR DESCRIPTION
## What changed
- Stopped re-exporting the split generated-C definition-count helper from integration support.
- Made the call-only and definition-count generated-C helpers private implementation details.
- Reworked the prototype-count regression to use the public single-definition helper.
- Added docs-truth guards so the weaker helper surface does not become public again.

## Why
Phase 5 generated-C proof tests should use the combined helper that proves both call resolution and exactly one emitted definition. Keeping the split helpers public made it easier to regress back to weaker checks.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth --quiet`
- `cargo test --lib --quiet`
- `cargo clippy -- -D warnings`
- `cargo test --tests --quiet`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`
