### PR TITLE
[codex] split type compatibility helper

### DIFF
--- a/src/typechecker/resolve.rs
+++ b/src/typechecker/resolve.rs
@@ -8,6 +8,8 @@ use crate::ast::{is_builtin_type_name, AstType};
 
 use super::TypeChecker;
 
+mod compatibility;
+
 impl TypeChecker {
     /// Resolve an AstType to a concrete Type.
     pub(crate) fn resolve_type(&self, ast_ty: &AstType) -> Type {
@@ -185,44 +187,5 @@ impl TypeChecker {
             }
             _ => Type::Unknown,
         }
-    }
-
-    /// Check if two types are compatible (for assignment/return contexts).
-    /// Returns true if the types are clearly compatible or if either is ambiguous.
-    /// Returns false only for clear mismatches between concrete primitive types.
-    pub(crate) fn types_compatible(&self, expected: &Type, actual: &Type) -> bool {
-        if expected == actual {
-            return true;
-        }
-        // Unknown types are always compatible (error recovery)
-        if *expected == Type::Unknown || *actual == Type::Unknown {
-            return true;
-        }
-        // Named/nominal types match only by explicit identity.
-        match (expected, actual) {
-            (Type::Named(a), Type::Named(b)) if a == b => return true,
-            (Type::Struct { name: a, .. }, Type::Struct { name: b, .. }) if a == b => return true,
-            (Type::Struct { name, .. }, Type::Named(n))
-            | (Type::Named(n), Type::Struct { name, .. })
-                if name == n =>
-            {
-                return true;
-            }
-            (Type::Enum { name: a, .. }, Type::Enum { name: b, .. }) if a == b => return true,
-            (Type::Enum { name, .. }, Type::Named(n))
-            | (Type::Named(n), Type::Enum { name, .. })
-                if name == n =>
-            {
-                return true;
-            }
-            _ => {}
-        }
-        // Never type is compatible with anything (diverging expression)
-        if *expected == Type::Never || *actual == Type::Never {
-            return true;
-        }
-        // Numeric width/sign conversions require explicit casts. Literal
-        // coercion is handled before this check at declaration sites.
-        false
     }
 }

--- a/src/typechecker/resolve/compatibility.rs
+++ b/src/typechecker/resolve/compatibility.rs
@@ -1,0 +1,44 @@
+use crate::ast::typed::Type;
+
+use super::TypeChecker;
+
+impl TypeChecker {
+    /// Check if two types are compatible (for assignment/return contexts).
+    /// Returns true if the types are clearly compatible or if either is ambiguous.
+    /// Returns false only for clear mismatches between concrete primitive types.
+    pub(crate) fn types_compatible(&self, expected: &Type, actual: &Type) -> bool {
+        if expected == actual {
+            return true;
+        }
+        // Unknown types are always compatible (error recovery)
+        if *expected == Type::Unknown || *actual == Type::Unknown {
+            return true;
+        }
+        // Named/nominal types match only by explicit identity.
+        match (expected, actual) {
+            (Type::Named(a), Type::Named(b)) if a == b => return true,
+            (Type::Struct { name: a, .. }, Type::Struct { name: b, .. }) if a == b => return true,
+            (Type::Struct { name, .. }, Type::Named(n))
+            | (Type::Named(n), Type::Struct { name, .. })
+                if name == n =>
+            {
+                return true;
+            }
+            (Type::Enum { name: a, .. }, Type::Enum { name: b, .. }) if a == b => return true,
+            (Type::Enum { name, .. }, Type::Named(n))
+            | (Type::Named(n), Type::Enum { name, .. })
+                if name == n =>
+            {
+                return true;
+            }
+            _ => {}
+        }
+        // Never type is compatible with anything (diverging expression)
+        if *expected == Type::Never || *actual == Type::Never {
+            return true;
+        }
+        // Numeric width/sign conversions require explicit casts. Literal
+        // coercion is handled before this check at declaration sites.
+        false
+    }
+}

--- a/tests/docs_truth/repo_hygiene/typechecker_resolve.rs
+++ b/tests/docs_truth/repo_hygiene/typechecker_resolve.rs
@@ -64,3 +64,26 @@ fn typechecker_type_resolution_uses_named_and_generic_helpers() {
         "generic type branch should delegate to resolve_generic_type"
     );
 }
+
+#[test]
+fn typechecker_type_compatibility_lives_in_focused_helper() {
+    let root = read("src/typechecker/resolve.rs");
+    let compatibility = read("src/typechecker/resolve/compatibility.rs");
+
+    assert!(
+        !root.contains("fn types_compatible("),
+        "resolve.rs should not own type compatibility checking"
+    );
+    assert!(
+        compatibility.contains("fn types_compatible("),
+        "type compatibility checking should live in focused resolve helper"
+    );
+    assert!(
+        root.contains("mod compatibility;"),
+        "type resolution should load the focused compatibility helper"
+    );
+    assert!(
+        root.lines().count() < 210,
+        "resolve.rs should stay focused on AstType resolution and field lookup"
+    );
+}


### PR DESCRIPTION
## What changed

- Moved `types_compatible` into `resolve/compatibility.rs`.
- Kept `resolve.rs` focused on AstType resolution and field lookup.
- Added a docs-truth guard for the focused compatibility helper.

## Validation

- `cargo test --test docs_truth typechecker_type_compatibility_lives_in_focused_helper --quiet`
- `cargo test --lib typechecker::tests::core_semantics::type_helpers --quiet`
- `cargo test --lib typechecker::tests::core_semantics --quiet`
- `cargo test --test integration single_file --quiet`
- `cargo test --test generic_diagnostics --quiet`
- `cargo fmt --check`
- `git diff --check`
- Rust/Zen size guards
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --test docs_truth --quiet`
- `cargo test --tests --quiet`