### PR TITLE
[codex] detect generic behavior inheritance cycles

### DIFF
--- a/src/typechecker/behavior_associations/inheritance.rs
+++ b/src/typechecker/behavior_associations/inheritance.rs
@@ -38,7 +38,7 @@ impl TypeChecker {
         let has_cycle = self.behavior_extends.get(behavior).is_some_and(|parents| {
             parents
                 .iter()
-                .any(|parent| self.behavior_extends_has_cycle(&parent.key, visiting, visited))
+                .any(|parent| self.behavior_extends_has_cycle(&parent.behavior, visiting, visited))
         });
         visiting.remove(behavior);
         has_cycle

--- a/src/typechecker/tests/generic_behaviors/extends/diagnostics/inheritance_edges.rs
+++ b/src/typechecker/tests/generic_behaviors/extends/diagnostics/inheritance_edges.rs
@@ -29,6 +29,34 @@ PrettyJson.extends(Json)
 }
 
 #[test]
+fn generic_behavior_extends_cycle_is_error() {
+    let program = parse_program(
+        r#"
+Json<T>: behavior {
+    encode: (Self) T
+}
+
+Pretty<T>: behavior {
+    pretty: (Self) T
+}
+
+Json.extends(Pretty<T>)
+Pretty.extends(Json<T>)
+"#,
+    );
+
+    let errors = TypeChecker::new()
+        .check_program(&program)
+        .expect_err("cyclic generic behavior inheritance should fail");
+    assert!(
+        errors
+            .iter()
+            .any(|d| d.message.contains("behavior inheritance cycle")),
+        "expected generic behavior inheritance cycle diagnostic, got {errors:?}"
+    );
+}
+
+#[test]
 fn behavior_extends_duplicate_parent_is_error() {
     let program = parse_program(
         r#"


### PR DESCRIPTION
## What changed

- Make behavior inheritance cycle traversal follow the parent behavior name instead of the mangled parent ref key.
- Add a regression for a generic cycle through `Json.extends(Pretty<T>)` and `Pretty.extends(Json<T>)`.

## Why

Generic parent refs are stored with keys such as `Pretty_T`, while the inheritance graph is indexed by bare behavior names. Following the key caused generic cycles to be missed.

## Validation

- `cargo fmt --check`
- `git diff --check`
- Rust/Zen file-size guards
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --test docs_truth --quiet`
- `cargo test --tests --quiet`
