### PR TITLE
[codex] pin imported generic type name collisions

### DIFF
--- a/tests/fixtures/ir_json/hir_multi_file_generic_imported_type_same_name.golden.json
+++ b/tests/fixtures/ir_json/hir_multi_file_generic_imported_type_same_name.golden.json
@@ -1,0 +1,117 @@
+{
+  "format": "zen.hir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "declarations": {
+    "types": [
+      {
+        "name": "Box_i32",
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "value",
+            "type": "i32"
+          }
+        ],
+        "variants": []
+      },
+      {
+        "name": "Choice_i32",
+        "kind": "enum",
+        "fields": [],
+        "variants": [
+          {
+            "name": "Value",
+            "tag": 0,
+            "payload": [
+              {
+                "name": "payload",
+                "type": "i32"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "right_Box_i32",
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "value",
+            "type": "i32"
+          },
+          {
+            "name": "extra",
+            "type": "i32"
+          }
+        ],
+        "variants": []
+      },
+      {
+        "name": "right_Choice_i32",
+        "kind": "enum",
+        "fields": [],
+        "variants": [
+          {
+            "name": "Extra",
+            "tag": 0,
+            "payload": [
+              {
+                "name": "payload",
+                "type": "i32"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "functions": [
+      {
+        "name": "main",
+        "params": [],
+        "return_type": "i32"
+      },
+      {
+        "name": "inner_i32",
+        "params": [
+          {
+            "name": "value",
+            "type": "i32"
+          }
+        ],
+        "return_type": "i32"
+      },
+      {
+        "name": "left_i32",
+        "params": [
+          {
+            "name": "value",
+            "type": "i32"
+          }
+        ],
+        "return_type": "i32"
+      },
+      {
+        "name": "right_inner_i32",
+        "params": [
+          {
+            "name": "value",
+            "type": "i32"
+          }
+        ],
+        "return_type": "i32"
+      },
+      {
+        "name": "right_i32",
+        "params": [
+          {
+            "name": "value",
+            "type": "i32"
+          }
+        ],
+        "return_type": "i32"
+      }
+    ],
+    "globals": []
+  }
+}

--- a/tests/fixtures/ir_json/layout_multi_file_generic_imported_type_same_name.golden.json
+++ b/tests/fixtures/ir_json/layout_multi_file_generic_imported_type_same_name.golden.json
@@ -1,0 +1,152 @@
+{
+  "format": "zen.layout.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "target": {
+    "pointer_size": 8,
+    "pointer_alignment": 8,
+    "usize_size": 8
+  },
+  "layouts": {
+    "Box_i32": {
+      "kind": "struct",
+      "size": 4,
+      "alignment": 4,
+      "fields": [
+        {
+          "name": "value",
+          "type": "i32",
+          "offset": 0
+        }
+      ]
+    },
+    "Choice_i32": {
+      "kind": "enum",
+      "size": 8,
+      "alignment": 4,
+      "variants": [
+        {
+          "name": "Value",
+          "tag": 0,
+          "payload_fields": [
+            {
+              "name": "payload",
+              "type": "i32",
+              "offset": 0
+            }
+          ]
+        }
+      ]
+    },
+    "StaticString": {
+      "kind": "static_string",
+      "size": 16,
+      "alignment": 8
+    },
+    "String": {
+      "kind": "dynamic_string",
+      "size": 32,
+      "alignment": 8
+    },
+    "bool": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "f32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "f64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "i16": {
+      "kind": "primitive",
+      "size": 2,
+      "alignment": 2
+    },
+    "i32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "i64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "i8": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "right_Box_i32": {
+      "kind": "struct",
+      "size": 8,
+      "alignment": 4,
+      "fields": [
+        {
+          "name": "value",
+          "type": "i32",
+          "offset": 0
+        },
+        {
+          "name": "extra",
+          "type": "i32",
+          "offset": 4
+        }
+      ]
+    },
+    "right_Choice_i32": {
+      "kind": "enum",
+      "size": 8,
+      "alignment": 4,
+      "variants": [
+        {
+          "name": "Extra",
+          "tag": 0,
+          "payload_fields": [
+            {
+              "name": "payload",
+              "type": "i32",
+              "offset": 0
+            }
+          ]
+        }
+      ]
+    },
+    "u16": {
+      "kind": "primitive",
+      "size": 2,
+      "alignment": 2
+    },
+    "u32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "u64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "u8": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "usize": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "void": {
+      "kind": "primitive",
+      "size": 0,
+      "alignment": 1
+    }
+  }
+}

--- a/tests/integration/cli_build/frontend_json/hir_golden/generic_values.rs
+++ b/tests/integration/cli_build/frontend_json/hir_golden/generic_values.rs
@@ -46,6 +46,15 @@ fn emit_json_hir_multi_file_generic_imported_diamond_same_name_schema_matches_go
 }
 
 #[test]
+fn emit_json_hir_multi_file_generic_imported_type_same_name_schema_matches_golden() {
+    assert_hir_golden(
+        "tests/zen/multi_file_generic_imported_type_same_name_collision/main.zen",
+        "tests/fixtures/ir_json/hir_multi_file_generic_imported_type_same_name.golden.json",
+        "multi-file imported generic type same-name input",
+    );
+}
+
+#[test]
 fn emit_json_hir_generic_recursive_function_schema_matches_golden() {
     assert_hir_golden(
         "tests/zen/generic_recursive_function.zen",

--- a/tests/integration/cli_build/frontend_json/layout_golden/generic.rs
+++ b/tests/integration/cli_build/frontend_json/layout_golden/generic.rs
@@ -81,3 +81,12 @@ fn emit_json_layout_multi_file_generic_result_multi_specialization_schema_matche
         "tests/fixtures/ir_json/layout_multi_file_generic_result_multi_specialization.golden.json",
     );
 }
+
+#[test]
+fn emit_json_layout_multi_file_generic_imported_type_same_name_schema_matches_golden() {
+    assert_layout_matches_fixture(
+        &fixture("tests/zen/multi_file_generic_imported_type_same_name_collision/main.zen"),
+        "multi-file imported generic type same-name program input",
+        "tests/fixtures/ir_json/layout_multi_file_generic_imported_type_same_name.golden.json",
+    );
+}


### PR DESCRIPTION
## What changed
- Added HIR and layout JSON goldens for `multi_file_generic_imported_type_same_name_collision/main.zen`.

## Why
This pins aggregate and enum monomorphization collisions across imported modules without carrying the noisier symbols/MIR goldens. The fixture now records `Box_i32`/`Choice_i32` separately from `right_Box_i32`/`right_Choice_i32`, including the distinct layout for the right-hand `Box`.

## Validation
- `cargo test --test integration emit_json_hir_multi_file_generic_imported_type_same_name_schema_matches_golden --quiet`
- `cargo test --test integration emit_json_layout_multi_file_generic_imported_type_same_name_schema_matches_golden --quiet`
- `cargo test --test integration frontend_json --quiet`
- `cargo fmt --check`
- `git diff --check`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`\n- `cargo clippy -- -D warnings`\n- `cargo test --lib --quiet`\n- `cargo test --test docs_truth --quiet`\n- `cargo test --tests --quiet`\n