### PR TITLE
[codex] split resolver impl block validation

### DIFF
--- a/src/resolver/declaration_validation.rs
+++ b/src/resolver/declaration_validation.rs
@@ -1,11 +1,11 @@
 use crate::ast::Declaration;
 use crate::error::Diagnostic;
 
-use super::metadata_helpers::behavior_ref_display;
 use super::symbol_table::ScopeStack;
-use super::{BehaviorRefMetadata, Resolver, SymbolTable};
+use super::{Resolver, SymbolTable};
 
 mod behavior_associations;
+mod impl_blocks;
 mod type_declarations;
 
 impl Resolver {
@@ -103,78 +103,17 @@ impl Resolver {
                 span,
                 ..
             } => {
-                if !self.is_known_type_name(table, &[], type_name) {
-                    diagnostics.push(Diagnostic::error(
-                        "E0201",
-                        format!("unknown type symbol '{type_name}'"),
-                        *span,
-                    ));
-                }
-                if let Some(behavior) = behavior {
-                    let behavior_known = self.is_known_behavior_name(table, behavior);
-                    if !behavior_known {
-                        diagnostics.push(Diagnostic::error(
-                            "E0202",
-                            format!("unknown behavior symbol '{behavior}'"),
-                            *span,
-                        ));
-                    }
-                    if self.is_known_type_name(table, &[], type_name) && behavior_known {
-                        let behavior_display = behavior_ref_display(behavior, behavior_type_args);
-                        if !table.record_behavior_impl(
-                            type_name,
-                            BehaviorRefMetadata {
-                                name: behavior.clone(),
-                                type_args: behavior_type_args.clone(),
-                            },
-                        ) {
-                            diagnostics.push(Diagnostic::error(
-                                "E0217",
-                                format!(
-                                    "duplicate behavior implementation `{behavior_display}` for `{type_name}`"
-                                ),
-                                *span,
-                            ));
-                        }
-                    }
-                }
-                for type_arg in behavior_type_args {
-                    self.validate_type_ref(table, &[], type_arg, *span, false, diagnostics);
-                }
-                for method in methods {
-                    if let Declaration::Function {
-                        type_params,
-                        params,
-                        return_type,
-                        body,
-                        span,
-                        ..
-                    } = method
-                    {
-                        self.validate_type_param_constraints(table, type_params, true, diagnostics);
-                        self.validate_params(table, type_params, params, true, diagnostics);
-                        if let Some(return_type) = return_type {
-                            self.validate_type_ref(
-                                table,
-                                type_params,
-                                return_type,
-                                *span,
-                                true,
-                                diagnostics,
-                            );
-                        }
-                        let scope_id = table.new_scope();
-                        let mut locals = self.param_locals(table, params, scope_id, diagnostics);
-                        self.validate_expr_refs(
-                            table,
-                            type_params,
-                            body,
-                            &mut locals,
-                            true,
-                            diagnostics,
-                        );
-                    }
-                }
+                self.validate_impl_block_declaration(
+                    table,
+                    impl_blocks::ImplBlockValidationInput {
+                        type_name,
+                        behavior: behavior.as_deref(),
+                        behavior_type_args,
+                        methods,
+                        span: *span,
+                    },
+                    diagnostics,
+                );
             }
             Declaration::Import { .. } | Declaration::Error { .. } => {}
             Declaration::Requires {

--- a/src/resolver/declaration_validation/impl_blocks.rs
+++ b/src/resolver/declaration_validation/impl_blocks.rs
@@ -1,0 +1,119 @@
+use crate::ast::{AstType, Declaration};
+use crate::error::{Diagnostic, Span};
+
+use super::super::metadata_helpers::behavior_ref_display;
+use super::super::{BehaviorRefMetadata, Resolver, SymbolTable};
+
+pub(super) struct ImplBlockValidationInput<'a> {
+    pub(super) type_name: &'a str,
+    pub(super) behavior: Option<&'a str>,
+    pub(super) behavior_type_args: &'a [AstType],
+    pub(super) methods: &'a [Declaration],
+    pub(super) span: Span,
+}
+
+impl Resolver {
+    pub(super) fn validate_impl_block_declaration(
+        &self,
+        table: &mut SymbolTable,
+        input: ImplBlockValidationInput<'_>,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        let ImplBlockValidationInput {
+            type_name,
+            behavior,
+            behavior_type_args,
+            methods,
+            span,
+        } = input;
+
+        if !self.is_known_type_name(table, &[], type_name) {
+            diagnostics.push(Diagnostic::error(
+                "E0201",
+                format!("unknown type symbol '{type_name}'"),
+                span,
+            ));
+        }
+        if let Some(behavior) = behavior {
+            self.validate_behavior_impl_declaration(
+                table,
+                type_name,
+                behavior,
+                behavior_type_args,
+                span,
+                diagnostics,
+            );
+        }
+        for type_arg in behavior_type_args {
+            self.validate_type_ref(table, &[], type_arg, span, false, diagnostics);
+        }
+        for method in methods {
+            self.validate_impl_block_method(table, method, diagnostics);
+        }
+    }
+
+    fn validate_behavior_impl_declaration(
+        &self,
+        table: &mut SymbolTable,
+        type_name: &str,
+        behavior: &str,
+        behavior_type_args: &[AstType],
+        span: Span,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        let behavior_known = self.is_known_behavior_name(table, behavior);
+        if !behavior_known {
+            diagnostics.push(Diagnostic::error(
+                "E0202",
+                format!("unknown behavior symbol '{behavior}'"),
+                span,
+            ));
+        }
+        if self.is_known_type_name(table, &[], type_name) && behavior_known {
+            let behavior_display = behavior_ref_display(behavior, behavior_type_args);
+            if !table.record_behavior_impl(
+                type_name,
+                BehaviorRefMetadata {
+                    name: behavior.to_string(),
+                    type_args: behavior_type_args.to_vec(),
+                },
+            ) {
+                diagnostics.push(Diagnostic::error(
+                    "E0217",
+                    format!(
+                        "duplicate behavior implementation `{behavior_display}` for `{type_name}`"
+                    ),
+                    span,
+                ));
+            }
+        }
+    }
+
+    fn validate_impl_block_method(
+        &self,
+        table: &mut SymbolTable,
+        method: &Declaration,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        let Declaration::Function {
+            type_params,
+            params,
+            return_type,
+            body,
+            span,
+            ..
+        } = method
+        else {
+            return;
+        };
+
+        self.validate_type_param_constraints(table, type_params, true, diagnostics);
+        self.validate_params(table, type_params, params, true, diagnostics);
+        if let Some(return_type) = return_type {
+            self.validate_type_ref(table, type_params, return_type, *span, true, diagnostics);
+        }
+        let scope_id = table.new_scope();
+        let mut locals = self.param_locals(table, params, scope_id, diagnostics);
+        self.validate_expr_refs(table, type_params, body, &mut locals, true, diagnostics);
+    }
+}

--- a/tests/docs_truth/repo_hygiene/resolver_validation.rs
+++ b/tests/docs_truth/repo_hygiene/resolver_validation.rs
@@ -69,3 +69,37 @@ fn resolver_type_declaration_validation_lives_in_focused_helper() {
         );
     }
 }
+
+#[test]
+fn resolver_impl_block_validation_lives_in_focused_helper() {
+    let declaration_validation = read("src/resolver/declaration_validation.rs");
+    let impl_blocks = read("src/resolver/declaration_validation/impl_blocks.rs");
+
+    for owned_detail in [
+        "table.record_behavior_impl",
+        "duplicate behavior implementation",
+        "BehaviorRefMetadata",
+    ] {
+        assert!(
+            !declaration_validation.contains(owned_detail),
+            "main resolver declaration validation should not own impl-block detail: {owned_detail}"
+        );
+        assert!(
+            impl_blocks.contains(owned_detail),
+            "resolver impl-block validation should live in focused helper: {owned_detail}"
+        );
+    }
+
+    assert!(
+        declaration_validation.contains("self.validate_impl_block_declaration"),
+        "main resolver declaration validation should dispatch impl-block validation through helper"
+    );
+    assert!(
+        impl_blocks.contains("pub(super) fn validate_impl_block_declaration"),
+        "impl-block helper should own the resolver impl-block validation entry point"
+    );
+    assert!(
+        declaration_validation.lines().count() < 180,
+        "declaration_validation.rs should stay compact after impl-block validation split"
+    );
+}


### PR DESCRIPTION
## What changed

- Moved resolver impl-block validation out of `src/resolver/declaration_validation.rs` into `src/resolver/declaration_validation/impl_blocks.rs`.
- Kept the root declaration validator as dispatch plus small declaration-specific branches.
- Added docs-truth coverage pinning impl-block duplicate behavior implementation handling and `BehaviorRefMetadata` recording to the focused helper.

## Why

The resolver declaration validator was close to the cleanup threshold and the impl-block branch mixed behavior impl edge recording, duplicate impl diagnostics, behavior type-arg validation, and method body validation. This split keeps that responsibility isolated without changing diagnostics or resolver semantics.

## Validation

- `cargo test --test docs_truth resolver_impl_block_validation_lives_in_focused_helper --quiet`
- `cargo test --test docs_truth resolver_validation --quiet`
- `cargo test --test resolver_phase2 impls --quiet`
- `cargo test --lib resolver_validation --quiet`
- `cargo test --test integration behavior_extends::overlaps --quiet`
- `cargo fmt --check`
- `git diff --check`
- file-size scan for `>= 250` line Rust files
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --test docs_truth --quiet`
- `cargo test --tests --quiet`