### PR TITLE
[codex] split build graph lowering traversal

### DIFF
--- a/src/build_graph/lowering.rs
+++ b/src/build_graph/lowering.rs
@@ -1,4 +1,4 @@
-use crate::ast::{Declaration, Expression, MatchArm, Program, Statement};
+use crate::ast::{Declaration, Program};
 
 #[path = "lowering/dsl.rs"]
 mod dsl;
@@ -8,12 +8,13 @@ mod host_effects;
 mod target_fields;
 #[path = "lowering/targets.rs"]
 mod targets;
+#[path = "lowering/traversal.rs"]
+mod traversal;
 
 use dsl::{BuildTargetDslIdent, HostEffectResultVariant};
 #[cfg(test)]
 use dsl::{BuildTargetDslKind, BuildTargetField};
-use host_effects::{declared_host_effect, host_effect};
-use targets::build_target_from_builder_add;
+use traversal::BuildProgramLowering;
 
 impl BuildGraph {
     pub fn from_build_program(program: &Program) -> Result<Self, BuildGraphError> {
@@ -30,205 +31,7 @@ impl BuildGraph {
             })
             .ok_or(BuildGraphError::MissingBuildFunction)?;
 
-        let mut lowering = BuildProgramLowering::default();
-        lowering.collect_expr(build_body, BuildTargetAddContext::StaticGraphBody);
+        let lowering = BuildProgramLowering::from_body(build_body);
         Self::from_input(lowering.into_input()?)
     }
-}
-
-#[derive(Default)]
-struct BuildProgramLowering {
-    targets: Vec<BuildTargetInput>,
-    declared_host_effects: Vec<HostEffect>,
-    used_host_effects: Vec<HostEffect>,
-    error: Option<BuildGraphError>,
-}
-
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum BuildTargetAddContext {
-    StaticGraphBody,
-    DynamicExpression,
-}
-
-impl BuildProgramLowering {
-    fn into_input(self) -> Result<BuildGraphInput, BuildGraphError> {
-        if let Some(error) = self.error {
-            return Err(error);
-        }
-        Ok(BuildGraphInput {
-            targets: self.targets,
-            declared_host_effects: self.declared_host_effects,
-            used_host_effects: self.used_host_effects,
-        })
-    }
-
-    fn collect_expr(&mut self, expr: &Expression, add_context: BuildTargetAddContext) {
-        if let Some(effect) = host_effect(expr) {
-            self.used_host_effects.push(effect);
-        }
-        if let Some(effect) = declared_host_effect(expr) {
-            self.declared_host_effects.push(effect);
-        }
-        if add_context == BuildTargetAddContext::DynamicExpression
-            && is_builder_add_call(expr)
-            && self.error.is_none()
-        {
-            self.error = Some(BuildGraphError::UnsupportedBuildScript(
-                "build targets must be added in the deterministic build graph body".to_string(),
-            ));
-        }
-        match build_target_from_builder_add(expr) {
-            Ok(Some(target)) => {
-                if add_context == BuildTargetAddContext::StaticGraphBody {
-                    self.targets.push(target);
-                }
-            }
-            Ok(None) => {}
-            Err(error) => {
-                if self.error.is_none() {
-                    self.error = Some(error);
-                }
-            }
-        }
-
-        match expr {
-            Expression::BinaryOp { left, right, .. } => {
-                self.collect_expr(left, BuildTargetAddContext::DynamicExpression);
-                self.collect_expr(right, BuildTargetAddContext::DynamicExpression);
-            }
-            Expression::UnaryOp { operand, .. } => {
-                self.collect_expr(operand, BuildTargetAddContext::DynamicExpression)
-            }
-            Expression::FunctionCall { args, .. }
-            | Expression::ArrayLiteral { elements: args, .. } => {
-                for arg in args {
-                    self.collect_expr(arg, BuildTargetAddContext::DynamicExpression);
-                }
-            }
-            Expression::MethodCall { receiver, args, .. } => {
-                self.collect_expr(receiver, add_context);
-                for arg in args {
-                    self.collect_expr(arg, BuildTargetAddContext::DynamicExpression);
-                }
-            }
-            Expression::MemberAccess { object, .. } => {
-                self.collect_expr(object, BuildTargetAddContext::DynamicExpression)
-            }
-            Expression::IndexAccess { object, index, .. } => {
-                self.collect_expr(object, BuildTargetAddContext::DynamicExpression);
-                self.collect_expr(index, BuildTargetAddContext::DynamicExpression);
-            }
-            Expression::StructLiteral { fields, .. } => {
-                for (_, field) in fields {
-                    self.collect_expr(field, BuildTargetAddContext::DynamicExpression);
-                }
-            }
-            Expression::EnumVariant { payload, .. } => {
-                if let Some(payload) = payload {
-                    self.collect_expr(payload, BuildTargetAddContext::DynamicExpression);
-                }
-            }
-            Expression::Match {
-                scrutinee, arms, ..
-            } => {
-                self.collect_expr(scrutinee, BuildTargetAddContext::DynamicExpression);
-                for MatchArm { guard, body, .. } in arms {
-                    if let Some(guard) = guard {
-                        self.collect_expr(guard, BuildTargetAddContext::DynamicExpression);
-                    }
-                    self.collect_expr(body, BuildTargetAddContext::DynamicExpression);
-                }
-            }
-            Expression::WhileLoop {
-                condition, body, ..
-            }
-            | Expression::If {
-                condition,
-                then_body: body,
-                ..
-            } => {
-                self.collect_expr(condition, BuildTargetAddContext::DynamicExpression);
-                self.collect_expr(body, BuildTargetAddContext::DynamicExpression);
-                if let Expression::If {
-                    else_body: Some(else_body),
-                    ..
-                } = expr
-                {
-                    self.collect_expr(else_body, BuildTargetAddContext::DynamicExpression);
-                }
-            }
-            Expression::Loop { body, .. } => {
-                self.collect_expr(body, BuildTargetAddContext::DynamicExpression)
-            }
-            Expression::Block {
-                statements, expr, ..
-            } => {
-                for statement in statements {
-                    self.collect_statement(statement, add_context);
-                }
-                if let Some(expr) = expr {
-                    self.collect_expr(expr, add_context);
-                }
-            }
-            Expression::Closure { body, .. } => {
-                self.collect_expr(body, BuildTargetAddContext::DynamicExpression)
-            }
-            Expression::Cast { expr, .. } | Expression::Defer { expr, .. } => {
-                self.collect_expr(expr, BuildTargetAddContext::DynamicExpression)
-            }
-            Expression::StringInterpolation { parts, .. } => {
-                for part in parts {
-                    if let crate::ast::StringPart::Expr(expr) = part {
-                        self.collect_expr(expr, BuildTargetAddContext::DynamicExpression);
-                    }
-                }
-            }
-            Expression::Range { start, end, .. } => {
-                self.collect_expr(start, BuildTargetAddContext::DynamicExpression);
-                self.collect_expr(end, BuildTargetAddContext::DynamicExpression);
-            }
-            Expression::IntLiteral { .. }
-            | Expression::FloatLiteral { .. }
-            | Expression::StringLiteral { .. }
-            | Expression::BoolLiteral { .. }
-            | Expression::Identifier { .. }
-            | Expression::LoopControl { .. }
-            | Expression::Break { .. }
-            | Expression::Continue { .. }
-            | Expression::Error { .. } => {}
-        }
-    }
-
-    fn collect_statement(&mut self, statement: &Statement, add_context: BuildTargetAddContext) {
-        match statement {
-            Statement::Expression { expr: value, .. } => {
-                self.collect_expr(value, add_context);
-            }
-            Statement::VarDecl { value, .. } => {
-                self.collect_expr(value, BuildTargetAddContext::DynamicExpression);
-            }
-            Statement::Assignment { target, value, .. } => {
-                self.collect_expr(target, BuildTargetAddContext::DynamicExpression);
-                self.collect_expr(value, BuildTargetAddContext::DynamicExpression);
-            }
-            Statement::Block { stmts, .. } => {
-                for stmt in stmts {
-                    self.collect_statement(stmt, add_context);
-                }
-            }
-        }
-    }
-}
-
-fn is_builder_add_call(expr: &Expression) -> bool {
-    matches!(
-        expr,
-        Expression::MethodCall { receiver, method, .. }
-            if method == BuildTargetDslIdent::Add.as_str()
-                && matches!(
-                    receiver.as_ref(),
-                    Expression::Identifier { name, .. }
-                        if name == BuildTargetDslIdent::Builder.as_str()
-                )
-    )
 }

--- a/src/build_graph/lowering/traversal.rs
+++ b/src/build_graph/lowering/traversal.rs
@@ -1,0 +1,210 @@
+use crate::ast::{Expression, MatchArm, Statement};
+
+use super::host_effects::{declared_host_effect, host_effect};
+use super::targets::build_target_from_builder_add;
+use super::{
+    BuildGraphError, BuildGraphInput, BuildTargetDslIdent, BuildTargetInput, HostEffect,
+};
+
+#[derive(Default)]
+pub(super) struct BuildProgramLowering {
+    targets: Vec<BuildTargetInput>,
+    declared_host_effects: Vec<HostEffect>,
+    used_host_effects: Vec<HostEffect>,
+    error: Option<BuildGraphError>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum BuildTargetAddContext {
+    StaticGraphBody,
+    DynamicExpression,
+}
+
+impl BuildProgramLowering {
+    pub(super) fn from_body(body: &Expression) -> Self {
+        let mut lowering = Self::default();
+        lowering.collect_expr(body, BuildTargetAddContext::StaticGraphBody);
+        lowering
+    }
+
+    pub(super) fn into_input(self) -> Result<BuildGraphInput, BuildGraphError> {
+        if let Some(error) = self.error {
+            return Err(error);
+        }
+        Ok(BuildGraphInput {
+            targets: self.targets,
+            declared_host_effects: self.declared_host_effects,
+            used_host_effects: self.used_host_effects,
+        })
+    }
+
+    fn collect_expr(&mut self, expr: &Expression, add_context: BuildTargetAddContext) {
+        if let Some(effect) = host_effect(expr) {
+            self.used_host_effects.push(effect);
+        }
+        if let Some(effect) = declared_host_effect(expr) {
+            self.declared_host_effects.push(effect);
+        }
+        if add_context == BuildTargetAddContext::DynamicExpression
+            && is_builder_add_call(expr)
+            && self.error.is_none()
+        {
+            self.error = Some(BuildGraphError::UnsupportedBuildScript(
+                "build targets must be added in the deterministic build graph body".to_string(),
+            ));
+        }
+        match build_target_from_builder_add(expr) {
+            Ok(Some(target)) => {
+                if add_context == BuildTargetAddContext::StaticGraphBody {
+                    self.targets.push(target);
+                }
+            }
+            Ok(None) => {}
+            Err(error) => {
+                if self.error.is_none() {
+                    self.error = Some(error);
+                }
+            }
+        }
+
+        match expr {
+            Expression::BinaryOp { left, right, .. } => {
+                self.collect_expr(left, BuildTargetAddContext::DynamicExpression);
+                self.collect_expr(right, BuildTargetAddContext::DynamicExpression);
+            }
+            Expression::UnaryOp { operand, .. } => {
+                self.collect_expr(operand, BuildTargetAddContext::DynamicExpression)
+            }
+            Expression::FunctionCall { args, .. }
+            | Expression::ArrayLiteral { elements: args, .. } => {
+                for arg in args {
+                    self.collect_expr(arg, BuildTargetAddContext::DynamicExpression);
+                }
+            }
+            Expression::MethodCall { receiver, args, .. } => {
+                self.collect_expr(receiver, add_context);
+                for arg in args {
+                    self.collect_expr(arg, BuildTargetAddContext::DynamicExpression);
+                }
+            }
+            Expression::MemberAccess { object, .. } => {
+                self.collect_expr(object, BuildTargetAddContext::DynamicExpression)
+            }
+            Expression::IndexAccess { object, index, .. } => {
+                self.collect_expr(object, BuildTargetAddContext::DynamicExpression);
+                self.collect_expr(index, BuildTargetAddContext::DynamicExpression);
+            }
+            Expression::StructLiteral { fields, .. } => {
+                for (_, field) in fields {
+                    self.collect_expr(field, BuildTargetAddContext::DynamicExpression);
+                }
+            }
+            Expression::EnumVariant { payload, .. } => {
+                if let Some(payload) = payload {
+                    self.collect_expr(payload, BuildTargetAddContext::DynamicExpression);
+                }
+            }
+            Expression::Match {
+                scrutinee, arms, ..
+            } => {
+                self.collect_expr(scrutinee, BuildTargetAddContext::DynamicExpression);
+                for MatchArm { guard, body, .. } in arms {
+                    if let Some(guard) = guard {
+                        self.collect_expr(guard, BuildTargetAddContext::DynamicExpression);
+                    }
+                    self.collect_expr(body, BuildTargetAddContext::DynamicExpression);
+                }
+            }
+            Expression::WhileLoop {
+                condition, body, ..
+            }
+            | Expression::If {
+                condition,
+                then_body: body,
+                ..
+            } => {
+                self.collect_expr(condition, BuildTargetAddContext::DynamicExpression);
+                self.collect_expr(body, BuildTargetAddContext::DynamicExpression);
+                if let Expression::If {
+                    else_body: Some(else_body),
+                    ..
+                } = expr
+                {
+                    self.collect_expr(else_body, BuildTargetAddContext::DynamicExpression);
+                }
+            }
+            Expression::Loop { body, .. } => {
+                self.collect_expr(body, BuildTargetAddContext::DynamicExpression)
+            }
+            Expression::Block {
+                statements, expr, ..
+            } => {
+                for statement in statements {
+                    self.collect_statement(statement, add_context);
+                }
+                if let Some(expr) = expr {
+                    self.collect_expr(expr, add_context);
+                }
+            }
+            Expression::Closure { body, .. } => {
+                self.collect_expr(body, BuildTargetAddContext::DynamicExpression)
+            }
+            Expression::Cast { expr, .. } | Expression::Defer { expr, .. } => {
+                self.collect_expr(expr, BuildTargetAddContext::DynamicExpression)
+            }
+            Expression::StringInterpolation { parts, .. } => {
+                for part in parts {
+                    if let crate::ast::StringPart::Expr(expr) = part {
+                        self.collect_expr(expr, BuildTargetAddContext::DynamicExpression);
+                    }
+                }
+            }
+            Expression::Range { start, end, .. } => {
+                self.collect_expr(start, BuildTargetAddContext::DynamicExpression);
+                self.collect_expr(end, BuildTargetAddContext::DynamicExpression);
+            }
+            Expression::IntLiteral { .. }
+            | Expression::FloatLiteral { .. }
+            | Expression::StringLiteral { .. }
+            | Expression::BoolLiteral { .. }
+            | Expression::Identifier { .. }
+            | Expression::LoopControl { .. }
+            | Expression::Break { .. }
+            | Expression::Continue { .. }
+            | Expression::Error { .. } => {}
+        }
+    }
+
+    fn collect_statement(&mut self, statement: &Statement, add_context: BuildTargetAddContext) {
+        match statement {
+            Statement::Expression { expr: value, .. } => {
+                self.collect_expr(value, add_context);
+            }
+            Statement::VarDecl { value, .. } => {
+                self.collect_expr(value, BuildTargetAddContext::DynamicExpression);
+            }
+            Statement::Assignment { target, value, .. } => {
+                self.collect_expr(target, BuildTargetAddContext::DynamicExpression);
+                self.collect_expr(value, BuildTargetAddContext::DynamicExpression);
+            }
+            Statement::Block { stmts, .. } => {
+                for stmt in stmts {
+                    self.collect_statement(stmt, add_context);
+                }
+            }
+        }
+    }
+}
+
+fn is_builder_add_call(expr: &Expression) -> bool {
+    matches!(
+        expr,
+        Expression::MethodCall { receiver, method, .. }
+            if method == BuildTargetDslIdent::Add.as_str()
+                && matches!(
+                    receiver.as_ref(),
+                    Expression::Identifier { name, .. }
+                        if name == BuildTargetDslIdent::Builder.as_str()
+                )
+    )
+}

--- a/tests/docs_truth/repo_hygiene/build_graph_dsl.rs
+++ b/tests/docs_truth/repo_hygiene/build_graph_dsl.rs
@@ -88,6 +88,7 @@ fn build_target_field_extraction_lives_in_focused_helper() {
 fn build_graph_host_effect_detection_lives_in_focused_helper() {
     let lowering = read("src/build_graph/lowering.rs");
     let host_effects = read("src/build_graph/lowering/host_effects.rs");
+    let traversal = read("src/build_graph/lowering/traversal.rs");
 
     assert!(
         lowering.lines().count() < 240,
@@ -113,7 +114,43 @@ fn build_graph_host_effect_detection_lives_in_focused_helper() {
         "build graph lowering should include the focused host-effect helper"
     );
     assert!(
-        lowering.contains("use host_effects::{declared_host_effect, host_effect};"),
-        "build graph lowering should import host-effect detection from the focused helper"
+        traversal.contains("use super::host_effects::{declared_host_effect, host_effect};"),
+        "build graph traversal should import host-effect detection from the focused helper"
+    );
+}
+
+#[test]
+fn build_graph_ast_traversal_lives_in_focused_helper() {
+    let lowering = read("src/build_graph/lowering.rs");
+    let traversal = read("src/build_graph/lowering/traversal.rs");
+
+    assert!(
+        lowering.lines().count() < 140,
+        "build graph lowering root should stay focused on locating build() and delegating traversal"
+    );
+    for helper in [
+        "struct BuildProgramLowering",
+        "enum BuildTargetAddContext",
+        "fn into_input",
+        "fn collect_expr",
+        "fn collect_statement",
+        "fn is_builder_add_call",
+    ] {
+        assert!(
+            !lowering.contains(helper),
+            "build graph AST traversal should live in traversal.rs: {helper}"
+        );
+        assert!(
+            traversal.contains(helper),
+            "traversal.rs should own build graph AST traversal: {helper}"
+        );
+    }
+    assert!(
+        lowering.contains("mod traversal;"),
+        "build graph lowering root should include the focused traversal module"
+    );
+    assert!(
+        lowering.contains("use traversal::BuildProgramLowering;"),
+        "build graph lowering root should delegate AST traversal through BuildProgramLowering"
     );
 }


### PR DESCRIPTION
## What changed

- Moved build graph AST traversal state and walking logic out of `src/build_graph/lowering.rs` into `src/build_graph/lowering/traversal.rs`.
- Kept the lowering root focused on locating `build()` and delegating to `BuildProgramLowering`.
- Added docs-truth coverage that pins traversal ownership and updates the host-effect guard for the new dependency edge.

## Why

`src/build_graph/lowering.rs` was near the cleanup threshold and mixed root orchestration with recursive AST traversal. This keeps the build graph lowering surface easier to review without changing behavior.

## Validation

- `cargo fmt --check`
- `git diff --check`
- file-size scan for `>= 250` line Rust files
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --test docs_truth --quiet`
- `cargo test --tests --quiet`