### PR TITLE
[codex] cover multi-file generic enum method layout

### DIFF
--- a/tests/fixtures/ir_json/layout_multi_file_generic_enum_method.golden.json
+++ b/tests/fixtures/ir_json/layout_multi_file_generic_enum_method.golden.json
@@ -1,0 +1,109 @@
+{
+  "format": "zen.layout.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "target": {
+    "pointer_size": 8,
+    "pointer_alignment": 8,
+    "usize_size": 8
+  },
+  "layouts": {
+    "Option_i32": {
+      "kind": "enum",
+      "size": 8,
+      "alignment": 4,
+      "variants": [
+        {
+          "name": "None",
+          "tag": 0
+        },
+        {
+          "name": "Some",
+          "tag": 1,
+          "payload_fields": [
+            {
+              "name": "payload",
+              "type": "i32",
+              "offset": 0
+            }
+          ]
+        }
+      ]
+    },
+    "StaticString": {
+      "kind": "static_string",
+      "size": 16,
+      "alignment": 8
+    },
+    "String": {
+      "kind": "dynamic_string",
+      "size": 32,
+      "alignment": 8
+    },
+    "bool": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "f32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "f64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "i16": {
+      "kind": "primitive",
+      "size": 2,
+      "alignment": 2
+    },
+    "i32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "i64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "i8": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "u16": {
+      "kind": "primitive",
+      "size": 2,
+      "alignment": 2
+    },
+    "u32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "u64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "u8": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "usize": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "void": {
+      "kind": "primitive",
+      "size": 0,
+      "alignment": 1
+    }
+  }
+}

--- a/tests/integration/cli_build/frontend_json/layout_golden/generic.rs
+++ b/tests/integration/cli_build/frontend_json/layout_golden/generic.rs
@@ -38,6 +38,15 @@ fn emit_json_layout_generic_enum_method_nested_result_schema_matches_golden() {
 }
 
 #[test]
+fn emit_json_layout_multi_file_generic_enum_method_schema_matches_golden() {
+    assert_layout_matches_fixture(
+        &fixture("tests/zen/multi_file_generic_enum_method/main.zen"),
+        "multi-file generic enum method program input",
+        "tests/fixtures/ir_json/layout_multi_file_generic_enum_method.golden.json",
+    );
+}
+
+#[test]
 fn emit_json_layout_multi_file_generic_method_nested_result_schema_matches_golden() {
     assert_layout_matches_fixture(
         &fixture("tests/zen/multi_file_type_method_nested_result_dependency/main.zen"),

--- a/tests/integration/cli_build/frontend_json/module_graph/symbols.rs
+++ b/tests/integration/cli_build/frontend_json/module_graph/symbols.rs
@@ -2,6 +2,9 @@ use super::emit_json;
 use super::write_two_module_project;
 use std::path::Path;
 
+#[path = "symbols/generic.rs"]
+mod generic;
+
 #[test]
 fn emit_json_symbols_command_outputs_module_symbol_tables() {
     let tmp = tempfile::tempdir().expect("create temp dir");
@@ -56,123 +59,6 @@ fn emit_json_symbols_command_outputs_module_symbol_tables() {
         }),
         "imported symbols should contain public add signature: {json}"
     );
-}
-
-#[test]
-fn emit_json_symbols_reports_multi_file_generic_method_nested_result_surface() {
-    let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/zen/multi_file_type_method_nested_result_dependency/main.zen");
-
-    let output = emit_json(
-        "symbols",
-        &source_path,
-        "multi-file generic method nested Result symbols",
-    );
-
-    assert!(
-        output.status.success(),
-        "zen emit-json symbols failed: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let json: serde_json::Value =
-        serde_json::from_slice(&output.stdout).expect("emit-json symbols stdout is json");
-    assert_eq!(json["format"], "zen.symbols.v0");
-    assert_eq!(json["semantic_status"], "resolved");
-
-    let modules = json["modules"].as_array().expect("modules array");
-    assert_eq!(
-        modules.len(),
-        3,
-        "multi-file fixture should report main, types, and model modules: {json}"
-    );
-
-    let main = module_by_file(modules, "main.zen");
-    assert_symbol(main, "Import", "Box", |symbol| {
-        symbol["import_source"] == "model"
-    });
-    assert_symbol(main, "Import", "Option", |symbol| {
-        symbol["import_source"] == "types"
-    });
-    assert_symbol(main, "Import", "Result", |symbol| {
-        symbol["import_source"] == "types"
-    });
-
-    let types = module_by_file(modules, "types.zen");
-    assert_symbol(types, "Type", "Option", |symbol| {
-        string_array_eq(&symbol["type_parameter_names"], &["T"])
-            && string_array_eq(&symbol["variant_names"], &["None", "Some"])
-    });
-    assert_symbol(types, "Type", "Result", |symbol| {
-        string_array_eq(&symbol["type_parameter_names"], &["T", "E"])
-            && string_array_eq(&symbol["variant_names"], &["Ok", "Err"])
-    });
-
-    let model = module_by_file(modules, "model.zen");
-    assert_symbol(model, "Type", "Box", |symbol| {
-        symbol["is_public"] == true
-            && string_array_eq(&symbol["type_parameter_names"], &["T"])
-            && field_type_array_eq(&symbol["field_type_names"], &[("value", "T")])
-    });
-    assert_symbol(model, "Value", "Box.wrap_result", |symbol| {
-        symbol["is_public"] == true
-            && string_array_eq(&symbol["parameter_type_names"], &["Box<T>"])
-            && symbol["return_type_name"] == "Result<Option<T>, StaticString>"
-    });
-    assert_symbol(model, "Value", "unwrap_result", |symbol| {
-        symbol["is_public"] == true
-            && string_array_eq(&symbol["parameter_type_names"], &["Result<T, E>", "T"])
-            && symbol["return_type_name"] == "T"
-    });
-}
-
-#[test]
-fn emit_json_symbols_reports_multi_file_generic_result_multi_specialization_surface() {
-    let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/zen/multi_file_generic_result_enum_multi_specialization/main.zen");
-
-    let output = emit_json(
-        "symbols",
-        &source_path,
-        "multi-file generic Result multi-specialization symbols",
-    );
-
-    assert!(
-        output.status.success(),
-        "zen emit-json symbols failed: stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let json: serde_json::Value =
-        serde_json::from_slice(&output.stdout).expect("emit-json symbols stdout is json");
-    assert_eq!(json["format"], "zen.symbols.v0");
-    assert_eq!(json["semantic_status"], "resolved");
-
-    let modules = json["modules"].as_array().expect("modules array");
-    assert_eq!(
-        modules.len(),
-        2,
-        "fixture should report main and result modules: {json}"
-    );
-
-    let main = module_by_file(modules, "main.zen");
-    assert_symbol(main, "Import", "Result", |symbol| {
-        symbol["import_source"] == "result"
-    });
-
-    let result = module_by_file(modules, "result.zen");
-    assert_symbol(result, "Type", "Result", |symbol| {
-        symbol["is_public"] == true
-            && string_array_eq(&symbol["type_parameter_names"], &["T", "E"])
-            && string_array_eq(&symbol["variant_names"], &["Ok", "Err"])
-    });
-    assert_symbol(result, "Value", "Result.unwrap_or", |symbol| {
-        symbol["is_public"] == true
-            && string_array_eq(&symbol["parameter_type_names"], &["Self", "T"])
-            && symbol["return_type_name"] == "T"
-    });
 }
 
 fn module_by_file<'a>(modules: &'a [serde_json::Value], file_name: &str) -> &'a serde_json::Value {

--- a/tests/integration/cli_build/frontend_json/module_graph/symbols/generic.rs
+++ b/tests/integration/cli_build/frontend_json/module_graph/symbols/generic.rs
@@ -1,0 +1,136 @@
+use super::*;
+
+#[test]
+fn emit_json_symbols_reports_multi_file_generic_enum_method_surface() {
+    let modules = symbols_modules_for_fixture(
+        "tests/zen/multi_file_generic_enum_method/main.zen",
+        "multi-file generic enum method symbols",
+    );
+
+    assert_eq!(
+        modules.len(),
+        2,
+        "fixture should report main and option modules: {modules:?}"
+    );
+
+    let main = module_by_file(&modules, "main.zen");
+    assert_symbol(main, "Import", "Option", |symbol| {
+        symbol["import_source"] == "option"
+    });
+
+    let option = module_by_file(&modules, "option.zen");
+    assert_symbol(option, "Type", "Option", |symbol| {
+        symbol["is_public"] == true
+            && string_array_eq(&symbol["type_parameter_names"], &["T"])
+            && string_array_eq(&symbol["variant_names"], &["None", "Some"])
+    });
+    assert_symbol(option, "Value", "Option.unwrap_or", |symbol| {
+        symbol["is_public"] == true
+            && string_array_eq(&symbol["parameter_type_names"], &["Self", "T"])
+            && symbol["return_type_name"] == "T"
+    });
+}
+
+#[test]
+fn emit_json_symbols_reports_multi_file_generic_method_nested_result_surface() {
+    let modules = symbols_modules_for_fixture(
+        "tests/zen/multi_file_type_method_nested_result_dependency/main.zen",
+        "multi-file generic method nested Result symbols",
+    );
+
+    assert_eq!(
+        modules.len(),
+        3,
+        "multi-file fixture should report main, types, and model modules: {modules:?}"
+    );
+
+    let main = module_by_file(&modules, "main.zen");
+    assert_symbol(main, "Import", "Box", |symbol| {
+        symbol["import_source"] == "model"
+    });
+    assert_symbol(main, "Import", "Option", |symbol| {
+        symbol["import_source"] == "types"
+    });
+    assert_symbol(main, "Import", "Result", |symbol| {
+        symbol["import_source"] == "types"
+    });
+
+    let types = module_by_file(&modules, "types.zen");
+    assert_symbol(types, "Type", "Option", |symbol| {
+        string_array_eq(&symbol["type_parameter_names"], &["T"])
+            && string_array_eq(&symbol["variant_names"], &["None", "Some"])
+    });
+    assert_symbol(types, "Type", "Result", |symbol| {
+        string_array_eq(&symbol["type_parameter_names"], &["T", "E"])
+            && string_array_eq(&symbol["variant_names"], &["Ok", "Err"])
+    });
+
+    let model = module_by_file(&modules, "model.zen");
+    assert_symbol(model, "Type", "Box", |symbol| {
+        symbol["is_public"] == true
+            && string_array_eq(&symbol["type_parameter_names"], &["T"])
+            && field_type_array_eq(&symbol["field_type_names"], &[("value", "T")])
+    });
+    assert_symbol(model, "Value", "Box.wrap_result", |symbol| {
+        symbol["is_public"] == true
+            && string_array_eq(&symbol["parameter_type_names"], &["Box<T>"])
+            && symbol["return_type_name"] == "Result<Option<T>, StaticString>"
+    });
+    assert_symbol(model, "Value", "unwrap_result", |symbol| {
+        symbol["is_public"] == true
+            && string_array_eq(&symbol["parameter_type_names"], &["Result<T, E>", "T"])
+            && symbol["return_type_name"] == "T"
+    });
+}
+
+#[test]
+fn emit_json_symbols_reports_multi_file_generic_result_multi_specialization_surface() {
+    let modules = symbols_modules_for_fixture(
+        "tests/zen/multi_file_generic_result_enum_multi_specialization/main.zen",
+        "multi-file generic Result multi-specialization symbols",
+    );
+
+    assert_eq!(
+        modules.len(),
+        2,
+        "fixture should report main and result modules: {modules:?}"
+    );
+
+    let main = module_by_file(&modules, "main.zen");
+    assert_symbol(main, "Import", "Result", |symbol| {
+        symbol["import_source"] == "result"
+    });
+
+    let result = module_by_file(&modules, "result.zen");
+    assert_symbol(result, "Type", "Result", |symbol| {
+        symbol["is_public"] == true
+            && string_array_eq(&symbol["type_parameter_names"], &["T", "E"])
+            && string_array_eq(&symbol["variant_names"], &["Ok", "Err"])
+    });
+    assert_symbol(result, "Value", "Result.unwrap_or", |symbol| {
+        symbol["is_public"] == true
+            && string_array_eq(&symbol["parameter_type_names"], &["Self", "T"])
+            && symbol["return_type_name"] == "T"
+    });
+}
+
+fn symbols_modules_for_fixture(source_path: &str, description: &str) -> Vec<serde_json::Value> {
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR")).join(source_path);
+    let output = emit_json("symbols", &source_path, description);
+
+    assert!(
+        output.status.success(),
+        "zen emit-json symbols failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("emit-json symbols stdout is json");
+    assert_eq!(json["format"], "zen.symbols.v0");
+    assert_eq!(json["semantic_status"], "resolved");
+    json["modules"]
+        .as_array()
+        .expect("modules array")
+        .to_owned()
+}


### PR DESCRIPTION
## What changed

- Split generic symbols surface assertions into a focused submodule so the main symbols test file stays small.
- Added focused symbols coverage for the multi-file imported `Option<T>.unwrap_or` enum-method fixture.
- Added a compact layout golden for `multi_file_generic_enum_method/main.zen`.

## Why

This adds another Phase 5 frontend boundary for imported generic enum methods while preserving the repo line-count hygiene guard.

## Validation

- `cargo test --test integration emit_json_symbols_reports_multi_file_generic_enum_method_surface --quiet`
- `cargo test --test integration emit_json_layout_multi_file_generic_enum_method_schema_matches_golden --quiet`
- `cargo test --test integration frontend_json --quiet`
- `cargo fmt --check`
- `git diff --check`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`\n- `cargo clippy -- -D warnings`\n- `cargo test --lib --quiet`\n- `cargo test --test docs_truth --quiet`\n- `cargo test --tests --quiet`