### PR TITLE
[codex] pin imported generic worklist chain lowering

### DIFF
--- a/tests/fixtures/ir_json/hir_multi_file_generic_imported_worklist_chain.golden.json
+++ b/tests/fixtures/ir_json/hir_multi_file_generic_imported_worklist_chain.golden.json
@@ -1,0 +1,46 @@
+{
+  "format": "zen.hir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "declarations": {
+    "types": [],
+    "functions": [
+      {
+        "name": "main",
+        "params": [],
+        "return_type": "i32"
+      },
+      {
+        "name": "inner_i32",
+        "params": [
+          {
+            "name": "value",
+            "type": "i32"
+          }
+        ],
+        "return_type": "i32"
+      },
+      {
+        "name": "middle_i32",
+        "params": [
+          {
+            "name": "value",
+            "type": "i32"
+          }
+        ],
+        "return_type": "i32"
+      },
+      {
+        "name": "outer_i32",
+        "params": [
+          {
+            "name": "value",
+            "type": "i32"
+          }
+        ],
+        "return_type": "i32"
+      }
+    ],
+    "globals": []
+  }
+}

--- a/tests/fixtures/ir_json/mir_multi_file_generic_imported_worklist_chain.golden.json
+++ b/tests/fixtures/ir_json/mir_multi_file_generic_imported_worklist_chain.golden.json
@@ -1,0 +1,131 @@
+{
+  "format": "zen.mir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "lowering_status": "minimal",
+  "functions": [
+    {
+      "name": "main",
+      "params": [],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [
+            {
+              "kind": "expr",
+              "value": {
+                "kind": "call",
+                "type": "void",
+                "function": "io_println",
+                "args": [
+                  {
+                    "kind": "string_interpolation",
+                    "type": "StaticString",
+                    "value": {
+                      "parts": 1
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "int",
+              "type": "i32",
+              "value": 0
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "inner_i32",
+      "params": [
+        {
+          "name": "value",
+          "type": "i32"
+        }
+      ],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "local",
+              "type": "i32",
+              "name": "value"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "middle_i32",
+      "params": [
+        {
+          "name": "value",
+          "type": "i32"
+        }
+      ],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "call",
+              "type": "i32",
+              "function": "inner_i32",
+              "args": [
+                {
+                  "kind": "local",
+                  "type": "i32",
+                  "name": "value"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "outer_i32",
+      "params": [
+        {
+          "name": "value",
+          "type": "i32"
+        }
+      ],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "call",
+              "type": "i32",
+              "function": "middle_i32",
+              "args": [
+                {
+                  "kind": "local",
+                  "type": "i32",
+                  "name": "value"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/integration/cli_build/frontend_json/hir_golden/generic_values.rs
+++ b/tests/integration/cli_build/frontend_json/hir_golden/generic_values.rs
@@ -28,6 +28,15 @@ fn emit_json_hir_generic_worklist_dedup_schema_matches_golden() {
 }
 
 #[test]
+fn emit_json_hir_multi_file_generic_imported_worklist_chain_schema_matches_golden() {
+    assert_hir_golden(
+        "tests/zen/multi_file_generic_imported_worklist_chain/main.zen",
+        "tests/fixtures/ir_json/hir_multi_file_generic_imported_worklist_chain.golden.json",
+        "multi-file imported generic worklist chain input",
+    );
+}
+
+#[test]
 fn emit_json_hir_generic_recursive_function_schema_matches_golden() {
     assert_hir_golden(
         "tests/zen/generic_recursive_function.zen",

--- a/tests/integration/cli_build/frontend_json/mir_golden/generic_values.rs
+++ b/tests/integration/cli_build/frontend_json/mir_golden/generic_values.rs
@@ -28,6 +28,15 @@ fn emit_json_mir_generic_worklist_dedup_schema_matches_golden() {
 }
 
 #[test]
+fn emit_json_mir_multi_file_generic_imported_worklist_chain_schema_matches_golden() {
+    assert_mir_golden(
+        "tests/zen/multi_file_generic_imported_worklist_chain/main.zen",
+        "tests/fixtures/ir_json/mir_multi_file_generic_imported_worklist_chain.golden.json",
+        "multi-file imported generic worklist chain input",
+    );
+}
+
+#[test]
 fn emit_json_mir_generic_recursive_function_schema_matches_golden() {
     assert_mir_golden(
         "tests/zen/generic_recursive_function.zen",


### PR DESCRIPTION
## What changed
- Added HIR and MIR JSON goldens for `multi_file_generic_imported_worklist_chain/main.zen`.

## Why
This pins the lower compiler boundary for imported generic worklist expansion, including the reachable `inner_i32`, `middle_i32`, and `outer_i32` specializations.

## Validation
- `cargo test --test integration emit_json_hir_multi_file_generic_imported_worklist_chain_schema_matches_golden --quiet`
- `cargo test --test integration emit_json_mir_multi_file_generic_imported_worklist_chain_schema_matches_golden --quiet`
- `cargo test --test integration frontend_json --quiet`
- `cargo fmt --check`
- `git diff --check`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`\n- `cargo clippy -- -D warnings`\n- `cargo test --lib --quiet`\n- `cargo test --test docs_truth --quiet`\n- `cargo test --tests --quiet`\n