### PR TITLE
[codex] pin type method return enum lowering

### DIFF
--- a/tests/fixtures/ir_json/hir_multi_file_type_method_return_enum.golden.json
+++ b/tests/fixtures/ir_json/hir_multi_file_type_method_return_enum.golden.json
@@ -1,0 +1,74 @@
+{
+  "format": "zen.hir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "declarations": {
+    "types": [
+      {
+        "name": "Box_i32",
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "value",
+            "type": "i32"
+          }
+        ],
+        "variants": []
+      },
+      {
+        "name": "Option_i32",
+        "kind": "enum",
+        "fields": [],
+        "variants": [
+          {
+            "name": "None",
+            "tag": 0,
+            "payload": []
+          },
+          {
+            "name": "Some",
+            "tag": 1,
+            "payload": [
+              {
+                "name": "payload",
+                "type": "i32"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "functions": [
+      {
+        "name": "main",
+        "params": [],
+        "return_type": "i32"
+      },
+      {
+        "name": "Box.wrap_i32",
+        "params": [
+          {
+            "name": "self",
+            "type": "Box_i32"
+          }
+        ],
+        "return_type": "Option_i32"
+      },
+      {
+        "name": "Box.value_or_i32",
+        "params": [
+          {
+            "name": "self",
+            "type": "Box_i32"
+          },
+          {
+            "name": "fallback",
+            "type": "i32"
+          }
+        ],
+        "return_type": "i32"
+      }
+    ],
+    "globals": []
+  }
+}

--- a/tests/fixtures/ir_json/mir_multi_file_type_method_return_enum.golden.json
+++ b/tests/fixtures/ir_json/mir_multi_file_type_method_return_enum.golden.json
@@ -1,0 +1,212 @@
+{
+  "format": "zen.mir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "lowering_status": "minimal",
+  "functions": [
+    {
+      "name": "main",
+      "params": [],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [
+            {
+              "kind": "let",
+              "name": "box",
+              "type": "Box_i32",
+              "mutable": false,
+              "value": {
+                "kind": "struct",
+                "type": "Box_i32",
+                "name": "Box_i32",
+                "args": [
+                  {
+                    "kind": "int",
+                    "type": "i32",
+                    "value": 97
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "expr",
+              "value": {
+                "kind": "call",
+                "type": "void",
+                "function": "io_println",
+                "args": [
+                  {
+                    "kind": "string_interpolation",
+                    "type": "StaticString",
+                    "value": {
+                      "parts": 1
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "int",
+              "type": "i32",
+              "value": 0
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Box.wrap_i32",
+      "params": [
+        {
+          "name": "self",
+          "type": "Box_i32"
+        }
+      ],
+      "return_type": "Option_i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "enum_variant",
+              "type": "Option_i32",
+              "name": "Option_i32.Some",
+              "args": [
+                {
+                  "kind": "field",
+                  "type": "i32",
+                  "target": {
+                    "kind": "local",
+                    "type": "Box_i32",
+                    "name": "self"
+                  },
+                  "field": "value"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Box.value_or_i32",
+      "params": [
+        {
+          "name": "self",
+          "type": "Box_i32"
+        },
+        {
+          "name": "fallback",
+          "type": "i32"
+        }
+      ],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [
+            {
+              "kind": "let",
+              "name": "value",
+              "type": "Option_i32",
+              "mutable": false,
+              "value": {
+                "kind": "call",
+                "type": "Option_i32",
+                "function": "Box.wrap_i32",
+                "args": [
+                  {
+                    "kind": "local",
+                    "type": "Box_i32",
+                    "name": "self"
+                  }
+                ]
+              }
+            }
+          ],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "match",
+              "type": "i32",
+              "target": {
+                "kind": "local",
+                "type": "Option_i32",
+                "name": "value"
+              },
+              "match_kind": "enum",
+              "arms": [
+                {
+                  "pattern": {
+                    "kind": "enum_variant",
+                    "name": "Option_i32.Some",
+                    "bindings": [
+                      {
+                        "name": "inner",
+                        "type": "i32"
+                      }
+                    ]
+                  },
+                  "body": {
+                    "label": "entry",
+                    "statements": [],
+                    "terminator": {
+                      "kind": "return",
+                      "value": {
+                        "kind": "block",
+                        "type": "i32",
+                        "value": {
+                          "has_result": true,
+                          "result": {
+                            "kind": "local",
+                            "name": "inner",
+                            "type": "i32"
+                          },
+                          "statement_count": 0
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "pattern": {
+                    "kind": "enum_variant",
+                    "name": "Option_i32.None",
+                    "bindings": []
+                  },
+                  "body": {
+                    "label": "entry",
+                    "statements": [],
+                    "terminator": {
+                      "kind": "return",
+                      "value": {
+                        "kind": "block",
+                        "type": "i32",
+                        "value": {
+                          "has_result": true,
+                          "result": {
+                            "kind": "local",
+                            "name": "fallback",
+                            "type": "i32"
+                          },
+                          "statement_count": 0
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/integration/cli_build/frontend_json/hir_golden/generic_methods.rs
+++ b/tests/integration/cli_build/frontend_json/hir_golden/generic_methods.rs
@@ -73,6 +73,15 @@ fn emit_json_hir_multi_file_type_impl_imported_type_dependency_schema_matches_go
 }
 
 #[test]
+fn emit_json_hir_multi_file_type_method_return_enum_schema_matches_golden() {
+    assert_hir_golden(
+        "tests/zen/multi_file_type_method_return_enum_dependency/main.zen",
+        "tests/fixtures/ir_json/hir_multi_file_type_method_return_enum.golden.json",
+        "multi-file type method return enum input",
+    );
+}
+
+#[test]
 fn emit_json_hir_generic_recursive_method_schema_matches_golden() {
     assert_hir_golden(
         "tests/zen/generic_recursive_method.zen",

--- a/tests/integration/cli_build/frontend_json/mir_golden/generic_methods.rs
+++ b/tests/integration/cli_build/frontend_json/mir_golden/generic_methods.rs
@@ -73,6 +73,15 @@ fn emit_json_mir_multi_file_type_impl_imported_type_dependency_schema_matches_go
 }
 
 #[test]
+fn emit_json_mir_multi_file_type_method_return_enum_schema_matches_golden() {
+    assert_mir_golden(
+        "tests/zen/multi_file_type_method_return_enum_dependency/main.zen",
+        "tests/fixtures/ir_json/mir_multi_file_type_method_return_enum.golden.json",
+        "multi-file type method return enum input",
+    );
+}
+
+#[test]
 fn emit_json_mir_generic_recursive_method_schema_matches_golden() {
     assert_mir_golden(
         "tests/zen/generic_recursive_method.zen",


### PR DESCRIPTION
## What changed
- Added HIR and MIR JSON goldens for `multi_file_type_method_return_enum_dependency/main.zen`.

## Why
This pins imported `Option<T>` specialization through multi-file type methods. The MIR records `Box.wrap_i32` producing `Option_i32.Some(self.value)` and `Box.value_or_i32` matching `Option_i32.Some`/`Option_i32.None`.

## Validation
- `cargo test --test integration emit_json_hir_multi_file_type_method_return_enum_schema_matches_golden --quiet`
- `cargo test --test integration emit_json_mir_multi_file_type_method_return_enum_schema_matches_golden --quiet`
- `cargo test --test integration frontend_json --quiet`
- `cargo fmt --check`
- `git diff --check`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`\n- `cargo clippy -- -D warnings`\n- `cargo test --lib --quiet`\n- `cargo test --test docs_truth --quiet`\n- `cargo test --tests --quiet`\n