### PR TITLE
[codex] cover phantom generic behavior bounds

### DIFF
--- a/src/typechecker/tests/generic_behaviors/generic_bounds/type_args.rs
+++ b/src/typechecker/tests/generic_behaviors/generic_bounds/type_args.rs
@@ -32,6 +32,38 @@ main = () i32 {
 }
 
 #[test]
+fn generic_behavior_bound_accepts_phantom_generic_target_impl() {
+    let program = parse_program(
+        r#"
+Tagged<T>: behavior {
+    tag: (Self) StaticString
+}
+
+Marker<T>: { id: i32 }
+
+Marker<T>.implements(Tagged<T>) {
+    tag = (self: Marker<T>) StaticString { "marker" }
+}
+
+accept<T: Tagged<i32>> = (value: T) T {
+    value.tag()
+    value
+}
+
+main = () i32 {
+    marker = Marker<i32> { id: 7 }
+    accepted = accept(marker)
+    accepted.id
+}
+"#,
+    );
+
+    TypeChecker::new()
+        .check_program(&program)
+        .expect("phantom generic target impl should satisfy matching generic behavior bound");
+}
+
+#[test]
 fn generic_behavior_bound_with_type_args_rejects_mismatched_impl() {
     let program = parse_program(
         r#"


### PR DESCRIPTION
## Summary
- add regression coverage for phantom generic target impls satisfying generic behavior bounds
- confirms the remembered specialization recovery from #1101 also covers behavior-bound checks

## Verification
- cargo fmt --check
- git diff --check
- Rust and Zen size guards
- cargo clippy -- -D warnings
- cargo test --lib --quiet
- cargo test --test docs_truth --quiet
- cargo test --tests --quiet