### PR TITLE
[codex] pin multi-file type method worklist lowering

### DIFF
--- a/tests/fixtures/ir_json/hir_multi_file_type_method_worklist.golden.json
+++ b/tests/fixtures/ir_json/hir_multi_file_type_method_worklist.golden.json
@@ -1,0 +1,48 @@
+{
+  "format": "zen.hir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "declarations": {
+    "types": [
+      {
+        "name": "Box_i32",
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "value",
+            "type": "i32"
+          }
+        ],
+        "variants": []
+      }
+    ],
+    "functions": [
+      {
+        "name": "main",
+        "params": [],
+        "return_type": "i32"
+      },
+      {
+        "name": "inner_i32",
+        "params": [
+          {
+            "name": "value",
+            "type": "i32"
+          }
+        ],
+        "return_type": "i32"
+      },
+      {
+        "name": "Box.get_inner_i32",
+        "params": [
+          {
+            "name": "self",
+            "type": "Box_i32"
+          }
+        ],
+        "return_type": "i32"
+      }
+    ],
+    "globals": []
+  }
+}

--- a/tests/fixtures/ir_json/mir_multi_file_type_method_worklist.golden.json
+++ b/tests/fixtures/ir_json/mir_multi_file_type_method_worklist.golden.json
@@ -1,0 +1,123 @@
+{
+  "format": "zen.mir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "lowering_status": "minimal",
+  "functions": [
+    {
+      "name": "main",
+      "params": [],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [
+            {
+              "kind": "let",
+              "name": "box",
+              "type": "Box_i32",
+              "mutable": false,
+              "value": {
+                "kind": "struct",
+                "type": "Box_i32",
+                "name": "Box_i32",
+                "args": [
+                  {
+                    "kind": "int",
+                    "type": "i32",
+                    "value": 31
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "expr",
+              "value": {
+                "kind": "call",
+                "type": "void",
+                "function": "io_println",
+                "args": [
+                  {
+                    "kind": "string_interpolation",
+                    "type": "StaticString",
+                    "value": {
+                      "parts": 1
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "int",
+              "type": "i32",
+              "value": 0
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "inner_i32",
+      "params": [
+        {
+          "name": "value",
+          "type": "i32"
+        }
+      ],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "local",
+              "type": "i32",
+              "name": "value"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Box.get_inner_i32",
+      "params": [
+        {
+          "name": "self",
+          "type": "Box_i32"
+        }
+      ],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "call",
+              "type": "i32",
+              "function": "inner_i32",
+              "args": [
+                {
+                  "kind": "field",
+                  "type": "i32",
+                  "target": {
+                    "kind": "local",
+                    "type": "Box_i32",
+                    "name": "self"
+                  },
+                  "field": "value"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/integration/cli_build/frontend_json/hir_golden/generic_methods.rs
+++ b/tests/integration/cli_build/frontend_json/hir_golden/generic_methods.rs
@@ -46,6 +46,15 @@ fn emit_json_hir_generic_method_method_worklist_schema_matches_golden() {
 }
 
 #[test]
+fn emit_json_hir_multi_file_type_method_worklist_schema_matches_golden() {
+    assert_hir_golden(
+        "tests/zen/multi_file_type_method_worklist/main.zen",
+        "tests/fixtures/ir_json/hir_multi_file_type_method_worklist.golden.json",
+        "multi-file type method worklist input",
+    );
+}
+
+#[test]
 fn emit_json_hir_generic_recursive_method_schema_matches_golden() {
     assert_hir_golden(
         "tests/zen/generic_recursive_method.zen",

--- a/tests/integration/cli_build/frontend_json/mir_golden/generic_methods.rs
+++ b/tests/integration/cli_build/frontend_json/mir_golden/generic_methods.rs
@@ -46,6 +46,15 @@ fn emit_json_mir_generic_method_method_worklist_schema_matches_golden() {
 }
 
 #[test]
+fn emit_json_mir_multi_file_type_method_worklist_schema_matches_golden() {
+    assert_mir_golden(
+        "tests/zen/multi_file_type_method_worklist/main.zen",
+        "tests/fixtures/ir_json/mir_multi_file_type_method_worklist.golden.json",
+        "multi-file type method worklist input",
+    );
+}
+
+#[test]
 fn emit_json_mir_generic_recursive_method_schema_matches_golden() {
     assert_mir_golden(
         "tests/zen/generic_recursive_method.zen",


### PR DESCRIPTION
## What changed
- Added HIR and MIR JSON goldens for `multi_file_type_method_worklist/main.zen`.

## Why
This pins method-specialization worklist behavior where an imported generic method queues a helper generic function. The MIR now records `Box.get_inner_i32(self: Box_i32)` lowering to `inner_i32(self.value)`.

## Validation
- `cargo test --test integration emit_json_hir_multi_file_type_method_worklist_schema_matches_golden --quiet`
- `cargo test --test integration emit_json_mir_multi_file_type_method_worklist_schema_matches_golden --quiet`
- `cargo test --test integration frontend_json --quiet`
- `cargo fmt --check`
- `git diff --check`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`\n- `cargo clippy -- -D warnings`\n- `cargo test --lib --quiet`\n- `cargo test --test docs_truth --quiet`\n- `cargo test --tests --quiet`\n