### PR TITLE
Add multi-file generic enum method goldens

### DIFF
--- a/tests/fixtures/ir_json/hir_multi_file_generic_enum_method.golden.json
+++ b/tests/fixtures/ir_json/hir_multi_file_generic_enum_method.golden.json
@@ -1,0 +1,53 @@
+{
+  "format": "zen.hir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "declarations": {
+    "types": [
+      {
+        "name": "Option_i32",
+        "kind": "enum",
+        "fields": [],
+        "variants": [
+          {
+            "name": "None",
+            "tag": 0,
+            "payload": []
+          },
+          {
+            "name": "Some",
+            "tag": 1,
+            "payload": [
+              {
+                "name": "payload",
+                "type": "i32"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "functions": [
+      {
+        "name": "main",
+        "params": [],
+        "return_type": "i32"
+      },
+      {
+        "name": "Option.unwrap_or_i32",
+        "params": [
+          {
+            "name": "self",
+            "type": "Option_i32"
+          },
+          {
+            "name": "fallback",
+            "type": "i32"
+          }
+        ],
+        "return_type": "i32"
+      }
+    ],
+    "globals": []
+  }
+}

--- a/tests/fixtures/ir_json/mir_multi_file_generic_enum_method.golden.json
+++ b/tests/fixtures/ir_json/mir_multi_file_generic_enum_method.golden.json
@@ -1,0 +1,185 @@
+{
+  "format": "zen.mir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "lowering_status": "minimal",
+  "functions": [
+    {
+      "name": "main",
+      "params": [],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [
+            {
+              "kind": "let",
+              "name": "some",
+              "type": "Option_i32",
+              "mutable": false,
+              "value": {
+                "kind": "enum_variant",
+                "type": "Option_i32",
+                "name": "Option_i32.Some",
+                "args": [
+                  {
+                    "kind": "int",
+                    "type": "i32",
+                    "value": 21
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "let",
+              "name": "none",
+              "type": "Option_i32",
+              "mutable": false,
+              "value": {
+                "kind": "enum_variant",
+                "type": "Option_i32",
+                "name": "Option_i32.None"
+              }
+            },
+            {
+              "kind": "expr",
+              "value": {
+                "kind": "call",
+                "type": "void",
+                "function": "io_println",
+                "args": [
+                  {
+                    "kind": "string_interpolation",
+                    "type": "StaticString",
+                    "value": {
+                      "parts": 1
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "expr",
+              "value": {
+                "kind": "call",
+                "type": "void",
+                "function": "io_println",
+                "args": [
+                  {
+                    "kind": "string_interpolation",
+                    "type": "StaticString",
+                    "value": {
+                      "parts": 1
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "int",
+              "type": "i32",
+              "value": 0
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Option.unwrap_or_i32",
+      "params": [
+        {
+          "name": "self",
+          "type": "Option_i32"
+        },
+        {
+          "name": "fallback",
+          "type": "i32"
+        }
+      ],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "match",
+              "type": "i32",
+              "target": {
+                "kind": "local",
+                "type": "Option_i32",
+                "name": "self"
+              },
+              "match_kind": "enum",
+              "arms": [
+                {
+                  "pattern": {
+                    "kind": "enum_variant",
+                    "name": "Option_i32.Some",
+                    "bindings": [
+                      {
+                        "name": "value",
+                        "type": "i32"
+                      }
+                    ]
+                  },
+                  "body": {
+                    "label": "entry",
+                    "statements": [],
+                    "terminator": {
+                      "kind": "return",
+                      "value": {
+                        "kind": "block",
+                        "type": "i32",
+                        "value": {
+                          "has_result": true,
+                          "result": {
+                            "kind": "local",
+                            "name": "value",
+                            "type": "i32"
+                          },
+                          "statement_count": 0
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "pattern": {
+                    "kind": "enum_variant",
+                    "name": "Option_i32.None",
+                    "bindings": []
+                  },
+                  "body": {
+                    "label": "entry",
+                    "statements": [],
+                    "terminator": {
+                      "kind": "return",
+                      "value": {
+                        "kind": "block",
+                        "type": "i32",
+                        "value": {
+                          "has_result": true,
+                          "result": {
+                            "kind": "local",
+                            "name": "fallback",
+                            "type": "i32"
+                          },
+                          "statement_count": 0
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/ir_json/typed_multi_file_generic_enum_method.golden.json
+++ b/tests/fixtures/ir_json/typed_multi_file_generic_enum_method.golden.json
@@ -1,0 +1,584 @@
+{
+  "format": "zen.typed.v0",
+  "semantic_status": "checked",
+  "program": {
+    "functions": [
+      {
+        "name": "main",
+        "params": [],
+        "return_type": "I32",
+        "body": {
+          "statements": [
+            {
+              "kind": {
+                "VarDecl": {
+                  "name": "some",
+                  "ty": {
+                    "Enum": {
+                      "name": "Option_i32",
+                      "variants": [
+                        [
+                          "None",
+                          null
+                        ],
+                        [
+                          "Some",
+                          "I32"
+                        ]
+                      ]
+                    }
+                  },
+                  "value": {
+                    "kind": {
+                      "EnumVariant": {
+                        "type_name": "Option_i32",
+                        "variant": "Some",
+                        "payload": {
+                          "kind": {
+                            "IntLiteral": 21
+                          },
+                          "ty": "I32",
+                          "span": {
+                            "file_id": 0,
+                            "start": 78,
+                            "end": 80
+                          }
+                        }
+                      }
+                    },
+                    "ty": {
+                      "Enum": {
+                        "name": "Option_i32",
+                        "variants": [
+                          [
+                            "None",
+                            null
+                          ],
+                          [
+                            "Some",
+                            "I32"
+                          ]
+                        ]
+                      }
+                    },
+                    "span": {
+                      "file_id": 0,
+                      "start": 61,
+                      "end": 81
+                    }
+                  },
+                  "mutable": false
+                }
+              },
+              "span": {
+                "file_id": 0,
+                "start": 54,
+                "end": 81
+              }
+            },
+            {
+              "kind": {
+                "VarDecl": {
+                  "name": "none",
+                  "ty": {
+                    "Enum": {
+                      "name": "Option_i32",
+                      "variants": [
+                        [
+                          "None",
+                          null
+                        ],
+                        [
+                          "Some",
+                          "I32"
+                        ]
+                      ]
+                    }
+                  },
+                  "value": {
+                    "kind": {
+                      "EnumVariant": {
+                        "type_name": "Option_i32",
+                        "variant": "None",
+                        "payload": null
+                      }
+                    },
+                    "ty": {
+                      "Enum": {
+                        "name": "Option_i32",
+                        "variants": [
+                          [
+                            "None",
+                            null
+                          ],
+                          [
+                            "Some",
+                            "I32"
+                          ]
+                        ]
+                      }
+                    },
+                    "span": {
+                      "file_id": 0,
+                      "start": 93,
+                      "end": 109
+                    }
+                  },
+                  "mutable": false
+                }
+              },
+              "span": {
+                "file_id": 0,
+                "start": 86,
+                "end": 109
+              }
+            },
+            {
+              "kind": {
+                "Expression": {
+                  "kind": {
+                    "FunctionCall": {
+                      "function": "io_println",
+                      "args": [
+                        {
+                          "kind": {
+                            "StringInterpolation": {
+                              "parts": [
+                                {
+                                  "Expr": {
+                                    "kind": {
+                                      "FunctionCall": {
+                                        "function": "Option.unwrap_or_i32",
+                                        "args": [
+                                          {
+                                            "kind": {
+                                              "Variable": "some"
+                                            },
+                                            "ty": {
+                                              "Enum": {
+                                                "name": "Option_i32",
+                                                "variants": [
+                                                  [
+                                                    "None",
+                                                    null
+                                                  ],
+                                                  [
+                                                    "Some",
+                                                    "I32"
+                                                  ]
+                                                ]
+                                              }
+                                            },
+                                            "span": {
+                                              "file_id": 0,
+                                              "start": 128,
+                                              "end": 132
+                                            }
+                                          },
+                                          {
+                                            "kind": {
+                                              "IntLiteral": 0
+                                            },
+                                            "ty": "I32",
+                                            "span": {
+                                              "file_id": 0,
+                                              "start": 143,
+                                              "end": 144
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "ty": "I32",
+                                    "span": {
+                                      "file_id": 0,
+                                      "start": 128,
+                                      "end": 145
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "ty": "Str",
+                          "span": {
+                            "file_id": 0,
+                            "start": 126,
+                            "end": 146
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "ty": "Void",
+                  "span": {
+                    "file_id": 0,
+                    "start": 114,
+                    "end": 148
+                  }
+                }
+              },
+              "span": {
+                "file_id": 0,
+                "start": 114,
+                "end": 148
+              }
+            },
+            {
+              "kind": {
+                "Expression": {
+                  "kind": {
+                    "FunctionCall": {
+                      "function": "io_println",
+                      "args": [
+                        {
+                          "kind": {
+                            "StringInterpolation": {
+                              "parts": [
+                                {
+                                  "Expr": {
+                                    "kind": {
+                                      "FunctionCall": {
+                                        "function": "Option.unwrap_or_i32",
+                                        "args": [
+                                          {
+                                            "kind": {
+                                              "Variable": "none"
+                                            },
+                                            "ty": {
+                                              "Enum": {
+                                                "name": "Option_i32",
+                                                "variants": [
+                                                  [
+                                                    "None",
+                                                    null
+                                                  ],
+                                                  [
+                                                    "Some",
+                                                    "I32"
+                                                  ]
+                                                ]
+                                              }
+                                            },
+                                            "span": {
+                                              "file_id": 0,
+                                              "start": 167,
+                                              "end": 171
+                                            }
+                                          },
+                                          {
+                                            "kind": {
+                                              "IntLiteral": 89
+                                            },
+                                            "ty": "I32",
+                                            "span": {
+                                              "file_id": 0,
+                                              "start": 182,
+                                              "end": 184
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "ty": "I32",
+                                    "span": {
+                                      "file_id": 0,
+                                      "start": 167,
+                                      "end": 185
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "ty": "Str",
+                          "span": {
+                            "file_id": 0,
+                            "start": 165,
+                            "end": 186
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "ty": "Void",
+                  "span": {
+                    "file_id": 0,
+                    "start": 153,
+                    "end": 188
+                  }
+                }
+              },
+              "span": {
+                "file_id": 0,
+                "start": 153,
+                "end": 188
+              }
+            }
+          ],
+          "expr": {
+            "kind": {
+              "IntLiteral": 0
+            },
+            "ty": "I32",
+            "span": {
+              "file_id": 0,
+              "start": 193,
+              "end": 194
+            }
+          },
+          "ty": "I32",
+          "span": {
+            "file_id": 0,
+            "start": 48,
+            "end": 196
+          }
+        },
+        "defers": [],
+        "span": {
+          "file_id": 0,
+          "start": 34,
+          "end": 196
+        }
+      },
+      {
+        "name": "Option.unwrap_or_i32",
+        "params": [
+          {
+            "name": "self",
+            "ty": {
+              "Enum": {
+                "name": "Option_i32",
+                "variants": [
+                  [
+                    "None",
+                    null
+                  ],
+                  [
+                    "Some",
+                    "I32"
+                  ]
+                ]
+              }
+            },
+            "span": {
+              "file_id": 1,
+              "start": 65,
+              "end": 75
+            }
+          },
+          {
+            "name": "fallback",
+            "ty": "I32",
+            "span": {
+              "file_id": 1,
+              "start": 77,
+              "end": 88
+            }
+          }
+        ],
+        "return_type": "I32",
+        "body": {
+          "statements": [],
+          "expr": {
+            "kind": {
+              "Match": {
+                "scrutinee": {
+                  "kind": {
+                    "Variable": "self"
+                  },
+                  "ty": {
+                    "Enum": {
+                      "name": "Option_i32",
+                      "variants": [
+                        [
+                          "None",
+                          null
+                        ],
+                        [
+                          "Some",
+                          "I32"
+                        ]
+                      ]
+                    }
+                  },
+                  "span": {
+                    "file_id": 1,
+                    "start": 98,
+                    "end": 102
+                  }
+                },
+                "arms": [
+                  {
+                    "pattern": {
+                      "EnumVariant": {
+                        "type_name": "Option_i32",
+                        "variant": "Some",
+                        "bindings": [
+                          [
+                            "value",
+                            "I32"
+                          ]
+                        ]
+                      }
+                    },
+                    "body": {
+                      "statements": [],
+                      "expr": {
+                        "kind": {
+                          "Block": {
+                            "statements": [],
+                            "expr": {
+                              "kind": {
+                                "Variable": "value"
+                              },
+                              "ty": "I32",
+                              "span": {
+                                "file_id": 1,
+                                "start": 129,
+                                "end": 134
+                              }
+                            },
+                            "ty": "I32",
+                            "span": {
+                              "file_id": 1,
+                              "start": 127,
+                              "end": 136
+                            }
+                          }
+                        },
+                        "ty": "I32",
+                        "span": {
+                          "file_id": 1,
+                          "start": 127,
+                          "end": 136
+                        }
+                      },
+                      "ty": "I32",
+                      "span": {
+                        "file_id": 1,
+                        "start": 127,
+                        "end": 136
+                      }
+                    },
+                    "span": {
+                      "file_id": 1,
+                      "start": 115,
+                      "end": 136
+                    }
+                  },
+                  {
+                    "pattern": {
+                      "EnumVariant": {
+                        "type_name": "Option_i32",
+                        "variant": "None",
+                        "bindings": []
+                      }
+                    },
+                    "body": {
+                      "statements": [],
+                      "expr": {
+                        "kind": {
+                          "Block": {
+                            "statements": [],
+                            "expr": {
+                              "kind": {
+                                "Variable": "fallback"
+                              },
+                              "ty": "I32",
+                              "span": {
+                                "file_id": 1,
+                                "start": 154,
+                                "end": 162
+                              }
+                            },
+                            "ty": "I32",
+                            "span": {
+                              "file_id": 1,
+                              "start": 152,
+                              "end": 164
+                            }
+                          }
+                        },
+                        "ty": "I32",
+                        "span": {
+                          "file_id": 1,
+                          "start": 152,
+                          "end": 164
+                        }
+                      },
+                      "ty": "I32",
+                      "span": {
+                        "file_id": 1,
+                        "start": 152,
+                        "end": 164
+                      }
+                    },
+                    "span": {
+                      "file_id": 1,
+                      "start": 147,
+                      "end": 164
+                    }
+                  }
+                ],
+                "kind": "EnumMatch"
+              }
+            },
+            "ty": "I32",
+            "span": {
+              "file_id": 1,
+              "start": 98,
+              "end": 164
+            }
+          },
+          "ty": "I32",
+          "span": {
+            "file_id": 1,
+            "start": 92,
+            "end": 166
+          }
+        },
+        "defers": [],
+        "span": {
+          "file_id": 1,
+          "start": 42,
+          "end": 166
+        }
+      }
+    ],
+    "types": [
+      {
+        "name": "Option_i32",
+        "kind": {
+          "Enum": {
+            "variants": [
+              {
+                "name": "None",
+                "tag": 0,
+                "payload": null
+              },
+              {
+                "name": "Some",
+                "tag": 1,
+                "payload": [
+                  [
+                    "payload",
+                    "I32"
+                  ]
+                ]
+              }
+            ]
+          }
+        },
+        "methods": [],
+        "span": {
+          "file_id": 0,
+          "start": 61,
+          "end": 81
+        }
+      }
+    ],
+    "globals": [],
+    "entry_point": "main"
+  }
+}

--- a/tests/integration/cli_build/frontend_json/hir_golden/generic_enums.rs
+++ b/tests/integration/cli_build/frontend_json/hir_golden/generic_enums.rs
@@ -53,3 +53,12 @@ fn emit_json_hir_multi_file_generic_result_multi_schema_matches_golden() {
         "multi-file generic Result multi-specialization",
     );
 }
+
+#[test]
+fn emit_json_hir_multi_file_generic_enum_method_schema_matches_golden() {
+    assert_hir_golden(
+        "tests/zen/multi_file_generic_enum_method/main.zen",
+        "tests/fixtures/ir_json/hir_multi_file_generic_enum_method.golden.json",
+        "multi-file generic enum method input",
+    );
+}

--- a/tests/integration/cli_build/frontend_json/mir_golden/generic_enums.rs
+++ b/tests/integration/cli_build/frontend_json/mir_golden/generic_enums.rs
@@ -53,3 +53,12 @@ fn emit_json_mir_multi_file_generic_result_multi_schema_matches_golden() {
         "multi-file generic Result multi-specialization",
     );
 }
+
+#[test]
+fn emit_json_mir_multi_file_generic_enum_method_schema_matches_golden() {
+    assert_mir_golden(
+        "tests/zen/multi_file_generic_enum_method/main.zen",
+        "tests/fixtures/ir_json/mir_multi_file_generic_enum_method.golden.json",
+        "multi-file generic enum method input",
+    );
+}

--- a/tests/integration/cli_build/frontend_json/typed_golden/generic_enums.rs
+++ b/tests/integration/cli_build/frontend_json/typed_golden/generic_enums.rs
@@ -55,6 +55,15 @@ fn emit_json_typed_multi_file_generic_result_multi_schema_matches_golden() {
 }
 
 #[test]
+fn emit_json_typed_multi_file_generic_enum_method_schema_matches_golden() {
+    assert_typed_golden(
+        "multi_file_generic_enum_method/main.zen",
+        "tests/fixtures/ir_json/typed_multi_file_generic_enum_method.golden.json",
+        "multi-file generic enum method",
+    );
+}
+
+#[test]
 fn emit_json_typed_generic_result_method_schema_matches_golden() {
     assert_typed_golden(
         "generic_result_enum_method.zen",


### PR DESCRIPTION
## Summary
- add typed/HIR/MIR JSON goldens for the multi-file generic enum method fixture
- pin imported Option<T>.unwrap_or specialization across compiler-owned JSON boundaries

## Tests
- cargo test --test integration emit_json_typed_multi_file_generic_enum_method_schema_matches_golden -- --nocapture (red first before fixture generation)
- cargo test --test integration multi_file_generic_enum_method -- --nocapture
- cargo fmt --check
- git diff --check
- cargo test --test docs_truth production_rust_files_stay_below_cleanup_threshold --quiet
- cargo test --test docs_truth zen_source_files_stay_below_cleanup_threshold --quiet
- cargo clippy -- -D warnings
- cargo test --lib --quiet
- cargo test --test docs_truth --quiet
- cargo test --tests --quiet