### PR TITLE
[codex] split AST declaration support types

### DIFF
--- a/src/ast/declarations.rs
+++ b/src/ast/declarations.rs
@@ -2,98 +2,10 @@ use crate::ast::expressions::Expression;
 use crate::ast::types::{AstType, Param};
 use crate::error::Span;
 use serde::Serialize;
-use std::fmt;
-use std::str::FromStr;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-pub enum TypeDeclarationKeyword {
-    Impl,
-    Implements,
-    Requires,
-    Extends,
-    Derive,
-}
+mod support;
 
-impl TypeDeclarationKeyword {
-    pub const ALL: &[TypeDeclarationKeyword] = &[
-        TypeDeclarationKeyword::Impl,
-        TypeDeclarationKeyword::Implements,
-        TypeDeclarationKeyword::Requires,
-        TypeDeclarationKeyword::Extends,
-        TypeDeclarationKeyword::Derive,
-    ];
-    pub const IMPL: &'static str = "impl";
-    pub const IMPLEMENTS: &'static str = "implements";
-    pub const REQUIRES: &'static str = "requires";
-    pub const EXTENDS: &'static str = "extends";
-    pub const DERIVE: &'static str = "derive";
-
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::Impl => Self::IMPL,
-            Self::Implements => Self::IMPLEMENTS,
-            Self::Requires => Self::REQUIRES,
-            Self::Extends => Self::EXTENDS,
-            Self::Derive => Self::DERIVE,
-        }
-    }
-}
-
-impl fmt::Display for TypeDeclarationKeyword {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-impl FromStr for TypeDeclarationKeyword {
-    type Err = ();
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        Self::ALL
-            .iter()
-            .copied()
-            .find(|keyword| keyword.as_str() == value)
-            .ok_or(())
-    }
-}
-
-/// A field in a struct definition.
-#[derive(Debug, Clone, PartialEq, Serialize)]
-pub struct StructField {
-    pub name: String,
-    pub ty: AstType,
-    pub default: Option<Expression>,
-    pub mutable: bool,
-    pub span: Span,
-}
-
-/// A variant in an enum definition.
-#[derive(Debug, Clone, PartialEq, Serialize)]
-pub struct EnumVariant {
-    pub name: String,
-    pub payload: Option<AstType>,
-    pub span: Span,
-}
-
-/// A method signature in a behavior (trait) definition.
-#[derive(Debug, Clone, PartialEq, Serialize)]
-pub struct BehaviorMethod {
-    pub name: String,
-    pub params: Vec<Param>,
-    pub return_type: Option<AstType>,
-    pub default_body: Option<Expression>,
-    pub span: Span,
-}
-
-/// Generic type parameter, optionally constrained by a behavior.
-/// e.g. `T` or `T: Serializable`
-#[derive(Debug, Clone, PartialEq, Serialize)]
-pub struct TypeParam {
-    pub name: String,
-    pub constraint: Option<String>,
-    pub constraint_type_args: Vec<AstType>,
-    pub span: Span,
-}
+pub use support::{BehaviorMethod, EnumVariant, StructField, TypeDeclarationKeyword, TypeParam};
 
 /// Declaration — top-level constructs in a Zen program.
 #[derive(Debug, Clone, PartialEq, Serialize)]

--- a/src/ast/declarations/support.rs
+++ b/src/ast/declarations/support.rs
@@ -1,0 +1,96 @@
+use crate::ast::expressions::Expression;
+use crate::ast::types::{AstType, Param};
+use crate::error::Span;
+use serde::Serialize;
+use std::fmt;
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum TypeDeclarationKeyword {
+    Impl,
+    Implements,
+    Requires,
+    Extends,
+    Derive,
+}
+
+impl TypeDeclarationKeyword {
+    pub const ALL: &[TypeDeclarationKeyword] = &[
+        TypeDeclarationKeyword::Impl,
+        TypeDeclarationKeyword::Implements,
+        TypeDeclarationKeyword::Requires,
+        TypeDeclarationKeyword::Extends,
+        TypeDeclarationKeyword::Derive,
+    ];
+    pub const IMPL: &'static str = "impl";
+    pub const IMPLEMENTS: &'static str = "implements";
+    pub const REQUIRES: &'static str = "requires";
+    pub const EXTENDS: &'static str = "extends";
+    pub const DERIVE: &'static str = "derive";
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Impl => Self::IMPL,
+            Self::Implements => Self::IMPLEMENTS,
+            Self::Requires => Self::REQUIRES,
+            Self::Extends => Self::EXTENDS,
+            Self::Derive => Self::DERIVE,
+        }
+    }
+}
+
+impl fmt::Display for TypeDeclarationKeyword {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for TypeDeclarationKeyword {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|keyword| keyword.as_str() == value)
+            .ok_or(())
+    }
+}
+
+/// A field in a struct definition.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct StructField {
+    pub name: String,
+    pub ty: AstType,
+    pub default: Option<Expression>,
+    pub mutable: bool,
+    pub span: Span,
+}
+
+/// A variant in an enum definition.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct EnumVariant {
+    pub name: String,
+    pub payload: Option<AstType>,
+    pub span: Span,
+}
+
+/// A method signature in a behavior (trait) definition.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct BehaviorMethod {
+    pub name: String,
+    pub params: Vec<Param>,
+    pub return_type: Option<AstType>,
+    pub default_body: Option<Expression>,
+    pub span: Span,
+}
+
+/// Generic type parameter, optionally constrained by a behavior.
+/// e.g. `T` or `T: Serializable`
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct TypeParam {
+    pub name: String,
+    pub constraint: Option<String>,
+    pub constraint_type_args: Vec<AstType>,
+    pub span: Span,
+}

--- a/tests/docs_truth/repo_hygiene/parser_enums/parser_surface.rs
+++ b/tests/docs_truth/repo_hygiene/parser_enums/parser_surface.rs
@@ -4,6 +4,7 @@ use super::*;
 fn parser_type_declaration_suffixes_use_owned_keyword_enum() {
     let source = read("src/parser/declarations.rs");
     let ast_declarations = read("src/ast/declarations.rs");
+    let ast_declaration_support = read("src/ast/declarations/support.rs");
 
     for forbidden in [
         r#"method_name == "impl""#,
@@ -40,10 +41,48 @@ fn parser_type_declaration_suffixes_use_owned_keyword_enum() {
         ".find(|keyword| keyword.as_str() == value)",
     ] {
         assert!(
-            ast_declarations.contains(required),
+            ast_declaration_support.contains(required),
             "TypeDeclarationKeyword spelling should parse through its static table: {required}"
         );
     }
+}
+
+#[test]
+fn ast_declaration_support_types_live_in_focused_helper() {
+    let root = read("src/ast/declarations.rs");
+    let support = read("src/ast/declarations/support.rs");
+
+    for support_type in [
+        "TypeDeclarationKeyword",
+        "StructField",
+        "EnumVariant",
+        "BehaviorMethod",
+        "TypeParam",
+    ] {
+        assert!(
+            !root.contains(&format!("enum {support_type}"))
+                && !root.contains(&format!("struct {support_type}")),
+            "AST declaration root should not own declaration support type: {support_type}"
+        );
+        assert!(
+            support.contains(&format!("enum {support_type}"))
+                || support.contains(&format!("struct {support_type}")),
+            "AST declaration support type should live in focused helper: {support_type}"
+        );
+    }
+
+    assert!(
+        root.contains("mod support;"),
+        "AST declaration root should include focused declaration support helper"
+    );
+    assert!(
+        root.contains("pub use support::{"),
+        "AST declaration root should re-export support types to keep public ast API stable"
+    );
+    assert!(
+        root.lines().count() < 170,
+        "AST declaration root should stay focused on the Declaration enum and declaration methods"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What changed

- Moved AST declaration support types from `src/ast/declarations.rs` into `src/ast/declarations/support.rs`.
- Kept `declarations.rs` focused on the `Declaration` enum and declaration methods.
- Re-exported support types from `declarations.rs` so existing `crate::ast` imports stay stable.
- Added docs-truth coverage pinning support-type ownership and `TypeDeclarationKeyword` spelling-table parsing in the focused helper.

## Why

`src/ast/declarations.rs` was near the cleanup threshold and mixed declaration metadata/support shapes with the main declaration enum. This is a mechanical ownership split that keeps the public AST API intact.

## Validation

- `cargo test --test docs_truth ast_declaration_support_types_live_in_focused_helper --quiet`
- `cargo test --test docs_truth parser_type_declaration_suffixes_use_owned_keyword_enum --quiet`
- `cargo test --test docs_truth parser_enums::parser_surface --quiet`
- `cargo test --lib parser --quiet`
- `cargo fmt --check`
- `git diff --check`
- file-size scan for `>= 250` line Rust files
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --test docs_truth --quiet`
- `cargo test --tests --quiet`