### PR TITLE
[codex] split IR layout builtins

### DIFF
--- a/src/ir_json/layout.rs
+++ b/src/ir_json/layout.rs
@@ -2,11 +2,14 @@ use std::collections::BTreeMap;
 
 use crate::ast::typed::{Type, TypeDefKind, TypedProgram, TypedTypeDef};
 
+#[path = "layout/builtins.rs"]
+mod builtins;
 #[path = "layout/metrics.rs"]
 mod metrics;
 #[path = "layout/schema.rs"]
 mod schema;
 
+use builtins::{builtin_layout_name, seed_builtin_layouts};
 use metrics::{align_to, scalar_layout, POINTER_ALIGN, POINTER_SIZE, USIZE_SIZE};
 use schema::{
     LayoutJsonField, LayoutJsonProgram, LayoutJsonTarget, LayoutJsonType, LayoutJsonVariant,
@@ -44,7 +47,7 @@ impl<'a> LayoutContext<'a> {
                 .collect(),
             layouts: BTreeMap::new(),
         };
-        context.seed_builtin_layouts();
+        seed_builtin_layouts(&mut context.layouts);
         for type_def in &program.types {
             context.layout_type_def(type_def);
         }
@@ -53,39 +56,6 @@ impl<'a> LayoutContext<'a> {
 
     fn layouts(self) -> BTreeMap<String, LayoutJsonType> {
         self.layouts
-    }
-
-    fn seed_builtin_layouts(&mut self) {
-        for (name, size, alignment) in [
-            ("bool", 1, 1),
-            ("i8", 1, 1),
-            ("u8", 1, 1),
-            ("i16", 2, 2),
-            ("u16", 2, 2),
-            ("i32", 4, 4),
-            ("u32", 4, 4),
-            ("f32", 4, 4),
-            ("i64", 8, 8),
-            ("u64", 8, 8),
-            ("usize", USIZE_SIZE, POINTER_ALIGN),
-            ("f64", 8, 8),
-            ("void", 0, 1),
-        ] {
-            self.layouts
-                .insert(name.into(), scalar_layout("primitive", size, alignment));
-        }
-        self.layouts.insert(
-            "StaticString".into(),
-            scalar_layout("static_string", POINTER_SIZE + USIZE_SIZE, POINTER_ALIGN),
-        );
-        self.layouts.insert(
-            "String".into(),
-            scalar_layout(
-                "dynamic_string",
-                POINTER_SIZE + USIZE_SIZE * 2 + POINTER_SIZE,
-                POINTER_ALIGN,
-            ),
-        );
     }
 
     fn layout_type_def(&mut self, type_def: &'a TypedTypeDef) -> LayoutJsonType {
@@ -162,22 +132,11 @@ impl<'a> LayoutContext<'a> {
     }
 
     fn layout_type(&mut self, ty: &Type) -> LayoutJsonType {
+        if let Some(name) = builtin_layout_name(ty) {
+            return self.layout_by_name(name);
+        }
+
         match ty {
-            Type::I8 => self.layout_by_name("i8"),
-            Type::I16 => self.layout_by_name("i16"),
-            Type::I32 => self.layout_by_name("i32"),
-            Type::I64 => self.layout_by_name("i64"),
-            Type::U8 => self.layout_by_name("u8"),
-            Type::U16 => self.layout_by_name("u16"),
-            Type::U32 => self.layout_by_name("u32"),
-            Type::U64 => self.layout_by_name("u64"),
-            Type::Usize => self.layout_by_name("usize"),
-            Type::F32 => self.layout_by_name("f32"),
-            Type::F64 => self.layout_by_name("f64"),
-            Type::Bool => self.layout_by_name("bool"),
-            Type::Void | Type::Never | Type::Unknown => self.layout_by_name("void"),
-            Type::Str => self.layout_by_name("StaticString"),
-            Type::String => self.layout_by_name("String"),
             Type::Named(name) => self.layout_named(name),
             Type::Struct { fields, .. } => self.layout_struct(fields),
             Type::Enum { name, .. } => self.layout_named(name),
@@ -195,6 +154,25 @@ impl<'a> LayoutContext<'a> {
             }
             Type::Ptr(_) | Type::MutPtr(_) | Type::RawPtr(_) | Type::Function { .. } => {
                 self.cache_compound_layout(ty, "pointer", POINTER_SIZE, POINTER_ALIGN)
+            }
+            Type::I8
+            | Type::I16
+            | Type::I32
+            | Type::I64
+            | Type::U8
+            | Type::U16
+            | Type::U32
+            | Type::U64
+            | Type::Usize
+            | Type::F32
+            | Type::F64
+            | Type::Bool
+            | Type::Void
+            | Type::Never
+            | Type::Unknown
+            | Type::Str
+            | Type::String => {
+                unreachable!("builtin layout types are handled before compound types")
             }
         }
     }

--- a/src/ir_json/layout/builtins.rs
+++ b/src/ir_json/layout/builtins.rs
@@ -1,0 +1,139 @@
+use std::collections::BTreeMap;
+
+use crate::ast::typed::Type;
+
+use super::metrics::{scalar_layout, POINTER_ALIGN, POINTER_SIZE, USIZE_SIZE};
+use super::schema::LayoutJsonType;
+
+pub(super) fn seed_builtin_layouts(layouts: &mut BTreeMap<String, LayoutJsonType>) {
+    for builtin in BuiltinLayout::ALL {
+        layouts.insert(builtin.name().into(), builtin.layout());
+    }
+}
+
+pub(super) fn builtin_layout_name(ty: &Type) -> Option<&'static str> {
+    BuiltinLayout::from_type(ty).map(BuiltinLayout::name)
+}
+
+#[derive(Clone, Copy)]
+enum BuiltinLayout {
+    Bool,
+    I8,
+    U8,
+    I16,
+    U16,
+    I32,
+    U32,
+    F32,
+    I64,
+    U64,
+    Usize,
+    F64,
+    Void,
+    StaticString,
+    DynamicString,
+}
+
+impl BuiltinLayout {
+    const ALL: &[Self] = &[
+        Self::Bool,
+        Self::I8,
+        Self::U8,
+        Self::I16,
+        Self::U16,
+        Self::I32,
+        Self::U32,
+        Self::F32,
+        Self::I64,
+        Self::U64,
+        Self::Usize,
+        Self::F64,
+        Self::Void,
+        Self::StaticString,
+        Self::DynamicString,
+    ];
+
+    fn from_type(ty: &Type) -> Option<Self> {
+        match ty {
+            Type::I8 => Some(Self::I8),
+            Type::I16 => Some(Self::I16),
+            Type::I32 => Some(Self::I32),
+            Type::I64 => Some(Self::I64),
+            Type::U8 => Some(Self::U8),
+            Type::U16 => Some(Self::U16),
+            Type::U32 => Some(Self::U32),
+            Type::U64 => Some(Self::U64),
+            Type::Usize => Some(Self::Usize),
+            Type::F32 => Some(Self::F32),
+            Type::F64 => Some(Self::F64),
+            Type::Bool => Some(Self::Bool),
+            Type::Void | Type::Never | Type::Unknown => Some(Self::Void),
+            Type::Str => Some(Self::StaticString),
+            Type::String => Some(Self::DynamicString),
+            Type::Named(_)
+            | Type::Struct { .. }
+            | Type::Enum { .. }
+            | Type::Array { .. }
+            | Type::Slice(_)
+            | Type::Ptr(_)
+            | Type::MutPtr(_)
+            | Type::RawPtr(_)
+            | Type::Function { .. } => None,
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::Bool => "bool",
+            Self::I8 => "i8",
+            Self::U8 => "u8",
+            Self::I16 => "i16",
+            Self::U16 => "u16",
+            Self::I32 => "i32",
+            Self::U32 => "u32",
+            Self::F32 => "f32",
+            Self::I64 => "i64",
+            Self::U64 => "u64",
+            Self::Usize => "usize",
+            Self::F64 => "f64",
+            Self::Void => "void",
+            Self::StaticString => "StaticString",
+            Self::DynamicString => "String",
+        }
+    }
+
+    fn layout(self) -> LayoutJsonType {
+        scalar_layout(self.kind(), self.size(), self.alignment())
+    }
+
+    fn kind(self) -> &'static str {
+        match self {
+            Self::StaticString => "static_string",
+            Self::DynamicString => "dynamic_string",
+            _ => "primitive",
+        }
+    }
+
+    fn size(self) -> u32 {
+        match self {
+            Self::Bool | Self::I8 | Self::U8 => 1,
+            Self::I16 | Self::U16 => 2,
+            Self::I32 | Self::U32 | Self::F32 => 4,
+            Self::I64 | Self::U64 | Self::F64 => 8,
+            Self::Usize => USIZE_SIZE,
+            Self::Void => 0,
+            Self::StaticString => POINTER_SIZE + USIZE_SIZE,
+            Self::DynamicString => POINTER_SIZE + USIZE_SIZE * 2 + POINTER_SIZE,
+        }
+    }
+
+    fn alignment(self) -> u32 {
+        match self {
+            Self::Bool | Self::I8 | Self::U8 | Self::Void => 1,
+            Self::I16 | Self::U16 => 2,
+            Self::I32 | Self::U32 | Self::F32 => 4,
+            Self::I64 | Self::U64 | Self::F64 => 8,
+            Self::Usize | Self::StaticString | Self::DynamicString => POINTER_ALIGN,
+        }
+    }
+}

--- a/tests/docs_truth/repo_hygiene/ir_json.rs
+++ b/tests/docs_truth/repo_hygiene/ir_json.rs
@@ -102,3 +102,46 @@ fn layout_json_schema_types_live_in_focused_helper() {
         "layout JSON lowering should stay focused on layout calculation"
     );
 }
+
+#[test]
+fn layout_json_builtin_layouts_live_in_focused_helper() {
+    let layout = read("src/ir_json/layout.rs");
+    let builtins = read("src/ir_json/layout/builtins.rs");
+
+    assert!(
+        !layout.contains("fn seed_builtin_layouts"),
+        "layout JSON lowering should not own builtin layout seeding"
+    );
+    assert!(
+        builtins.contains("pub(super) fn seed_builtin_layouts"),
+        "builtin layout seeding should live in the focused builtins helper"
+    );
+    assert!(
+        builtins.contains("pub(super) fn builtin_layout_name"),
+        "builtin layout helper should own builtin Type-to-layout-name mapping"
+    );
+    for required in ["enum BuiltinLayout", "const ALL: &[Self]", "fn from_type"] {
+        assert!(
+            builtins.contains(required),
+            "builtin layout helper should centralize builtin layout spelling through an enum table: {required}"
+        );
+    }
+    for builtin in ["StaticString", "dynamic_string", "primitive"] {
+        assert!(
+            !layout.contains(builtin),
+            "layout JSON lowering should not own builtin layout spelling: {builtin}"
+        );
+        assert!(
+            builtins.contains(builtin),
+            "builtin layout helper should own builtin layout spelling: {builtin}"
+        );
+    }
+    assert!(
+        layout.contains("mod builtins;"),
+        "layout JSON lowering should include the focused builtin layout helper"
+    );
+    assert!(
+        layout.contains("use builtins::{builtin_layout_name, seed_builtin_layouts};"),
+        "layout JSON lowering should delegate builtin layout handling through the focused helper"
+    );
+}


### PR DESCRIPTION
## What changed

- Moved builtin layout seeding from `src/ir_json/layout.rs` into `src/ir_json/layout/builtins.rs`.
- Centralized builtin layout names, JSON kinds, sizes, and alignments through a local `BuiltinLayout` enum/table.
- Added docs-truth coverage pinning builtin layout ownership and keeping `layout.rs` focused on recursive user and compound type layout.

## Why

`layout.rs` was near the cleanup threshold and mixed builtin ABI facts with recursive layout calculation. The split keeps static string, dynamic string, primitive, and void layout spelling in one focused place without changing emitted layout JSON.

## Validation

- `cargo fmt --check`
- `git diff --check`
- file-size scan for `>= 250` line Rust files
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --test docs_truth --quiet`
- `cargo test --test integration frontend_json::layout_json --quiet`
- `cargo test --test integration frontend_json::layout_golden --quiet`
- `cargo test --tests --quiet`