### PR TITLE
[codex] pin multifile result enum specialization lowering

### DIFF
--- a/tests/fixtures/ir_json/hir_multi_file_generic_result_multi_specialization.golden.json
+++ b/tests/fixtures/ir_json/hir_multi_file_generic_result_multi_specialization.golden.json
@@ -1,0 +1,99 @@
+{
+  "format": "zen.hir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "declarations": {
+    "types": [
+      {
+        "name": "Result_i32_StaticString",
+        "kind": "enum",
+        "fields": [],
+        "variants": [
+          {
+            "name": "Ok",
+            "tag": 0,
+            "payload": [
+              {
+                "name": "payload",
+                "type": "i32"
+              }
+            ]
+          },
+          {
+            "name": "Err",
+            "tag": 1,
+            "payload": [
+              {
+                "name": "payload",
+                "type": "StaticString"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Result_bool_StaticString",
+        "kind": "enum",
+        "fields": [],
+        "variants": [
+          {
+            "name": "Ok",
+            "tag": 0,
+            "payload": [
+              {
+                "name": "payload",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "Err",
+            "tag": 1,
+            "payload": [
+              {
+                "name": "payload",
+                "type": "StaticString"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "functions": [
+      {
+        "name": "main",
+        "params": [],
+        "return_type": "i32"
+      },
+      {
+        "name": "Result.unwrap_or_i32_StaticString",
+        "params": [
+          {
+            "name": "self",
+            "type": "Result_i32_StaticString"
+          },
+          {
+            "name": "fallback",
+            "type": "i32"
+          }
+        ],
+        "return_type": "i32"
+      },
+      {
+        "name": "Result.unwrap_or_bool_StaticString",
+        "params": [
+          {
+            "name": "self",
+            "type": "Result_bool_StaticString"
+          },
+          {
+            "name": "fallback",
+            "type": "bool"
+          }
+        ],
+        "return_type": "bool"
+      }
+    ],
+    "globals": []
+  }
+}

--- a/tests/fixtures/ir_json/mir_multi_file_generic_result_multi_specialization.golden.json
+++ b/tests/fixtures/ir_json/mir_multi_file_generic_result_multi_specialization.golden.json
@@ -1,0 +1,356 @@
+{
+  "format": "zen.mir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "lowering_status": "minimal",
+  "functions": [
+    {
+      "name": "main",
+      "params": [],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [
+            {
+              "kind": "let",
+              "name": "ok_int",
+              "type": "Result_i32_StaticString",
+              "mutable": false,
+              "value": {
+                "kind": "enum_variant",
+                "type": "Result_i32_StaticString",
+                "name": "Result_i32_StaticString.Ok",
+                "args": [
+                  {
+                    "kind": "int",
+                    "type": "i32",
+                    "value": 55
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "let",
+              "name": "err_int",
+              "type": "Result_i32_StaticString",
+              "mutable": false,
+              "value": {
+                "kind": "enum_variant",
+                "type": "Result_i32_StaticString",
+                "name": "Result_i32_StaticString.Err",
+                "args": [
+                  {
+                    "kind": "static_string",
+                    "type": "StaticString",
+                    "value": "bad"
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "let",
+              "name": "ok_bool",
+              "type": "Result_bool_StaticString",
+              "mutable": false,
+              "value": {
+                "kind": "enum_variant",
+                "type": "Result_bool_StaticString",
+                "name": "Result_bool_StaticString.Ok",
+                "args": [
+                  {
+                    "kind": "bool",
+                    "type": "bool",
+                    "value": false
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "let",
+              "name": "err_bool",
+              "type": "Result_bool_StaticString",
+              "mutable": false,
+              "value": {
+                "kind": "enum_variant",
+                "type": "Result_bool_StaticString",
+                "name": "Result_bool_StaticString.Err",
+                "args": [
+                  {
+                    "kind": "static_string",
+                    "type": "StaticString",
+                    "value": "nope"
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "expr",
+              "value": {
+                "kind": "call",
+                "type": "void",
+                "function": "io_println",
+                "args": [
+                  {
+                    "kind": "string_interpolation",
+                    "type": "StaticString",
+                    "value": {
+                      "parts": 1
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "expr",
+              "value": {
+                "kind": "call",
+                "type": "void",
+                "function": "io_println",
+                "args": [
+                  {
+                    "kind": "string_interpolation",
+                    "type": "StaticString",
+                    "value": {
+                      "parts": 1
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "expr",
+              "value": {
+                "kind": "call",
+                "type": "void",
+                "function": "io_println",
+                "args": [
+                  {
+                    "kind": "string_interpolation",
+                    "type": "StaticString",
+                    "value": {
+                      "parts": 1
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "expr",
+              "value": {
+                "kind": "call",
+                "type": "void",
+                "function": "io_println",
+                "args": [
+                  {
+                    "kind": "string_interpolation",
+                    "type": "StaticString",
+                    "value": {
+                      "parts": 1
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "int",
+              "type": "i32",
+              "value": 0
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Result.unwrap_or_i32_StaticString",
+      "params": [
+        {
+          "name": "self",
+          "type": "Result_i32_StaticString"
+        },
+        {
+          "name": "fallback",
+          "type": "i32"
+        }
+      ],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "match",
+              "type": "i32",
+              "target": {
+                "kind": "local",
+                "type": "Result_i32_StaticString",
+                "name": "self"
+              },
+              "match_kind": "enum",
+              "arms": [
+                {
+                  "pattern": {
+                    "kind": "enum_variant",
+                    "name": "Result_i32_StaticString.Ok",
+                    "bindings": [
+                      {
+                        "name": "value",
+                        "type": "i32"
+                      }
+                    ]
+                  },
+                  "body": {
+                    "label": "entry",
+                    "statements": [],
+                    "terminator": {
+                      "kind": "return",
+                      "value": {
+                        "kind": "block",
+                        "type": "i32",
+                        "value": {
+                          "has_result": true,
+                          "result": {
+                            "kind": "local",
+                            "name": "value",
+                            "type": "i32"
+                          },
+                          "statement_count": 0
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "pattern": {
+                    "kind": "enum_variant",
+                    "name": "Result_i32_StaticString.Err",
+                    "bindings": []
+                  },
+                  "body": {
+                    "label": "entry",
+                    "statements": [],
+                    "terminator": {
+                      "kind": "return",
+                      "value": {
+                        "kind": "block",
+                        "type": "i32",
+                        "value": {
+                          "has_result": true,
+                          "result": {
+                            "kind": "local",
+                            "name": "fallback",
+                            "type": "i32"
+                          },
+                          "statement_count": 0
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Result.unwrap_or_bool_StaticString",
+      "params": [
+        {
+          "name": "self",
+          "type": "Result_bool_StaticString"
+        },
+        {
+          "name": "fallback",
+          "type": "bool"
+        }
+      ],
+      "return_type": "bool",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "match",
+              "type": "bool",
+              "target": {
+                "kind": "local",
+                "type": "Result_bool_StaticString",
+                "name": "self"
+              },
+              "match_kind": "enum",
+              "arms": [
+                {
+                  "pattern": {
+                    "kind": "enum_variant",
+                    "name": "Result_bool_StaticString.Ok",
+                    "bindings": [
+                      {
+                        "name": "value",
+                        "type": "bool"
+                      }
+                    ]
+                  },
+                  "body": {
+                    "label": "entry",
+                    "statements": [],
+                    "terminator": {
+                      "kind": "return",
+                      "value": {
+                        "kind": "block",
+                        "type": "bool",
+                        "value": {
+                          "has_result": true,
+                          "result": {
+                            "kind": "local",
+                            "name": "value",
+                            "type": "bool"
+                          },
+                          "statement_count": 0
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "pattern": {
+                    "kind": "enum_variant",
+                    "name": "Result_bool_StaticString.Err",
+                    "bindings": []
+                  },
+                  "body": {
+                    "label": "entry",
+                    "statements": [],
+                    "terminator": {
+                      "kind": "return",
+                      "value": {
+                        "kind": "block",
+                        "type": "bool",
+                        "value": {
+                          "has_result": true,
+                          "result": {
+                            "kind": "local",
+                            "name": "fallback",
+                            "type": "bool"
+                          },
+                          "statement_count": 0
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/integration/cli_build/frontend_json/hir_golden/generic_enums.rs
+++ b/tests/integration/cli_build/frontend_json/hir_golden/generic_enums.rs
@@ -44,3 +44,12 @@ fn emit_json_hir_generic_result_multi_schema_matches_golden() {
         "generic Result multi-specialization",
     );
 }
+
+#[test]
+fn emit_json_hir_multi_file_generic_result_multi_schema_matches_golden() {
+    assert_hir_golden(
+        "tests/zen/multi_file_generic_result_enum_multi_specialization/main.zen",
+        "tests/fixtures/ir_json/hir_multi_file_generic_result_multi_specialization.golden.json",
+        "multi-file generic Result multi-specialization",
+    );
+}

--- a/tests/integration/cli_build/frontend_json/mir_golden/generic_enums.rs
+++ b/tests/integration/cli_build/frontend_json/mir_golden/generic_enums.rs
@@ -44,3 +44,12 @@ fn emit_json_mir_generic_result_multi_schema_matches_golden() {
         "generic Result multi-specialization",
     );
 }
+
+#[test]
+fn emit_json_mir_multi_file_generic_result_multi_schema_matches_golden() {
+    assert_mir_golden(
+        "tests/zen/multi_file_generic_result_enum_multi_specialization/main.zen",
+        "tests/fixtures/ir_json/mir_multi_file_generic_result_multi_specialization.golden.json",
+        "multi-file generic Result multi-specialization",
+    );
+}


### PR DESCRIPTION
## What changed
- Added HIR and MIR JSON goldens for `multi_file_generic_result_enum_multi_specialization/main.zen`.

## Why
This pins multi-file `Result<T, E>` enum multi-specialization beyond generated-C and layout coverage. The fixtures now record both `Result_i32_StaticString` and `Result_bool_StaticString` plus their concrete `Result.unwrap_or_*` method bodies.

## Validation
- `cargo test --test integration emit_json_hir_multi_file_generic_result_multi_schema_matches_golden --quiet`
- `cargo test --test integration emit_json_mir_multi_file_generic_result_multi_schema_matches_golden --quiet`
- `cargo test --test integration frontend_json --quiet`
- `cargo fmt --check`
- `git diff --check`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`\n- `cargo clippy -- -D warnings`\n- `cargo test --lib --quiet`\n- `cargo test --test docs_truth --quiet`\n- `cargo test --tests --quiet`