### PR TITLE
[codex] pin multi-file generic result method lowering

### DIFF
--- a/tests/fixtures/ir_json/hir_multi_file_generic_result_method.golden.json
+++ b/tests/fixtures/ir_json/hir_multi_file_generic_result_method.golden.json
@@ -1,0 +1,58 @@
+{
+  "format": "zen.hir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "declarations": {
+    "types": [
+      {
+        "name": "Result_i32_StaticString",
+        "kind": "enum",
+        "fields": [],
+        "variants": [
+          {
+            "name": "Ok",
+            "tag": 0,
+            "payload": [
+              {
+                "name": "payload",
+                "type": "i32"
+              }
+            ]
+          },
+          {
+            "name": "Err",
+            "tag": 1,
+            "payload": [
+              {
+                "name": "payload",
+                "type": "StaticString"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "functions": [
+      {
+        "name": "main",
+        "params": [],
+        "return_type": "i32"
+      },
+      {
+        "name": "Result.unwrap_or_i32_StaticString",
+        "params": [
+          {
+            "name": "self",
+            "type": "Result_i32_StaticString"
+          },
+          {
+            "name": "fallback",
+            "type": "i32"
+          }
+        ],
+        "return_type": "i32"
+      }
+    ],
+    "globals": []
+  }
+}

--- a/tests/fixtures/ir_json/mir_multi_file_generic_result_method.golden.json
+++ b/tests/fixtures/ir_json/mir_multi_file_generic_result_method.golden.json
@@ -1,0 +1,192 @@
+{
+  "format": "zen.mir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "lowering_status": "minimal",
+  "functions": [
+    {
+      "name": "main",
+      "params": [],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [
+            {
+              "kind": "let",
+              "name": "ok",
+              "type": "Result_i32_StaticString",
+              "mutable": false,
+              "value": {
+                "kind": "enum_variant",
+                "type": "Result_i32_StaticString",
+                "name": "Result_i32_StaticString.Ok",
+                "args": [
+                  {
+                    "kind": "int",
+                    "type": "i32",
+                    "value": 55
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "let",
+              "name": "err",
+              "type": "Result_i32_StaticString",
+              "mutable": false,
+              "value": {
+                "kind": "enum_variant",
+                "type": "Result_i32_StaticString",
+                "name": "Result_i32_StaticString.Err",
+                "args": [
+                  {
+                    "kind": "static_string",
+                    "type": "StaticString",
+                    "value": "bad"
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "expr",
+              "value": {
+                "kind": "call",
+                "type": "void",
+                "function": "io_println",
+                "args": [
+                  {
+                    "kind": "string_interpolation",
+                    "type": "StaticString",
+                    "value": {
+                      "parts": 1
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "expr",
+              "value": {
+                "kind": "call",
+                "type": "void",
+                "function": "io_println",
+                "args": [
+                  {
+                    "kind": "string_interpolation",
+                    "type": "StaticString",
+                    "value": {
+                      "parts": 1
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "int",
+              "type": "i32",
+              "value": 0
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Result.unwrap_or_i32_StaticString",
+      "params": [
+        {
+          "name": "self",
+          "type": "Result_i32_StaticString"
+        },
+        {
+          "name": "fallback",
+          "type": "i32"
+        }
+      ],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "match",
+              "type": "i32",
+              "target": {
+                "kind": "local",
+                "type": "Result_i32_StaticString",
+                "name": "self"
+              },
+              "match_kind": "enum",
+              "arms": [
+                {
+                  "pattern": {
+                    "kind": "enum_variant",
+                    "name": "Result_i32_StaticString.Ok",
+                    "bindings": [
+                      {
+                        "name": "value",
+                        "type": "i32"
+                      }
+                    ]
+                  },
+                  "body": {
+                    "label": "entry",
+                    "statements": [],
+                    "terminator": {
+                      "kind": "return",
+                      "value": {
+                        "kind": "block",
+                        "type": "i32",
+                        "value": {
+                          "has_result": true,
+                          "result": {
+                            "kind": "local",
+                            "name": "value",
+                            "type": "i32"
+                          },
+                          "statement_count": 0
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "pattern": {
+                    "kind": "enum_variant",
+                    "name": "Result_i32_StaticString.Err",
+                    "bindings": []
+                  },
+                  "body": {
+                    "label": "entry",
+                    "statements": [],
+                    "terminator": {
+                      "kind": "return",
+                      "value": {
+                        "kind": "block",
+                        "type": "i32",
+                        "value": {
+                          "has_result": true,
+                          "result": {
+                            "kind": "local",
+                            "name": "fallback",
+                            "type": "i32"
+                          },
+                          "statement_count": 0
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/integration/cli_build/frontend_json/hir_golden/generic_methods.rs
+++ b/tests/integration/cli_build/frontend_json/hir_golden/generic_methods.rs
@@ -82,6 +82,15 @@ fn emit_json_hir_multi_file_generic_method_nested_result_schema_matches_golden()
 }
 
 #[test]
+fn emit_json_hir_multi_file_generic_result_method_schema_matches_golden() {
+    assert_hir_golden(
+        "tests/zen/multi_file_generic_result_enum_method/main.zen",
+        "tests/fixtures/ir_json/hir_multi_file_generic_result_method.golden.json",
+        "multi-file generic Result method input",
+    );
+}
+
+#[test]
 fn emit_json_hir_generic_result_method_schema_matches_golden() {
     assert_hir_golden(
         "tests/zen/generic_result_enum_method.zen",

--- a/tests/integration/cli_build/frontend_json/mir_golden/generic_methods.rs
+++ b/tests/integration/cli_build/frontend_json/mir_golden/generic_methods.rs
@@ -82,6 +82,15 @@ fn emit_json_mir_multi_file_generic_method_nested_result_schema_matches_golden()
 }
 
 #[test]
+fn emit_json_mir_multi_file_generic_result_method_schema_matches_golden() {
+    assert_mir_golden(
+        "tests/zen/multi_file_generic_result_enum_method/main.zen",
+        "tests/fixtures/ir_json/mir_multi_file_generic_result_method.golden.json",
+        "multi-file generic Result method input",
+    );
+}
+
+#[test]
 fn emit_json_mir_generic_result_method_schema_matches_golden() {
     assert_mir_golden(
         "tests/zen/generic_result_enum_method.zen",


### PR DESCRIPTION
## What changed
- Added HIR and MIR JSON goldens for `multi_file_generic_result_enum_method/main.zen`.

## Why
This pins lower compiler-owned boundaries for an imported `Result<T, E>.unwrap_or` generic enum method fixture that already has runtime/generated-C plus symbols/layout coverage.

## Validation
- `cargo test --test integration emit_json_hir_multi_file_generic_result_method_schema_matches_golden --quiet`
- `cargo test --test integration emit_json_mir_multi_file_generic_result_method_schema_matches_golden --quiet`
- `cargo test --test integration frontend_json --quiet`
- `cargo fmt --check`
- `git diff --check`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`\n- `cargo clippy -- -D warnings`\n- `cargo test --lib --quiet`\n- `cargo test --test docs_truth --quiet`\n- `cargo test --tests --quiet`\n