### PR TITLE
[codex] split ast type reference task collection

### DIFF
--- a/src/typechecker/generic_type_validation.rs
+++ b/src/typechecker/generic_type_validation.rs
@@ -1,82 +1,9 @@
 use super::*;
 
+mod ast_tasks;
 mod resolver_type_references;
 
 impl TypeChecker {
-    #[cfg(test)]
-    pub(super) fn collect_ast_type_reference_validation_tasks(
-        decls: &[Declaration],
-    ) -> Vec<AstTypeReferenceValidationTask<'_>> {
-        let mut tasks = Vec::new();
-        for decl in decls {
-            Self::push_ast_type_reference_validation_task(decl, &mut tasks);
-        }
-        tasks
-    }
-
-    pub(super) fn push_ast_type_reference_validation_task<'a>(
-        decl: &'a Declaration,
-        tasks: &mut Vec<AstTypeReferenceValidationTask<'a>>,
-    ) {
-        match decl {
-            Declaration::Struct {
-                type_params,
-                fields,
-                ..
-            } => tasks.push(AstTypeReferenceValidationTask::Struct {
-                type_params,
-                fields,
-            }),
-            Declaration::Enum {
-                type_params,
-                variants,
-                ..
-            } => tasks.push(AstTypeReferenceValidationTask::Enum {
-                type_params,
-                variants,
-            }),
-            Declaration::Function {
-                type_params,
-                params,
-                return_type,
-                body,
-                ..
-            } => tasks.push(AstTypeReferenceValidationTask::Function {
-                type_params,
-                params,
-                return_type,
-                body,
-            }),
-            Declaration::Method {
-                type_params,
-                params,
-                return_type,
-                body,
-                ..
-            } => tasks.push(AstTypeReferenceValidationTask::Method {
-                type_params,
-                params,
-                return_type,
-                body,
-            }),
-            Declaration::Behavior {
-                type_params,
-                methods,
-                ..
-            } => tasks.push(AstTypeReferenceValidationTask::Behavior {
-                type_params,
-                methods,
-            }),
-            Declaration::ImplBlock { methods, .. } => {
-                tasks.push(AstTypeReferenceValidationTask::ImplBlock { methods });
-            }
-            Declaration::TopLevelExpr { expr, .. } => {
-                tasks.push(AstTypeReferenceValidationTask::TopLevelExpr { expr });
-            }
-            _ => {}
-        }
-    }
-
     pub(super) fn validate_ast_type_reference_tasks(
         &mut self,
         tasks: &[AstTypeReferenceValidationTask<'_>],

--- a/src/typechecker/generic_type_validation/ast_tasks.rs
+++ b/src/typechecker/generic_type_validation/ast_tasks.rs
@@ -1,0 +1,77 @@
+use super::*;
+
+impl TypeChecker {
+    #[cfg(test)]
+    pub(in crate::typechecker) fn collect_ast_type_reference_validation_tasks(
+        decls: &[Declaration],
+    ) -> Vec<AstTypeReferenceValidationTask<'_>> {
+        let mut tasks = Vec::new();
+        for decl in decls {
+            Self::push_ast_type_reference_validation_task(decl, &mut tasks);
+        }
+        tasks
+    }
+
+    pub(in crate::typechecker) fn push_ast_type_reference_validation_task<'a>(
+        decl: &'a Declaration,
+        tasks: &mut Vec<AstTypeReferenceValidationTask<'a>>,
+    ) {
+        match decl {
+            Declaration::Struct {
+                type_params,
+                fields,
+                ..
+            } => tasks.push(AstTypeReferenceValidationTask::Struct {
+                type_params,
+                fields,
+            }),
+            Declaration::Enum {
+                type_params,
+                variants,
+                ..
+            } => tasks.push(AstTypeReferenceValidationTask::Enum {
+                type_params,
+                variants,
+            }),
+            Declaration::Function {
+                type_params,
+                params,
+                return_type,
+                body,
+                ..
+            } => tasks.push(AstTypeReferenceValidationTask::Function {
+                type_params,
+                params,
+                return_type,
+                body,
+            }),
+            Declaration::Method {
+                type_params,
+                params,
+                return_type,
+                body,
+                ..
+            } => tasks.push(AstTypeReferenceValidationTask::Method {
+                type_params,
+                params,
+                return_type,
+                body,
+            }),
+            Declaration::Behavior {
+                type_params,
+                methods,
+                ..
+            } => tasks.push(AstTypeReferenceValidationTask::Behavior {
+                type_params,
+                methods,
+            }),
+            Declaration::ImplBlock { methods, .. } => {
+                tasks.push(AstTypeReferenceValidationTask::ImplBlock { methods });
+            }
+            Declaration::TopLevelExpr { expr, .. } => {
+                tasks.push(AstTypeReferenceValidationTask::TopLevelExpr { expr });
+            }
+            _ => {}
+        }
+    }
+}

--- a/tests/docs_truth/repo_hygiene/typechecker_generic_type_references.rs
+++ b/tests/docs_truth/repo_hygiene/typechecker_generic_type_references.rs
@@ -64,3 +64,32 @@ fn resolver_type_reference_collection_validation_lives_in_focused_helper() {
         "resolver_type_references.rs should stay focused on resolver task dispatch"
     );
 }
+
+#[test]
+fn ast_type_reference_task_collection_lives_in_focused_helper() {
+    let root = read("src/typechecker/generic_type_validation.rs");
+    let tasks = read("src/typechecker/generic_type_validation/ast_tasks.rs");
+
+    for helper in [
+        "fn collect_ast_type_reference_validation_tasks(",
+        "fn push_ast_type_reference_validation_task",
+    ] {
+        assert!(
+            !root.contains(helper),
+            "generic_type_validation.rs should not own AST type-reference task collection helper `{helper}`"
+        );
+        assert!(
+            tasks.contains(helper),
+            "AST type-reference task collection helper should live in focused module: {helper}"
+        );
+    }
+
+    assert!(
+        root.contains("mod ast_tasks;"),
+        "generic type validation should include focused AST task collection"
+    );
+    assert!(
+        root.lines().count() < 180,
+        "generic_type_validation.rs should stay focused on task execution and resolver helpers"
+    );
+}


### PR DESCRIPTION
## What changed

- Moved AST type-reference validation task collection into `generic_type_validation/ast_tasks.rs`.
- Kept `generic_type_validation.rs` focused on task execution and resolver validation helpers.
- Added a docs-truth guard for the focused task collection module.

## Validation

- `cargo test --test docs_truth ast_type_reference_task_collection_lives_in_focused_helper --quiet`
- `cargo test --lib typechecker::tests::declaration_validation::tasks --quiet`
- `cargo test --lib typechecker::tests::declaration_validation --quiet`
- `cargo test --test generic_diagnostics --quiet`
- `cargo fmt --check`
- `git diff --check`
- Rust/Zen size guards
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --test docs_truth --quiet`
- `cargo test --tests --quiet`