### PR TITLE
[codex] fix scoped generic UFC inference

### DIFF
--- a/src/typechecker/expressions.rs
+++ b/src/typechecker/expressions.rs
@@ -20,7 +20,6 @@ use crate::ast::{AstType, Expression, Param};
 use crate::error::{Diagnostic, Span};
 
 use super::monomorphize_inference::InferenceConflict;
-use super::monomorphize_types::concrete_name_matches_generic;
 use super::{BehaviorBound, FuncInfo, TypeChecker};
 
 impl TypeChecker {

--- a/src/typechecker/expressions/call_validation.rs
+++ b/src/typechecker/expressions/call_validation.rs
@@ -59,13 +59,13 @@ impl TypeChecker {
         self.structs
             .values()
             .filter(|info| !info.type_params.is_empty())
-            .find(|info| concrete_name_matches_generic(concrete_name, &info.name))
+            .find(|info| self.concrete_type_name_matches_generic(concrete_name, &info.name))
             .map(|info| info.name.clone())
             .or_else(|| {
                 self.enums
                     .values()
                     .filter(|info| !info.type_params.is_empty())
-                    .find(|info| concrete_name_matches_generic(concrete_name, &info.name))
+                    .find(|info| self.concrete_type_name_matches_generic(concrete_name, &info.name))
                     .map(|info| info.name.clone())
             })
     }

--- a/src/typechecker/expressions/method_call_support.rs
+++ b/src/typechecker/expressions/method_call_support.rs
@@ -58,15 +58,17 @@ impl TypeChecker {
                 self.check_call_signature("method", &method_key, &info.params, &typed_args, &span);
                 (method_key.clone(), self.resolve_type(&info.return_type))
             };
-            Ok(TypedExpression {
+            return Ok(TypedExpression {
                 kind: TypedExprKind::FunctionCall {
                     function: resolved_method,
                     args: typed_args,
                 },
                 ty: ret_type,
                 span,
-            })
-        } else if let Some(generic_base) = self.generic_base_type_name(&type_name) {
+            });
+        }
+
+        if let Some(generic_base) = self.generic_base_type_name(&type_name) {
             let generic_method_key = Self::method_key(&generic_base, method);
             if let Some(info) = self.methods.get(&generic_method_key).cloned() {
                 if !info.type_params.is_empty() {
@@ -77,14 +79,14 @@ impl TypeChecker {
                         &typed_args,
                         span,
                     );
-                    Ok(TypedExpression {
+                    return Ok(TypedExpression {
                         kind: TypedExprKind::FunctionCall {
                             function: mangled,
                             args: typed_args,
                         },
                         ty: ret_type,
                         span,
-                    })
+                    });
                 } else {
                     if !type_args.is_empty() {
                         self.diagnostics.push(Diagnostic::error(
@@ -103,19 +105,19 @@ impl TypeChecker {
                         &typed_args,
                         &span,
                     );
-                    Ok(TypedExpression {
+                    return Ok(TypedExpression {
                         kind: TypedExprKind::FunctionCall {
                             function: format!("{}_{}", generic_base, method),
                             args: typed_args,
                         },
                         ty: self.resolve_type(&info.return_type),
                         span,
-                    })
+                    });
                 }
-            } else {
-                self.unknown_method_expr(&type_name, method, typed_args, span)
             }
-        } else if let Some(info) = self.functions.get(method).cloned() {
+        }
+
+        if let Some(info) = self.functions.get(method).cloned() {
             // UFC: x.f(args) -> f(x, args)
             let (resolved_function, ret_type) = if !info.type_params.is_empty() {
                 self.resolve_generic_function_call(method, &info, type_args, &typed_args, span)

--- a/src/typechecker/monomorphize.rs
+++ b/src/typechecker/monomorphize.rs
@@ -6,7 +6,6 @@ use crate::ast::typed::Type;
 use crate::ast::AstType;
 use crate::error::{Diagnostic, Span};
 
-pub(super) use super::monomorphize_types::concrete_name_matches_generic;
 pub(crate) use super::monomorphize_types::type_to_ast;
 use super::TypeChecker;
 

--- a/src/typechecker/monomorphize_inference.rs
+++ b/src/typechecker/monomorphize_inference.rs
@@ -159,7 +159,7 @@ impl TypeChecker {
             Type::Struct {
                 name: actual_name,
                 fields: actual_fields,
-            } if super::monomorphize::concrete_name_matches_generic(actual_name, generic_name) => {
+            } if self.concrete_type_name_matches_generic(actual_name, generic_name) => {
                 if let Some(info) = self.structs.get(generic_name) {
                     for ((_, expected), (_, actual)) in info.fields.iter().zip(actual_fields.iter())
                     {
@@ -170,7 +170,7 @@ impl TypeChecker {
             Type::Enum {
                 name: actual_name,
                 variants: actual_variants,
-            } if super::monomorphize::concrete_name_matches_generic(actual_name, generic_name) => {
+            } if self.concrete_type_name_matches_generic(actual_name, generic_name) => {
                 if let Some(info) = self.enums.get(generic_name) {
                     for ((_, expected_payload), (_, actual_payload)) in
                         info.variants.iter().zip(actual_variants.iter())

--- a/src/typechecker/monomorphize_names.rs
+++ b/src/typechecker/monomorphize_names.rs
@@ -93,6 +93,23 @@ impl TypeChecker {
         self.specialized_types_seen.get(&key).cloned()
     }
 
+    pub(crate) fn remember_specialized_type_source(&mut self, concrete: &str, generic: &str) {
+        self.specialized_type_generic_names
+            .insert(concrete.to_string(), generic.to_string());
+    }
+
+    pub(crate) fn concrete_type_name_matches_generic(
+        &self,
+        concrete_name: &str,
+        generic_name: &str,
+    ) -> bool {
+        super::monomorphize_types::concrete_name_matches_generic(concrete_name, generic_name)
+            || self
+                .specialized_type_generic_names
+                .get(concrete_name)
+                .is_some_and(|source| source == generic_name)
+    }
+
     pub(crate) fn generic_specialization_key(
         &self,
         kind: &str,

--- a/src/typechecker/monomorphize_specialized_type_names.rs
+++ b/src/typechecker/monomorphize_specialized_type_names.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use crate::ast::typed::Type;
 use crate::ast::AstType;
 
-use super::monomorphize_types::{concrete_name_matches_generic, type_to_ast};
+use super::monomorphize_types::type_to_ast;
 use super::TypeChecker;
 
 impl TypeChecker {
@@ -19,7 +19,7 @@ impl TypeChecker {
             .iter()
             .find(|(name, info)| {
                 concrete_name != name.as_str()
-                    && concrete_name_matches_generic(concrete_name, name)
+                    && self.concrete_type_name_matches_generic(concrete_name, name)
                     && !info.type_params.is_empty()
             })
             .map(|(name, info)| (name.clone(), info.type_params.clone()))
@@ -35,7 +35,7 @@ impl TypeChecker {
             .iter()
             .find(|(name, info)| {
                 concrete_name != name.as_str()
-                    && concrete_name_matches_generic(concrete_name, name)
+                    && self.concrete_type_name_matches_generic(concrete_name, name)
                     && !info.type_params.is_empty()
             })
             .map(|(name, info)| (name.clone(), info.type_params.clone()))

--- a/src/typechecker/monomorphize_specialized_types.rs
+++ b/src/typechecker/monomorphize_specialized_types.rs
@@ -52,6 +52,7 @@ impl TypeChecker {
             &requested,
             info.specialization_scope.as_deref(),
         );
+        self.remember_specialized_type_source(&mangled, name);
         if !already_emitted {
             self.specialized_types.push(TypedTypeDef {
                 name: mangled,
@@ -112,6 +113,7 @@ impl TypeChecker {
             &requested,
             info.specialization_scope.as_deref(),
         );
+        self.remember_specialized_type_source(&mangled, name);
         if !already_emitted {
             let typed_variants = variants
                 .into_iter()

--- a/src/typechecker/state.rs
+++ b/src/typechecker/state.rs
@@ -16,6 +16,7 @@ pub struct TypeChecker {
     specialized_types: Vec<TypedTypeDef>,
     specialized_types_seen: HashMap<String, String>,
     specialized_type_name_owners: HashMap<String, String>,
+    specialized_type_generic_names: HashMap<String, String>,
     type_substitutions: Vec<HashMap<String, Type>>,
     imports: HashMap<String, Vec<String>>, // imported name -> source module path
     scopes: Vec<Scope>,
@@ -56,6 +57,7 @@ impl TypeChecker {
             specialized_types: Vec::new(),
             specialized_types_seen: HashMap::new(),
             specialized_type_name_owners: HashMap::new(),
+            specialized_type_generic_names: HashMap::new(),
             type_substitutions: Vec::new(),
             imports: HashMap::new(),
             scopes: vec![Scope::new()], // global scope

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -22,6 +22,8 @@ mod import_visibility_dependencies;
 mod import_visibility_private_methods;
 #[path = "integration/multi_file_fixtures.rs"]
 mod multi_file_fixtures;
+#[path = "integration/multi_file_phase5_fixtures.rs"]
+mod multi_file_phase5_fixtures;
 #[path = "integration/public_examples.rs"]
 mod public_examples;
 #[path = "integration/runtime_fixtures.rs"]

--- a/tests/integration/generic_specializations/multifile_generated_c.rs
+++ b/tests/integration/generic_specializations/multifile_generated_c.rs
@@ -4,3 +4,5 @@ use crate::support::*;
 mod enum_dependencies;
 #[path = "multifile_generated_c/method_worklist_dependencies.rs"]
 mod method_worklist_dependencies;
+#[path = "multifile_generated_c/scoped_type_inference.rs"]
+mod scoped_type_inference;

--- a/tests/integration/generic_specializations/multifile_generated_c/scoped_type_inference.rs
+++ b/tests/integration/generic_specializations/multifile_generated_c/scoped_type_inference.rs
@@ -1,0 +1,29 @@
+use super::*;
+
+#[test]
+fn imported_ufc_infers_from_scoped_generic_type_specialization() {
+    let c_source = compile_to_c_with_generated_call_check(
+        &test_dir().join("multi_file_generic_imported_scoped_type_inference/main.zen"),
+    );
+    assert!(c_source.contains("typedef struct Box_i32 Box_i32;"));
+    assert!(c_source.contains("typedef struct right_Box_i32 right_Box_i32;"));
+    assert!(c_source.contains("typedef struct Holder_right_Box_i32 Holder_right_Box_i32;"));
+    assert!(c_source.contains("int32_t take_box_i32(right_Box_i32 box)"));
+    assert!(c_source.contains("int32_t Box_extra_i32(right_Box_i32 self)"));
+    assert!(c_source.contains("int32_t Holder_extra_right_Box_i32(Holder_right_Box_i32 self)"));
+    assert!(c_source.contains("take_box_i32(box)"));
+    assert!(c_source.contains("Box_extra_i32(box)"));
+    assert!(c_source.contains("Holder_extra_right_Box_i32(holder)"));
+    assert!(c_source.contains("const int32_t found = self.value.extra;"));
+    assert!(c_source.contains("left_i32(1LL)"));
+    assert!(c_source.contains("right_i32(2LL)"));
+    assert_c_call_resolves_to_single_definition(&c_source, "take_box_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Box_extra_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Holder_extra_right_Box_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "left_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "right_i32");
+    assert!(!c_source.contains("T take_box"));
+    assert!(!c_source.contains("T Box_extra"));
+    assert!(!c_source.contains("T Holder_extra"));
+    assert!(!c_source.contains("take_box(box"));
+}

--- a/tests/integration/multi_file_phase5_fixtures.rs
+++ b/tests/integration/multi_file_phase5_fixtures.rs
@@ -1,0 +1,8 @@
+use super::*;
+
+#[test]
+fn test_multi_file_imported_scoped_generic_type_inference_ufc() {
+    let zen_path = test_dir().join("multi_file_generic_imported_scoped_type_inference/main.zen");
+    let actual = compile_and_run(&zen_path);
+    assert_eq!(actual, "1\n60\n");
+}

--- a/tests/zen/multi_file_generic_imported_scoped_type_inference/left.zen
+++ b/tests/zen/multi_file_generic_imported_scoped_type_inference/left.zen
@@ -1,0 +1,8 @@
+Box<T>: {
+    value: T
+}
+
+pub left<T> = (value: T) T {
+    box = Box<T> { value: value }
+    box.value
+}

--- a/tests/zen/multi_file_generic_imported_scoped_type_inference/main.zen
+++ b/tests/zen/multi_file_generic_imported_scoped_type_inference/main.zen
@@ -1,0 +1,9 @@
+{ io } = std
+{ left } = left
+{ right } = right
+
+main = () i32 {
+    io.println("${left<i32>(1)}")
+    io.println("${right<i32>(2)}")
+    0
+}

--- a/tests/zen/multi_file_generic_imported_scoped_type_inference/right.zen
+++ b/tests/zen/multi_file_generic_imported_scoped_type_inference/right.zen
@@ -1,0 +1,28 @@
+Box<T>: {
+    value: T,
+    extra: i32
+}
+
+Holder<T>: {
+    value: T
+}
+
+take_box<T> = (box: Box<T>) T {
+    box.value
+}
+
+Box.extra<T> = (self: Self) i32 {
+    self.extra
+}
+
+Holder.extra<T> = (self: Self) i32 {
+    found = self.value.extra
+    found
+}
+
+pub right<T> = (value: T) i32 {
+    box = Box<T> { value: value, extra: 29 }
+    holder = Holder<Box<T>> { value: box }
+    checked = box.take_box()
+    checked + box.extra() + holder.extra()
+}


### PR DESCRIPTION
## What changed

- Track source generic type names for emitted specialized type names, including collision-scoped names such as `right_Box_i32`.
- Use that provenance when recovering generic bases for inference, method lookup, and type-to-AST recovery.
- Let generic receiver method lookup fall through to UFC free-function lookup when no type method exists.
- Add a multi-file regression covering imported UFC inference, scoped private generic types, scoped receiver method lookup, and `Self` recovery.

## Why

Imported modules can each define private generic types with the same source name. The collision resolver scopes the second emitted type name, but generic inference and recovery were still relying on prefix spelling like `Box_i32`. That made `right_Box_i32` stop matching `Box<T>` and could block UFC calls or generic method recovery.

## Validation

- `cargo fmt --check`
- `git diff --check`
- file-size scan for Rust files >=250 lines
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --tests --quiet`
- `cargo test --test docs_truth --quiet`