### PR TITLE
[codex] split typechecker AST declaration tasks

### DIFF
--- a/src/typechecker/declaration_tasks.rs
+++ b/src/typechecker/declaration_tasks.rs
@@ -1,4 +1,5 @@
 include!("declaration_tasks_callables.rs");
+include!("declaration_tasks_ast.rs");
 
 enum ResolverTypeDeclarationMetadataTask<'a> {
     Struct {
@@ -17,123 +18,11 @@ struct ResolverStructFieldDefaultValidationTask<'a> {
     span: Span,
 }
 
-enum AstTypeDeclarationTask<'a> {
-    Struct {
-        name: &'a str,
-        type_params: &'a [ast::TypeParam],
-        fields: &'a [StructField],
-    },
-    Enum {
-        name: &'a str,
-        type_params: &'a [ast::TypeParam],
-        variants: &'a [EnumVariant],
-    },
-}
-
-struct BehaviorDeclarationTask<'a> {
-    name: &'a str,
-    type_params: &'a [ast::TypeParam],
-    methods: &'a [BehaviorMethod],
-}
-
-struct AstImportDeclarationTask<'a> {
-    names: &'a [String],
-    module_path: &'a [String],
-}
-
-#[derive(Default)]
-struct AstDeclarationCollectionTasks<'a> {
-    behaviors: Vec<BehaviorDeclarationTask<'a>>,
-    types: Vec<AstTypeDeclarationTask<'a>>,
-    callable: Vec<CallableDeclarationTask<'a>>,
-    impl_blocks: Vec<ImplBlockDeclarationTask<'a>>,
-    imports: Vec<AstImportDeclarationTask<'a>>,
-    precollection_validations: AstPrecollectionValidationTasks<'a>,
-}
-
 #[derive(Default)]
 struct DeclarationCollectionReplayTasks<'a> {
     ast: AstDeclarationCollectionTasks<'a>,
     resolver: ResolverDeclarationMetadataTasks<'a>,
     resolver_semantics: ResolverDeclarationSemanticValidationTasks<'a>,
-}
-
-struct AstStructFieldDefaultValidationTask<'a> {
-    type_params: &'a [ast::TypeParam],
-    fields: &'a [StructField],
-}
-
-enum AstTypeReferenceValidationTask<'a> {
-    Struct {
-        type_params: &'a [ast::TypeParam],
-        fields: &'a [StructField],
-    },
-    Enum {
-        type_params: &'a [ast::TypeParam],
-        variants: &'a [EnumVariant],
-    },
-    Function {
-        type_params: &'a [ast::TypeParam],
-        params: &'a [Param],
-        return_type: &'a Option<AstType>,
-        body: &'a Expression,
-    },
-    Method {
-        type_params: &'a [ast::TypeParam],
-        params: &'a [Param],
-        return_type: &'a Option<AstType>,
-        body: &'a Expression,
-    },
-    Behavior {
-        type_params: &'a [ast::TypeParam],
-        methods: &'a [BehaviorMethod],
-    },
-    ImplBlock {
-        methods: &'a [Declaration],
-    },
-    TopLevelExpr {
-        expr: &'a Expression,
-    },
-}
-
-enum SelfTypeContextValidationTask<'a> {
-    Struct {
-        fields: &'a [StructField],
-    },
-    Enum {
-        variants: &'a [EnumVariant],
-    },
-    Function {
-        params: &'a [Param],
-        return_type: &'a Option<AstType>,
-        body: &'a Expression,
-        span: Span,
-    },
-    Method {
-        params: &'a [Param],
-        return_type: &'a Option<AstType>,
-        body: &'a Expression,
-        span: Span,
-    },
-    Behavior {
-        methods: &'a [BehaviorMethod],
-    },
-    ImplBlock {
-        behavior_type_args: &'a [AstType],
-        methods: &'a [Declaration],
-        span: Span,
-    },
-    Requires {
-        behavior_type_args: &'a [AstType],
-        span: Span,
-    },
-    BehaviorExtends {
-        parent_type_args: &'a [AstType],
-        span: Span,
-    },
-    TopLevelExpr {
-        expr: &'a Expression,
-    },
 }
 
 enum ResolverTypeReferenceValidationTask<'a> {
@@ -177,25 +66,6 @@ struct ResolverBehaviorDeclarationMetadataTask<'a> {
 }
 
 include!("declaration_tasks_behavior_associations.rs");
-
-#[derive(Default)]
-struct AstDeclarationValidationTasks<'a> {
-    behavior_associations: BehaviorAssociationValidationTasks<'a>,
-    type_references: Vec<AstTypeReferenceValidationTask<'a>>,
-    struct_field_defaults: Vec<AstStructFieldDefaultValidationTask<'a>>,
-}
-
-#[derive(Default)]
-struct AstPrecollectionValidationTasks<'a> {
-    self_type_contexts: Vec<SelfTypeContextValidationTask<'a>>,
-    behavior_associations: BehaviorAssociationValidationTasks<'a>,
-}
-
-impl<'a> BehaviorAssociationValidationTaskSource<'a> for AstDeclarationValidationTasks<'a> {
-    fn behavior_association_tasks(&self) -> &BehaviorAssociationValidationTasks<'a> {
-        &self.behavior_associations
-    }
-}
 
 #[derive(Default)]
 struct ResolverDeclarationMetadataTasks<'a> {

--- a/src/typechecker/declaration_tasks_ast.rs
+++ b/src/typechecker/declaration_tasks_ast.rs
@@ -1,0 +1,130 @@
+enum AstTypeDeclarationTask<'a> {
+    Struct {
+        name: &'a str,
+        type_params: &'a [ast::TypeParam],
+        fields: &'a [StructField],
+    },
+    Enum {
+        name: &'a str,
+        type_params: &'a [ast::TypeParam],
+        variants: &'a [EnumVariant],
+    },
+}
+
+struct BehaviorDeclarationTask<'a> {
+    name: &'a str,
+    type_params: &'a [ast::TypeParam],
+    methods: &'a [BehaviorMethod],
+}
+
+struct AstImportDeclarationTask<'a> {
+    names: &'a [String],
+    module_path: &'a [String],
+}
+
+#[derive(Default)]
+struct AstDeclarationCollectionTasks<'a> {
+    behaviors: Vec<BehaviorDeclarationTask<'a>>,
+    types: Vec<AstTypeDeclarationTask<'a>>,
+    callable: Vec<CallableDeclarationTask<'a>>,
+    impl_blocks: Vec<ImplBlockDeclarationTask<'a>>,
+    imports: Vec<AstImportDeclarationTask<'a>>,
+    precollection_validations: AstPrecollectionValidationTasks<'a>,
+}
+
+struct AstStructFieldDefaultValidationTask<'a> {
+    type_params: &'a [ast::TypeParam],
+    fields: &'a [StructField],
+}
+
+enum AstTypeReferenceValidationTask<'a> {
+    Struct {
+        type_params: &'a [ast::TypeParam],
+        fields: &'a [StructField],
+    },
+    Enum {
+        type_params: &'a [ast::TypeParam],
+        variants: &'a [EnumVariant],
+    },
+    Function {
+        type_params: &'a [ast::TypeParam],
+        params: &'a [Param],
+        return_type: &'a Option<AstType>,
+        body: &'a Expression,
+    },
+    Method {
+        type_params: &'a [ast::TypeParam],
+        params: &'a [Param],
+        return_type: &'a Option<AstType>,
+        body: &'a Expression,
+    },
+    Behavior {
+        type_params: &'a [ast::TypeParam],
+        methods: &'a [BehaviorMethod],
+    },
+    ImplBlock {
+        methods: &'a [Declaration],
+    },
+    TopLevelExpr {
+        expr: &'a Expression,
+    },
+}
+
+enum SelfTypeContextValidationTask<'a> {
+    Struct {
+        fields: &'a [StructField],
+    },
+    Enum {
+        variants: &'a [EnumVariant],
+    },
+    Function {
+        params: &'a [Param],
+        return_type: &'a Option<AstType>,
+        body: &'a Expression,
+        span: Span,
+    },
+    Method {
+        params: &'a [Param],
+        return_type: &'a Option<AstType>,
+        body: &'a Expression,
+        span: Span,
+    },
+    Behavior {
+        methods: &'a [BehaviorMethod],
+    },
+    ImplBlock {
+        behavior_type_args: &'a [AstType],
+        methods: &'a [Declaration],
+        span: Span,
+    },
+    Requires {
+        behavior_type_args: &'a [AstType],
+        span: Span,
+    },
+    BehaviorExtends {
+        parent_type_args: &'a [AstType],
+        span: Span,
+    },
+    TopLevelExpr {
+        expr: &'a Expression,
+    },
+}
+
+#[derive(Default)]
+struct AstDeclarationValidationTasks<'a> {
+    behavior_associations: BehaviorAssociationValidationTasks<'a>,
+    type_references: Vec<AstTypeReferenceValidationTask<'a>>,
+    struct_field_defaults: Vec<AstStructFieldDefaultValidationTask<'a>>,
+}
+
+#[derive(Default)]
+struct AstPrecollectionValidationTasks<'a> {
+    self_type_contexts: Vec<SelfTypeContextValidationTask<'a>>,
+    behavior_associations: BehaviorAssociationValidationTasks<'a>,
+}
+
+impl<'a> BehaviorAssociationValidationTaskSource<'a> for AstDeclarationValidationTasks<'a> {
+    fn behavior_association_tasks(&self) -> &BehaviorAssociationValidationTasks<'a> {
+        &self.behavior_associations
+    }
+}

--- a/tests/docs_truth/repo_hygiene/typechecker_declaration_collection.rs
+++ b/tests/docs_truth/repo_hygiene/typechecker_declaration_collection.rs
@@ -93,3 +93,41 @@ fn declaration_callable_tasks_live_in_focused_helper() {
         "declaration_tasks.rs should stay focused on shared declaration task wiring"
     );
 }
+
+#[test]
+fn declaration_ast_tasks_live_in_focused_helper() {
+    let root = read("src/typechecker/declaration_tasks.rs");
+    let ast_tasks = read("src/typechecker/declaration_tasks_ast.rs");
+
+    for helper in [
+        "AstTypeDeclarationTask",
+        "BehaviorDeclarationTask",
+        "AstImportDeclarationTask",
+        "AstDeclarationCollectionTasks",
+        "AstStructFieldDefaultValidationTask",
+        "AstTypeReferenceValidationTask",
+        "SelfTypeContextValidationTask",
+        "AstDeclarationValidationTasks",
+        "AstPrecollectionValidationTasks",
+    ] {
+        assert!(
+            !root.contains(&format!("struct {helper}"))
+                && !root.contains(&format!("enum {helper}")),
+            "declaration_tasks.rs should not own AST task shape: {helper}"
+        );
+        assert!(
+            ast_tasks.contains(&format!("struct {helper}"))
+                || ast_tasks.contains(&format!("enum {helper}")),
+            "AST declaration task shape should live in focused helper: {helper}"
+        );
+    }
+
+    assert!(
+        root.contains("include!(\"declaration_tasks_ast.rs\");"),
+        "declaration tasks should include focused AST task shapes"
+    );
+    assert!(
+        root.lines().count() < 160,
+        "declaration_tasks.rs should stay focused on resolver task wiring after AST task split"
+    );
+}


### PR DESCRIPTION
## What changed

- Moved AST-side declaration task shapes from `src/typechecker/declaration_tasks.rs` into `src/typechecker/declaration_tasks_ast.rs`.
- Kept resolver task wiring and resolver task shapes in the declaration task root.
- Added docs-truth coverage that pins AST task ownership and tightens the root file cap after the split.

## Why

`declaration_tasks.rs` was near the cleanup threshold and mixed AST collection/validation task data with resolver replay task data. This split is item relocation only and keeps the root focused on shared resolver task wiring.

## Validation

- `cargo test --test docs_truth declaration_ast_tasks_live_in_focused_helper --quiet`
- `cargo test --lib declaration_validation --quiet`
- `cargo test --lib resolver_validation::replay_tasks --quiet`
- `cargo test --test docs_truth typechecker_declaration_collection --quiet`
- `cargo fmt --check`
- `git diff --check`
- file-size scan for `>= 250` line Rust files
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --test docs_truth --quiet`
- `cargo test --tests --quiet`