### PR TITLE
[codex] reuse ast operator spelling in c codegen

### DIFF
--- a/src/codegen/c/operators.rs
+++ b/src/codegen/c/operators.rs
@@ -1,32 +1,9 @@
 use crate::ast::expressions::{BinaryOp, UnaryOp};
 
 pub(super) fn c_binary_op(op: BinaryOp) -> &'static str {
-    match op {
-        BinaryOp::Add => "+",
-        BinaryOp::Sub => "-",
-        BinaryOp::Mul => "*",
-        BinaryOp::Div => "/",
-        BinaryOp::Mod => "%",
-        BinaryOp::Eq => "==",
-        BinaryOp::NotEq => "!=",
-        BinaryOp::Lt => "<",
-        BinaryOp::Gt => ">",
-        BinaryOp::LtEq => "<=",
-        BinaryOp::GtEq => ">=",
-        BinaryOp::And => "&&",
-        BinaryOp::Or => "||",
-        BinaryOp::BitAnd => "&",
-        BinaryOp::BitOr => "|",
-        BinaryOp::BitXor => "^",
-        BinaryOp::ShiftLeft => "<<",
-        BinaryOp::ShiftRight => ">>",
-    }
+    op.symbol()
 }
 
 pub(super) fn c_unary_op(op: UnaryOp) -> &'static str {
-    match op {
-        UnaryOp::Neg => "-",
-        UnaryOp::Not => "!",
-        UnaryOp::BitNot => "~",
-    }
+    op.symbol()
 }

--- a/tests/docs_truth/repo_hygiene/codegen_c.rs
+++ b/tests/docs_truth/repo_hygiene/codegen_c.rs
@@ -50,6 +50,16 @@ fn codegen_c_expression_operator_spelling_lives_in_focused_helper() {
         );
     }
     assert!(
+        operators.contains("op.symbol()"),
+        "C operator spelling should reuse AST operator symbols instead of repeating a C-only table"
+    );
+    for duplicated_table_entry in ["BinaryOp::Add =>", "UnaryOp::Neg =>"] {
+        assert!(
+            !operators.contains(duplicated_table_entry),
+            "C operator helper should not duplicate AST operator spelling: {duplicated_table_entry}"
+        );
+    }
+    assert!(
         c_mod.contains("mod operators;"),
         "C codegen should load focused operator spelling helper"
     );


### PR DESCRIPTION
## What changed

- Removed the duplicate C-only binary/unary operator spelling match tables.
- Kept the focused C helper functions, but made them delegate to `BinaryOp::symbol()` and `UnaryOp::symbol()`.
- Tightened docs-truth so the duplicate C operator table does not come back.

## Why

The AST operator enums already own these spellings. Repeating the same table in C codegen adds drift risk without behavior benefit.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test docs_truth codegen_c_expression_operator_spelling_lives_in_focused_helper --quiet`
- `cargo test codegen::c::tests::expression_emission --quiet`
- `cargo test emit_json_mir_minimal_function_schema_matches_golden --quiet`
- `cargo test --test docs_truth production_rust_files_stay_below_cleanup_threshold --quiet`
- `cargo test --test docs_truth zen_source_files_stay_below_cleanup_threshold --quiet`
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet`
- `cargo test --test docs_truth --quiet`
- `cargo test --tests --quiet`