### PR TITLE
[codex] cover multi-file generic method nested symbols layout

### DIFF
--- a/tests/fixtures/ir_json/layout_multi_file_generic_method_nested_result.golden.json
+++ b/tests/fixtures/ir_json/layout_multi_file_generic_method_nested_result.golden.json
@@ -1,0 +1,150 @@
+{
+  "format": "zen.layout.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "target": {
+    "pointer_size": 8,
+    "pointer_alignment": 8,
+    "usize_size": 8
+  },
+  "layouts": {
+    "Box_i32": {
+      "kind": "struct",
+      "size": 4,
+      "alignment": 4,
+      "fields": [
+        {
+          "name": "value",
+          "type": "i32",
+          "offset": 0
+        }
+      ]
+    },
+    "Option_i32": {
+      "kind": "enum",
+      "size": 8,
+      "alignment": 4,
+      "variants": [
+        {
+          "name": "None",
+          "tag": 0
+        },
+        {
+          "name": "Some",
+          "tag": 1,
+          "payload_fields": [
+            {
+              "name": "payload",
+              "type": "i32",
+              "offset": 0
+            }
+          ]
+        }
+      ]
+    },
+    "Result_Option_i32_StaticString": {
+      "kind": "enum",
+      "size": 24,
+      "alignment": 8,
+      "variants": [
+        {
+          "name": "Ok",
+          "tag": 0,
+          "payload_fields": [
+            {
+              "name": "payload",
+              "type": "Option_i32",
+              "offset": 0
+            }
+          ]
+        },
+        {
+          "name": "Err",
+          "tag": 1,
+          "payload_fields": [
+            {
+              "name": "payload",
+              "type": "StaticString",
+              "offset": 0
+            }
+          ]
+        }
+      ]
+    },
+    "StaticString": {
+      "kind": "static_string",
+      "size": 16,
+      "alignment": 8
+    },
+    "String": {
+      "kind": "dynamic_string",
+      "size": 32,
+      "alignment": 8
+    },
+    "bool": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "f32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "f64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "i16": {
+      "kind": "primitive",
+      "size": 2,
+      "alignment": 2
+    },
+    "i32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "i64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "i8": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "u16": {
+      "kind": "primitive",
+      "size": 2,
+      "alignment": 2
+    },
+    "u32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "u64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "u8": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "usize": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "void": {
+      "kind": "primitive",
+      "size": 0,
+      "alignment": 1
+    }
+  }
+}

--- a/tests/integration/cli_build/frontend_json/layout_golden/generic.rs
+++ b/tests/integration/cli_build/frontend_json/layout_golden/generic.rs
@@ -36,3 +36,12 @@ fn emit_json_layout_generic_enum_method_nested_result_schema_matches_golden() {
         "tests/fixtures/ir_json/layout_generic_enum_method_nested_result.golden.json",
     );
 }
+
+#[test]
+fn emit_json_layout_multi_file_generic_method_nested_result_schema_matches_golden() {
+    assert_layout_matches_fixture(
+        &fixture("tests/zen/multi_file_type_method_nested_result_dependency/main.zen"),
+        "multi-file generic method nested Result program input",
+        "tests/fixtures/ir_json/layout_multi_file_generic_method_nested_result.golden.json",
+    );
+}

--- a/tests/integration/cli_build/frontend_json/module_graph/symbols.rs
+++ b/tests/integration/cli_build/frontend_json/module_graph/symbols.rs
@@ -1,5 +1,6 @@
 use super::emit_json;
 use super::write_two_module_project;
+use std::path::Path;
 
 #[test]
 fn emit_json_symbols_command_outputs_module_symbol_tables() {
@@ -55,4 +56,124 @@ fn emit_json_symbols_command_outputs_module_symbol_tables() {
         }),
         "imported symbols should contain public add signature: {json}"
     );
+}
+
+#[test]
+fn emit_json_symbols_reports_multi_file_generic_method_nested_result_surface() {
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/zen/multi_file_type_method_nested_result_dependency/main.zen");
+
+    let output = emit_json(
+        "symbols",
+        &source_path,
+        "multi-file generic method nested Result symbols",
+    );
+
+    assert!(
+        output.status.success(),
+        "zen emit-json symbols failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("emit-json symbols stdout is json");
+    assert_eq!(json["format"], "zen.symbols.v0");
+    assert_eq!(json["semantic_status"], "resolved");
+
+    let modules = json["modules"].as_array().expect("modules array");
+    assert_eq!(
+        modules.len(),
+        3,
+        "multi-file fixture should report main, types, and model modules: {json}"
+    );
+
+    let main = module_by_file(modules, "main.zen");
+    assert_symbol(main, "Import", "Box", |symbol| {
+        symbol["import_source"] == "model"
+    });
+    assert_symbol(main, "Import", "Option", |symbol| {
+        symbol["import_source"] == "types"
+    });
+    assert_symbol(main, "Import", "Result", |symbol| {
+        symbol["import_source"] == "types"
+    });
+
+    let types = module_by_file(modules, "types.zen");
+    assert_symbol(types, "Type", "Option", |symbol| {
+        string_array_eq(&symbol["type_parameter_names"], &["T"])
+            && string_array_eq(&symbol["variant_names"], &["None", "Some"])
+    });
+    assert_symbol(types, "Type", "Result", |symbol| {
+        string_array_eq(&symbol["type_parameter_names"], &["T", "E"])
+            && string_array_eq(&symbol["variant_names"], &["Ok", "Err"])
+    });
+
+    let model = module_by_file(modules, "model.zen");
+    assert_symbol(model, "Type", "Box", |symbol| {
+        symbol["is_public"] == true
+            && string_array_eq(&symbol["type_parameter_names"], &["T"])
+            && field_type_array_eq(&symbol["field_type_names"], &[("value", "T")])
+    });
+    assert_symbol(model, "Value", "Box.wrap_result", |symbol| {
+        symbol["is_public"] == true
+            && string_array_eq(&symbol["parameter_type_names"], &["Box<T>"])
+            && symbol["return_type_name"] == "Result<Option<T>, StaticString>"
+    });
+    assert_symbol(model, "Value", "unwrap_result", |symbol| {
+        symbol["is_public"] == true
+            && string_array_eq(&symbol["parameter_type_names"], &["Result<T, E>", "T"])
+            && symbol["return_type_name"] == "T"
+    });
+}
+
+fn module_by_file<'a>(modules: &'a [serde_json::Value], file_name: &str) -> &'a serde_json::Value {
+    modules
+        .iter()
+        .find(|module| {
+            module["canonical_path"]
+                .as_str()
+                .and_then(|path| Path::new(path).file_name())
+                .is_some_and(|name| name.to_string_lossy() == file_name)
+        })
+        .unwrap_or_else(|| panic!("missing module for {file_name}"))
+}
+
+fn assert_symbol(
+    module: &serde_json::Value,
+    namespace: &str,
+    name: &str,
+    extra: impl Fn(&serde_json::Value) -> bool,
+) {
+    let symbols = module["symbols"].as_array().expect("module symbols array");
+    assert!(
+        symbols.iter().any(|symbol| {
+            symbol["namespace"] == namespace && symbol["name"] == name && extra(symbol)
+        }),
+        "missing {namespace} symbol {name} in module {}",
+        module["canonical_path"]
+    );
+}
+
+fn string_array_eq(value: &serde_json::Value, expected: &[&str]) -> bool {
+    value.as_array().is_some_and(|actual| {
+        actual
+            .iter()
+            .map(serde_json::Value::as_str)
+            .collect::<Option<Vec<_>>>()
+            .is_some_and(|actual| actual == expected)
+    })
+}
+
+fn field_type_array_eq(value: &serde_json::Value, expected: &[(&str, &str)]) -> bool {
+    value.as_array().is_some_and(|actual| {
+        let actual = actual
+            .iter()
+            .map(|field| {
+                let field = field.as_array()?;
+                Some((field.first()?.as_str()?, field.get(1)?.as_str()?))
+            })
+            .collect::<Option<Vec<_>>>();
+        actual.is_some_and(|actual| actual == expected)
+    })
 }


### PR DESCRIPTION
## What changed

- Added focused symbols JSON coverage for the multi-file generic method nested Result fixture.
- Added a compact layout golden for the same multi-file fixture.

## Why

The fixture already had typed/HIR/MIR coverage; this pins the remaining symbols and layout surfaces without adding a 1000+ line symbols golden.

## Validation

- `cargo test --test integration emit_json_symbols_reports_multi_file_generic_method_nested_result_surface --quiet`
- `cargo test --test integration emit_json_layout_multi_file_generic_method_nested_result_schema_matches_golden --quiet`
- `cargo test --test integration frontend_json --quiet`
- `cargo fmt --check`
- `git diff --check`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`\n- `cargo clippy -- -D warnings`\n- `cargo test --lib --quiet`\n- `cargo test --test docs_truth --quiet`\n- `cargo test --tests --quiet`