### PR TITLE
[codex] cover multi-file generic result multi layout

### DIFF
--- a/tests/fixtures/ir_json/layout_multi_file_generic_result_multi_specialization.golden.json
+++ b/tests/fixtures/ir_json/layout_multi_file_generic_result_multi_specialization.golden.json
@@ -1,0 +1,145 @@
+{
+  "format": "zen.layout.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "target": {
+    "pointer_size": 8,
+    "pointer_alignment": 8,
+    "usize_size": 8
+  },
+  "layouts": {
+    "Result_bool_StaticString": {
+      "kind": "enum",
+      "size": 24,
+      "alignment": 8,
+      "variants": [
+        {
+          "name": "Ok",
+          "tag": 0,
+          "payload_fields": [
+            {
+              "name": "payload",
+              "type": "bool",
+              "offset": 0
+            }
+          ]
+        },
+        {
+          "name": "Err",
+          "tag": 1,
+          "payload_fields": [
+            {
+              "name": "payload",
+              "type": "StaticString",
+              "offset": 0
+            }
+          ]
+        }
+      ]
+    },
+    "Result_i32_StaticString": {
+      "kind": "enum",
+      "size": 24,
+      "alignment": 8,
+      "variants": [
+        {
+          "name": "Ok",
+          "tag": 0,
+          "payload_fields": [
+            {
+              "name": "payload",
+              "type": "i32",
+              "offset": 0
+            }
+          ]
+        },
+        {
+          "name": "Err",
+          "tag": 1,
+          "payload_fields": [
+            {
+              "name": "payload",
+              "type": "StaticString",
+              "offset": 0
+            }
+          ]
+        }
+      ]
+    },
+    "StaticString": {
+      "kind": "static_string",
+      "size": 16,
+      "alignment": 8
+    },
+    "String": {
+      "kind": "dynamic_string",
+      "size": 32,
+      "alignment": 8
+    },
+    "bool": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "f32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "f64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "i16": {
+      "kind": "primitive",
+      "size": 2,
+      "alignment": 2
+    },
+    "i32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "i64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "i8": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "u16": {
+      "kind": "primitive",
+      "size": 2,
+      "alignment": 2
+    },
+    "u32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "u64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "u8": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "usize": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "void": {
+      "kind": "primitive",
+      "size": 0,
+      "alignment": 1
+    }
+  }
+}

--- a/tests/integration/cli_build/frontend_json/layout_golden/generic.rs
+++ b/tests/integration/cli_build/frontend_json/layout_golden/generic.rs
@@ -45,3 +45,12 @@ fn emit_json_layout_multi_file_generic_method_nested_result_schema_matches_golde
         "tests/fixtures/ir_json/layout_multi_file_generic_method_nested_result.golden.json",
     );
 }
+
+#[test]
+fn emit_json_layout_multi_file_generic_result_multi_specialization_schema_matches_golden() {
+    assert_layout_matches_fixture(
+        &fixture("tests/zen/multi_file_generic_result_enum_multi_specialization/main.zen"),
+        "multi-file generic Result multi-specialization program input",
+        "tests/fixtures/ir_json/layout_multi_file_generic_result_multi_specialization.golden.json",
+    );
+}

--- a/tests/integration/cli_build/frontend_json/module_graph/symbols.rs
+++ b/tests/integration/cli_build/frontend_json/module_graph/symbols.rs
@@ -127,6 +127,54 @@ fn emit_json_symbols_reports_multi_file_generic_method_nested_result_surface() {
     });
 }
 
+#[test]
+fn emit_json_symbols_reports_multi_file_generic_result_multi_specialization_surface() {
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/zen/multi_file_generic_result_enum_multi_specialization/main.zen");
+
+    let output = emit_json(
+        "symbols",
+        &source_path,
+        "multi-file generic Result multi-specialization symbols",
+    );
+
+    assert!(
+        output.status.success(),
+        "zen emit-json symbols failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("emit-json symbols stdout is json");
+    assert_eq!(json["format"], "zen.symbols.v0");
+    assert_eq!(json["semantic_status"], "resolved");
+
+    let modules = json["modules"].as_array().expect("modules array");
+    assert_eq!(
+        modules.len(),
+        2,
+        "fixture should report main and result modules: {json}"
+    );
+
+    let main = module_by_file(modules, "main.zen");
+    assert_symbol(main, "Import", "Result", |symbol| {
+        symbol["import_source"] == "result"
+    });
+
+    let result = module_by_file(modules, "result.zen");
+    assert_symbol(result, "Type", "Result", |symbol| {
+        symbol["is_public"] == true
+            && string_array_eq(&symbol["type_parameter_names"], &["T", "E"])
+            && string_array_eq(&symbol["variant_names"], &["Ok", "Err"])
+    });
+    assert_symbol(result, "Value", "Result.unwrap_or", |symbol| {
+        symbol["is_public"] == true
+            && string_array_eq(&symbol["parameter_type_names"], &["Self", "T"])
+            && symbol["return_type_name"] == "T"
+    });
+}
+
 fn module_by_file<'a>(modules: &'a [serde_json::Value], file_name: &str) -> &'a serde_json::Value {
     modules
         .iter()


### PR DESCRIPTION
## What changed

- Added focused symbols coverage for the multi-file imported `Result<T, E>` multi-specialization fixture.
- Added a compact layout golden proving both `Result<i32, StaticString>` and `Result<bool, StaticString>` layouts are emitted.

## Why

This pins the frontend symbols/layout surfaces for a Phase 5 multi-file generic enum fixture that already has runtime and generated-C coverage.

## Validation

- `cargo test --test integration emit_json_symbols_reports_multi_file_generic_result_multi_specialization_surface --quiet`
- `cargo test --test integration emit_json_layout_multi_file_generic_result_multi_specialization_schema_matches_golden --quiet`
- `cargo test --test integration frontend_json --quiet`
- `cargo fmt --check`
- `git diff --check`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`\n- `cargo clippy -- -D warnings`\n- `cargo test --lib --quiet`\n- `cargo test --test docs_truth --quiet`\n- `cargo test --tests --quiet`