### PR TITLE
Add typed multi-file generic Result method golden

### DIFF
--- a/tests/fixtures/ir_json/typed_multi_file_generic_result_method.golden.json
+++ b/tests/fixtures/ir_json/typed_multi_file_generic_result_method.golden.json
@@ -1,0 +1,599 @@
+{
+  "format": "zen.typed.v0",
+  "semantic_status": "checked",
+  "program": {
+    "functions": [
+      {
+        "name": "main",
+        "params": [],
+        "return_type": "I32",
+        "body": {
+          "statements": [
+            {
+              "kind": {
+                "VarDecl": {
+                  "name": "ok",
+                  "ty": {
+                    "Enum": {
+                      "name": "Result_i32_StaticString",
+                      "variants": [
+                        [
+                          "Ok",
+                          "I32"
+                        ],
+                        [
+                          "Err",
+                          "Str"
+                        ]
+                      ]
+                    }
+                  },
+                  "value": {
+                    "kind": {
+                      "EnumVariant": {
+                        "type_name": "Result_i32_StaticString",
+                        "variant": "Ok",
+                        "payload": {
+                          "kind": {
+                            "IntLiteral": 55
+                          },
+                          "ty": "I32",
+                          "span": {
+                            "file_id": 0,
+                            "start": 88,
+                            "end": 90
+                          }
+                        }
+                      }
+                    },
+                    "ty": {
+                      "Enum": {
+                        "name": "Result_i32_StaticString",
+                        "variants": [
+                          [
+                            "Ok",
+                            "I32"
+                          ],
+                          [
+                            "Err",
+                            "Str"
+                          ]
+                        ]
+                      }
+                    },
+                    "span": {
+                      "file_id": 0,
+                      "start": 59,
+                      "end": 91
+                    }
+                  },
+                  "mutable": false
+                }
+              },
+              "span": {
+                "file_id": 0,
+                "start": 54,
+                "end": 91
+              }
+            },
+            {
+              "kind": {
+                "VarDecl": {
+                  "name": "err",
+                  "ty": {
+                    "Enum": {
+                      "name": "Result_i32_StaticString",
+                      "variants": [
+                        [
+                          "Ok",
+                          "I32"
+                        ],
+                        [
+                          "Err",
+                          "Str"
+                        ]
+                      ]
+                    }
+                  },
+                  "value": {
+                    "kind": {
+                      "EnumVariant": {
+                        "type_name": "Result_i32_StaticString",
+                        "variant": "Err",
+                        "payload": {
+                          "kind": {
+                            "StringLiteral": "bad"
+                          },
+                          "ty": "Str",
+                          "span": {
+                            "file_id": 0,
+                            "start": 132,
+                            "end": 137
+                          }
+                        }
+                      }
+                    },
+                    "ty": {
+                      "Enum": {
+                        "name": "Result_i32_StaticString",
+                        "variants": [
+                          [
+                            "Ok",
+                            "I32"
+                          ],
+                          [
+                            "Err",
+                            "Str"
+                          ]
+                        ]
+                      }
+                    },
+                    "span": {
+                      "file_id": 0,
+                      "start": 102,
+                      "end": 138
+                    }
+                  },
+                  "mutable": false
+                }
+              },
+              "span": {
+                "file_id": 0,
+                "start": 96,
+                "end": 138
+              }
+            },
+            {
+              "kind": {
+                "Expression": {
+                  "kind": {
+                    "FunctionCall": {
+                      "function": "io_println",
+                      "args": [
+                        {
+                          "kind": {
+                            "StringInterpolation": {
+                              "parts": [
+                                {
+                                  "Expr": {
+                                    "kind": {
+                                      "FunctionCall": {
+                                        "function": "Result.unwrap_or_i32_StaticString",
+                                        "args": [
+                                          {
+                                            "kind": {
+                                              "Variable": "ok"
+                                            },
+                                            "ty": {
+                                              "Enum": {
+                                                "name": "Result_i32_StaticString",
+                                                "variants": [
+                                                  [
+                                                    "Ok",
+                                                    "I32"
+                                                  ],
+                                                  [
+                                                    "Err",
+                                                    "Str"
+                                                  ]
+                                                ]
+                                              }
+                                            },
+                                            "span": {
+                                              "file_id": 0,
+                                              "start": 157,
+                                              "end": 159
+                                            }
+                                          },
+                                          {
+                                            "kind": {
+                                              "IntLiteral": 0
+                                            },
+                                            "ty": "I32",
+                                            "span": {
+                                              "file_id": 0,
+                                              "start": 170,
+                                              "end": 171
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "ty": "I32",
+                                    "span": {
+                                      "file_id": 0,
+                                      "start": 157,
+                                      "end": 172
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "ty": "Str",
+                          "span": {
+                            "file_id": 0,
+                            "start": 155,
+                            "end": 173
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "ty": "Void",
+                  "span": {
+                    "file_id": 0,
+                    "start": 143,
+                    "end": 175
+                  }
+                }
+              },
+              "span": {
+                "file_id": 0,
+                "start": 143,
+                "end": 175
+              }
+            },
+            {
+              "kind": {
+                "Expression": {
+                  "kind": {
+                    "FunctionCall": {
+                      "function": "io_println",
+                      "args": [
+                        {
+                          "kind": {
+                            "StringInterpolation": {
+                              "parts": [
+                                {
+                                  "Expr": {
+                                    "kind": {
+                                      "FunctionCall": {
+                                        "function": "Result.unwrap_or_i32_StaticString",
+                                        "args": [
+                                          {
+                                            "kind": {
+                                              "Variable": "err"
+                                            },
+                                            "ty": {
+                                              "Enum": {
+                                                "name": "Result_i32_StaticString",
+                                                "variants": [
+                                                  [
+                                                    "Ok",
+                                                    "I32"
+                                                  ],
+                                                  [
+                                                    "Err",
+                                                    "Str"
+                                                  ]
+                                                ]
+                                              }
+                                            },
+                                            "span": {
+                                              "file_id": 0,
+                                              "start": 194,
+                                              "end": 197
+                                            }
+                                          },
+                                          {
+                                            "kind": {
+                                              "IntLiteral": 144
+                                            },
+                                            "ty": "I32",
+                                            "span": {
+                                              "file_id": 0,
+                                              "start": 208,
+                                              "end": 211
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "ty": "I32",
+                                    "span": {
+                                      "file_id": 0,
+                                      "start": 194,
+                                      "end": 212
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "ty": "Str",
+                          "span": {
+                            "file_id": 0,
+                            "start": 192,
+                            "end": 213
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "ty": "Void",
+                  "span": {
+                    "file_id": 0,
+                    "start": 180,
+                    "end": 215
+                  }
+                }
+              },
+              "span": {
+                "file_id": 0,
+                "start": 180,
+                "end": 215
+              }
+            }
+          ],
+          "expr": {
+            "kind": {
+              "IntLiteral": 0
+            },
+            "ty": "I32",
+            "span": {
+              "file_id": 0,
+              "start": 220,
+              "end": 221
+            }
+          },
+          "ty": "I32",
+          "span": {
+            "file_id": 0,
+            "start": 48,
+            "end": 223
+          }
+        },
+        "defers": [],
+        "span": {
+          "file_id": 0,
+          "start": 34,
+          "end": 223
+        }
+      },
+      {
+        "name": "Result.unwrap_or_i32_StaticString",
+        "params": [
+          {
+            "name": "self",
+            "ty": {
+              "Enum": {
+                "name": "Result_i32_StaticString",
+                "variants": [
+                  [
+                    "Ok",
+                    "I32"
+                  ],
+                  [
+                    "Err",
+                    "Str"
+                  ]
+                ]
+              }
+            },
+            "span": {
+              "file_id": 1,
+              "start": 71,
+              "end": 81
+            }
+          },
+          {
+            "name": "fallback",
+            "ty": "I32",
+            "span": {
+              "file_id": 1,
+              "start": 83,
+              "end": 94
+            }
+          }
+        ],
+        "return_type": "I32",
+        "body": {
+          "statements": [],
+          "expr": {
+            "kind": {
+              "Match": {
+                "scrutinee": {
+                  "kind": {
+                    "Variable": "self"
+                  },
+                  "ty": {
+                    "Enum": {
+                      "name": "Result_i32_StaticString",
+                      "variants": [
+                        [
+                          "Ok",
+                          "I32"
+                        ],
+                        [
+                          "Err",
+                          "Str"
+                        ]
+                      ]
+                    }
+                  },
+                  "span": {
+                    "file_id": 1,
+                    "start": 104,
+                    "end": 108
+                  }
+                },
+                "arms": [
+                  {
+                    "pattern": {
+                      "EnumVariant": {
+                        "type_name": "Result_i32_StaticString",
+                        "variant": "Ok",
+                        "bindings": [
+                          [
+                            "value",
+                            "I32"
+                          ]
+                        ]
+                      }
+                    },
+                    "body": {
+                      "statements": [],
+                      "expr": {
+                        "kind": {
+                          "Block": {
+                            "statements": [],
+                            "expr": {
+                              "kind": {
+                                "Variable": "value"
+                              },
+                              "ty": "I32",
+                              "span": {
+                                "file_id": 1,
+                                "start": 133,
+                                "end": 138
+                              }
+                            },
+                            "ty": "I32",
+                            "span": {
+                              "file_id": 1,
+                              "start": 131,
+                              "end": 140
+                            }
+                          }
+                        },
+                        "ty": "I32",
+                        "span": {
+                          "file_id": 1,
+                          "start": 131,
+                          "end": 140
+                        }
+                      },
+                      "ty": "I32",
+                      "span": {
+                        "file_id": 1,
+                        "start": 131,
+                        "end": 140
+                      }
+                    },
+                    "span": {
+                      "file_id": 1,
+                      "start": 121,
+                      "end": 140
+                    }
+                  },
+                  {
+                    "pattern": {
+                      "EnumVariant": {
+                        "type_name": "Result_i32_StaticString",
+                        "variant": "Err",
+                        "bindings": []
+                      }
+                    },
+                    "body": {
+                      "statements": [],
+                      "expr": {
+                        "kind": {
+                          "Block": {
+                            "statements": [],
+                            "expr": {
+                              "kind": {
+                                "Variable": "fallback"
+                              },
+                              "ty": "I32",
+                              "span": {
+                                "file_id": 1,
+                                "start": 160,
+                                "end": 168
+                              }
+                            },
+                            "ty": "I32",
+                            "span": {
+                              "file_id": 1,
+                              "start": 158,
+                              "end": 170
+                            }
+                          }
+                        },
+                        "ty": "I32",
+                        "span": {
+                          "file_id": 1,
+                          "start": 158,
+                          "end": 170
+                        }
+                      },
+                      "ty": "I32",
+                      "span": {
+                        "file_id": 1,
+                        "start": 158,
+                        "end": 170
+                      }
+                    },
+                    "span": {
+                      "file_id": 1,
+                      "start": 151,
+                      "end": 170
+                    }
+                  }
+                ],
+                "kind": "EnumMatch"
+              }
+            },
+            "ty": "I32",
+            "span": {
+              "file_id": 1,
+              "start": 104,
+              "end": 170
+            }
+          },
+          "ty": "I32",
+          "span": {
+            "file_id": 1,
+            "start": 98,
+            "end": 172
+          }
+        },
+        "defers": [],
+        "span": {
+          "file_id": 1,
+          "start": 45,
+          "end": 172
+        }
+      }
+    ],
+    "types": [
+      {
+        "name": "Result_i32_StaticString",
+        "kind": {
+          "Enum": {
+            "variants": [
+              {
+                "name": "Ok",
+                "tag": 0,
+                "payload": [
+                  [
+                    "payload",
+                    "I32"
+                  ]
+                ]
+              },
+              {
+                "name": "Err",
+                "tag": 1,
+                "payload": [
+                  [
+                    "payload",
+                    "Str"
+                  ]
+                ]
+              }
+            ]
+          }
+        },
+        "methods": [],
+        "span": {
+          "file_id": 0,
+          "start": 59,
+          "end": 91
+        }
+      }
+    ],
+    "globals": [],
+    "entry_point": "main"
+  }
+}

--- a/tests/integration/cli_build/frontend_json/typed_golden/generic_enums.rs
+++ b/tests/integration/cli_build/frontend_json/typed_golden/generic_enums.rs
@@ -73,6 +73,15 @@ fn emit_json_typed_generic_result_method_schema_matches_golden() {
 }
 
 #[test]
+fn emit_json_typed_multi_file_generic_result_method_schema_matches_golden() {
+    assert_typed_golden(
+        "multi_file_generic_result_enum_method/main.zen",
+        "tests/fixtures/ir_json/typed_multi_file_generic_result_method.golden.json",
+        "multi-file generic Result method",
+    );
+}
+
+#[test]
 fn emit_json_typed_nested_generic_result_schema_matches_golden() {
     assert_typed_golden(
         "generic_nested_result_enum.zen",


### PR DESCRIPTION
## Summary
- add typed JSON golden coverage for the multi-file generic Result enum method fixture
- pin imported Result<T, E>.unwrap_or specialization at the typed compiler-owned boundary

## Tests
- cargo test --test integration emit_json_typed_multi_file_generic_result_method_schema_matches_golden -- --nocapture (red first before fixture generation)
- cargo test --test integration multi_file_generic_result_method -- --nocapture
- cargo fmt --check
- git diff --check
- cargo test --test docs_truth production_rust_files_stay_below_cleanup_threshold --quiet
- cargo test --test docs_truth zen_source_files_stay_below_cleanup_threshold --quiet
- cargo clippy -- -D warnings
- cargo test --lib --quiet
- cargo test --test docs_truth --quiet
- cargo test --tests --quiet