### PR TITLE
[codex] pin generic enum method nested layout

### DIFF
--- a/tests/fixtures/ir_json/layout_generic_enum_method_nested_result.golden.json
+++ b/tests/fixtures/ir_json/layout_generic_enum_method_nested_result.golden.json
@@ -1,0 +1,138 @@
+{
+  "format": "zen.layout.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "target": {
+    "pointer_size": 8,
+    "pointer_alignment": 8,
+    "usize_size": 8
+  },
+  "layouts": {
+    "Option_i32": {
+      "kind": "enum",
+      "size": 8,
+      "alignment": 4,
+      "variants": [
+        {
+          "name": "None",
+          "tag": 0
+        },
+        {
+          "name": "Some",
+          "tag": 1,
+          "payload_fields": [
+            {
+              "name": "payload",
+              "type": "i32",
+              "offset": 0
+            }
+          ]
+        }
+      ]
+    },
+    "Result_Option_i32_StaticString": {
+      "kind": "enum",
+      "size": 24,
+      "alignment": 8,
+      "variants": [
+        {
+          "name": "Ok",
+          "tag": 0,
+          "payload_fields": [
+            {
+              "name": "payload",
+              "type": "Option_i32",
+              "offset": 0
+            }
+          ]
+        },
+        {
+          "name": "Err",
+          "tag": 1,
+          "payload_fields": [
+            {
+              "name": "payload",
+              "type": "StaticString",
+              "offset": 0
+            }
+          ]
+        }
+      ]
+    },
+    "StaticString": {
+      "kind": "static_string",
+      "size": 16,
+      "alignment": 8
+    },
+    "String": {
+      "kind": "dynamic_string",
+      "size": 32,
+      "alignment": 8
+    },
+    "bool": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "f32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "f64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "i16": {
+      "kind": "primitive",
+      "size": 2,
+      "alignment": 2
+    },
+    "i32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "i64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "i8": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "u16": {
+      "kind": "primitive",
+      "size": 2,
+      "alignment": 2
+    },
+    "u32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "u64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "u8": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "usize": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "void": {
+      "kind": "primitive",
+      "size": 0,
+      "alignment": 1
+    }
+  }
+}

--- a/tests/integration/cli_build/frontend_json/layout_golden/generic.rs
+++ b/tests/integration/cli_build/frontend_json/layout_golden/generic.rs
@@ -27,3 +27,12 @@ fn emit_json_layout_nested_generic_result_schema_matches_golden() {
         "tests/fixtures/ir_json/layout_nested_generic_result.golden.json",
     );
 }
+
+#[test]
+fn emit_json_layout_generic_enum_method_nested_result_schema_matches_golden() {
+    assert_layout_matches_fixture(
+        &fixture("tests/zen/generic_enum_method_nested_result.zen"),
+        "generic enum method nested Result program input",
+        "tests/fixtures/ir_json/layout_generic_enum_method_nested_result.golden.json",
+    );
+}


### PR DESCRIPTION
## What changed

- Added layout JSON golden coverage for `tests/zen/generic_enum_method_nested_result.zen`.
- Bound the golden through the existing frontend JSON layout golden test slice.

## Why

This completes the layout boundary for the same Phase 5 nested generic enum method fixture already covered by runtime, generated C assertions, typed/HIR/MIR, and symbols JSON.

## Validation

- `cargo test --test integration emit_json_layout_generic_enum_method_nested_result_schema_matches_golden --quiet`
- `cargo test --test integration frontend_json --quiet`
- `cargo fmt --check`
- `git diff --check`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`\n- `cargo clippy -- -D warnings`\n- `cargo test --lib --quiet`\n- `cargo test --test docs_truth --quiet`\n- `cargo test --tests --quiet`