### PR TITLE
[codex] cover multifile enum method worklist

### DIFF
--- a/tests/integration/generic_specializations/multifile_generated_c/enum_dependencies.rs
+++ b/tests/integration/generic_specializations/multifile_generated_c/enum_dependencies.rs
@@ -101,3 +101,32 @@ fn multi_file_generic_enum_specializations_do_not_emit_unspecialized_c_symbols()
     assert!(!c_source.contains("Box_T"));
     assert!(!c_source.contains("Choice_T"));
 }
+
+#[test]
+fn multi_file_generic_enum_method_worklist_specializations_emit_reachable_methods_once() {
+    let c_source = compile_to_c_with_generated_call_check(
+        &test_dir().join("multi_file_generic_enum_method_worklist/main.zen"),
+    );
+
+    assert!(c_source.contains("typedef struct Option_i32 Option_i32;"));
+    assert!(c_source.contains("typedef struct Option_bool Option_bool;"));
+    assert!(c_source.contains("int32_t Option_value_or_i32(Option_i32 self, int32_t fallback)"));
+    assert!(c_source.contains("int32_t Option_unwrap_or_i32(Option_i32 self, int32_t fallback)"));
+    assert!(c_source.contains("bool Option_value_or_bool(Option_bool self, bool fallback)"));
+    assert!(c_source.contains("bool Option_unwrap_or_bool(Option_bool self, bool fallback)"));
+    assert!(c_source.contains("Option_value_or_i32(some_int, 0LL)"));
+    assert!(c_source.contains("Option_value_or_i32(none_int, 97LL)"));
+    assert!(c_source.contains("Option_value_or_bool(some_bool, false)"));
+    assert!(c_source.contains("Option_value_or_bool(none_bool, true)"));
+    assert!(c_source.contains("Option_unwrap_or_i32(self, fallback)"));
+    assert!(c_source.contains("Option_unwrap_or_bool(self, fallback)"));
+    assert_c_call_resolves_to_single_definition(&c_source, "Option_value_or_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Option_unwrap_or_i32");
+    assert_c_call_resolves_to_single_definition(&c_source, "Option_value_or_bool");
+    assert_c_call_resolves_to_single_definition(&c_source, "Option_unwrap_or_bool");
+    assert!(!c_source.contains("Option_T"));
+    assert!(!c_source.contains("T Option_value_or"));
+    assert!(!c_source.contains("T Option_unwrap_or"));
+    assert!(!c_source.contains("Option_value_or(some"));
+    assert!(!c_source.contains("Option_unwrap_or(self"));
+}

--- a/tests/integration/multi_file_phase5_fixtures.rs
+++ b/tests/integration/multi_file_phase5_fixtures.rs
@@ -57,6 +57,13 @@ fn test_multi_file_generic_enum_method_imports() {
 }
 
 #[test]
+fn test_multi_file_generic_enum_method_worklist_imports() {
+    let zen_path = test_dir().join("multi_file_generic_enum_method_worklist/main.zen");
+    let actual = compile_and_run(&zen_path);
+    assert_eq!(actual, "31\n97\ntrue\ntrue\n");
+}
+
+#[test]
 fn test_multi_file_generic_result_enum_method_imports() {
     let zen_path = test_dir().join("multi_file_generic_result_enum_method/main.zen");
     let actual = compile_and_run(&zen_path);

--- a/tests/zen/multi_file_generic_enum_method_worklist/main.zen
+++ b/tests/zen/multi_file_generic_enum_method_worklist/main.zen
@@ -1,0 +1,15 @@
+{ io } = std
+{ Option } = option
+
+main = () i32 {
+    some_int = Option<i32>.Some(31)
+    none_int = Option<i32>.None
+    some_bool = Option<bool>.Some(true)
+    none_bool = Option<bool>.None
+
+    io.println("${some_int.value_or(0)}")
+    io.println("${none_int.value_or(97)}")
+    io.println("${some_bool.value_or(false)}")
+    io.println("${none_bool.value_or(true)}")
+    0
+}

--- a/tests/zen/multi_file_generic_enum_method_worklist/option.zen
+++ b/tests/zen/multi_file_generic_enum_method_worklist/option.zen
@@ -1,0 +1,13 @@
+pub Option<T>:
+    None,
+    Some(T)
+
+pub Option.unwrap_or<T> = (self: Self, fallback: T) T {
+    self ?
+        | Some(value) { value }
+        | None { fallback }
+}
+
+pub Option.value_or<T> = (self: Self, fallback: T) T {
+    self.unwrap_or<T>(fallback)
+}


### PR DESCRIPTION
## What changed
- Added a multi-file `Option<T>` fixture where `Option.value_or<T>` calls `Option.unwrap_or<T>` inside its generic method body.
- Covered both `i32` and `bool` instantiations with generated-C and executable tests.

## Why
This pins a missing Phase 5 worklist case: imported generic enum methods need to enqueue and emit other reachable generic enum methods for every concrete instantiation.

## Validation
- `cargo test --test integration multi_file_generic_enum_method_worklist_specializations_emit_reachable_methods_once --quiet`
- `cargo test --test integration test_multi_file_generic_enum_method_worklist_imports --quiet`
- `cargo test --test integration generic_specializations::multifile_generated_c::enum_dependencies --quiet`
- `cargo test --test integration multi_file_phase5_fixtures --quiet`
- `cargo test --test integration generic_specialization --quiet`
- `cargo fmt --check`
- `git diff --check`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`\n- `cargo clippy -- -D warnings`\n- `cargo test --lib --quiet`\n- `cargo test --test docs_truth --quiet`\n- `cargo test --tests --quiet`