### PR TITLE
Add imported generic function return enum goldens

### DIFF
--- a/tests/fixtures/ir_json/hir_multi_file_imported_generic_function_return_enum.golden.json
+++ b/tests/fixtures/ir_json/hir_multi_file_imported_generic_function_return_enum.golden.json
@@ -1,0 +1,63 @@
+{
+  "format": "zen.hir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "declarations": {
+    "types": [
+      {
+        "name": "Option_i32",
+        "kind": "enum",
+        "fields": [],
+        "variants": [
+          {
+            "name": "None",
+            "tag": 0,
+            "payload": []
+          },
+          {
+            "name": "Some",
+            "tag": 1,
+            "payload": [
+              {
+                "name": "payload",
+                "type": "i32"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "functions": [
+      {
+        "name": "main",
+        "params": [],
+        "return_type": "i32"
+      },
+      {
+        "name": "wrap_i32",
+        "params": [
+          {
+            "name": "value",
+            "type": "i32"
+          }
+        ],
+        "return_type": "Option_i32"
+      },
+      {
+        "name": "unwrap_i32",
+        "params": [
+          {
+            "name": "value",
+            "type": "Option_i32"
+          },
+          {
+            "name": "fallback",
+            "type": "i32"
+          }
+        ],
+        "return_type": "i32"
+      }
+    ],
+    "globals": []
+  }
+}

--- a/tests/fixtures/ir_json/mir_multi_file_imported_generic_function_return_enum.golden.json
+++ b/tests/fixtures/ir_json/mir_multi_file_imported_generic_function_return_enum.golden.json
@@ -1,0 +1,188 @@
+{
+  "format": "zen.mir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "lowering_status": "minimal",
+  "functions": [
+    {
+      "name": "main",
+      "params": [],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [
+            {
+              "kind": "let",
+              "name": "value",
+              "type": "Option_i32",
+              "mutable": false,
+              "value": {
+                "kind": "call",
+                "type": "Option_i32",
+                "function": "wrap_i32",
+                "args": [
+                  {
+                    "kind": "int",
+                    "type": "i32",
+                    "value": 107
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "expr",
+              "value": {
+                "kind": "call",
+                "type": "void",
+                "function": "io_println",
+                "args": [
+                  {
+                    "kind": "string_interpolation",
+                    "type": "StaticString",
+                    "value": {
+                      "parts": 1
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "int",
+              "type": "i32",
+              "value": 0
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "wrap_i32",
+      "params": [
+        {
+          "name": "value",
+          "type": "i32"
+        }
+      ],
+      "return_type": "Option_i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "enum_variant",
+              "type": "Option_i32",
+              "name": "Option_i32.Some",
+              "args": [
+                {
+                  "kind": "local",
+                  "type": "i32",
+                  "name": "value"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "unwrap_i32",
+      "params": [
+        {
+          "name": "value",
+          "type": "Option_i32"
+        },
+        {
+          "name": "fallback",
+          "type": "i32"
+        }
+      ],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "match",
+              "type": "i32",
+              "target": {
+                "kind": "local",
+                "type": "Option_i32",
+                "name": "value"
+              },
+              "match_kind": "enum",
+              "arms": [
+                {
+                  "pattern": {
+                    "kind": "enum_variant",
+                    "name": "Option_i32.Some",
+                    "bindings": [
+                      {
+                        "name": "inner",
+                        "type": "i32"
+                      }
+                    ]
+                  },
+                  "body": {
+                    "label": "entry",
+                    "statements": [],
+                    "terminator": {
+                      "kind": "return",
+                      "value": {
+                        "kind": "block",
+                        "type": "i32",
+                        "value": {
+                          "has_result": true,
+                          "result": {
+                            "kind": "local",
+                            "name": "inner",
+                            "type": "i32"
+                          },
+                          "statement_count": 0
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "pattern": {
+                    "kind": "enum_variant",
+                    "name": "Option_i32.None",
+                    "bindings": []
+                  },
+                  "body": {
+                    "label": "entry",
+                    "statements": [],
+                    "terminator": {
+                      "kind": "return",
+                      "value": {
+                        "kind": "block",
+                        "type": "i32",
+                        "value": {
+                          "has_result": true,
+                          "result": {
+                            "kind": "local",
+                            "name": "fallback",
+                            "type": "i32"
+                          },
+                          "statement_count": 0
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/ir_json/typed_multi_file_imported_generic_function_return_enum.golden.json
+++ b/tests/fixtures/ir_json/typed_multi_file_imported_generic_function_return_enum.golden.json
@@ -1,0 +1,534 @@
+{
+  "format": "zen.typed.v0",
+  "semantic_status": "checked",
+  "program": {
+    "functions": [
+      {
+        "name": "main",
+        "params": [],
+        "return_type": "I32",
+        "body": {
+          "statements": [
+            {
+              "kind": {
+                "VarDecl": {
+                  "name": "value",
+                  "ty": {
+                    "Enum": {
+                      "name": "Option_i32",
+                      "variants": [
+                        [
+                          "None",
+                          null
+                        ],
+                        [
+                          "Some",
+                          "I32"
+                        ]
+                      ]
+                    }
+                  },
+                  "value": {
+                    "kind": {
+                      "FunctionCall": {
+                        "function": "wrap_i32",
+                        "args": [
+                          {
+                            "kind": {
+                              "IntLiteral": 107
+                            },
+                            "ty": "I32",
+                            "span": {
+                              "file_id": 0,
+                              "start": 72,
+                              "end": 75
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "ty": {
+                      "Enum": {
+                        "name": "Option_i32",
+                        "variants": [
+                          [
+                            "None",
+                            null
+                          ],
+                          [
+                            "Some",
+                            "I32"
+                          ]
+                        ]
+                      }
+                    },
+                    "span": {
+                      "file_id": 0,
+                      "start": 67,
+                      "end": 76
+                    }
+                  },
+                  "mutable": false
+                }
+              },
+              "span": {
+                "file_id": 0,
+                "start": 59,
+                "end": 76
+              }
+            },
+            {
+              "kind": {
+                "Expression": {
+                  "kind": {
+                    "FunctionCall": {
+                      "function": "io_println",
+                      "args": [
+                        {
+                          "kind": {
+                            "StringInterpolation": {
+                              "parts": [
+                                {
+                                  "Expr": {
+                                    "kind": {
+                                      "FunctionCall": {
+                                        "function": "unwrap_i32",
+                                        "args": [
+                                          {
+                                            "kind": {
+                                              "Variable": "value"
+                                            },
+                                            "ty": {
+                                              "Enum": {
+                                                "name": "Option_i32",
+                                                "variants": [
+                                                  [
+                                                    "None",
+                                                    null
+                                                  ],
+                                                  [
+                                                    "Some",
+                                                    "I32"
+                                                  ]
+                                                ]
+                                              }
+                                            },
+                                            "span": {
+                                              "file_id": 0,
+                                              "start": 102,
+                                              "end": 107
+                                            }
+                                          },
+                                          {
+                                            "kind": {
+                                              "IntLiteral": 0
+                                            },
+                                            "ty": "I32",
+                                            "span": {
+                                              "file_id": 0,
+                                              "start": 109,
+                                              "end": 110
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "ty": "I32",
+                                    "span": {
+                                      "file_id": 0,
+                                      "start": 95,
+                                      "end": 111
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "ty": "Str",
+                          "span": {
+                            "file_id": 0,
+                            "start": 93,
+                            "end": 112
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "ty": "Void",
+                  "span": {
+                    "file_id": 0,
+                    "start": 81,
+                    "end": 114
+                  }
+                }
+              },
+              "span": {
+                "file_id": 0,
+                "start": 81,
+                "end": 114
+              }
+            }
+          ],
+          "expr": {
+            "kind": {
+              "IntLiteral": 0
+            },
+            "ty": "I32",
+            "span": {
+              "file_id": 0,
+              "start": 119,
+              "end": 120
+            }
+          },
+          "ty": "I32",
+          "span": {
+            "file_id": 0,
+            "start": 53,
+            "end": 122
+          }
+        },
+        "defers": [],
+        "span": {
+          "file_id": 0,
+          "start": 39,
+          "end": 122
+        }
+      },
+      {
+        "name": "wrap_i32",
+        "params": [
+          {
+            "name": "value",
+            "ty": "I32",
+            "span": {
+              "file_id": 1,
+              "start": 35,
+              "end": 43
+            }
+          }
+        ],
+        "return_type": {
+          "Enum": {
+            "name": "Option_i32",
+            "variants": [
+              [
+                "None",
+                null
+              ],
+              [
+                "Some",
+                "I32"
+              ]
+            ]
+          }
+        },
+        "body": {
+          "statements": [],
+          "expr": {
+            "kind": {
+              "EnumVariant": {
+                "type_name": "Option_i32",
+                "variant": "Some",
+                "payload": {
+                  "kind": {
+                    "Variable": "value"
+                  },
+                  "ty": "I32",
+                  "span": {
+                    "file_id": 1,
+                    "start": 76,
+                    "end": 81
+                  }
+                }
+              }
+            },
+            "ty": {
+              "Enum": {
+                "name": "Option_i32",
+                "variants": [
+                  [
+                    "None",
+                    null
+                  ],
+                  [
+                    "Some",
+                    "I32"
+                  ]
+                ]
+              }
+            },
+            "span": {
+              "file_id": 1,
+              "start": 61,
+              "end": 82
+            }
+          },
+          "ty": {
+            "Enum": {
+              "name": "Option_i32",
+              "variants": [
+                [
+                  "None",
+                  null
+                ],
+                [
+                  "Some",
+                  "I32"
+                ]
+              ]
+            }
+          },
+          "span": {
+            "file_id": 1,
+            "start": 55,
+            "end": 84
+          }
+        },
+        "defers": [],
+        "span": {
+          "file_id": 1,
+          "start": 24,
+          "end": 84
+        }
+      },
+      {
+        "name": "unwrap_i32",
+        "params": [
+          {
+            "name": "value",
+            "ty": {
+              "Enum": {
+                "name": "Option_i32",
+                "variants": [
+                  [
+                    "None",
+                    null
+                  ],
+                  [
+                    "Some",
+                    "I32"
+                  ]
+                ]
+              }
+            },
+            "span": {
+              "file_id": 1,
+              "start": 103,
+              "end": 119
+            }
+          },
+          {
+            "name": "fallback",
+            "ty": "I32",
+            "span": {
+              "file_id": 1,
+              "start": 121,
+              "end": 132
+            }
+          }
+        ],
+        "return_type": "I32",
+        "body": {
+          "statements": [],
+          "expr": {
+            "kind": {
+              "Match": {
+                "scrutinee": {
+                  "kind": {
+                    "Variable": "value"
+                  },
+                  "ty": {
+                    "Enum": {
+                      "name": "Option_i32",
+                      "variants": [
+                        [
+                          "None",
+                          null
+                        ],
+                        [
+                          "Some",
+                          "I32"
+                        ]
+                      ]
+                    }
+                  },
+                  "span": {
+                    "file_id": 1,
+                    "start": 142,
+                    "end": 147
+                  }
+                },
+                "arms": [
+                  {
+                    "pattern": {
+                      "EnumVariant": {
+                        "type_name": "Option_i32",
+                        "variant": "Some",
+                        "bindings": [
+                          [
+                            "inner",
+                            "I32"
+                          ]
+                        ]
+                      }
+                    },
+                    "body": {
+                      "statements": [],
+                      "expr": {
+                        "kind": {
+                          "Block": {
+                            "statements": [],
+                            "expr": {
+                              "kind": {
+                                "Variable": "inner"
+                              },
+                              "ty": "I32",
+                              "span": {
+                                "file_id": 1,
+                                "start": 174,
+                                "end": 179
+                              }
+                            },
+                            "ty": "I32",
+                            "span": {
+                              "file_id": 1,
+                              "start": 172,
+                              "end": 181
+                            }
+                          }
+                        },
+                        "ty": "I32",
+                        "span": {
+                          "file_id": 1,
+                          "start": 172,
+                          "end": 181
+                        }
+                      },
+                      "ty": "I32",
+                      "span": {
+                        "file_id": 1,
+                        "start": 172,
+                        "end": 181
+                      }
+                    },
+                    "span": {
+                      "file_id": 1,
+                      "start": 160,
+                      "end": 181
+                    }
+                  },
+                  {
+                    "pattern": {
+                      "EnumVariant": {
+                        "type_name": "Option_i32",
+                        "variant": "None",
+                        "bindings": []
+                      }
+                    },
+                    "body": {
+                      "statements": [],
+                      "expr": {
+                        "kind": {
+                          "Block": {
+                            "statements": [],
+                            "expr": {
+                              "kind": {
+                                "Variable": "fallback"
+                              },
+                              "ty": "I32",
+                              "span": {
+                                "file_id": 1,
+                                "start": 199,
+                                "end": 207
+                              }
+                            },
+                            "ty": "I32",
+                            "span": {
+                              "file_id": 1,
+                              "start": 197,
+                              "end": 209
+                            }
+                          }
+                        },
+                        "ty": "I32",
+                        "span": {
+                          "file_id": 1,
+                          "start": 197,
+                          "end": 209
+                        }
+                      },
+                      "ty": "I32",
+                      "span": {
+                        "file_id": 1,
+                        "start": 197,
+                        "end": 209
+                      }
+                    },
+                    "span": {
+                      "file_id": 1,
+                      "start": 192,
+                      "end": 209
+                    }
+                  }
+                ],
+                "kind": "EnumMatch"
+              }
+            },
+            "ty": "I32",
+            "span": {
+              "file_id": 1,
+              "start": 142,
+              "end": 209
+            }
+          },
+          "ty": "I32",
+          "span": {
+            "file_id": 1,
+            "start": 136,
+            "end": 211
+          }
+        },
+        "defers": [],
+        "span": {
+          "file_id": 1,
+          "start": 90,
+          "end": 211
+        }
+      }
+    ],
+    "types": [
+      {
+        "name": "Option_i32",
+        "kind": {
+          "Enum": {
+            "variants": [
+              {
+                "name": "None",
+                "tag": 0,
+                "payload": null
+              },
+              {
+                "name": "Some",
+                "tag": 1,
+                "payload": [
+                  [
+                    "payload",
+                    "I32"
+                  ]
+                ]
+              }
+            ]
+          }
+        },
+        "methods": [],
+        "span": {
+          "file_id": 1,
+          "start": 61,
+          "end": 82
+        }
+      }
+    ],
+    "globals": [],
+    "entry_point": "main"
+  }
+}

--- a/tests/integration/cli_build/frontend_json/hir_golden/generic_values.rs
+++ b/tests/integration/cli_build/frontend_json/hir_golden/generic_values.rs
@@ -64,6 +64,15 @@ fn emit_json_hir_multi_file_generic_imported_scoped_type_inference_schema_matche
 }
 
 #[test]
+fn emit_json_hir_multi_file_imported_generic_function_return_enum_schema_matches_golden() {
+    assert_hir_golden(
+        "tests/zen/multi_file_imported_generic_function_return_enum_dependency/main.zen",
+        "tests/fixtures/ir_json/hir_multi_file_imported_generic_function_return_enum.golden.json",
+        "multi-file imported generic function return enum input",
+    );
+}
+
+#[test]
 fn emit_json_hir_generic_recursive_function_schema_matches_golden() {
     assert_hir_golden(
         "tests/zen/generic_recursive_function.zen",

--- a/tests/integration/cli_build/frontend_json/mir_golden/generic_values.rs
+++ b/tests/integration/cli_build/frontend_json/mir_golden/generic_values.rs
@@ -46,6 +46,15 @@ fn emit_json_mir_multi_file_generic_imported_diamond_same_name_schema_matches_go
 }
 
 #[test]
+fn emit_json_mir_multi_file_imported_generic_function_return_enum_schema_matches_golden() {
+    assert_mir_golden(
+        "tests/zen/multi_file_imported_generic_function_return_enum_dependency/main.zen",
+        "tests/fixtures/ir_json/mir_multi_file_imported_generic_function_return_enum.golden.json",
+        "multi-file imported generic function return enum input",
+    );
+}
+
+#[test]
 fn emit_json_mir_generic_recursive_function_schema_matches_golden() {
     assert_mir_golden(
         "tests/zen/generic_recursive_function.zen",

--- a/tests/integration/cli_build/frontend_json/typed_golden/generic_values.rs
+++ b/tests/integration/cli_build/frontend_json/typed_golden/generic_values.rs
@@ -37,6 +37,15 @@ fn emit_json_typed_generic_recursive_function_schema_matches_golden() {
 }
 
 #[test]
+fn emit_json_typed_multi_file_imported_generic_function_return_enum_schema_matches_golden() {
+    assert_typed_golden(
+        "multi_file_imported_generic_function_return_enum_dependency/main.zen",
+        "tests/fixtures/ir_json/typed_multi_file_imported_generic_function_return_enum.golden.json",
+        "multi-file imported generic function return enum",
+    );
+}
+
+#[test]
 fn emit_json_typed_generic_vec_schema_matches_golden() {
     assert_typed_golden(
         "generic_vec.zen",


### PR DESCRIPTION
## Summary
- add typed/HIR/MIR JSON goldens for an imported generic function returning a generic enum dependency
- pin the existing multi-file Option<T> fixture across compiler-owned JSON boundaries

## Tests
- cargo test --test integration emit_json_typed_multi_file_imported_generic_function_return_enum_schema_matches_golden -- --nocapture (red first before fixture generation)
- cargo test --test integration multi_file_imported_generic_function_return_enum -- --nocapture
- cargo test --test integration multi_file_generic_enum_specializations_do_not_emit_unspecialized_c_symbols -- --nocapture
- cargo fmt --check
- git diff --check
- cargo test --test docs_truth production_rust_files_stay_below_cleanup_threshold --quiet
- cargo test --test docs_truth zen_source_files_stay_below_cleanup_threshold --quiet
- cargo clippy -- -D warnings
- cargo test --lib --quiet
- cargo test --tests --quiet
- cargo test --test docs_truth --quiet