### PR TITLE
[codex] reject generic target behavior overlaps

### DIFF
--- a/src/typechecker/behavior_impl_validation/generic_templates.rs
+++ b/src/typechecker/behavior_impl_validation/generic_templates.rs
@@ -1,6 +1,9 @@
+mod coherence;
+mod method_lookup;
 mod type_matching;
 
 use super::*;
+use method_lookup::{generic_behavior_actual_method, GenericBehaviorActualMethod};
 use type_matching::{generic_impl_ast_types_compatible, generic_impl_type_display};
 
 #[derive(Clone, Copy)]
@@ -10,12 +13,6 @@ struct GenericBehaviorImplTemplateContext<'a> {
     behavior: &'a str,
     behavior_type_args: &'a [AstType],
     methods: &'a [Declaration],
-    span: Span,
-}
-
-struct GenericBehaviorActualMethod<'a> {
-    params: &'a [Param],
-    return_type: &'a Option<AstType>,
     span: Span,
 }
 
@@ -69,6 +66,15 @@ impl TypeChecker {
         else {
             return;
         };
+        if self.reject_generic_behavior_impl_coherence_conflict(
+            type_name,
+            type_args,
+            behavior,
+            behavior_type_args,
+            span,
+        ) {
+            return;
+        }
         let required_methods =
             self.behavior_methods_for_impl(behavior, &behavior_substitutions, &mut HashSet::new());
 
@@ -82,6 +88,7 @@ impl TypeChecker {
         };
         self.check_generic_behavior_extra_methods(&context, &required_methods);
         self.check_generic_behavior_required_methods(context, &required_methods);
+        self.record_generic_behavior_impl_ref(behavior, behavior_type_args);
         self.generic_behavior_impls
             .push(GenericBehaviorImplTemplate {
                 type_name: type_name.to_string(),
@@ -216,24 +223,4 @@ impl TypeChecker {
             ));
         }
     }
-}
-
-fn generic_behavior_actual_method<'a>(
-    methods: &'a [Declaration],
-    required_name: &str,
-) -> Option<GenericBehaviorActualMethod<'a>> {
-    methods.iter().find_map(|method| match method {
-        Declaration::Function {
-            name,
-            params,
-            return_type,
-            span,
-            ..
-        } if name == required_name => Some(GenericBehaviorActualMethod {
-            params: params.as_slice(),
-            return_type,
-            span: *span,
-        }),
-        _ => None,
-    })
 }

--- a/src/typechecker/behavior_impl_validation/generic_templates/coherence.rs
+++ b/src/typechecker/behavior_impl_validation/generic_templates/coherence.rs
@@ -1,0 +1,103 @@
+use super::*;
+
+impl TypeChecker {
+    pub(super) fn reject_generic_behavior_impl_coherence_conflict(
+        &mut self,
+        type_name: &str,
+        type_args: &[AstType],
+        behavior: &str,
+        behavior_type_args: &[AstType],
+        span: Span,
+    ) -> bool {
+        let behavior_ref = self.behavior_parent_ref(behavior, behavior_type_args);
+        if self.generic_behavior_impls.iter().any(|implementation| {
+            implementation.type_name == type_name && {
+                let existing = self.behavior_parent_ref(
+                    &implementation.behavior,
+                    &implementation.behavior_type_args,
+                );
+                existing.key == behavior_ref.key
+            }
+        }) {
+            self.diagnostics.push(Diagnostic::error(
+                "E6003",
+                format!(
+                    "duplicate implementation of behavior `{}` for generic type `{}`",
+                    behavior_ref.key,
+                    generic_target_display(type_name, type_args)
+                ),
+                span,
+            ));
+            return true;
+        }
+
+        if let Some(existing) =
+            self.find_overlapping_generic_behavior_impl(type_name, &behavior_ref)
+        {
+            self.diagnostics.push(Diagnostic::error(
+                "E6010",
+                format!(
+                    "overlapping implementations of behaviors `{}` and `{}` for generic type `{}`",
+                    existing,
+                    behavior_ref.key,
+                    generic_target_display(type_name, type_args)
+                ),
+                span,
+            ));
+            return true;
+        }
+
+        false
+    }
+
+    pub(super) fn record_generic_behavior_impl_ref(
+        &mut self,
+        behavior: &str,
+        behavior_type_args: &[AstType],
+    ) {
+        let behavior_ref = self.behavior_parent_ref(behavior, behavior_type_args);
+        self.behavior_refs_by_key
+            .insert(behavior_ref.key.clone(), behavior_ref);
+    }
+
+    fn find_overlapping_generic_behavior_impl(
+        &self,
+        type_name: &str,
+        behavior_ref: &BehaviorParentRef,
+    ) -> Option<String> {
+        self.generic_behavior_impls
+            .iter()
+            .filter(|implementation| implementation.type_name == type_name)
+            .map(|implementation| {
+                self.behavior_parent_ref(
+                    &implementation.behavior,
+                    &implementation.behavior_type_args,
+                )
+            })
+            .find(|existing| {
+                self.behavior_ref_inherits_from_inner(
+                    existing,
+                    &behavior_ref.key,
+                    &mut HashSet::new(),
+                ) || self.behavior_ref_inherits_from_inner(
+                    behavior_ref,
+                    &existing.key,
+                    &mut HashSet::new(),
+                )
+            })
+            .map(|existing| existing.key)
+    }
+}
+
+fn generic_target_display(type_name: &str, type_args: &[AstType]) -> String {
+    if type_args.is_empty() {
+        return type_name.to_string();
+    }
+
+    let args = type_args
+        .iter()
+        .map(AstType::display_name)
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("{type_name}<{args}>")
+}

--- a/src/typechecker/behavior_impl_validation/generic_templates/method_lookup.rs
+++ b/src/typechecker/behavior_impl_validation/generic_templates/method_lookup.rs
@@ -1,0 +1,27 @@
+use super::*;
+
+pub(super) struct GenericBehaviorActualMethod<'a> {
+    pub(super) params: &'a [Param],
+    pub(super) return_type: &'a Option<AstType>,
+    pub(super) span: Span,
+}
+
+pub(super) fn generic_behavior_actual_method<'a>(
+    methods: &'a [Declaration],
+    required_name: &str,
+) -> Option<GenericBehaviorActualMethod<'a>> {
+    methods.iter().find_map(|method| match method {
+        Declaration::Function {
+            name,
+            params,
+            return_type,
+            span,
+            ..
+        } if name == required_name => Some(GenericBehaviorActualMethod {
+            params: params.as_slice(),
+            return_type,
+            span: *span,
+        }),
+        _ => None,
+    })
+}

--- a/src/typechecker/tests/generic_behaviors/generic_target_impls.rs
+++ b/src/typechecker/tests/generic_behaviors/generic_target_impls.rs
@@ -118,3 +118,41 @@ main = () i32 {
         .check_program(&program)
         .expect("generic child behavior impl should satisfy inherited parent bound");
 }
+
+#[test]
+fn generic_target_behavior_impl_rejects_parent_child_overlap() {
+    let program = parse_program(
+        r#"
+Json<T>: behavior {
+    encode: (Self) T
+}
+
+Pretty<T>: behavior {
+    pretty: (Self) T
+}
+
+Pretty.extends(Json<T>)
+
+Box<T>: { value: T }
+
+Box<T>.implements(Json<T>) {
+    encode = (self: Box<T>) T { self.value }
+}
+
+Box<T>.implements(Pretty<T>) {
+    encode = (self: Box<T>) T { self.value }
+    pretty = (self: Box<T>) T { self.value }
+}
+"#,
+    );
+
+    let errors = TypeChecker::new()
+        .check_program(&program)
+        .expect_err("generic target parent/child behavior overlap should fail");
+    assert!(
+        errors.iter().any(|d| d.message.contains(
+            "overlapping implementations of behaviors `Json_T` and `Pretty_T` for generic type `Box<T>`"
+        )),
+        "expected generic target behavior overlap diagnostic, got {errors:?}"
+    );
+}


### PR DESCRIPTION
## What changed
- Added a generic target behavior coherence check so `Box<T>.implements(Json<T>)` and `Box<T>.implements(Pretty<T>)` conflict when `Pretty<T>` inherits `Json<T>`.
- Split generic behavior impl validation helpers into focused `coherence` and `method_lookup` modules to keep file-size hygiene clean.
- Added a failing-first unit test covering parent/child overlap for generic target behavior impl templates.

## Validation
- `cargo fmt --check`
- `git diff --check`
- Rust source size guard and tracked `.zen` source size guard
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --test docs_truth --quiet`
- `cargo test --tests --quiet`
