### PR TITLE
[codex] split expected pattern local traversal

### DIFF
--- a/src/typechecker/resolver_validation_support.rs
+++ b/src/typechecker/resolver_validation_support.rs
@@ -18,5 +18,6 @@ include!("resolver_validation_support/behavior_refs.rs");
 include!("resolver_validation_support/expected_behavior_edges.rs");
 include!("resolver_validation_support/expected_locals.rs");
 include!("resolver_validation_support/expected_local_traversal.rs");
+include!("resolver_validation_support/expected_pattern_locals.rs");
 include!("resolver_validation_support/expected_formatting.rs");
 include!("resolver_validation_support/expected_helpers.rs");

--- a/src/typechecker/resolver_validation_support/expected_local_traversal.rs
+++ b/src/typechecker/resolver_validation_support/expected_local_traversal.rs
@@ -179,58 +179,6 @@ fn resolver_var_decl_binds_local(
     constant || mutable || !locals.is_mutable(name)
 }
 
-fn expected_resolver_pattern_locals(
-    pattern: &ast::Pattern,
-    scope_cursor: &mut ResolverScopeCursor,
-    locals: &mut ResolverLocalScope,
-    expected: &mut HashSet<(String, u32)>,
-) {
-    match pattern {
-        ast::Pattern::Identifier { name, .. } => {
-            expected_resolver_pattern_binding(name, locals, expected);
-        }
-        ast::Pattern::Struct { fields, .. } => {
-            for (name, nested) in fields {
-                if let Some(nested) = nested {
-                    expected_resolver_pattern_locals(nested, scope_cursor, locals, expected);
-                } else {
-                    expected_resolver_pattern_binding(name, locals, expected);
-                }
-            }
-        }
-        ast::Pattern::Enum {
-            payload: Some(payload),
-            ..
-        } => {
-            expected_resolver_pattern_locals(payload, scope_cursor, locals, expected);
-        }
-        ast::Pattern::Or { patterns, .. } => {
-            for pattern in patterns {
-                expected_resolver_pattern_locals(pattern, scope_cursor, locals, expected);
-            }
-        }
-        ast::Pattern::Literal { value, .. } => {
-            expected_resolver_expr_locals(value, scope_cursor, locals, expected);
-        }
-        ast::Pattern::Range { start, end, .. } => {
-            expected_resolver_expr_locals(start, scope_cursor, locals, expected);
-            expected_resolver_expr_locals(end, scope_cursor, locals, expected);
-        }
-        ast::Pattern::Wildcard { .. }
-        | ast::Pattern::Enum { payload: None, .. }
-        | ast::Pattern::BoolTrue { .. }
-        | ast::Pattern::BoolFalse { .. } => {}
-    }
-}
-
-fn expected_resolver_pattern_binding(
-    name: &str,
-    locals: &mut ResolverLocalScope,
-    expected: &mut HashSet<(String, u32)>,
-) {
-    expected_resolver_local(name, false, locals, expected);
-}
-
 fn expected_resolver_local(
     name: &str,
     mutable: bool,

--- a/src/typechecker/resolver_validation_support/expected_pattern_locals.rs
+++ b/src/typechecker/resolver_validation_support/expected_pattern_locals.rs
@@ -1,0 +1,51 @@
+fn expected_resolver_pattern_locals(
+    pattern: &ast::Pattern,
+    scope_cursor: &mut ResolverScopeCursor,
+    locals: &mut ResolverLocalScope,
+    expected: &mut HashSet<(String, u32)>,
+) {
+    match pattern {
+        ast::Pattern::Identifier { name, .. } => {
+            expected_resolver_pattern_binding(name, locals, expected);
+        }
+        ast::Pattern::Struct { fields, .. } => {
+            for (name, nested) in fields {
+                if let Some(nested) = nested {
+                    expected_resolver_pattern_locals(nested, scope_cursor, locals, expected);
+                } else {
+                    expected_resolver_pattern_binding(name, locals, expected);
+                }
+            }
+        }
+        ast::Pattern::Enum {
+            payload: Some(payload),
+            ..
+        } => {
+            expected_resolver_pattern_locals(payload, scope_cursor, locals, expected);
+        }
+        ast::Pattern::Or { patterns, .. } => {
+            for pattern in patterns {
+                expected_resolver_pattern_locals(pattern, scope_cursor, locals, expected);
+            }
+        }
+        ast::Pattern::Literal { value, .. } => {
+            expected_resolver_expr_locals(value, scope_cursor, locals, expected);
+        }
+        ast::Pattern::Range { start, end, .. } => {
+            expected_resolver_expr_locals(start, scope_cursor, locals, expected);
+            expected_resolver_expr_locals(end, scope_cursor, locals, expected);
+        }
+        ast::Pattern::Wildcard { .. }
+        | ast::Pattern::Enum { payload: None, .. }
+        | ast::Pattern::BoolTrue { .. }
+        | ast::Pattern::BoolFalse { .. } => {}
+    }
+}
+
+fn expected_resolver_pattern_binding(
+    name: &str,
+    locals: &mut ResolverLocalScope,
+    expected: &mut HashSet<(String, u32)>,
+) {
+    expected_resolver_local(name, false, locals, expected);
+}

--- a/tests/docs_truth/repo_hygiene/file_size/resolver_validation_splits.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/resolver_validation_splits.rs
@@ -186,3 +186,33 @@ fn scalar_absence_descriptors_live_in_focused_support_module() {
         "resolver_validation_support.rs should include focused scalar absence descriptors"
     );
 }
+
+#[test]
+fn expected_pattern_local_traversal_lives_in_focused_support_module() {
+    let root = read("src/typechecker/resolver_validation_support/expected_local_traversal.rs");
+    let patterns = read("src/typechecker/resolver_validation_support/expected_pattern_locals.rs");
+    let includes = read("src/typechecker/resolver_validation_support.rs");
+
+    for helper in [
+        "fn expected_resolver_pattern_locals(",
+        "fn expected_resolver_pattern_binding(",
+    ] {
+        assert!(
+            !root.contains(helper),
+            "expected_local_traversal.rs should not own pattern-local helper `{helper}`"
+        );
+        assert!(
+            patterns.contains(helper),
+            "expected pattern-local helper should live in focused support module: {helper}"
+        );
+    }
+
+    assert!(
+        root.lines().count() < 200,
+        "expected_local_traversal.rs should stay focused on expression and statement traversal"
+    );
+    assert!(
+        includes.contains("include!(\"resolver_validation_support/expected_pattern_locals.rs\");"),
+        "resolver_validation_support.rs should include focused expected pattern-local helpers"
+    );
+}


### PR DESCRIPTION
## What changed

- Moved expected pattern-local traversal helpers into `expected_pattern_locals.rs`.
- Kept `expected_local_traversal.rs` focused on expression and statement traversal.
- Added a docs-truth guard for the focused support include.

## Validation

- `cargo test --test docs_truth expected_pattern_local_traversal_lives_in_focused_support_module --quiet`
- `cargo test --lib typechecker::tests::resolver_validation::expected_locals --quiet`
- `cargo fmt --check`
- `git diff --check`
- Rust/Zen size guards
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --test docs_truth --quiet`
- `cargo test --tests --quiet`