### PR TITLE
[codex] cover multi-file generic result method layout

### DIFF
--- a/tests/fixtures/ir_json/layout_multi_file_generic_result_method.golden.json
+++ b/tests/fixtures/ir_json/layout_multi_file_generic_result_method.golden.json
@@ -1,0 +1,116 @@
+{
+  "format": "zen.layout.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "target": {
+    "pointer_size": 8,
+    "pointer_alignment": 8,
+    "usize_size": 8
+  },
+  "layouts": {
+    "Result_i32_StaticString": {
+      "kind": "enum",
+      "size": 24,
+      "alignment": 8,
+      "variants": [
+        {
+          "name": "Ok",
+          "tag": 0,
+          "payload_fields": [
+            {
+              "name": "payload",
+              "type": "i32",
+              "offset": 0
+            }
+          ]
+        },
+        {
+          "name": "Err",
+          "tag": 1,
+          "payload_fields": [
+            {
+              "name": "payload",
+              "type": "StaticString",
+              "offset": 0
+            }
+          ]
+        }
+      ]
+    },
+    "StaticString": {
+      "kind": "static_string",
+      "size": 16,
+      "alignment": 8
+    },
+    "String": {
+      "kind": "dynamic_string",
+      "size": 32,
+      "alignment": 8
+    },
+    "bool": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "f32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "f64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "i16": {
+      "kind": "primitive",
+      "size": 2,
+      "alignment": 2
+    },
+    "i32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "i64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "i8": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "u16": {
+      "kind": "primitive",
+      "size": 2,
+      "alignment": 2
+    },
+    "u32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "u64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "u8": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "usize": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "void": {
+      "kind": "primitive",
+      "size": 0,
+      "alignment": 1
+    }
+  }
+}

--- a/tests/integration/cli_build/frontend_json/layout_golden/generic.rs
+++ b/tests/integration/cli_build/frontend_json/layout_golden/generic.rs
@@ -47,6 +47,15 @@ fn emit_json_layout_multi_file_generic_enum_method_schema_matches_golden() {
 }
 
 #[test]
+fn emit_json_layout_multi_file_generic_result_method_schema_matches_golden() {
+    assert_layout_matches_fixture(
+        &fixture("tests/zen/multi_file_generic_result_enum_method/main.zen"),
+        "multi-file generic Result method program input",
+        "tests/fixtures/ir_json/layout_multi_file_generic_result_method.golden.json",
+    );
+}
+
+#[test]
 fn emit_json_layout_multi_file_generic_method_nested_result_schema_matches_golden() {
     assert_layout_matches_fixture(
         &fixture("tests/zen/multi_file_type_method_nested_result_dependency/main.zen"),

--- a/tests/integration/cli_build/frontend_json/module_graph/symbols/generic.rs
+++ b/tests/integration/cli_build/frontend_json/module_graph/symbols/generic.rs
@@ -32,6 +32,37 @@ fn emit_json_symbols_reports_multi_file_generic_enum_method_surface() {
 }
 
 #[test]
+fn emit_json_symbols_reports_multi_file_generic_result_method_surface() {
+    let modules = symbols_modules_for_fixture(
+        "tests/zen/multi_file_generic_result_enum_method/main.zen",
+        "multi-file generic Result enum method symbols",
+    );
+
+    assert_eq!(
+        modules.len(),
+        2,
+        "fixture should report main and result modules: {modules:?}"
+    );
+
+    let main = module_by_file(&modules, "main.zen");
+    assert_symbol(main, "Import", "Result", |symbol| {
+        symbol["import_source"] == "result"
+    });
+
+    let result = module_by_file(&modules, "result.zen");
+    assert_symbol(result, "Type", "Result", |symbol| {
+        symbol["is_public"] == true
+            && string_array_eq(&symbol["type_parameter_names"], &["T", "E"])
+            && string_array_eq(&symbol["variant_names"], &["Ok", "Err"])
+    });
+    assert_symbol(result, "Value", "Result.unwrap_or", |symbol| {
+        symbol["is_public"] == true
+            && string_array_eq(&symbol["parameter_type_names"], &["Self", "T"])
+            && symbol["return_type_name"] == "T"
+    });
+}
+
+#[test]
 fn emit_json_symbols_reports_multi_file_generic_method_nested_result_surface() {
     let modules = symbols_modules_for_fixture(
         "tests/zen/multi_file_type_method_nested_result_dependency/main.zen",


### PR DESCRIPTION
## What changed

- Added focused symbols coverage for the multi-file imported `Result<T, E>.unwrap_or` enum-method fixture.
- Added a compact layout golden for `multi_file_generic_result_enum_method/main.zen`.

## Why

This pins another Phase 5 frontend boundary for imported generic enum methods that already had runtime and generated-C evidence.

## Validation

- `cargo test --test integration emit_json_symbols_reports_multi_file_generic_result_method_surface --quiet`
- `cargo test --test integration emit_json_layout_multi_file_generic_result_method_schema_matches_golden --quiet`
- `cargo test --test integration frontend_json --quiet`
- `cargo fmt --check`
- `git diff --check`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`\n- `cargo clippy -- -D warnings`\n- `cargo test --lib --quiet`\n- `cargo test --test docs_truth --quiet`\n- `cargo test --tests --quiet`