### PR TITLE
[codex] cover multifile result error specialization

### DIFF
--- a/tests/fixtures/ir_json/layout_multi_file_generic_result_error_multi_specialization.golden.json
+++ b/tests/fixtures/ir_json/layout_multi_file_generic_result_error_multi_specialization.golden.json
@@ -1,0 +1,145 @@
+{
+  "format": "zen.layout.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "target": {
+    "pointer_size": 8,
+    "pointer_alignment": 8,
+    "usize_size": 8
+  },
+  "layouts": {
+    "Result_i32_bool": {
+      "kind": "enum",
+      "size": 8,
+      "alignment": 4,
+      "variants": [
+        {
+          "name": "Ok",
+          "tag": 0,
+          "payload_fields": [
+            {
+              "name": "payload",
+              "type": "i32",
+              "offset": 0
+            }
+          ]
+        },
+        {
+          "name": "Err",
+          "tag": 1,
+          "payload_fields": [
+            {
+              "name": "payload",
+              "type": "bool",
+              "offset": 0
+            }
+          ]
+        }
+      ]
+    },
+    "Result_i32_i32": {
+      "kind": "enum",
+      "size": 8,
+      "alignment": 4,
+      "variants": [
+        {
+          "name": "Ok",
+          "tag": 0,
+          "payload_fields": [
+            {
+              "name": "payload",
+              "type": "i32",
+              "offset": 0
+            }
+          ]
+        },
+        {
+          "name": "Err",
+          "tag": 1,
+          "payload_fields": [
+            {
+              "name": "payload",
+              "type": "i32",
+              "offset": 0
+            }
+          ]
+        }
+      ]
+    },
+    "StaticString": {
+      "kind": "static_string",
+      "size": 16,
+      "alignment": 8
+    },
+    "String": {
+      "kind": "dynamic_string",
+      "size": 32,
+      "alignment": 8
+    },
+    "bool": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "f32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "f64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "i16": {
+      "kind": "primitive",
+      "size": 2,
+      "alignment": 2
+    },
+    "i32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "i64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "i8": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "u16": {
+      "kind": "primitive",
+      "size": 2,
+      "alignment": 2
+    },
+    "u32": {
+      "kind": "primitive",
+      "size": 4,
+      "alignment": 4
+    },
+    "u64": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "u8": {
+      "kind": "primitive",
+      "size": 1,
+      "alignment": 1
+    },
+    "usize": {
+      "kind": "primitive",
+      "size": 8,
+      "alignment": 8
+    },
+    "void": {
+      "kind": "primitive",
+      "size": 0,
+      "alignment": 1
+    }
+  }
+}

--- a/tests/integration/cli_build/frontend_json/layout_golden/generic.rs
+++ b/tests/integration/cli_build/frontend_json/layout_golden/generic.rs
@@ -83,6 +83,15 @@ fn emit_json_layout_multi_file_generic_result_multi_specialization_schema_matche
 }
 
 #[test]
+fn emit_json_layout_multi_file_generic_result_error_multi_specialization_schema_matches_golden() {
+    assert_layout_matches_fixture(
+        &fixture("tests/zen/multi_file_generic_result_error_multi_specialization/main.zen"),
+        "multi-file generic Result error multi-specialization program input",
+        "tests/fixtures/ir_json/layout_multi_file_generic_result_error_multi_specialization.golden.json",
+    );
+}
+
+#[test]
 fn emit_json_layout_multi_file_generic_imported_type_same_name_schema_matches_golden() {
     assert_layout_matches_fixture(
         &fixture("tests/zen/multi_file_generic_imported_type_same_name_collision/main.zen"),

--- a/tests/integration/generic_specializations/multifile_generated_c/enum_dependencies.rs
+++ b/tests/integration/generic_specializations/multifile_generated_c/enum_dependencies.rs
@@ -130,3 +130,28 @@ fn multi_file_generic_enum_method_worklist_specializations_emit_reachable_method
     assert!(!c_source.contains("Option_value_or(some"));
     assert!(!c_source.contains("Option_unwrap_or(self"));
 }
+
+#[test]
+fn multi_file_generic_result_error_type_specializations_do_not_collapse() {
+    let c_source = compile_to_c_with_generated_call_check(
+        &test_dir().join("multi_file_generic_result_error_multi_specialization/main.zen"),
+    );
+
+    assert!(c_source.contains("typedef struct Result_i32_bool Result_i32_bool;"));
+    assert!(c_source.contains("typedef struct Result_i32_i32 Result_i32_i32;"));
+    assert!(
+        c_source.contains("bool Result_unwrap_err_i32_bool(Result_i32_bool self, bool fallback)")
+    );
+    assert!(c_source
+        .contains("int32_t Result_unwrap_err_i32_i32(Result_i32_i32 self, int32_t fallback)"));
+    assert!(c_source.contains("Result_unwrap_err_i32_bool(err_bool, false)"));
+    assert!(c_source.contains("Result_unwrap_err_i32_bool(ok_bool, false)"));
+    assert!(c_source.contains("Result_unwrap_err_i32_i32(err_i32, 0LL)"));
+    assert!(c_source.contains("Result_unwrap_err_i32_i32(ok_i32, 88LL)"));
+    assert_c_call_resolves_to_single_definition(&c_source, "Result_unwrap_err_i32_bool");
+    assert_c_call_resolves_to_single_definition(&c_source, "Result_unwrap_err_i32_i32");
+    assert!(!c_source.contains("Result_T"));
+    assert!(!c_source.contains("Result_i32_E"));
+    assert!(!c_source.contains("E Result_unwrap_err"));
+    assert!(!c_source.contains("Result_unwrap_err(err"));
+}

--- a/tests/integration/multi_file_phase5_fixtures.rs
+++ b/tests/integration/multi_file_phase5_fixtures.rs
@@ -78,6 +78,13 @@ fn test_multi_file_generic_result_enum_multi_specialization_imports() {
 }
 
 #[test]
+fn test_multi_file_generic_result_error_multi_specialization_imports() {
+    let zen_path = test_dir().join("multi_file_generic_result_error_multi_specialization/main.zen");
+    let actual = compile_and_run(&zen_path);
+    assert_eq!(actual, "true\nfalse\n44\n88\n");
+}
+
+#[test]
 fn test_multi_file_imported_scoped_generic_type_inference_ufc() {
     let zen_path = test_dir().join("multi_file_generic_imported_scoped_type_inference/main.zen");
     let actual = compile_and_run(&zen_path);

--- a/tests/zen/multi_file_generic_result_error_multi_specialization/main.zen
+++ b/tests/zen/multi_file_generic_result_error_multi_specialization/main.zen
@@ -1,0 +1,15 @@
+{ io } = std
+{ Result } = result
+
+main = () i32 {
+    err_bool = Result<i32, bool>.Err(true)
+    ok_bool = Result<i32, bool>.Ok(12)
+    err_i32 = Result<i32, i32>.Err(44)
+    ok_i32 = Result<i32, i32>.Ok(5)
+
+    io.println("${err_bool.unwrap_err(false)}")
+    io.println("${ok_bool.unwrap_err(false)}")
+    io.println("${err_i32.unwrap_err(0)}")
+    io.println("${ok_i32.unwrap_err(88)}")
+    0
+}

--- a/tests/zen/multi_file_generic_result_error_multi_specialization/result.zen
+++ b/tests/zen/multi_file_generic_result_error_multi_specialization/result.zen
@@ -1,0 +1,9 @@
+pub Result<T, E>:
+    Ok(T),
+    Err(E)
+
+pub Result.unwrap_err<T, E> = (self: Self, fallback: E) E {
+    self ?
+        | Ok(_) { fallback }
+        | Err(error) { error }
+}


### PR DESCRIPTION
## What changed
- Added a multi-file `Result<T, E>` fixture where `T` remains `i32` while `E` specializes as `bool` and `i32`.
- Added generated-C, executable, and layout-golden coverage for the distinct error-type specializations.

## Why
Existing Result multi-specialization coverage varied `T` while keeping `E = StaticString`. This proves the error type participates in specialization and does not collapse to a generic or stale concrete type.

## Validation
- `cargo test --test integration multi_file_generic_result_error_type_specializations_do_not_collapse --quiet`
- `cargo test --test integration test_multi_file_generic_result_error_multi_specialization_imports --quiet`
- `cargo test --test integration emit_json_layout_multi_file_generic_result_error_multi_specialization_schema_matches_golden --quiet`
- `cargo test --test integration result_error --quiet`
- `cargo test --test integration generic_specializations::multifile_generated_c::enum_dependencies --quiet`
- `cargo test --test integration multi_file_phase5_fixtures --quiet`
- `cargo test --test integration generic_specialization --quiet`
- `cargo test --test integration frontend_json --quiet`
- `cargo fmt --check`
- `git diff --check`
- `find src tests -name '*.rs' -print0 | xargs -0 wc -l | awk '$1 >= 250 && $2 != "total" { print }'`\n- `cargo clippy -- -D warnings`\n- `cargo test --lib --quiet`\n- `cargo test --test docs_truth --quiet`\n- `cargo test --tests --quiet`