### PR TITLE
[codex] cover multi-file generic function return enum layout

### DIFF
--- a/tests/fixtures/ir_json/layout_multi_file_generic_function_return_enum.golden.json
+++ b/tests/fixtures/ir_json/layout_multi_file_generic_function_return_enum.golden.json
@@ -1,0 +1,109 @@
+{
+  "format": "zen.layout.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "target": {
+    "pointer_size": 8,
+    "pointer_alignment": 8,
+    "usize_size": 8
+  },
+  "layouts": {
+    "Option_i32": {
+      "kind": "enum",
+      "size": 8,
+      "alignment": 4,
+      "variants": [
+        {
+          "name": "None",
+          "tag": 0
+        },
+        {
+          "name": "Some",
+          "tag": 1,
+          "payload_fields": [
+            {
+              "name": "payload",
+              "type": "i32",
+              "offset": 0
+            }
+          ]
+        }
+      ]
+    },
+    "StaticString": {
+      "kind": "static_string",
+      "size": 16,
+      "alignment": 8
+    },
+    "String": {
+      "kind": "dynamic_string",
+      "size": 32,
+      "alignment": 8
+    },
+    "bool": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "f32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "f64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "i16": {
+      "kind": "primitive",
+      "size": 2,
+      "alignment": 2
+    },
+    "i32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "i64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "i8": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "u16": {
+      "kind": "primitive",
+      "size": 2,
+      "alignment": 2
+    },
+    "u32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "u64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "u8": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "usize": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "void": {
+      "kind": "primitive",
+      "size": 0,
+      "alignment": 1
+    }
+  }
+}

--- a/tests/integration/cli_build/frontend_json/layout_golden/generic.rs
+++ b/tests/integration/cli_build/frontend_json/layout_golden/generic.rs
@@ -56,6 +56,15 @@ fn emit_json_layout_multi_file_generic_result_method_schema_matches_golden() {
 }
 
 #[test]
+fn emit_json_layout_multi_file_generic_function_return_enum_schema_matches_golden() {
+    assert_layout_matches_fixture(
+        &fixture("tests/zen/multi_file_imported_generic_function_return_enum_dependency/main.zen"),
+        "multi-file generic function return enum program input",
+        "tests/fixtures/ir_json/layout_multi_file_generic_function_return_enum.golden.json",
+    );
+}
+
+#[test]
 fn emit_json_layout_multi_file_generic_method_nested_result_schema_matches_golden() {
     assert_layout_matches_fixture(
         &fixture("tests/zen/multi_file_type_method_nested_result_dependency/main.zen"),

--- a/tests/integration/cli_build/frontend_json/module_graph/symbols/generic.rs
+++ b/tests/integration/cli_build/frontend_json/module_graph/symbols/generic.rs
@@ -63,6 +63,50 @@ fn emit_json_symbols_reports_multi_file_generic_result_method_surface() {
 }
 
 #[test]
+fn emit_json_symbols_reports_multi_file_generic_function_return_enum_surface() {
+    let modules = symbols_modules_for_fixture(
+        "tests/zen/multi_file_imported_generic_function_return_enum_dependency/main.zen",
+        "multi-file imported generic function return enum symbols",
+    );
+
+    assert_eq!(
+        modules.len(),
+        3,
+        "fixture should report main, model, and types modules: {modules:?}"
+    );
+
+    let main = module_by_file(&modules, "main.zen");
+    assert_symbol(main, "Import", "wrap", |symbol| {
+        symbol["import_source"] == "model"
+    });
+    assert_symbol(main, "Import", "unwrap", |symbol| {
+        symbol["import_source"] == "model"
+    });
+
+    let model = module_by_file(&modules, "model.zen");
+    assert_symbol(model, "Import", "Option", |symbol| {
+        symbol["import_source"] == "types"
+    });
+    assert_symbol(model, "Value", "wrap", |symbol| {
+        symbol["is_public"] == true
+            && string_array_eq(&symbol["parameter_type_names"], &["T"])
+            && symbol["return_type_name"] == "Option<T>"
+    });
+    assert_symbol(model, "Value", "unwrap", |symbol| {
+        symbol["is_public"] == true
+            && string_array_eq(&symbol["parameter_type_names"], &["Option<T>", "T"])
+            && symbol["return_type_name"] == "T"
+    });
+
+    let types = module_by_file(&modules, "types.zen");
+    assert_symbol(types, "Type", "Option", |symbol| {
+        symbol["is_public"] == true
+            && string_array_eq(&symbol["type_parameter_names"], &["T"])
+            && string_array_eq(&symbol["variant_names"], &["None", "Some"])
+    });
+}
+
+#[test]
 fn emit_json_symbols_reports_multi_file_generic_method_nested_result_surface() {
     let modules = symbols_modules_for_fixture(
         "tests/zen/multi_file_type_method_nested_result_dependency/main.zen",


### PR DESCRIPTION
## What changed

- Added focused symbols coverage for imported generic functions returning/using an imported `Option<T>`.
- Added a compact layout golden for `multi_file_imported_generic_function_return_enum_dependency/main.zen`.

## Why

This pins another Phase 5 frontend boundary for imported generic functions that depend on imported generic enum types.

## Validation

- `cargo test --test integration emit_json_symbols_reports_multi_file_generic_function_return_enum_surface --quiet`
- `cargo test --test integration emit_json_layout_multi_file_generic_function_return_enum_schema_matches_golden --quiet`
- `cargo test --test integration frontend_json --quiet`
- `cargo fmt --check`
- `git diff --check`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`\n- `cargo clippy -- -D warnings`\n- `cargo test --lib --quiet`\n- `cargo test --test docs_truth --quiet`\n- `cargo test --tests --quiet`