### PR TITLE
[codex] pin scoped generic type inference lowering

### DIFF
--- a/tests/fixtures/ir_json/hir_multi_file_generic_imported_scoped_type_inference.golden.json
+++ b/tests/fixtures/ir_json/hir_multi_file_generic_imported_scoped_type_inference.golden.json
@@ -1,0 +1,104 @@
+{
+  "format": "zen.hir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "declarations": {
+    "types": [
+      {
+        "name": "Box_i32",
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "value",
+            "type": "i32"
+          }
+        ],
+        "variants": []
+      },
+      {
+        "name": "right_Box_i32",
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "value",
+            "type": "i32"
+          },
+          {
+            "name": "extra",
+            "type": "i32"
+          }
+        ],
+        "variants": []
+      },
+      {
+        "name": "Holder_right_Box_i32",
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "value",
+            "type": "right_Box_i32"
+          }
+        ],
+        "variants": []
+      }
+    ],
+    "functions": [
+      {
+        "name": "main",
+        "params": [],
+        "return_type": "i32"
+      },
+      {
+        "name": "left_i32",
+        "params": [
+          {
+            "name": "value",
+            "type": "i32"
+          }
+        ],
+        "return_type": "i32"
+      },
+      {
+        "name": "take_box_i32",
+        "params": [
+          {
+            "name": "box",
+            "type": "right_Box_i32"
+          }
+        ],
+        "return_type": "i32"
+      },
+      {
+        "name": "Box.extra_i32",
+        "params": [
+          {
+            "name": "self",
+            "type": "right_Box_i32"
+          }
+        ],
+        "return_type": "i32"
+      },
+      {
+        "name": "Holder.extra_right_Box_i32",
+        "params": [
+          {
+            "name": "self",
+            "type": "Holder_right_Box_i32"
+          }
+        ],
+        "return_type": "i32"
+      },
+      {
+        "name": "right_i32",
+        "params": [
+          {
+            "name": "value",
+            "type": "i32"
+          }
+        ],
+        "return_type": "i32"
+      }
+    ],
+    "globals": []
+  }
+}

--- a/tests/fixtures/ir_json/layout_multi_file_generic_imported_scoped_type_inference.golden.json
+++ b/tests/fixtures/ir_json/layout_multi_file_generic_imported_scoped_type_inference.golden.json
@@ -1,0 +1,128 @@
+{
+  "format": "zen.layout.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "target": {
+    "pointer_size": 8,
+    "pointer_alignment": 8,
+    "usize_size": 8
+  },
+  "layouts": {
+    "Box_i32": {
+      "kind": "struct",
+      "size": 4,
+      "alignment": 4,
+      "fields": [
+        {
+          "name": "value",
+          "type": "i32",
+          "offset": 0
+        }
+      ]
+    },
+    "Holder_right_Box_i32": {
+      "kind": "struct",
+      "size": 8,
+      "alignment": 4,
+      "fields": [
+        {
+          "name": "value",
+          "type": "right_Box_i32",
+          "offset": 0
+        }
+      ]
+    },
+    "StaticString": {
+      "kind": "static_string",
+      "size": 16,
+      "alignment": 8
+    },
+    "String": {
+      "kind": "dynamic_string",
+      "size": 32,
+      "alignment": 8
+    },
+    "bool": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "f32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "f64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "i16": {
+      "kind": "primitive",
+      "size": 2,
+      "alignment": 2
+    },
+    "i32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "i64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "i8": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "right_Box_i32": {
+      "kind": "struct",
+      "size": 8,
+      "alignment": 4,
+      "fields": [
+        {
+          "name": "value",
+          "type": "i32",
+          "offset": 0
+        },
+        {
+          "name": "extra",
+          "type": "i32",
+          "offset": 4
+        }
+      ]
+    },
+    "u16": {
+      "kind": "primitive",
+      "size": 2,
+      "alignment": 2
+    },
+    "u32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "u64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "u8": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "usize": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "void": {
+      "kind": "primitive",
+      "size": 0,
+      "alignment": 1
+    }
+  }
+}

--- a/tests/integration/cli_build/frontend_json/hir_golden/generic_values.rs
+++ b/tests/integration/cli_build/frontend_json/hir_golden/generic_values.rs
@@ -55,6 +55,15 @@ fn emit_json_hir_multi_file_generic_imported_type_same_name_schema_matches_golde
 }
 
 #[test]
+fn emit_json_hir_multi_file_generic_imported_scoped_type_inference_schema_matches_golden() {
+    assert_hir_golden(
+        "tests/zen/multi_file_generic_imported_scoped_type_inference/main.zen",
+        "tests/fixtures/ir_json/hir_multi_file_generic_imported_scoped_type_inference.golden.json",
+        "multi-file imported generic scoped type inference input",
+    );
+}
+
+#[test]
 fn emit_json_hir_generic_recursive_function_schema_matches_golden() {
     assert_hir_golden(
         "tests/zen/generic_recursive_function.zen",

--- a/tests/integration/cli_build/frontend_json/layout_golden/generic.rs
+++ b/tests/integration/cli_build/frontend_json/layout_golden/generic.rs
@@ -90,3 +90,12 @@ fn emit_json_layout_multi_file_generic_imported_type_same_name_schema_matches_go
         "tests/fixtures/ir_json/layout_multi_file_generic_imported_type_same_name.golden.json",
     );
 }
+
+#[test]
+fn emit_json_layout_multi_file_generic_imported_scoped_type_inference_schema_matches_golden() {
+    assert_layout_matches_fixture(
+        &fixture("tests/zen/multi_file_generic_imported_scoped_type_inference/main.zen"),
+        "multi-file imported generic scoped type inference program input",
+        "tests/fixtures/ir_json/layout_multi_file_generic_imported_scoped_type_inference.golden.json",
+    );
+}


### PR DESCRIPTION
## What changed
- Added HIR and layout JSON goldens for `multi_file_generic_imported_scoped_type_inference/main.zen`.

## Why
This pins scoped generic type inference across imported modules without carrying the larger MIR golden. The HIR/layout now record `Box_i32`, `right_Box_i32`, and `Holder_right_Box_i32` as distinct concrete types, including their different field layouts.

## Validation
- `cargo test --test integration emit_json_hir_multi_file_generic_imported_scoped_type_inference_schema_matches_golden --quiet`
- `cargo test --test integration emit_json_layout_multi_file_generic_imported_scoped_type_inference_schema_matches_golden --quiet`
- `cargo test --test integration frontend_json --quiet`
- `cargo fmt --check`
- `git diff --check`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`\n- `cargo clippy -- -D warnings`\n- `cargo test --lib --quiet`\n- `cargo test --test docs_truth --quiet`\n- `cargo test --tests --quiet`