### PR TITLE
[codex] allow self in behavior impl signatures

### DIFF
--- a/src/typechecker/behavior_impl_support.rs
+++ b/src/typechecker/behavior_impl_support.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 mod default_methods;
+mod type_matching;
 
 impl TypeChecker {
     pub(super) fn resolver_impl_ref_for(

--- a/src/typechecker/behavior_impl_support/default_methods.rs
+++ b/src/typechecker/behavior_impl_support/default_methods.rs
@@ -194,8 +194,10 @@ impl TypeChecker {
         actual: &AstType,
         self_type_name: &str,
     ) -> bool {
-        match expected {
-            AstType::SelfType => matches!(actual, AstType::Named(name) if name == self_type_name),
+        match (expected, actual) {
+            (AstType::SelfType, AstType::SelfType) => true,
+            (AstType::SelfType, AstType::Named(name))
+            | (AstType::Named(name), AstType::SelfType) => name == self_type_name,
             _ => expected == actual,
         }
     }

--- a/src/typechecker/behavior_impl_support/default_methods.rs
+++ b/src/typechecker/behavior_impl_support/default_methods.rs
@@ -187,31 +187,6 @@ impl TypeChecker {
             .collect();
         self.behavior_type_param_substitutions(&parent.behavior, &parent_type_args)
     }
-
-    pub(in crate::typechecker) fn impl_ast_types_compatible(
-        &self,
-        expected: &AstType,
-        actual: &AstType,
-        self_type_name: &str,
-    ) -> bool {
-        match (expected, actual) {
-            (AstType::SelfType, AstType::SelfType) => true,
-            (AstType::SelfType, AstType::Named(name))
-            | (AstType::Named(name), AstType::SelfType) => name == self_type_name,
-            _ => expected == actual,
-        }
-    }
-
-    pub(in crate::typechecker) fn impl_type_display(
-        &self,
-        ty: &AstType,
-        self_type_name: &str,
-    ) -> String {
-        match ty {
-            AstType::SelfType => self_type_name.to_string(),
-            _ => ty.display_name(),
-        }
-    }
 }
 
 fn default_behavior_type_params(type_args: &[AstType]) -> Vec<ast::TypeParam> {

--- a/src/typechecker/behavior_impl_support/type_matching.rs
+++ b/src/typechecker/behavior_impl_support/type_matching.rs
@@ -1,0 +1,22 @@
+use super::*;
+
+impl TypeChecker {
+    pub(in crate::typechecker) fn impl_ast_types_compatible(
+        &self,
+        expected: &AstType,
+        actual: &AstType,
+        self_type_name: &str,
+    ) -> bool {
+        let expected = concrete_self_ast_type_for_target(expected, self_type_name, &[]);
+        let actual = concrete_self_ast_type_for_target(actual, self_type_name, &[]);
+        expected == actual
+    }
+
+    pub(in crate::typechecker) fn impl_type_display(
+        &self,
+        ty: &AstType,
+        self_type_name: &str,
+    ) -> String {
+        concrete_self_ast_type_for_target(ty, self_type_name, &[]).display_name()
+    }
+}

--- a/src/typechecker/behavior_impl_validation/generic_templates/type_matching.rs
+++ b/src/typechecker/behavior_impl_validation/generic_templates/type_matching.rs
@@ -6,10 +6,11 @@ pub(super) fn generic_impl_ast_types_compatible(
     type_name: &str,
     target_type_args: &[AstType],
 ) -> bool {
+    let self_type = generic_impl_self_type(type_name, target_type_args);
     match (expected, actual) {
-        (AstType::SelfType, actual) => {
-            actual == &generic_impl_self_type(type_name, target_type_args)
-        }
+        (AstType::SelfType, AstType::SelfType) => true,
+        (AstType::SelfType, actual) => actual == &self_type,
+        (expected, AstType::SelfType) => expected == &self_type,
         (
             AstType::Generic {
                 name,

--- a/src/typechecker/behavior_impl_validation/generic_templates/type_matching.rs
+++ b/src/typechecker/behavior_impl_validation/generic_templates/type_matching.rs
@@ -1,4 +1,5 @@
 use crate::ast::AstType;
+use crate::typechecker::concrete_self_ast_type_for_target;
 
 pub(super) fn generic_impl_ast_types_compatible(
     expected: &AstType,
@@ -6,80 +7,9 @@ pub(super) fn generic_impl_ast_types_compatible(
     type_name: &str,
     target_type_args: &[AstType],
 ) -> bool {
-    let self_type = generic_impl_self_type(type_name, target_type_args);
-    match (expected, actual) {
-        (AstType::SelfType, AstType::SelfType) => true,
-        (AstType::SelfType, actual) => actual == &self_type,
-        (expected, AstType::SelfType) => expected == &self_type,
-        (
-            AstType::Generic {
-                name,
-                type_args: expected_args,
-            },
-            AstType::Generic {
-                name: actual_name,
-                type_args: actual_args,
-            },
-        ) => {
-            name == actual_name
-                && generic_impl_ast_type_slices_compatible(
-                    expected_args,
-                    actual_args,
-                    type_name,
-                    target_type_args,
-                )
-        }
-        (
-            AstType::Array { elem, size },
-            AstType::Array {
-                elem: actual,
-                size: actual_size,
-            },
-        ) => {
-            size == actual_size
-                && generic_impl_ast_types_compatible(elem, actual, type_name, target_type_args)
-        }
-        (AstType::Slice(inner), AstType::Slice(actual))
-        | (AstType::Ptr(inner), AstType::Ptr(actual))
-        | (AstType::MutPtr(inner), AstType::MutPtr(actual))
-        | (AstType::RawPtr(inner), AstType::RawPtr(actual)) => {
-            generic_impl_ast_types_compatible(inner, actual, type_name, target_type_args)
-        }
-        (
-            AstType::Function { params, ret },
-            AstType::Function {
-                params: actual,
-                ret: actual_ret,
-            },
-        ) => {
-            generic_impl_ast_type_slices_compatible(params, actual, type_name, target_type_args)
-                && generic_impl_ast_types_compatible(ret, actual_ret, type_name, target_type_args)
-        }
-        _ => expected == actual,
-    }
-}
-
-fn generic_impl_ast_type_slices_compatible(
-    expected: &[AstType],
-    actual: &[AstType],
-    type_name: &str,
-    target_type_args: &[AstType],
-) -> bool {
-    expected.len() == actual.len()
-        && expected.iter().zip(actual).all(|(expected, actual)| {
-            generic_impl_ast_types_compatible(expected, actual, type_name, target_type_args)
-        })
-}
-
-fn generic_impl_self_type(type_name: &str, type_args: &[AstType]) -> AstType {
-    if type_args.is_empty() {
-        AstType::Named(type_name.to_string())
-    } else {
-        AstType::Generic {
-            name: type_name.to_string(),
-            type_args: type_args.to_vec(),
-        }
-    }
+    let expected = concrete_self_ast_type_for_target(expected, type_name, target_type_args);
+    let actual = concrete_self_ast_type_for_target(actual, type_name, target_type_args);
+    expected == actual
 }
 
 pub(super) fn generic_impl_type_display(
@@ -87,8 +17,5 @@ pub(super) fn generic_impl_type_display(
     type_name: &str,
     type_args: &[AstType],
 ) -> String {
-    match ty {
-        AstType::SelfType => generic_impl_self_type(type_name, type_args).display_name(),
-        _ => ty.display_name(),
-    }
+    concrete_self_ast_type_for_target(ty, type_name, type_args).display_name()
 }

--- a/src/typechecker/tests/generic_behaviors.rs
+++ b/src/typechecker/tests/generic_behaviors.rs
@@ -6,6 +6,7 @@ mod generic_bounds;
 mod generic_function_diagnostics;
 mod generic_target_alpha_impls;
 mod generic_target_impls;
+mod impl_self_types;
 mod impl_type_args;
 mod impls_and_requires;
 mod requires;

--- a/src/typechecker/tests/generic_behaviors/generic_target_impls.rs
+++ b/src/typechecker/tests/generic_behaviors/generic_target_impls.rs
@@ -49,6 +49,58 @@ Box<T>.implements(Json<T>) {
 }
 
 #[test]
+fn generic_target_behavior_impl_accepts_nested_self_types() {
+    let program = parse_program(
+        r#"
+Holder<T>: { value: T }
+
+Json<T>: behavior {
+    take: (Holder<Self>) T
+}
+
+Box<T>: { value: T }
+
+Box<T>.implements(Json<T>) {
+    take = (holder: Holder<Self>) T { holder.value.value }
+}
+"#,
+    );
+
+    TypeChecker::new()
+        .check_program(&program)
+        .expect("generic target behavior impl may use nested Self");
+}
+
+#[test]
+fn generic_target_behavior_impl_rejects_nested_type_arg_shape() {
+    let program = parse_program(
+        r#"
+Holder<T>: { value: T }
+
+Json<T>: behavior {
+    take: (Holder<Self>) T
+}
+
+Box<T>: { value: T }
+
+Box<T>.implements(Json<T>) {
+    take = (holder: Holder<T>) T { holder.value }
+}
+"#,
+    );
+
+    let errors = TypeChecker::new()
+        .check_program(&program)
+        .expect_err("generic target behavior impl nested mismatch should fail");
+    assert!(
+        errors.iter().any(|d| d.message.contains(
+            "parameter 1 for method `take` in behavior `Json<T>` expects `Holder<Box<T>>`, found `Holder<T>`"
+        )),
+        "expected generic target behavior impl nested diagnostic, got {errors:?}"
+    );
+}
+
+#[test]
 fn generic_target_behavior_impl_checks_return_shape() {
     let program = parse_program(
         r#"

--- a/src/typechecker/tests/generic_behaviors/generic_target_impls.rs
+++ b/src/typechecker/tests/generic_behaviors/generic_target_impls.rs
@@ -28,6 +28,27 @@ Box<T>.implements(Json<T>) {
 }
 
 #[test]
+fn generic_target_behavior_impl_accepts_self_parameter() {
+    let program = parse_program(
+        r#"
+Json<T>: behavior {
+    encode: (Self) T
+}
+
+Box<T>: { value: T }
+
+Box<T>.implements(Json<T>) {
+    encode = (self: Self) T { self.value }
+}
+"#,
+    );
+
+    TypeChecker::new()
+        .check_program(&program)
+        .expect("generic target behavior impl method may use Self for the impl target");
+}
+
+#[test]
 fn generic_target_behavior_impl_checks_return_shape() {
     let program = parse_program(
         r#"

--- a/src/typechecker/tests/generic_behaviors/impl_self_types.rs
+++ b/src/typechecker/tests/generic_behaviors/impl_self_types.rs
@@ -1,0 +1,50 @@
+use super::*;
+
+#[test]
+fn behavior_impl_required_method_accepts_self_parameter() {
+    let program = parse_program(
+        r#"
+Point: { x: i32 }
+
+Json: behavior {
+    to_json: (Self) StaticString
+}
+
+Point.implements(Json) {
+    to_json = (value: Self) StaticString { "point" }
+}
+"#,
+    );
+
+    TypeChecker::new()
+        .check_program(&program)
+        .expect("behavior impl method may use Self for the impl target");
+}
+
+#[test]
+fn behavior_impl_required_method_accepts_nested_self_types() {
+    let program = parse_program(
+        r#"
+Point: { x: i32 }
+Holder<T>: { value: T }
+
+Json: behavior {
+    by_ptr: (Ptr<Self>) StaticString
+    by_array: ([Self; 1]) StaticString
+    by_function: ((Self) Self) StaticString
+    wrap: (Self) Holder<Self>
+}
+
+Point.implements(Json) {
+    by_ptr = (value: Ptr<Point>) StaticString { "ptr" }
+    by_array = (value: [Point; 1]) StaticString { "array" }
+    by_function = (value: (Point) Point) StaticString { "function" }
+    wrap = (value: Point) Holder<Point> { Holder<Point> { value: value } }
+}
+"#,
+    );
+
+    TypeChecker::new()
+        .check_program(&program)
+        .expect("behavior impl signatures may use concrete target types inside Self-shaped types");
+}

--- a/src/typechecker/tests/generic_behaviors/impl_type_args.rs
+++ b/src/typechecker/tests/generic_behaviors/impl_type_args.rs
@@ -84,6 +84,28 @@ Point.requires(Json<StaticString>)
 }
 
 #[test]
+fn behavior_impl_generic_behavior_accepts_nested_self_after_substitution() {
+    let program = parse_program(
+        r#"
+Point: { x: i32 }
+Holder<T>: { value: T }
+
+Json<T>: behavior {
+    inspect: (Holder<T>) StaticString
+}
+
+Point.implements(Json<Point>) {
+    inspect = (value: Holder<Self>) StaticString { "point" }
+}
+"#,
+    );
+
+    TypeChecker::new()
+        .check_program(&program)
+        .expect("substituted generic behavior method signature may use nested Self");
+}
+
+#[test]
 fn behavior_impl_generic_behavior_type_arg_bound_failure_is_error() {
     let program = parse_program(
         r#"

--- a/src/typechecker/tests/generic_behaviors/impls_and_requires.rs
+++ b/src/typechecker/tests/generic_behaviors/impls_and_requires.rs
@@ -22,27 +22,6 @@ Point.implements(Json) {
 }
 
 #[test]
-fn behavior_impl_required_method_accepts_self_parameter() {
-    let program = parse_program(
-        r#"
-Point: { x: i32 }
-
-Json: behavior {
-    to_json: (Self) StaticString
-}
-
-Point.implements(Json) {
-    to_json = (value: Self) StaticString { "point" }
-}
-"#,
-    );
-
-    TypeChecker::new()
-        .check_program(&program)
-        .expect("behavior impl method may use Self for the impl target");
-}
-
-#[test]
 fn behavior_impl_missing_required_method_is_error() {
     let program = parse_program(
         r#"

--- a/src/typechecker/tests/generic_behaviors/impls_and_requires.rs
+++ b/src/typechecker/tests/generic_behaviors/impls_and_requires.rs
@@ -22,6 +22,27 @@ Point.implements(Json) {
 }
 
 #[test]
+fn behavior_impl_required_method_accepts_self_parameter() {
+    let program = parse_program(
+        r#"
+Point: { x: i32 }
+
+Json: behavior {
+    to_json: (Self) StaticString
+}
+
+Point.implements(Json) {
+    to_json = (value: Self) StaticString { "point" }
+}
+"#,
+    );
+
+    TypeChecker::new()
+        .check_program(&program)
+        .expect("behavior impl method may use Self for the impl target");
+}
+
+#[test]
 fn behavior_impl_missing_required_method_is_error() {
     let program = parse_program(
         r#"

--- a/tests/zen/behavior_generic_target_association.zen
+++ b/tests/zen/behavior_generic_target_association.zen
@@ -9,7 +9,7 @@ Box<T>: {
 }
 
 Box<T>.implements(Json<T>) {
-    encode = (self: Box<T>) T {
+    encode = (self: Self) T {
         self.value
     }
 }

--- a/tests/zen/behavior_json_generic_dispatch.zen
+++ b/tests/zen/behavior_json_generic_dispatch.zen
@@ -9,7 +9,7 @@ Point: {
 }
 
 Point.implements(Json) {
-    to_json = (self: Point) StaticString {
+    to_json = (self: Self) StaticString {
         "point"
     }
 }


### PR DESCRIPTION
## Summary
- allow behavior impl method signatures to spell the impl target as `Self`
- cover non-generic and generic-target behavior impls with focused regressions
- exercise existing runtime fixtures with `Self` receiver spelling

## Verification
- cargo fmt --check
- git diff --check
- Rust and Zen size guards
- cargo clippy -- -D warnings
- cargo test --lib --quiet
- cargo test --test docs_truth --quiet
- cargo test --tests --quiet