### PR TITLE
[codex] split frontend diagnostics fixtures

### DIFF
--- a/tests/docs_truth/repo_hygiene/file_size/thresholds.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/thresholds.rs
@@ -2,7 +2,7 @@ use super::super::*;
 
 #[test]
 fn production_rust_files_stay_below_cleanup_threshold() {
-    const MAX_LINES: usize = 286;
+    const MAX_LINES: usize = 250;
 
     let output = std::process::Command::new("git")
         .args(["ls-files", "*.rs"])

--- a/tests/integration/frontend_diagnostics.rs
+++ b/tests/integration/frontend_diagnostics.rs
@@ -2,31 +2,28 @@ use super::*;
 
 #[path = "frontend_diagnostics/behavior_extends/mod.rs"]
 mod behavior_extends;
-
 #[path = "frontend_diagnostics/generic_behavior_imports.rs"]
 mod generic_behavior_imports;
+#[path = "frontend_diagnostics/imported_generic_arity.rs"]
+mod imported_generic_arity;
+#[path = "frontend_diagnostics/support.rs"]
+mod support;
+
+use support::{compile_to_c_panic_message, write_tmp_module};
 
 #[test]
 fn integration_frontend_helper_runs_resolver_diagnostics() {
     let tmp = tempfile::tempdir().expect("create temp dir");
-    let zen_path = tmp.path().join("bad_resolver_ref.zen");
-    std::fs::write(
-        &zen_path,
+    let zen_path = write_tmp_module(
+        tmp.path(),
+        "bad_resolver_ref.zen",
         r#"
 main = () i32 {
     missing_local
 }
 "#,
-    )
-    .expect("write test file");
-
-    let panic = std::panic::catch_unwind(|| compile_to_c(&zen_path))
-        .expect_err("compile_to_c should reject resolver errors");
-    let message = panic
-        .downcast_ref::<String>()
-        .map(String::as_str)
-        .or_else(|| panic.downcast_ref::<&str>().copied())
-        .unwrap_or("<non-string panic>");
+    );
+    let message = compile_to_c_panic_message(&zen_path);
 
     assert!(
         message.contains("unknown value symbol 'missing_local'"),
@@ -37,9 +34,9 @@ main = () i32 {
 #[test]
 fn integration_frontend_helper_reports_imported_module_type_diagnostics() {
     let tmp = tempfile::tempdir().expect("create temp dir");
-    let math_path = tmp.path().join("math.zen");
-    std::fs::write(
-        &math_path,
+    write_tmp_module(
+        tmp.path(),
+        "math.zen",
         r#"
 pub add = (a: i32, b: i32) i32 {
     a + b
@@ -49,12 +46,10 @@ pub broken = () i32 {
     true
 }
 "#,
-    )
-    .expect("write imported module");
-
-    let main_path = tmp.path().join("main.zen");
-    std::fs::write(
-        &main_path,
+    );
+    let main_path = write_tmp_module(
+        tmp.path(),
+        "main.zen",
         r#"
 { add } = math
 
@@ -62,183 +57,11 @@ main = () i32 {
     add(1, 2)
 }
 "#,
-    )
-    .expect("write entry module");
-
-    let panic = std::panic::catch_unwind(|| compile_to_c(&main_path))
-        .expect_err("compile_to_c should reject imported module type errors");
-    let message = panic
-        .downcast_ref::<String>()
-        .map(String::as_str)
-        .or_else(|| panic.downcast_ref::<&str>().copied())
-        .unwrap_or("<non-string panic>");
+    );
+    let message = compile_to_c_panic_message(&main_path);
 
     assert!(
         message.contains("return type mismatch: expected `i32`, found `bool`"),
         "expected imported module type diagnostic, panic={message}"
-    );
-}
-
-#[test]
-fn imported_generic_enum_method_explicit_type_arg_arity_is_error() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let result_path = tmp.path().join("result.zen");
-    std::fs::write(
-        &result_path,
-        r#"
-pub Result<T, E>:
-    Ok(T),
-    Err(E)
-
-pub Result.unwrap_or<T, E> = (self: Self, fallback: T) T {
-    self ?
-        | Ok(value) { value }
-        | Err(_) { fallback }
-}
-"#,
-    )
-    .expect("write result module");
-
-    let main_path = tmp.path().join("main.zen");
-    std::fs::write(
-        &main_path,
-        r#"
-{ Result } = result
-
-main = () i32 {
-    value = Result<i32, StaticString>.Ok(1)
-    value.unwrap_or<i32>(0)
-}
-"#,
-    )
-    .expect("write entry module");
-
-    let panic = std::panic::catch_unwind(|| compile_to_c(&main_path))
-        .expect_err("compile_to_c should reject imported generic method arity errors");
-    let message = panic
-        .downcast_ref::<String>()
-        .map(String::as_str)
-        .or_else(|| panic.downcast_ref::<&str>().copied())
-        .unwrap_or("<non-string panic>");
-
-    assert!(
-        message.contains("generic method `Result.unwrap_or` expects 2 type arguments, found 1"),
-        "expected imported generic method arity diagnostic, panic={message}"
-    );
-    assert!(
-        !message.contains("cannot infer type argument"),
-        "imported generic method arity failure should not also report inference, panic={message}"
-    );
-    assert!(
-        !message.contains("argument 2"),
-        "imported generic method arity failure should not also report argument mismatch, panic={message}"
-    );
-}
-
-#[test]
-fn imported_generic_function_explicit_type_arg_arity_is_error() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let helpers_path = tmp.path().join("helpers.zen");
-    std::fs::write(
-        &helpers_path,
-        r#"
-pub take_second<T, U> = (value: U) U {
-    value
-}
-"#,
-    )
-    .expect("write helpers module");
-
-    let main_path = tmp.path().join("main.zen");
-    std::fs::write(
-        &main_path,
-        r#"
-{ take_second } = helpers
-
-main = () i32 {
-    take_second<i32>(1)
-}
-"#,
-    )
-    .expect("write entry module");
-
-    let panic = std::panic::catch_unwind(|| compile_to_c(&main_path))
-        .expect_err("compile_to_c should reject imported generic function arity errors");
-    let message = panic
-        .downcast_ref::<String>()
-        .map(String::as_str)
-        .or_else(|| panic.downcast_ref::<&str>().copied())
-        .unwrap_or("<non-string panic>");
-
-    assert!(
-        message.contains("generic function `take_second` expects 2 type arguments, found 1"),
-        "expected imported generic function arity diagnostic, panic={message}"
-    );
-    assert!(
-        !message.contains("cannot infer type argument"),
-        "imported generic function arity failure should not also report inference, panic={message}"
-    );
-    assert!(
-        !message.contains("argument 1"),
-        "imported generic function arity failure should not also report argument mismatch, panic={message}"
-    );
-}
-
-#[test]
-fn imported_generic_aggregate_constructor_type_arg_arity_is_error() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let types_path = tmp.path().join("types.zen");
-    std::fs::write(
-        &types_path,
-        r#"
-pub Box<T>: {
-    value: T
-}
-
-pub Option<T>:
-    Some(T),
-    None
-"#,
-    )
-    .expect("write types module");
-
-    let main_path = tmp.path().join("main.zen");
-    std::fs::write(
-        &main_path,
-        r#"
-{ Box, Option } = types
-
-main = () i32 {
-    boxed = Box<i32, StaticString> { value: 1 }
-    value = Option<i32, StaticString>.Some(1)
-    boxed.value
-}
-"#,
-    )
-    .expect("write entry module");
-
-    let panic = std::panic::catch_unwind(|| compile_to_c(&main_path))
-        .expect_err("compile_to_c should reject imported generic constructor arity errors");
-    let message = panic
-        .downcast_ref::<String>()
-        .map(String::as_str)
-        .or_else(|| panic.downcast_ref::<&str>().copied())
-        .unwrap_or("<non-string panic>");
-
-    assert!(
-        message.contains("generic struct `Box` expects 1 type arguments, found 2"),
-        "expected imported generic struct constructor arity diagnostic, panic={message}"
-    );
-    assert!(
-        message.contains("generic enum `Option` expects 1 type arguments, found 2"),
-        "expected imported generic enum constructor arity diagnostic, panic={message}"
-    );
-    assert!(
-        !message.contains("field `value` for struct `Box`"),
-        "imported generic struct constructor arity failure should not also report field mismatch, panic={message}"
-    );
-    assert!(
-        !message.contains("payload for enum variant"),
-        "imported generic enum constructor arity failure should not also report payload mismatch, panic={message}"
     );
 }

--- a/tests/integration/frontend_diagnostics/imported_generic_arity.rs
+++ b/tests/integration/frontend_diagnostics/imported_generic_arity.rs
@@ -1,0 +1,135 @@
+use super::support::{compile_to_c_panic_message, write_tmp_module};
+
+#[test]
+fn imported_generic_enum_method_explicit_type_arg_arity_is_error() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    write_tmp_module(
+        tmp.path(),
+        "result.zen",
+        r#"
+pub Result<T, E>:
+    Ok(T),
+    Err(E)
+
+pub Result.unwrap_or<T, E> = (self: Self, fallback: T) T {
+    self ?
+        | Ok(value) { value }
+        | Err(_) { fallback }
+}
+"#,
+    );
+    let main_path = write_tmp_module(
+        tmp.path(),
+        "main.zen",
+        r#"
+{ Result } = result
+
+main = () i32 {
+    value = Result<i32, StaticString>.Ok(1)
+    value.unwrap_or<i32>(0)
+}
+"#,
+    );
+    let message = compile_to_c_panic_message(&main_path);
+
+    assert!(
+        message.contains("generic method `Result.unwrap_or` expects 2 type arguments, found 1"),
+        "expected imported generic method arity diagnostic, panic={message}"
+    );
+    assert!(
+        !message.contains("cannot infer type argument"),
+        "imported generic method arity failure should not also report inference, panic={message}"
+    );
+    assert!(
+        !message.contains("argument 2"),
+        "imported generic method arity failure should not also report argument mismatch, panic={message}"
+    );
+}
+
+#[test]
+fn imported_generic_function_explicit_type_arg_arity_is_error() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    write_tmp_module(
+        tmp.path(),
+        "helpers.zen",
+        r#"
+pub take_second<T, U> = (value: U) U {
+    value
+}
+"#,
+    );
+    let main_path = write_tmp_module(
+        tmp.path(),
+        "main.zen",
+        r#"
+{ take_second } = helpers
+
+main = () i32 {
+    take_second<i32>(1)
+}
+"#,
+    );
+    let message = compile_to_c_panic_message(&main_path);
+
+    assert!(
+        message.contains("generic function `take_second` expects 2 type arguments, found 1"),
+        "expected imported generic function arity diagnostic, panic={message}"
+    );
+    assert!(
+        !message.contains("cannot infer type argument"),
+        "imported generic function arity failure should not also report inference, panic={message}"
+    );
+    assert!(
+        !message.contains("argument 1"),
+        "imported generic function arity failure should not also report argument mismatch, panic={message}"
+    );
+}
+
+#[test]
+fn imported_generic_aggregate_constructor_type_arg_arity_is_error() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    write_tmp_module(
+        tmp.path(),
+        "types.zen",
+        r#"
+pub Box<T>: {
+    value: T
+}
+
+pub Option<T>:
+    Some(T),
+    None
+"#,
+    );
+    let main_path = write_tmp_module(
+        tmp.path(),
+        "main.zen",
+        r#"
+{ Box, Option } = types
+
+main = () i32 {
+    boxed = Box<i32, StaticString> { value: 1 }
+    value = Option<i32, StaticString>.Some(1)
+    boxed.value
+}
+"#,
+    );
+    let message = compile_to_c_panic_message(&main_path);
+
+    assert!(
+        message.contains("generic struct `Box` expects 1 type arguments, found 2"),
+        "expected imported generic struct constructor arity diagnostic, panic={message}"
+    );
+    assert!(
+        message.contains("generic enum `Option` expects 1 type arguments, found 2"),
+        "expected imported generic enum constructor arity diagnostic, panic={message}"
+    );
+    assert!(
+        !message.contains("field `value` for struct `Box`"),
+        "imported generic struct constructor arity failure should not also report field mismatch, panic={message}"
+    );
+    assert!(
+        !message.contains("payload for enum variant"),
+        "imported generic enum constructor arity failure should not also report payload mismatch, panic={message}"
+    );
+}

--- a/tests/integration/frontend_diagnostics/support.rs
+++ b/tests/integration/frontend_diagnostics/support.rs
@@ -1,0 +1,20 @@
+use std::path::{Path, PathBuf};
+
+use crate::compile_to_c;
+
+pub(crate) fn write_tmp_module(dir: &Path, name: &str, source: &str) -> PathBuf {
+    let path = dir.join(name);
+    std::fs::write(&path, source).unwrap_or_else(|err| panic!("write {}: {err}", path.display()));
+    path
+}
+
+pub(crate) fn compile_to_c_panic_message(zen_path: &Path) -> String {
+    let panic = std::panic::catch_unwind(|| compile_to_c(zen_path))
+        .expect_err("compile_to_c should reject frontend diagnostics");
+    panic
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| panic.downcast_ref::<&str>().copied())
+        .unwrap_or("<non-string panic>")
+        .to_string()
+}


### PR DESCRIPTION
## What changed

- Moved imported generic arity integration diagnostics into a focused `frontend_diagnostics/imported_generic_arity.rs` module.
- Added a tiny shared helper for temp module writing and frontend panic-message capture.
- Reduced `tests/integration/frontend_diagnostics.rs` from 244 lines to 67 lines.
- Tightened the docs-truth Rust file-size guard from 286 lines to 250 now that the tree is below that threshold.

## Why

The parent frontend diagnostics file was near the cleanup threshold and carried repeated temp-file/panic-message boilerplate. This keeps the diagnostic coverage intact while making future growth harder to hide in a large file.

## Validation

- `cargo fmt --check`
- `git diff --check`
- file-size scan for Rust files >=250 lines
- `cargo test --test integration frontend_diagnostics -- --nocapture`
- `cargo test --test docs_truth production_rust_files_stay_below_cleanup_threshold --quiet`
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --tests --quiet`
- `cargo test --test docs_truth --quiet`