### PR TITLE
[codex] split multi-file generic fixtures

### DIFF
--- a/tests/docs_truth/repo_hygiene/file_size/integration_fixture_splits.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/integration_fixture_splits.rs
@@ -31,3 +31,30 @@ fn generic_single_file_fixture_tests_live_in_focused_helper() {
         "single_file_fixtures.rs should include the focused generic fixture module by path"
     );
 }
+
+#[test]
+fn generic_multi_file_fixture_tests_live_in_phase5_helper() {
+    let root = read("tests/integration/multi_file_fixtures.rs");
+    let phase5 = read("tests/integration/multi_file_phase5_fixtures.rs");
+
+    for test_name in [
+        "test_multi_file_generic_imports",
+        "test_multi_file_generic_imported_worklist_chain_imports",
+        "test_multi_file_generic_result_enum_multi_specialization_imports",
+        "test_multi_file_generic_imported_transitive_dependency_imports",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "multi_file_fixtures.rs should not own generic Phase 5 fixture test: {test_name}"
+        );
+        assert!(
+            phase5.contains(&format!("fn {test_name}")),
+            "generic multi-file Phase 5 fixture tests should live in focused helper: {test_name}"
+        );
+    }
+
+    assert!(
+        root.lines().count() < 190,
+        "multi_file_fixtures.rs should stay focused on non-generic multi-file fixture tests"
+    );
+}

--- a/tests/integration/discovery.rs
+++ b/tests/integration/discovery.rs
@@ -32,7 +32,10 @@ fn all_expected_outputs_are_exercised_by_runtime_tests() {
         "tests/integration/single_file_fixtures",
     ]);
     let runtime_tests = runtime_test_sources(["tests/integration/runtime_fixtures.rs"]);
-    let multi_file_tests = runtime_test_sources(["tests/integration/multi_file_fixtures.rs"]);
+    let multi_file_tests = runtime_test_sources([
+        "tests/integration/multi_file_fixtures.rs",
+        "tests/integration/multi_file_phase5_fixtures.rs",
+    ]);
 
     let mut uncovered = Vec::new();
     for entry in std::fs::read_dir(&expected_dir).expect("read tests/zen/expected") {

--- a/tests/integration/multi_file_fixtures.rs
+++ b/tests/integration/multi_file_fixtures.rs
@@ -8,76 +8,6 @@ fn test_multi_file_imports() {
 }
 
 #[test]
-fn test_multi_file_generic_imports() {
-    let zen_path = test_dir().join("multi_file_generic/main.zen");
-    let actual = compile_and_run(&zen_path);
-    assert_eq!(actual, "42\n7\n5\n9\n");
-}
-
-#[test]
-fn test_multi_file_generic_imported_type_dependency_imports() {
-    let zen_path = test_dir().join("multi_file_generic_imported_type_dependency/main.zen");
-    let actual = compile_and_run(&zen_path);
-    assert_eq!(actual, "73\n");
-}
-
-#[test]
-fn test_multi_file_generic_imported_worklist_chain_imports() {
-    let zen_path = test_dir().join("multi_file_generic_imported_worklist_chain/main.zen");
-    let actual = compile_and_run(&zen_path);
-    assert_eq!(actual, "83\n");
-}
-
-#[test]
-fn test_multi_file_generic_imported_diamond_same_name_imports() {
-    let zen_path = test_dir().join("multi_file_generic_imported_diamond_same_name/main.zen");
-    let actual = compile_and_run(&zen_path);
-    assert_eq!(actual, "11\n29\n");
-}
-
-#[test]
-fn test_multi_file_generic_imported_type_same_name_collision_imports() {
-    let zen_path = test_dir().join("multi_file_generic_imported_type_same_name_collision/main.zen");
-    let actual = compile_and_run(&zen_path);
-    assert_eq!(actual, "11\n29\n");
-}
-
-#[test]
-fn test_multi_file_generic_recursive_function_imports() {
-    let zen_path = test_dir().join("multi_file_generic_recursive_function/main.zen");
-    let actual = compile_and_run(&zen_path);
-    assert_eq!(actual, "97\n");
-}
-
-#[test]
-fn test_multi_file_generic_imported_transitive_dependency_imports() {
-    let zen_path = test_dir().join("multi_file_generic_imported_transitive_dependency/main.zen");
-    let actual = compile_and_run(&zen_path);
-    assert_eq!(actual, "89\n");
-}
-
-#[test]
-fn test_multi_file_generic_enum_method_imports() {
-    let zen_path = test_dir().join("multi_file_generic_enum_method/main.zen");
-    let actual = compile_and_run(&zen_path);
-    assert_eq!(actual, "21\n89\n");
-}
-
-#[test]
-fn test_multi_file_generic_result_enum_method_imports() {
-    let zen_path = test_dir().join("multi_file_generic_result_enum_method/main.zen");
-    let actual = compile_and_run(&zen_path);
-    assert_eq!(actual, "55\n144\n");
-}
-
-#[test]
-fn test_multi_file_generic_result_enum_multi_specialization_imports() {
-    let zen_path = test_dir().join("multi_file_generic_result_enum_multi_specialization/main.zen");
-    let actual = compile_and_run(&zen_path);
-    assert_eq!(actual, "55\n144\nfalse\ntrue\n");
-}
-
-#[test]
 fn test_multi_file_type_impl_imports() {
     let zen_path = test_dir().join("multi_file_type_impl/main.zen");
     let actual = compile_and_run(&zen_path);
@@ -230,14 +160,6 @@ fn test_multi_file_imported_function_imported_return_type_behavior() {
         test_dir().join("multi_file_imported_function_imported_return_type_behavior/main.zen");
     let actual = compile_and_run(&zen_path);
     assert_eq!(actual, "113\n");
-}
-
-#[test]
-fn test_multi_file_imported_generic_function_return_enum_dependency() {
-    let zen_path =
-        test_dir().join("multi_file_imported_generic_function_return_enum_dependency/main.zen");
-    let actual = compile_and_run(&zen_path);
-    assert_eq!(actual, "107\n");
 }
 
 // ── Discovery test: all .zen files have matching .expected ──────────

--- a/tests/integration/multi_file_phase5_fixtures.rs
+++ b/tests/integration/multi_file_phase5_fixtures.rs
@@ -1,8 +1,86 @@
 use super::*;
 
 #[test]
+fn test_multi_file_generic_imports() {
+    let zen_path = test_dir().join("multi_file_generic/main.zen");
+    let actual = compile_and_run(&zen_path);
+    assert_eq!(actual, "42\n7\n5\n9\n");
+}
+
+#[test]
+fn test_multi_file_generic_imported_type_dependency_imports() {
+    let zen_path = test_dir().join("multi_file_generic_imported_type_dependency/main.zen");
+    let actual = compile_and_run(&zen_path);
+    assert_eq!(actual, "73\n");
+}
+
+#[test]
+fn test_multi_file_generic_imported_worklist_chain_imports() {
+    let zen_path = test_dir().join("multi_file_generic_imported_worklist_chain/main.zen");
+    let actual = compile_and_run(&zen_path);
+    assert_eq!(actual, "83\n");
+}
+
+#[test]
+fn test_multi_file_generic_imported_diamond_same_name_imports() {
+    let zen_path = test_dir().join("multi_file_generic_imported_diamond_same_name/main.zen");
+    let actual = compile_and_run(&zen_path);
+    assert_eq!(actual, "11\n29\n");
+}
+
+#[test]
+fn test_multi_file_generic_imported_type_same_name_collision_imports() {
+    let zen_path = test_dir().join("multi_file_generic_imported_type_same_name_collision/main.zen");
+    let actual = compile_and_run(&zen_path);
+    assert_eq!(actual, "11\n29\n");
+}
+
+#[test]
+fn test_multi_file_generic_recursive_function_imports() {
+    let zen_path = test_dir().join("multi_file_generic_recursive_function/main.zen");
+    let actual = compile_and_run(&zen_path);
+    assert_eq!(actual, "97\n");
+}
+
+#[test]
+fn test_multi_file_generic_imported_transitive_dependency_imports() {
+    let zen_path = test_dir().join("multi_file_generic_imported_transitive_dependency/main.zen");
+    let actual = compile_and_run(&zen_path);
+    assert_eq!(actual, "89\n");
+}
+
+#[test]
+fn test_multi_file_generic_enum_method_imports() {
+    let zen_path = test_dir().join("multi_file_generic_enum_method/main.zen");
+    let actual = compile_and_run(&zen_path);
+    assert_eq!(actual, "21\n89\n");
+}
+
+#[test]
+fn test_multi_file_generic_result_enum_method_imports() {
+    let zen_path = test_dir().join("multi_file_generic_result_enum_method/main.zen");
+    let actual = compile_and_run(&zen_path);
+    assert_eq!(actual, "55\n144\n");
+}
+
+#[test]
+fn test_multi_file_generic_result_enum_multi_specialization_imports() {
+    let zen_path = test_dir().join("multi_file_generic_result_enum_multi_specialization/main.zen");
+    let actual = compile_and_run(&zen_path);
+    assert_eq!(actual, "55\n144\nfalse\ntrue\n");
+}
+
+#[test]
 fn test_multi_file_imported_scoped_generic_type_inference_ufc() {
     let zen_path = test_dir().join("multi_file_generic_imported_scoped_type_inference/main.zen");
     let actual = compile_and_run(&zen_path);
     assert_eq!(actual, "1\n60\n");
+}
+
+#[test]
+fn test_multi_file_imported_generic_function_return_enum_dependency() {
+    let zen_path =
+        test_dir().join("multi_file_imported_generic_function_return_enum_dependency/main.zen");
+    let actual = compile_and_run(&zen_path);
+    assert_eq!(actual, "107\n");
 }


### PR DESCRIPTION
## What changed

- Moved generic multi-file specialization runtime fixtures from `multi_file_fixtures.rs` into `multi_file_phase5_fixtures.rs`.
- Added a docs-truth guard so representative generic Phase 5 multi-file fixtures stay in the Phase 5 helper.
- Updated discovery to count the Phase 5 helper when proving `.expected` outputs have runtime coverage.

## Why

`multi_file_fixtures.rs` was close to the Rust cleanup threshold and mixed generic specialization evidence with non-generic multi-file behavior/import coverage. The split keeps the root focused while preserving Phase 5 runtime coverage.

## Validation

- `cargo test --test docs_truth generic_multi_file_fixture_tests_live_in_phase5_helper --quiet`
- `cargo test --test integration multi_file_phase5_fixtures --quiet`
- `cargo test --test integration all_expected_outputs_are_exercised_by_runtime_tests --quiet`
- `cargo fmt --check`
- `git diff --check`
- file-size guard for Rust files >= 250 lines
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --test docs_truth --quiet`
- `cargo test --tests --quiet`