### PR TITLE
[codex] split monomorphize inference substitution

### DIFF
--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -32,6 +32,7 @@ mod monomorphize;
 mod monomorphize_dependencies;
 mod monomorphize_inference;
 mod monomorphize_inference_shapes;
+mod monomorphize_inference_substitution;
 mod monomorphize_method_self;
 mod monomorphize_names;
 mod monomorphize_specialized_type_names;

--- a/src/typechecker/monomorphize_inference_shapes.rs
+++ b/src/typechecker/monomorphize_inference_shapes.rs
@@ -4,6 +4,9 @@ use crate::ast::typed::Type;
 use crate::ast::AstType;
 
 use super::monomorphize_inference::InferenceConflict;
+use super::monomorphize_inference_substitution::{
+    ast_type_substitutions, substitute_inference_ast_type,
+};
 use super::TypeChecker;
 
 impl TypeChecker {
@@ -184,56 +187,5 @@ impl TypeChecker {
                     .collect(),
             )
         })
-    }
-}
-
-fn ast_type_substitutions(params: &[String], args: &[AstType]) -> HashMap<String, AstType> {
-    params.iter().cloned().zip(args.iter().cloned()).collect()
-}
-
-fn substitute_inference_ast_type(
-    ast_type: &AstType,
-    substitutions: &HashMap<String, AstType>,
-) -> AstType {
-    match ast_type {
-        AstType::Named(name) => substitutions
-            .get(name)
-            .cloned()
-            .unwrap_or_else(|| ast_type.clone()),
-        AstType::Ptr(inner) => AstType::Ptr(Box::new(substitute_inference_ast_type(
-            inner,
-            substitutions,
-        ))),
-        AstType::MutPtr(inner) => AstType::MutPtr(Box::new(substitute_inference_ast_type(
-            inner,
-            substitutions,
-        ))),
-        AstType::RawPtr(inner) => AstType::RawPtr(Box::new(substitute_inference_ast_type(
-            inner,
-            substitutions,
-        ))),
-        AstType::Slice(inner) => AstType::Slice(Box::new(substitute_inference_ast_type(
-            inner,
-            substitutions,
-        ))),
-        AstType::Array { elem, size } => AstType::Array {
-            elem: Box::new(substitute_inference_ast_type(elem, substitutions)),
-            size: *size,
-        },
-        AstType::Function { params, ret } => AstType::Function {
-            params: params
-                .iter()
-                .map(|param| substitute_inference_ast_type(param, substitutions))
-                .collect(),
-            ret: Box::new(substitute_inference_ast_type(ret, substitutions)),
-        },
-        AstType::Generic { name, type_args } => AstType::Generic {
-            name: name.clone(),
-            type_args: type_args
-                .iter()
-                .map(|arg| substitute_inference_ast_type(arg, substitutions))
-                .collect(),
-        },
-        _ => ast_type.clone(),
     }
 }

--- a/src/typechecker/monomorphize_inference_substitution.rs
+++ b/src/typechecker/monomorphize_inference_substitution.rs
@@ -1,0 +1,57 @@
+use std::collections::HashMap;
+
+use crate::ast::AstType;
+
+pub(super) fn ast_type_substitutions(
+    params: &[String],
+    args: &[AstType],
+) -> HashMap<String, AstType> {
+    params.iter().cloned().zip(args.iter().cloned()).collect()
+}
+
+pub(super) fn substitute_inference_ast_type(
+    ast_type: &AstType,
+    substitutions: &HashMap<String, AstType>,
+) -> AstType {
+    match ast_type {
+        AstType::Named(name) => substitutions
+            .get(name)
+            .cloned()
+            .unwrap_or_else(|| ast_type.clone()),
+        AstType::Ptr(inner) => AstType::Ptr(Box::new(substitute_inference_ast_type(
+            inner,
+            substitutions,
+        ))),
+        AstType::MutPtr(inner) => AstType::MutPtr(Box::new(substitute_inference_ast_type(
+            inner,
+            substitutions,
+        ))),
+        AstType::RawPtr(inner) => AstType::RawPtr(Box::new(substitute_inference_ast_type(
+            inner,
+            substitutions,
+        ))),
+        AstType::Slice(inner) => AstType::Slice(Box::new(substitute_inference_ast_type(
+            inner,
+            substitutions,
+        ))),
+        AstType::Array { elem, size } => AstType::Array {
+            elem: Box::new(substitute_inference_ast_type(elem, substitutions)),
+            size: *size,
+        },
+        AstType::Function { params, ret } => AstType::Function {
+            params: params
+                .iter()
+                .map(|param| substitute_inference_ast_type(param, substitutions))
+                .collect(),
+            ret: Box::new(substitute_inference_ast_type(ret, substitutions)),
+        },
+        AstType::Generic { name, type_args } => AstType::Generic {
+            name: name.clone(),
+            type_args: type_args
+                .iter()
+                .map(|arg| substitute_inference_ast_type(arg, substitutions))
+                .collect(),
+        },
+        _ => ast_type.clone(),
+    }
+}

--- a/tests/docs_truth/repo_hygiene/file_size/lexer_and_monomorphize.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/lexer_and_monomorphize.rs
@@ -124,3 +124,31 @@ fn monomorphize_specialized_type_name_recovery_lives_in_focused_helper() {
         "typechecker module should include the focused specialized type-name helper"
     );
 }
+
+#[test]
+fn monomorphize_inference_substitution_lives_in_focused_helper() {
+    let shapes = read("src/typechecker/monomorphize_inference_shapes.rs");
+    let substitution = read("src/typechecker/monomorphize_inference_substitution.rs");
+    let module = read("src/typechecker/mod.rs");
+
+    assert!(
+        shapes.lines().count() < 200,
+        "monomorphize_inference_shapes.rs should stay focused on generic shape matching"
+    );
+    assert!(
+        !shapes.contains("fn substitute_inference_ast_type"),
+        "inference AstType substitution should live in monomorphize_inference_substitution.rs"
+    );
+    assert!(
+        substitution.contains("pub(super) fn substitute_inference_ast_type"),
+        "monomorphize_inference_substitution.rs should own recursive inference AstType substitution"
+    );
+    assert!(
+        substitution.contains("pub(super) fn ast_type_substitutions"),
+        "monomorphize_inference_substitution.rs should own inference substitution map construction"
+    );
+    assert!(
+        module.contains("mod monomorphize_inference_substitution;"),
+        "typechecker module should include the focused monomorphize inference substitution helper"
+    );
+}


### PR DESCRIPTION
## What changed

- Moved recursive inference `AstType` substitution helpers into `monomorphize_inference_substitution.rs`.
- Kept `monomorphize_inference_shapes.rs` focused on matching concrete generic shapes.
- Added a docs-truth guard for the split and module include.

## Validation

- `cargo test --test docs_truth monomorphize_inference_substitution_lives_in_focused_helper --quiet`
- `cargo test --test integration method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols --quiet`
- `cargo test --test generic_diagnostics generic_method_inference_conflict_through_generic_struct_type_is_error --quiet`
- `cargo test --test generic_diagnostics generic_method_inference_conflict_through_function_type_is_error --quiet`
- `cargo fmt --check`
- `git diff --check`
- Rust/Zen size guards
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --test docs_truth --quiet`
- `cargo test --tests --quiet`