### PR TITLE
[codex] split generic single-file fixtures

### DIFF
--- a/tests/docs_truth/repo_hygiene/file_size.rs
+++ b/tests/docs_truth/repo_hygiene/file_size.rs
@@ -6,6 +6,7 @@ mod declaration_validation_splits;
 mod focused_tests;
 mod function_method_template_splits;
 mod generic_behavior_splits;
+mod integration_fixture_splits;
 mod lexer_and_monomorphize;
 mod module_system_splits;
 mod parser_enum_splits;

--- a/tests/docs_truth/repo_hygiene/file_size/integration_fixture_splits.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/integration_fixture_splits.rs
@@ -1,0 +1,33 @@
+use super::super::*;
+
+#[test]
+fn generic_single_file_fixture_tests_live_in_focused_helper() {
+    let root = read("tests/integration/single_file_fixtures.rs");
+    let generic = read("tests/integration/single_file_fixtures/generic.rs");
+
+    for test_name in [
+        "test_generic_identity",
+        "test_generic_enum_method_nested_result",
+        "test_generic_result_enum_multi_specialization",
+        "test_generic_recursive_method",
+        "test_generic_ufc_dedup",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "single_file_fixtures.rs should not own generic fixture test: {test_name}"
+        );
+        assert!(
+            generic.contains(&format!("fn {test_name}")),
+            "generic single-file fixture tests should live in focused helper: {test_name}"
+        );
+    }
+
+    assert!(
+        root.lines().count() < 170,
+        "single_file_fixtures.rs should stay focused on core and behavior fixture tests"
+    );
+    assert!(
+        root.contains("#[path = \"single_file_fixtures/generic.rs\"]"),
+        "single_file_fixtures.rs should include the focused generic fixture module by path"
+    );
+}

--- a/tests/integration/discovery.rs
+++ b/tests/integration/discovery.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::path::Path;
 
 #[test]
 fn all_zen_files_have_expected_output() {
@@ -26,12 +27,12 @@ fn all_zen_files_have_expected_output() {
 fn all_expected_outputs_are_exercised_by_runtime_tests() {
     let dir = test_dir();
     let expected_dir = dir.join("expected");
-    let single_file_tests = std::fs::read_to_string("tests/integration/single_file_fixtures.rs")
-        .expect("read single-file runtime tests");
-    let runtime_tests = std::fs::read_to_string("tests/integration/runtime_fixtures.rs")
-        .expect("read runtime tests");
-    let multi_file_tests = std::fs::read_to_string("tests/integration/multi_file_fixtures.rs")
-        .expect("read multi-file runtime tests");
+    let single_file_tests = runtime_test_sources([
+        "tests/integration/single_file_fixtures.rs",
+        "tests/integration/single_file_fixtures",
+    ]);
+    let runtime_tests = runtime_test_sources(["tests/integration/runtime_fixtures.rs"]);
+    let multi_file_tests = runtime_test_sources(["tests/integration/multi_file_fixtures.rs"]);
 
     let mut uncovered = Vec::new();
     for entry in std::fs::read_dir(&expected_dir).expect("read tests/zen/expected") {
@@ -57,4 +58,39 @@ fn all_expected_outputs_are_exercised_by_runtime_tests() {
         uncovered.is_empty(),
         "expected fixtures without runtime coverage: {uncovered:?}"
     );
+}
+
+fn runtime_test_sources<const N: usize>(paths: [&str; N]) -> String {
+    let mut sources = String::new();
+    for path in paths {
+        append_runtime_test_sources(Path::new(path), &mut sources);
+    }
+    sources
+}
+
+fn append_runtime_test_sources(path: &Path, sources: &mut String) {
+    if !path.exists() {
+        return;
+    }
+
+    if path.is_file() {
+        sources.push_str(
+            &std::fs::read_to_string(path)
+                .unwrap_or_else(|err| panic!("read runtime test source {path:?}: {err}")),
+        );
+        sources.push('\n');
+        return;
+    }
+
+    let mut entries = std::fs::read_dir(path)
+        .unwrap_or_else(|err| panic!("read runtime test source dir {path:?}: {err}"))
+        .map(|entry| entry.expect("read runtime test source dir entry").path())
+        .collect::<Vec<_>>();
+    entries.sort();
+
+    for entry in entries {
+        if entry.is_dir() || entry.extension().and_then(|ext| ext.to_str()) == Some("rs") {
+            append_runtime_test_sources(&entry, sources);
+        }
+    }
 }

--- a/tests/integration/single_file_fixtures.rs
+++ b/tests/integration/single_file_fixtures.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+#[path = "single_file_fixtures/generic.rs"]
+mod generic;
+
 #[test]
 fn test_hello() {
     run_test("hello");
@@ -56,123 +59,8 @@ fn test_functions() {
 }
 
 #[test]
-fn test_generic_identity() {
-    run_test("generic_identity");
-}
-
-#[test]
-fn test_generic_struct() {
-    run_test("generic_struct");
-}
-
-#[test]
-fn test_generic_enum_option() {
-    run_test("generic_enum_option");
-}
-
-#[test]
-fn test_generic_enum_method() {
-    run_test("generic_enum_method");
-}
-
-#[test]
-fn test_generic_enum_multi_specialization() {
-    run_test("generic_enum_multi_specialization");
-}
-
-#[test]
-fn test_generic_method() {
-    run_test("generic_method");
-}
-
-#[test]
-fn test_generic_method_self() {
-    run_test("generic_method_self");
-}
-
-#[test]
-fn test_generic_method_worklist() {
-    run_test("generic_method_worklist");
-}
-
-#[test]
-fn test_generic_method_method_worklist() {
-    run_test("generic_method_method_worklist");
-}
-
-#[test]
-fn test_generic_method_nested_result() {
-    run_test("generic_method_nested_result");
-}
-
-#[test]
-fn test_generic_enum_method_nested_result() {
-    run_test("generic_enum_method_nested_result");
-}
-
-#[test]
 fn test_type_impl_methods() {
     run_test("type_impl_methods");
-}
-
-#[test]
-fn test_generic_type_impl_methods() {
-    run_test("generic_type_impl_methods");
-}
-
-#[test]
-fn test_generic_result_enum() {
-    run_test("generic_result_enum");
-}
-
-#[test]
-fn test_generic_result_enum_method() {
-    run_test("generic_result_enum_method");
-}
-
-#[test]
-fn test_generic_result_enum_multi_specialization() {
-    run_test("generic_result_enum_multi_specialization");
-}
-
-#[test]
-fn test_generic_nested_result_enum() {
-    run_test("generic_nested_result_enum");
-}
-
-#[test]
-fn test_generic_vec() {
-    run_test("generic_vec");
-}
-
-#[test]
-fn test_generic_worklist() {
-    run_test("generic_worklist");
-}
-
-#[test]
-fn test_generic_worklist_dedup() {
-    run_test("generic_worklist_dedup");
-}
-
-#[test]
-fn test_generic_recursive_function() {
-    run_test("generic_recursive_function");
-}
-
-#[test]
-fn test_generic_recursive_method() {
-    run_test("generic_recursive_method");
-}
-
-#[test]
-fn test_generic_ufc_function() {
-    run_test("generic_ufc_function");
-}
-
-#[test]
-fn test_generic_ufc_dedup() {
-    run_test("generic_ufc_dedup");
 }
 
 #[test]

--- a/tests/integration/single_file_fixtures/generic.rs
+++ b/tests/integration/single_file_fixtures/generic.rs
@@ -1,0 +1,116 @@
+use super::*;
+
+#[test]
+fn test_generic_identity() {
+    run_test("generic_identity");
+}
+
+#[test]
+fn test_generic_struct() {
+    run_test("generic_struct");
+}
+
+#[test]
+fn test_generic_enum_option() {
+    run_test("generic_enum_option");
+}
+
+#[test]
+fn test_generic_enum_method() {
+    run_test("generic_enum_method");
+}
+
+#[test]
+fn test_generic_enum_multi_specialization() {
+    run_test("generic_enum_multi_specialization");
+}
+
+#[test]
+fn test_generic_method() {
+    run_test("generic_method");
+}
+
+#[test]
+fn test_generic_method_self() {
+    run_test("generic_method_self");
+}
+
+#[test]
+fn test_generic_method_worklist() {
+    run_test("generic_method_worklist");
+}
+
+#[test]
+fn test_generic_method_method_worklist() {
+    run_test("generic_method_method_worklist");
+}
+
+#[test]
+fn test_generic_method_nested_result() {
+    run_test("generic_method_nested_result");
+}
+
+#[test]
+fn test_generic_enum_method_nested_result() {
+    run_test("generic_enum_method_nested_result");
+}
+
+#[test]
+fn test_generic_type_impl_methods() {
+    run_test("generic_type_impl_methods");
+}
+
+#[test]
+fn test_generic_result_enum() {
+    run_test("generic_result_enum");
+}
+
+#[test]
+fn test_generic_result_enum_method() {
+    run_test("generic_result_enum_method");
+}
+
+#[test]
+fn test_generic_result_enum_multi_specialization() {
+    run_test("generic_result_enum_multi_specialization");
+}
+
+#[test]
+fn test_generic_nested_result_enum() {
+    run_test("generic_nested_result_enum");
+}
+
+#[test]
+fn test_generic_vec() {
+    run_test("generic_vec");
+}
+
+#[test]
+fn test_generic_worklist() {
+    run_test("generic_worklist");
+}
+
+#[test]
+fn test_generic_worklist_dedup() {
+    run_test("generic_worklist_dedup");
+}
+
+#[test]
+fn test_generic_recursive_function() {
+    run_test("generic_recursive_function");
+}
+
+#[test]
+fn test_generic_recursive_method() {
+    run_test("generic_recursive_method");
+}
+
+#[test]
+fn test_generic_ufc_function() {
+    run_test("generic_ufc_function");
+}
+
+#[test]
+fn test_generic_ufc_dedup() {
+    run_test("generic_ufc_dedup");
+}


### PR DESCRIPTION
## What changed

- Moved pure generic single-file runtime fixture tests into `tests/integration/single_file_fixtures/generic.rs`.
- Added a docs-truth split guard so those generic fixture tests do not drift back into the root fixture file.
- Updated discovery to scan focused runtime-test helper modules, so expected-output coverage works with split integration fixtures.

## Why

`single_file_fixtures.rs` was close to the Rust file-size cleanup threshold and mixed core, generic, and behavior coverage. This keeps the root fixture list focused and lets future fixture groups split without breaking discovery.

## Validation

- `cargo test --test docs_truth generic_single_file_fixture_tests_live_in_focused_helper --quiet`
- `cargo test --test integration single_file_fixtures --quiet`
- `cargo test --test integration all_expected_outputs_are_exercised_by_runtime_tests --quiet`
- `cargo fmt --check`
- `git diff --check`
- file-size guard for Rust files >= 250 lines
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --test docs_truth --quiet`
- `cargo test --tests --quiet`