### PR TITLE
[codex] split generic method mutability tests

### DIFF
--- a/src/typechecker/tests/resolver_collection/function_method_templates/generic_methods.rs
+++ b/src/typechecker/tests/resolver_collection/function_method_templates/generic_methods.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 mod integrity;
+mod param_mutability;
 
 #[test]
 fn collect_declarations_with_symbols_uses_resolver_generic_method_template_metadata() {
@@ -166,75 +167,4 @@ Box.choose<T> = (self: Box, left: T, right: T) T {
     assert_eq!(template.params[0].ty, AstType::Named("Box".to_string()));
     assert_eq!(template.params[1].ty, AstType::Named("T".to_string()));
     assert_eq!(template.params[2].ty, AstType::Named("T".to_string()));
-}
-
-#[test]
-fn collect_declarations_with_symbols_preserves_generic_method_template_param_mutability_by_position(
-) {
-    let mut program = parse_program(
-        r#"
-Box: { value: i32 }
-Box.keep<T> = (self: Box, mut value: T) T {
-    value = value
-    value
-}
-"#,
-    );
-    let symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    if let Declaration::Method { params, .. } = &mut program.declarations[1] {
-        params[1].name = "stale".to_string();
-    }
-    let mut tc = TypeChecker::new();
-
-    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
-
-    let template = tc
-        .generic_methods
-        .get("Box.keep")
-        .expect("generic method template");
-    assert_eq!(template.params[1].name, "value");
-    assert!(
-        template.params[1].mutable,
-        "resolver-restored method parameter name should preserve positional mutability"
-    );
-}
-
-#[test]
-fn collect_declarations_with_symbols_ignores_stale_generic_method_template_param_names_for_mutability(
-) {
-    let mut program = parse_program(
-        r#"
-Box: { value: i32 }
-Box.choose<T> = (self: Box, left: T, mut right: T) T {
-    right = right
-    right
-}
-"#,
-    );
-    let symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    if let Declaration::Method { params, .. } = &mut program.declarations[1] {
-        params.swap(1, 2);
-    }
-    let mut tc = TypeChecker::new();
-
-    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
-
-    let template = tc
-        .generic_methods
-        .get("Box.choose")
-        .expect("generic method template");
-    assert_eq!(template.params[1].name, "left");
-    assert_eq!(template.params[2].name, "right");
-    assert!(
-            template.params[1].mutable,
-            "resolver-restored first non-self method parameter should keep first AST position mutability"
-        );
-    assert!(
-            !template.params[2].mutable,
-            "resolver-restored second non-self method parameter should keep second AST position mutability"
-        );
 }

--- a/src/typechecker/tests/resolver_collection/function_method_templates/generic_methods/param_mutability.rs
+++ b/src/typechecker/tests/resolver_collection/function_method_templates/generic_methods/param_mutability.rs
@@ -1,0 +1,72 @@
+use super::*;
+
+#[test]
+fn collect_declarations_with_symbols_preserves_generic_method_template_param_mutability_by_position(
+) {
+    let mut program = parse_program(
+        r#"
+Box: { value: i32 }
+Box.keep<T> = (self: Box, mut value: T) T {
+    value = value
+    value
+}
+"#,
+    );
+    let symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    if let Declaration::Method { params, .. } = &mut program.declarations[1] {
+        params[1].name = "stale".to_string();
+    }
+    let mut tc = TypeChecker::new();
+
+    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
+
+    let template = tc
+        .generic_methods
+        .get("Box.keep")
+        .expect("generic method template");
+    assert_eq!(template.params[1].name, "value");
+    assert!(
+        template.params[1].mutable,
+        "resolver-restored method parameter name should preserve positional mutability"
+    );
+}
+
+#[test]
+fn collect_declarations_with_symbols_ignores_stale_generic_method_template_param_names_for_mutability(
+) {
+    let mut program = parse_program(
+        r#"
+Box: { value: i32 }
+Box.choose<T> = (self: Box, left: T, mut right: T) T {
+    right = right
+    right
+}
+"#,
+    );
+    let symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    if let Declaration::Method { params, .. } = &mut program.declarations[1] {
+        params.swap(1, 2);
+    }
+    let mut tc = TypeChecker::new();
+
+    tc.collect_declarations_with_symbols(&program.declarations, &symbols);
+
+    let template = tc
+        .generic_methods
+        .get("Box.choose")
+        .expect("generic method template");
+    assert_eq!(template.params[1].name, "left");
+    assert_eq!(template.params[2].name, "right");
+    assert!(
+        template.params[1].mutable,
+        "resolver-restored first non-self method parameter should keep first AST position mutability"
+    );
+    assert!(
+        !template.params[2].mutable,
+        "resolver-restored second non-self method parameter should keep second AST position mutability"
+    );
+}

--- a/tests/docs_truth/repo_hygiene/file_size/function_method_template_splits.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/function_method_template_splits.rs
@@ -66,3 +66,36 @@ fn generic_function_mutability_tests_live_in_focused_helper() {
         "generic_functions.rs should include the focused parameter mutability module"
     );
 }
+
+#[test]
+fn generic_method_mutability_tests_live_in_focused_helper() {
+    let root = read(
+        "src/typechecker/tests/resolver_collection/function_method_templates/generic_methods.rs",
+    );
+    let mutability = read(
+        "src/typechecker/tests/resolver_collection/function_method_templates/generic_methods/param_mutability.rs",
+    );
+
+    for test_name in [
+        "collect_declarations_with_symbols_preserves_generic_method_template_param_mutability_by_position",
+        "collect_declarations_with_symbols_ignores_stale_generic_method_template_param_names_for_mutability",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "generic_methods.rs should not own parameter mutability replay test: {test_name}"
+        );
+        assert!(
+            mutability.contains(&format!("fn {test_name}")),
+            "generic method parameter mutability replay should live in focused module: {test_name}"
+        );
+    }
+
+    assert!(
+        root.lines().count() < 190,
+        "generic_methods.rs should stay focused on generic method template shape metadata"
+    );
+    assert!(
+        root.contains("mod param_mutability;"),
+        "generic_methods.rs should include the focused parameter mutability module"
+    );
+}


### PR DESCRIPTION
## What changed

- Moved generic method parameter-mutability replay tests into `generic_methods/param_mutability.rs`.
- Added a docs-truth guard so generic method mutability replay tests stay in the focused helper.
- Reduced `generic_methods.rs` from 240 lines to 170 lines.

## Why

This keeps Phase 5 generic method template tests below the cleanup threshold and aligns them with the existing generic function and type-impl generic method mutability split pattern.

## Validation

- `cargo test --test docs_truth generic_method_mutability_tests_live_in_focused_helper --quiet`
- `cargo test --lib collect_declarations_with_symbols_preserves_generic_method_template_param_mutability_by_position --quiet`
- `cargo test --lib collect_declarations_with_symbols_ignores_stale_generic_method_template_param_names_for_mutability --quiet`
- `cargo fmt --check`
- `git diff --check`
- file-size guard for Rust files >= 250 lines
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --test docs_truth --quiet`
- `cargo test --tests --quiet`