### PR TITLE
[codex] split C atomic intrinsic lowering

### DIFF
--- a/src/codegen/c/intrinsics.rs
+++ b/src/codegen/c/intrinsics.rs
@@ -1,6 +1,7 @@
 use super::*;
 use names::CIntrinsic;
 
+mod atomics;
 mod memory;
 mod names;
 mod pointers;
@@ -29,46 +30,11 @@ impl CEmitter {
         if let Some(emitted) = intrinsic.emit_memory(self, args, result_ty) {
             return emitted;
         }
+        if let Some(emitted) = intrinsic.emit_atomic(self, args) {
+            return emitted;
+        }
 
         match intrinsic {
-            // -- Atomic operations ----------------------------------------
-            CIntrinsic::AtomicLoad => {
-                let ptr = self.emit_expr_inline(&args[0]);
-                format!("__atomic_load_n({}, __ATOMIC_SEQ_CST)", ptr)
-            }
-            CIntrinsic::AtomicStore => {
-                let ptr = self.emit_expr_inline(&args[0]);
-                let val = self.emit_expr_inline(&args[1]);
-                format!("__atomic_store_n({}, {}, __ATOMIC_SEQ_CST)", ptr, val)
-            }
-            CIntrinsic::AtomicAdd => {
-                let ptr = self.emit_expr_inline(&args[0]);
-                let val = self.emit_expr_inline(&args[1]);
-                format!("__atomic_fetch_add({}, {}, __ATOMIC_SEQ_CST)", ptr, val)
-            }
-            CIntrinsic::AtomicSub => {
-                let ptr = self.emit_expr_inline(&args[0]);
-                let val = self.emit_expr_inline(&args[1]);
-                format!("__atomic_fetch_sub({}, {}, __ATOMIC_SEQ_CST)", ptr, val)
-            }
-            CIntrinsic::AtomicCas => {
-                let ptr = self.emit_expr_inline(&args[0]);
-                let expected = self.emit_expr_inline(&args[1]);
-                let desired = self.emit_expr_inline(&args[2]);
-                let tmp = self.fresh_tmp();
-                self.line(&format!("uint64_t {} = {};", tmp, expected));
-                format!(
-                    "__atomic_compare_exchange_n({}, &{}, {}, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST)",
-                    ptr, tmp, desired
-                )
-            }
-            CIntrinsic::AtomicXchg => {
-                let ptr = self.emit_expr_inline(&args[0]);
-                let val = self.emit_expr_inline(&args[1]);
-                format!("__atomic_exchange_n({}, {}, __ATOMIC_SEQ_CST)", ptr, val)
-            }
-            CIntrinsic::Fence => "(__atomic_thread_fence(__ATOMIC_SEQ_CST), (void)0)".into(),
-
             // -- Debug / trap / panic -------------------------------------
             CIntrinsic::Trap => "(__builtin_trap(), (void)0)".into(),
             CIntrinsic::Debugtrap => "(__builtin_debugtrap(), (void)0)".into(),

--- a/src/codegen/c/intrinsics/atomics.rs
+++ b/src/codegen/c/intrinsics/atomics.rs
@@ -1,0 +1,61 @@
+use super::*;
+
+impl CIntrinsic {
+    pub(super) fn emit_atomic(
+        self,
+        emitter: &mut CEmitter,
+        args: &[TypedExpression],
+    ) -> Option<String> {
+        match self {
+            CIntrinsic::AtomicLoad => {
+                let ptr = emitter.emit_expr_inline(&args[0]);
+                Some(format!("__atomic_load_n({}, __ATOMIC_SEQ_CST)", ptr))
+            }
+            CIntrinsic::AtomicStore => {
+                let ptr = emitter.emit_expr_inline(&args[0]);
+                let val = emitter.emit_expr_inline(&args[1]);
+                Some(format!(
+                    "__atomic_store_n({}, {}, __ATOMIC_SEQ_CST)",
+                    ptr, val
+                ))
+            }
+            CIntrinsic::AtomicAdd => {
+                let ptr = emitter.emit_expr_inline(&args[0]);
+                let val = emitter.emit_expr_inline(&args[1]);
+                Some(format!(
+                    "__atomic_fetch_add({}, {}, __ATOMIC_SEQ_CST)",
+                    ptr, val
+                ))
+            }
+            CIntrinsic::AtomicSub => {
+                let ptr = emitter.emit_expr_inline(&args[0]);
+                let val = emitter.emit_expr_inline(&args[1]);
+                Some(format!(
+                    "__atomic_fetch_sub({}, {}, __ATOMIC_SEQ_CST)",
+                    ptr, val
+                ))
+            }
+            CIntrinsic::AtomicCas => {
+                let ptr = emitter.emit_expr_inline(&args[0]);
+                let expected = emitter.emit_expr_inline(&args[1]);
+                let desired = emitter.emit_expr_inline(&args[2]);
+                let tmp = emitter.fresh_tmp();
+                emitter.line(&format!("uint64_t {} = {};", tmp, expected));
+                Some(format!(
+                    "__atomic_compare_exchange_n({}, &{}, {}, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST)",
+                    ptr, tmp, desired
+                ))
+            }
+            CIntrinsic::AtomicXchg => {
+                let ptr = emitter.emit_expr_inline(&args[0]);
+                let val = emitter.emit_expr_inline(&args[1]);
+                Some(format!(
+                    "__atomic_exchange_n({}, {}, __ATOMIC_SEQ_CST)",
+                    ptr, val
+                ))
+            }
+            CIntrinsic::Fence => Some("(__atomic_thread_fence(__ATOMIC_SEQ_CST), (void)0)".into()),
+            _ => None,
+        }
+    }
+}

--- a/tests/docs_truth/repo_hygiene/parser_enums/codegen_and_tools/intrinsics.rs
+++ b/tests/docs_truth/repo_hygiene/parser_enums/codegen_and_tools/intrinsics.rs
@@ -179,3 +179,37 @@ fn codegen_c_pointer_intrinsics_live_in_focused_helper() {
         "C intrinsic dispatcher should stay compact after category helpers own detailed lowering"
     );
 }
+
+#[test]
+fn codegen_c_atomic_intrinsics_live_in_focused_helper() {
+    let lowering = read("src/codegen/c/intrinsics.rs");
+    let atomics = read("src/codegen/c/intrinsics/atomics.rs");
+
+    for atomic_variant in [
+        "CIntrinsic::AtomicLoad =>",
+        "CIntrinsic::AtomicStore =>",
+        "CIntrinsic::AtomicAdd =>",
+        "CIntrinsic::AtomicSub =>",
+        "CIntrinsic::AtomicCas =>",
+        "CIntrinsic::AtomicXchg =>",
+        "CIntrinsic::Fence =>",
+    ] {
+        assert!(
+            !lowering.contains(atomic_variant),
+            "main C intrinsic dispatcher should route atomic lowering to a focused helper: {atomic_variant}"
+        );
+        assert!(
+            atomics.contains(atomic_variant),
+            "C atomic intrinsic lowering should live in the focused atomic helper: {atomic_variant}"
+        );
+    }
+
+    assert!(
+        lowering.contains("intrinsic.emit_atomic(self, args)"),
+        "main C intrinsic dispatcher should delegate atomic lowering through CIntrinsic"
+    );
+    assert!(
+        atomics.contains("pub(super) fn emit_atomic"),
+        "atomic helper should own the C atomic lowering entry point"
+    );
+}


### PR DESCRIPTION
## What changed

- Moved atomic intrinsic C lowering from `src/codegen/c/intrinsics.rs` into `src/codegen/c/intrinsics/atomics.rs`.
- Added `CIntrinsic::emit_atomic` to match the existing syscall, pointer, and memory helper pattern.
- Added docs-truth coverage pinning atomic lowering ownership in the focused helper.

## Why

The C intrinsic dispatcher was carrying category-specific atomic lowering while other categories already lived in helper modules. This keeps the dispatcher compact and makes atomic lowering reviewable in isolation without changing emitted C.

## Validation

- `cargo test --test docs_truth codegen_c_atomic_intrinsics_live_in_focused_helper --quiet`
- `cargo test --test docs_truth codegen_c_intrinsics --quiet`
- `cargo test --lib intrinsic_spellings_round_trip_through_single_table --quiet`
- `cargo test --lib atomic_intrinsics_are_rejected_as_effect_gates --quiet`
- `cargo fmt --check`
- `git diff --check`
- file-size scan for `>= 250` line Rust files
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --test docs_truth --quiet`
- `cargo test --tests --quiet`