### PR TITLE
[codex] split parser generic declarations

### DIFF
--- a/src/parser/declarations.rs
+++ b/src/parser/declarations.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::parser::keywords::ParserBehaviorKeyword;
 
 mod function_forms;
+mod generic;
 
 impl Parser {
     pub(super) fn consume_mutability_keyword(&mut self) -> bool {
@@ -58,78 +59,7 @@ impl Parser {
             // Generic type/function: `Name<T>...`
             Token::Lt => {
                 let type_params = self.parse_type_params()?;
-                self.skip_newlines();
-                match self.peek() {
-                    Token::Assign => {
-                        // Generic function: `name<T> = (params) ret { body }`
-                        self.parse_function_def(name, type_params, public, name_span)
-                    }
-                    Token::Dot => {
-                        // Generic receiver method: `Type<T>.method = (self: Type<T>) ...`
-                        self.advance(); // consume .
-                        let (method_name, _method_span) = self.expect_identifier()?;
-                        self.skip_newlines();
-
-                        if let Ok(keyword) = method_name.parse::<TypeDeclarationKeyword>() {
-                            if matches!(keyword, TypeDeclarationKeyword::Impl) {
-                                return self.parse_impl_block_with_type_params(
-                                    name,
-                                    type_params,
-                                    name_span,
-                                );
-                            }
-                            if matches!(keyword, TypeDeclarationKeyword::Implements) {
-                                return self.parse_behavior_impl_block_with_type_params(
-                                    name,
-                                    type_params,
-                                    name_span,
-                                );
-                            }
-                            return self
-                                .reject_gated_generic_association_target(keyword, name_span);
-                        }
-
-                        let mut all_type_params = type_params;
-                        if matches!(self.peek(), Token::Lt) {
-                            all_type_params.extend(self.parse_type_params()?);
-                        }
-
-                        self.skip_newlines();
-                        self.expect(&Token::Assign)?;
-                        self.skip_newlines();
-
-                        let (params, return_type, body) =
-                            self.parse_function_signature_and_body()?;
-                        let span = name_span.merge(body.span());
-                        Ok(Declaration::Method {
-                            type_name: name,
-                            method_name,
-                            type_params: all_type_params,
-                            params,
-                            return_type,
-                            body,
-                            public,
-                            span,
-                        })
-                    }
-                    Token::Colon if self.is_struct_def() => {
-                        self.parse_struct_def_with_params(name, type_params, public, name_span)
-                    }
-                    Token::Colon
-                        if self.colon_is_followed_by_identifier(
-                            ParserBehaviorKeyword::Behavior.as_str(),
-                        ) =>
-                    {
-                        self.parse_behavior_def(name, type_params, public, name_span)
-                    }
-                    Token::Colon => {
-                        self.parse_enum_def_with_params(name, type_params, public, name_span)
-                    }
-                    _ => Err(CompileError::Syntax(
-                        "expected '=' or ':' after generic type parameters".to_string(),
-                        Some(self.peek_span()),
-                    )),
-                }
+                self.parse_generic_declaration(name, type_params, public, name_span)
             }
 
             // Method: `Type.method = ...`
@@ -198,41 +128,6 @@ impl Parser {
                 ),
                 Some(self.peek_span()),
             )),
-        }
-    }
-
-    // ── Function ──────────────────────────────────────────────
-
-    fn reject_gated_generic_association_target<T>(
-        &mut self,
-        keyword: TypeDeclarationKeyword,
-        name_span: Span,
-    ) -> Result<T, CompileError> {
-        let span = self.gated_association_call_span(name_span);
-        Err(CompileError::Syntax(
-            format!(
-                "generic association target `Type<T>.{keyword}` is gated; use non-generic `{keyword}` associations or keep the generic behavior target deferred to docs/V1_SPEC.md"
-            ),
-            Some(span),
-        ))
-    }
-
-    fn gated_association_call_span(&mut self, name_span: Span) -> Span {
-        if !matches!(self.peek(), Token::LParen) {
-            return name_span.merge(self.prev_span());
-        }
-
-        self.advance();
-        let behavior_span = self.expect_identifier().map(|(_, span)| span).ok();
-        if matches!(self.peek(), Token::Lt) {
-            let _ = self.parse_type_arg_list();
-        }
-        self.skip_newlines();
-        match self.expect(&Token::RParen) {
-            Ok(end) => name_span.merge(end),
-            Err(_) => behavior_span
-                .map(|span| name_span.merge(span))
-                .unwrap_or_else(|| name_span.merge(self.prev_span())),
         }
     }
 }

--- a/src/parser/declarations/generic.rs
+++ b/src/parser/declarations/generic.rs
@@ -1,0 +1,113 @@
+use super::*;
+use crate::parser::keywords::ParserBehaviorKeyword;
+
+impl Parser {
+    pub(in crate::parser) fn parse_generic_declaration(
+        &mut self,
+        name: String,
+        type_params: Vec<TypeParam>,
+        public: bool,
+        name_span: Span,
+    ) -> Result<Declaration, CompileError> {
+        self.skip_newlines();
+        match self.peek() {
+            Token::Assign => {
+                // Generic function: `name<T> = (params) ret { body }`
+                self.parse_function_def(name, type_params, public, name_span)
+            }
+            Token::Dot => {
+                // Generic receiver method: `Type<T>.method = (self: Type<T>) ...`
+                self.advance();
+                let (method_name, _method_span) = self.expect_identifier()?;
+                self.skip_newlines();
+
+                if let Ok(keyword) = method_name.parse::<TypeDeclarationKeyword>() {
+                    if matches!(keyword, TypeDeclarationKeyword::Impl) {
+                        return self.parse_impl_block_with_type_params(
+                            name,
+                            type_params,
+                            name_span,
+                        );
+                    }
+                    if matches!(keyword, TypeDeclarationKeyword::Implements) {
+                        return self.parse_behavior_impl_block_with_type_params(
+                            name,
+                            type_params,
+                            name_span,
+                        );
+                    }
+                    return self.reject_gated_generic_association_target(keyword, name_span);
+                }
+
+                let mut all_type_params = type_params;
+                if matches!(self.peek(), Token::Lt) {
+                    all_type_params.extend(self.parse_type_params()?);
+                }
+
+                self.skip_newlines();
+                self.expect(&Token::Assign)?;
+                self.skip_newlines();
+
+                let (params, return_type, body) = self.parse_function_signature_and_body()?;
+                let span = name_span.merge(body.span());
+                Ok(Declaration::Method {
+                    type_name: name,
+                    method_name,
+                    type_params: all_type_params,
+                    params,
+                    return_type,
+                    body,
+                    public,
+                    span,
+                })
+            }
+            Token::Colon if self.is_struct_def() => {
+                self.parse_struct_def_with_params(name, type_params, public, name_span)
+            }
+            Token::Colon
+                if self
+                    .colon_is_followed_by_identifier(ParserBehaviorKeyword::Behavior.as_str()) =>
+            {
+                self.parse_behavior_def(name, type_params, public, name_span)
+            }
+            Token::Colon => self.parse_enum_def_with_params(name, type_params, public, name_span),
+            _ => Err(CompileError::Syntax(
+                "expected '=' or ':' after generic type parameters".to_string(),
+                Some(self.peek_span()),
+            )),
+        }
+    }
+
+    fn reject_gated_generic_association_target<T>(
+        &mut self,
+        keyword: TypeDeclarationKeyword,
+        name_span: Span,
+    ) -> Result<T, CompileError> {
+        let span = self.gated_association_call_span(name_span);
+        Err(CompileError::Syntax(
+            format!(
+                "generic association target `Type<T>.{keyword}` is gated; use non-generic `{keyword}` associations or keep the generic behavior target deferred to docs/V1_SPEC.md"
+            ),
+            Some(span),
+        ))
+    }
+
+    fn gated_association_call_span(&mut self, name_span: Span) -> Span {
+        if !matches!(self.peek(), Token::LParen) {
+            return name_span.merge(self.prev_span());
+        }
+
+        self.advance();
+        let behavior_span = self.expect_identifier().map(|(_, span)| span).ok();
+        if matches!(self.peek(), Token::Lt) {
+            let _ = self.parse_type_arg_list();
+        }
+        self.skip_newlines();
+        match self.expect(&Token::RParen) {
+            Ok(end) => name_span.merge(end),
+            Err(_) => behavior_span
+                .map(|span| name_span.merge(span))
+                .unwrap_or_else(|| name_span.merge(self.prev_span())),
+        }
+    }
+}

--- a/tests/docs_truth/repo_hygiene/mod.rs
+++ b/tests/docs_truth/repo_hygiene/mod.rs
@@ -12,6 +12,7 @@ mod ir_json;
 mod module_system;
 mod parser_behavior_declarations;
 mod parser_core;
+mod parser_declarations;
 mod parser_enums;
 mod parser_function_forms;
 mod parser_keywords;

--- a/tests/docs_truth/repo_hygiene/parser_declarations.rs
+++ b/tests/docs_truth/repo_hygiene/parser_declarations.rs
@@ -1,0 +1,31 @@
+use super::*;
+
+#[test]
+fn parser_generic_declarations_live_in_focused_helper() {
+    let declarations = read("src/parser/declarations.rs");
+    let generic = read("src/parser/declarations/generic.rs");
+
+    for helper in [
+        "parse_generic_declaration",
+        "reject_gated_generic_association_target",
+        "gated_association_call_span",
+    ] {
+        assert!(
+            !declarations.contains(&format!("fn {helper}")),
+            "parser declaration dispatch should not own generic declaration helper: {helper}"
+        );
+        assert!(
+            generic.contains(&format!("fn {helper}")),
+            "generic declaration parsing should live in the focused helper: {helper}"
+        );
+    }
+
+    assert!(
+        declarations.contains("mod generic;"),
+        "parser declaration dispatch should load the focused generic-declarations helper"
+    );
+    assert!(
+        declarations.lines().count() < 190,
+        "parser declaration dispatch should stay small after generic declarations move out"
+    );
+}


### PR DESCRIPTION
## What changed
- Moved generic declaration parsing out of `src/parser/declarations.rs` into `src/parser/declarations/generic.rs`.
- Added a docs-truth repo-hygiene guard so generic declaration helpers stay in the focused module and declaration dispatch stays small.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth production_rust_files_stay_below_cleanup_threshold --quiet`
- `cargo test --test docs_truth zen_source_files_stay_below_cleanup_threshold --quiet`
- `cargo test --test docs_truth parser_generic_declarations_live_in_focused_helper --quiet`
- `cargo test --lib parser::tests --quiet`
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --test docs_truth --quiet`
- `cargo test --tests --quiet`