### PR TITLE
[codex] pin type impl imported type lowering

### DIFF
--- a/tests/fixtures/ir_json/hir_multi_file_type_impl_imported_type_dependency.golden.json
+++ b/tests/fixtures/ir_json/hir_multi_file_type_impl_imported_type_dependency.golden.json
@@ -1,0 +1,59 @@
+{
+  "format": "zen.hir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "declarations": {
+    "types": [
+      {
+        "name": "Box_i32",
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "value",
+            "type": "i32"
+          }
+        ],
+        "variants": []
+      },
+      {
+        "name": "Holder_i32",
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "value",
+            "type": "i32"
+          }
+        ],
+        "variants": []
+      }
+    ],
+    "functions": [
+      {
+        "name": "main",
+        "params": [],
+        "return_type": "i32"
+      },
+      {
+        "name": "Holder.get_i32",
+        "params": [
+          {
+            "name": "self",
+            "type": "Holder_i32"
+          }
+        ],
+        "return_type": "i32"
+      },
+      {
+        "name": "Box.get_held_i32",
+        "params": [
+          {
+            "name": "self",
+            "type": "Box_i32"
+          }
+        ],
+        "return_type": "i32"
+      }
+    ],
+    "globals": []
+  }
+}

--- a/tests/fixtures/ir_json/mir_multi_file_type_impl_imported_type_dependency.golden.json
+++ b/tests/fixtures/ir_json/mir_multi_file_type_impl_imported_type_dependency.golden.json
@@ -1,0 +1,147 @@
+{
+  "format": "zen.mir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "lowering_status": "minimal",
+  "functions": [
+    {
+      "name": "main",
+      "params": [],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [
+            {
+              "kind": "let",
+              "name": "box",
+              "type": "Box_i32",
+              "mutable": false,
+              "value": {
+                "kind": "struct",
+                "type": "Box_i32",
+                "name": "Box_i32",
+                "args": [
+                  {
+                    "kind": "int",
+                    "type": "i32",
+                    "value": 61
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "expr",
+              "value": {
+                "kind": "call",
+                "type": "void",
+                "function": "io_println",
+                "args": [
+                  {
+                    "kind": "string_interpolation",
+                    "type": "StaticString",
+                    "value": {
+                      "parts": 1
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "int",
+              "type": "i32",
+              "value": 0
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Holder.get_i32",
+      "params": [
+        {
+          "name": "self",
+          "type": "Holder_i32"
+        }
+      ],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "field",
+              "type": "i32",
+              "target": {
+                "kind": "local",
+                "type": "Holder_i32",
+                "name": "self"
+              },
+              "field": "value"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Box.get_held_i32",
+      "params": [
+        {
+          "name": "self",
+          "type": "Box_i32"
+        }
+      ],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [
+            {
+              "kind": "let",
+              "name": "holder",
+              "type": "Holder_i32",
+              "mutable": false,
+              "value": {
+                "kind": "struct",
+                "type": "Holder_i32",
+                "name": "Holder_i32",
+                "args": [
+                  {
+                    "kind": "field",
+                    "type": "i32",
+                    "target": {
+                      "kind": "local",
+                      "type": "Box_i32",
+                      "name": "self"
+                    },
+                    "field": "value"
+                  }
+                ]
+              }
+            }
+          ],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "call",
+              "type": "i32",
+              "function": "Holder.get_i32",
+              "args": [
+                {
+                  "kind": "local",
+                  "type": "Holder_i32",
+                  "name": "holder"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/integration/cli_build/frontend_json/hir_golden/generic_methods.rs
+++ b/tests/integration/cli_build/frontend_json/hir_golden/generic_methods.rs
@@ -64,6 +64,15 @@ fn emit_json_hir_multi_file_generic_imported_type_dependency_schema_matches_gold
 }
 
 #[test]
+fn emit_json_hir_multi_file_type_impl_imported_type_dependency_schema_matches_golden() {
+    assert_hir_golden(
+        "tests/zen/multi_file_type_impl_imported_type_dependency/main.zen",
+        "tests/fixtures/ir_json/hir_multi_file_type_impl_imported_type_dependency.golden.json",
+        "multi-file type impl imported type dependency input",
+    );
+}
+
+#[test]
 fn emit_json_hir_generic_recursive_method_schema_matches_golden() {
     assert_hir_golden(
         "tests/zen/generic_recursive_method.zen",

--- a/tests/integration/cli_build/frontend_json/mir_golden/generic_methods.rs
+++ b/tests/integration/cli_build/frontend_json/mir_golden/generic_methods.rs
@@ -64,6 +64,15 @@ fn emit_json_mir_multi_file_generic_imported_type_dependency_schema_matches_gold
 }
 
 #[test]
+fn emit_json_mir_multi_file_type_impl_imported_type_dependency_schema_matches_golden() {
+    assert_mir_golden(
+        "tests/zen/multi_file_type_impl_imported_type_dependency/main.zen",
+        "tests/fixtures/ir_json/mir_multi_file_type_impl_imported_type_dependency.golden.json",
+        "multi-file type impl imported type dependency input",
+    );
+}
+
+#[test]
 fn emit_json_mir_generic_recursive_method_schema_matches_golden() {
     assert_mir_golden(
         "tests/zen/generic_recursive_method.zen",


### PR DESCRIPTION
## What changed
- Added HIR and MIR JSON goldens for `multi_file_type_impl_imported_type_dependency/main.zen`.

## Why
This pins imported generic method dispatch from a concrete type impl method. The MIR now records `Box.get_held_i32` constructing `Holder_i32` from `self.value` and returning `Holder.get_i32(holder)`.

## Validation
- `cargo test --test integration emit_json_hir_multi_file_type_impl_imported_type_dependency_schema_matches_golden --quiet`
- `cargo test --test integration emit_json_mir_multi_file_type_impl_imported_type_dependency_schema_matches_golden --quiet`
- `cargo test --test integration frontend_json --quiet`
- `cargo fmt --check`
- `git diff --check`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`\n- `cargo clippy -- -D warnings`\n- `cargo test --lib --quiet`\n- `cargo test --test docs_truth --quiet`\n- `cargo test --tests --quiet`\n