### PR TITLE
[codex] split resolver behavior ref helpers

### DIFF
--- a/src/resolver/metadata_helpers.rs
+++ b/src/resolver/metadata_helpers.rs
@@ -1,11 +1,13 @@
-use crate::ast::{
-    behavior_type_args_match_target_params, AstType, BehaviorMethod, EnumVariant, Param,
-    StructField, TypeParam,
-};
+use crate::ast::{AstType, BehaviorMethod, EnumVariant, Param, StructField, TypeParam};
 
 use super::symbol_table::{
     BehaviorMethodTypeMetadata, MethodSignatureMetadata, TypeParameterBoundMetadata,
     TypeParameterBoundRefMetadata, ValueSignatureMetadata,
+};
+
+mod behavior_refs;
+pub(super) use behavior_refs::{
+    behavior_ref_display, resolver_behavior_impl_method_key_with_target_args, resolver_method_key,
 };
 
 fn resolver_return_type_name(return_type: &Option<AstType>) -> String {
@@ -97,93 +99,6 @@ fn type_param_bound_display(type_param: &TypeParam) -> Option<String> {
     })
 }
 
-pub(super) fn behavior_ref_display(behavior: &str, type_args: &[AstType]) -> String {
-    if type_args.is_empty() {
-        behavior.to_string()
-    } else {
-        format!(
-            "{}<{}>",
-            behavior,
-            type_args
-                .iter()
-                .map(AstType::display_name)
-                .collect::<Vec<_>>()
-                .join(", ")
-        )
-    }
-}
-
-pub(super) fn resolver_method_key(type_name: &str, method_name: &str) -> String {
-    format!("{type_name}.{method_name}")
-}
-
-pub(super) fn resolver_behavior_impl_method_key(
-    type_name: &str,
-    method_name: &str,
-    behavior: &str,
-    behavior_type_args: &[AstType],
-) -> String {
-    if behavior_type_args.is_empty() {
-        return resolver_method_key(type_name, method_name);
-    }
-
-    format!(
-        "{}__{}",
-        resolver_method_key(type_name, method_name),
-        behavior_ref_symbol_suffix(behavior, behavior_type_args)
-    )
-}
-
-pub(super) fn resolver_behavior_impl_method_key_with_target_args(
-    type_name: &str,
-    method_name: &str,
-    behavior: &str,
-    behavior_type_args: &[AstType],
-    target_type_args: &[AstType],
-) -> String {
-    if target_type_args.is_empty() {
-        return resolver_behavior_impl_method_key(
-            type_name,
-            method_name,
-            behavior,
-            behavior_type_args,
-        );
-    }
-
-    if behavior_type_args_match_target_params(behavior_type_args, target_type_args) {
-        format!(
-            "{}__{}",
-            resolver_method_key(type_name, method_name),
-            behavior
-        )
-    } else {
-        resolver_behavior_impl_method_key(type_name, method_name, behavior, behavior_type_args)
-    }
-}
-
-pub(super) fn behavior_ref_symbol_suffix(behavior: &str, type_args: &[AstType]) -> String {
-    let mut parts = vec![sanitize_symbol_part(behavior)];
-    parts.extend(
-        type_args
-            .iter()
-            .map(AstType::display_name)
-            .map(|name| sanitize_symbol_part(&name)),
-    );
-    parts.join("_")
-}
-
-fn sanitize_symbol_part(name: &str) -> String {
-    let mut out = String::new();
-    for ch in name.chars() {
-        if ch.is_ascii_alphanumeric() {
-            out.push(ch);
-        } else {
-            out.push('_');
-        }
-    }
-    out
-}
-
 pub(super) fn resolver_field_types(fields: &[StructField]) -> Vec<(String, AstType, String)> {
     fields
         .iter()
@@ -232,6 +147,9 @@ pub(super) fn resolver_behavior_method_types(
         })
         .collect()
 }
+
+#[cfg(test)]
+use behavior_refs::resolver_behavior_impl_method_key;
 
 #[cfg(test)]
 mod tests;

--- a/src/resolver/metadata_helpers/behavior_refs.rs
+++ b/src/resolver/metadata_helpers/behavior_refs.rs
@@ -1,0 +1,91 @@
+use crate::ast::{behavior_type_args_match_target_params, AstType};
+
+pub(in crate::resolver) fn behavior_ref_display(behavior: &str, type_args: &[AstType]) -> String {
+    if type_args.is_empty() {
+        behavior.to_string()
+    } else {
+        format!(
+            "{}<{}>",
+            behavior,
+            type_args
+                .iter()
+                .map(AstType::display_name)
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    }
+}
+
+pub(in crate::resolver) fn resolver_method_key(type_name: &str, method_name: &str) -> String {
+    format!("{type_name}.{method_name}")
+}
+
+pub(in crate::resolver) fn resolver_behavior_impl_method_key(
+    type_name: &str,
+    method_name: &str,
+    behavior: &str,
+    behavior_type_args: &[AstType],
+) -> String {
+    if behavior_type_args.is_empty() {
+        return resolver_method_key(type_name, method_name);
+    }
+
+    format!(
+        "{}__{}",
+        resolver_method_key(type_name, method_name),
+        behavior_ref_symbol_suffix(behavior, behavior_type_args)
+    )
+}
+
+pub(in crate::resolver) fn resolver_behavior_impl_method_key_with_target_args(
+    type_name: &str,
+    method_name: &str,
+    behavior: &str,
+    behavior_type_args: &[AstType],
+    target_type_args: &[AstType],
+) -> String {
+    if target_type_args.is_empty() {
+        return resolver_behavior_impl_method_key(
+            type_name,
+            method_name,
+            behavior,
+            behavior_type_args,
+        );
+    }
+
+    if behavior_type_args_match_target_params(behavior_type_args, target_type_args) {
+        format!(
+            "{}__{}",
+            resolver_method_key(type_name, method_name),
+            behavior
+        )
+    } else {
+        resolver_behavior_impl_method_key(type_name, method_name, behavior, behavior_type_args)
+    }
+}
+
+pub(in crate::resolver) fn behavior_ref_symbol_suffix(
+    behavior: &str,
+    type_args: &[AstType],
+) -> String {
+    let mut parts = vec![sanitize_symbol_part(behavior)];
+    parts.extend(
+        type_args
+            .iter()
+            .map(AstType::display_name)
+            .map(|name| sanitize_symbol_part(&name)),
+    );
+    parts.join("_")
+}
+
+fn sanitize_symbol_part(name: &str) -> String {
+    let mut out = String::new();
+    for ch in name.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch);
+        } else {
+            out.push('_');
+        }
+    }
+    out
+}

--- a/tests/docs_truth/repo_hygiene/mod.rs
+++ b/tests/docs_truth/repo_hygiene/mod.rs
@@ -17,6 +17,7 @@ mod parser_function_forms;
 mod parser_keywords;
 mod removed_syntax;
 mod resolver_expression_validation;
+mod resolver_metadata_helpers;
 mod resolver_symbol_table;
 mod resolver_validation;
 mod semantic_overlap;

--- a/tests/docs_truth/repo_hygiene/resolver_metadata_helpers.rs
+++ b/tests/docs_truth/repo_hygiene/resolver_metadata_helpers.rs
@@ -1,0 +1,33 @@
+use super::*;
+
+#[test]
+fn resolver_behavior_ref_helpers_live_in_focused_module() {
+    let root = read("src/resolver/metadata_helpers.rs");
+    let behavior_refs = read("src/resolver/metadata_helpers/behavior_refs.rs");
+
+    for helper in [
+        "fn behavior_ref_display(",
+        "fn resolver_behavior_impl_method_key(",
+        "fn resolver_behavior_impl_method_key_with_target_args(",
+        "fn behavior_ref_symbol_suffix(",
+        "fn sanitize_symbol_part(",
+    ] {
+        assert!(
+            !root.contains(helper),
+            "resolver metadata_helpers.rs should not own behavior-ref helper `{helper}`"
+        );
+        assert!(
+            behavior_refs.contains(helper),
+            "resolver behavior-ref metadata helper should live in focused module: {helper}"
+        );
+    }
+
+    assert!(
+        root.lines().count() < 190,
+        "metadata_helpers.rs should stay focused on non-behavior-ref metadata construction"
+    );
+    assert!(
+        root.contains("mod behavior_refs;"),
+        "metadata_helpers.rs should include focused behavior-ref helpers"
+    );
+}


### PR DESCRIPTION
## What changed

- Moved resolver behavior-ref display/key/suffix helpers into `metadata_helpers/behavior_refs.rs`.
- Kept `metadata_helpers.rs` focused on value/type/field/variant metadata construction.
- Added a docs-truth guard for the focused behavior-ref helper module.

## Validation

- `cargo test --test docs_truth resolver_behavior_ref_helpers_live_in_focused_module --quiet`
- `cargo test --lib resolver::metadata_helpers::tests --quiet`
- `cargo test --test resolver_phase2 --quiet`
- `cargo test --lib resolver:: --quiet`
- `cargo test --lib typechecker::tests::resolver_behavior_impls_requires --quiet`
- `cargo fmt --check`
- `git diff --check`
- Rust/Zen size guards
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --test docs_truth --quiet`
- `cargo test --tests --quiet`