### PR TITLE
Add Result error specialization JSON goldens

### DIFF
--- a/tests/fixtures/ir_json/hir_multi_file_generic_result_error_multi_specialization.golden.json
+++ b/tests/fixtures/ir_json/hir_multi_file_generic_result_error_multi_specialization.golden.json
@@ -1,0 +1,99 @@
+{
+  "format": "zen.hir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "declarations": {
+    "types": [
+      {
+        "name": "Result_i32_bool",
+        "kind": "enum",
+        "fields": [],
+        "variants": [
+          {
+            "name": "Ok",
+            "tag": 0,
+            "payload": [
+              {
+                "name": "payload",
+                "type": "i32"
+              }
+            ]
+          },
+          {
+            "name": "Err",
+            "tag": 1,
+            "payload": [
+              {
+                "name": "payload",
+                "type": "bool"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Result_i32_i32",
+        "kind": "enum",
+        "fields": [],
+        "variants": [
+          {
+            "name": "Ok",
+            "tag": 0,
+            "payload": [
+              {
+                "name": "payload",
+                "type": "i32"
+              }
+            ]
+          },
+          {
+            "name": "Err",
+            "tag": 1,
+            "payload": [
+              {
+                "name": "payload",
+                "type": "i32"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "functions": [
+      {
+        "name": "main",
+        "params": [],
+        "return_type": "i32"
+      },
+      {
+        "name": "Result.unwrap_err_i32_bool",
+        "params": [
+          {
+            "name": "self",
+            "type": "Result_i32_bool"
+          },
+          {
+            "name": "fallback",
+            "type": "bool"
+          }
+        ],
+        "return_type": "bool"
+      },
+      {
+        "name": "Result.unwrap_err_i32_i32",
+        "params": [
+          {
+            "name": "self",
+            "type": "Result_i32_i32"
+          },
+          {
+            "name": "fallback",
+            "type": "i32"
+          }
+        ],
+        "return_type": "i32"
+      }
+    ],
+    "globals": []
+  }
+}

--- a/tests/fixtures/ir_json/mir_multi_file_generic_result_error_multi_specialization.golden.json
+++ b/tests/fixtures/ir_json/mir_multi_file_generic_result_error_multi_specialization.golden.json
@@ -1,0 +1,356 @@
+{
+  "format": "zen.mir.v0",
+  "schema_version": 0,
+  "semantic_status": "checked",
+  "lowering_status": "minimal",
+  "functions": [
+    {
+      "name": "main",
+      "params": [],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [
+            {
+              "kind": "let",
+              "name": "err_bool",
+              "type": "Result_i32_bool",
+              "mutable": false,
+              "value": {
+                "kind": "enum_variant",
+                "type": "Result_i32_bool",
+                "name": "Result_i32_bool.Err",
+                "args": [
+                  {
+                    "kind": "bool",
+                    "type": "bool",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "let",
+              "name": "ok_bool",
+              "type": "Result_i32_bool",
+              "mutable": false,
+              "value": {
+                "kind": "enum_variant",
+                "type": "Result_i32_bool",
+                "name": "Result_i32_bool.Ok",
+                "args": [
+                  {
+                    "kind": "int",
+                    "type": "i32",
+                    "value": 12
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "let",
+              "name": "err_i32",
+              "type": "Result_i32_i32",
+              "mutable": false,
+              "value": {
+                "kind": "enum_variant",
+                "type": "Result_i32_i32",
+                "name": "Result_i32_i32.Err",
+                "args": [
+                  {
+                    "kind": "int",
+                    "type": "i32",
+                    "value": 44
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "let",
+              "name": "ok_i32",
+              "type": "Result_i32_i32",
+              "mutable": false,
+              "value": {
+                "kind": "enum_variant",
+                "type": "Result_i32_i32",
+                "name": "Result_i32_i32.Ok",
+                "args": [
+                  {
+                    "kind": "int",
+                    "type": "i32",
+                    "value": 5
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "expr",
+              "value": {
+                "kind": "call",
+                "type": "void",
+                "function": "io_println",
+                "args": [
+                  {
+                    "kind": "string_interpolation",
+                    "type": "StaticString",
+                    "value": {
+                      "parts": 1
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "expr",
+              "value": {
+                "kind": "call",
+                "type": "void",
+                "function": "io_println",
+                "args": [
+                  {
+                    "kind": "string_interpolation",
+                    "type": "StaticString",
+                    "value": {
+                      "parts": 1
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "expr",
+              "value": {
+                "kind": "call",
+                "type": "void",
+                "function": "io_println",
+                "args": [
+                  {
+                    "kind": "string_interpolation",
+                    "type": "StaticString",
+                    "value": {
+                      "parts": 1
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "kind": "expr",
+              "value": {
+                "kind": "call",
+                "type": "void",
+                "function": "io_println",
+                "args": [
+                  {
+                    "kind": "string_interpolation",
+                    "type": "StaticString",
+                    "value": {
+                      "parts": 1
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "int",
+              "type": "i32",
+              "value": 0
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Result.unwrap_err_i32_bool",
+      "params": [
+        {
+          "name": "self",
+          "type": "Result_i32_bool"
+        },
+        {
+          "name": "fallback",
+          "type": "bool"
+        }
+      ],
+      "return_type": "bool",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "match",
+              "type": "bool",
+              "target": {
+                "kind": "local",
+                "type": "Result_i32_bool",
+                "name": "self"
+              },
+              "match_kind": "enum",
+              "arms": [
+                {
+                  "pattern": {
+                    "kind": "enum_variant",
+                    "name": "Result_i32_bool.Ok",
+                    "bindings": []
+                  },
+                  "body": {
+                    "label": "entry",
+                    "statements": [],
+                    "terminator": {
+                      "kind": "return",
+                      "value": {
+                        "kind": "block",
+                        "type": "bool",
+                        "value": {
+                          "has_result": true,
+                          "result": {
+                            "kind": "local",
+                            "name": "fallback",
+                            "type": "bool"
+                          },
+                          "statement_count": 0
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "pattern": {
+                    "kind": "enum_variant",
+                    "name": "Result_i32_bool.Err",
+                    "bindings": [
+                      {
+                        "name": "error",
+                        "type": "bool"
+                      }
+                    ]
+                  },
+                  "body": {
+                    "label": "entry",
+                    "statements": [],
+                    "terminator": {
+                      "kind": "return",
+                      "value": {
+                        "kind": "block",
+                        "type": "bool",
+                        "value": {
+                          "has_result": true,
+                          "result": {
+                            "kind": "local",
+                            "name": "error",
+                            "type": "bool"
+                          },
+                          "statement_count": 0
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Result.unwrap_err_i32_i32",
+      "params": [
+        {
+          "name": "self",
+          "type": "Result_i32_i32"
+        },
+        {
+          "name": "fallback",
+          "type": "i32"
+        }
+      ],
+      "return_type": "i32",
+      "blocks": [
+        {
+          "label": "entry",
+          "statements": [],
+          "terminator": {
+            "kind": "return",
+            "value": {
+              "kind": "match",
+              "type": "i32",
+              "target": {
+                "kind": "local",
+                "type": "Result_i32_i32",
+                "name": "self"
+              },
+              "match_kind": "enum",
+              "arms": [
+                {
+                  "pattern": {
+                    "kind": "enum_variant",
+                    "name": "Result_i32_i32.Ok",
+                    "bindings": []
+                  },
+                  "body": {
+                    "label": "entry",
+                    "statements": [],
+                    "terminator": {
+                      "kind": "return",
+                      "value": {
+                        "kind": "block",
+                        "type": "i32",
+                        "value": {
+                          "has_result": true,
+                          "result": {
+                            "kind": "local",
+                            "name": "fallback",
+                            "type": "i32"
+                          },
+                          "statement_count": 0
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "pattern": {
+                    "kind": "enum_variant",
+                    "name": "Result_i32_i32.Err",
+                    "bindings": [
+                      {
+                        "name": "error",
+                        "type": "i32"
+                      }
+                    ]
+                  },
+                  "body": {
+                    "label": "entry",
+                    "statements": [],
+                    "terminator": {
+                      "kind": "return",
+                      "value": {
+                        "kind": "block",
+                        "type": "i32",
+                        "value": {
+                          "has_result": true,
+                          "result": {
+                            "kind": "local",
+                            "name": "error",
+                            "type": "i32"
+                          },
+                          "statement_count": 0
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/ir_json/typed_multi_file_generic_result_error_multi_specialization.golden.json
+++ b/tests/fixtures/ir_json/typed_multi_file_generic_result_error_multi_specialization.golden.json
@@ -1,0 +1,1154 @@
+{
+  "format": "zen.typed.v0",
+  "semantic_status": "checked",
+  "program": {
+    "functions": [
+      {
+        "name": "main",
+        "params": [],
+        "return_type": "I32",
+        "body": {
+          "statements": [
+            {
+              "kind": {
+                "VarDecl": {
+                  "name": "err_bool",
+                  "ty": {
+                    "Enum": {
+                      "name": "Result_i32_bool",
+                      "variants": [
+                        [
+                          "Ok",
+                          "I32"
+                        ],
+                        [
+                          "Err",
+                          "Bool"
+                        ]
+                      ]
+                    }
+                  },
+                  "value": {
+                    "kind": {
+                      "EnumVariant": {
+                        "type_name": "Result_i32_bool",
+                        "variant": "Err",
+                        "payload": {
+                          "kind": {
+                            "BoolLiteral": true
+                          },
+                          "ty": "Bool",
+                          "span": {
+                            "file_id": 0,
+                            "start": 87,
+                            "end": 91
+                          }
+                        }
+                      }
+                    },
+                    "ty": {
+                      "Enum": {
+                        "name": "Result_i32_bool",
+                        "variants": [
+                          [
+                            "Ok",
+                            "I32"
+                          ],
+                          [
+                            "Err",
+                            "Bool"
+                          ]
+                        ]
+                      }
+                    },
+                    "span": {
+                      "file_id": 0,
+                      "start": 65,
+                      "end": 92
+                    }
+                  },
+                  "mutable": false
+                }
+              },
+              "span": {
+                "file_id": 0,
+                "start": 54,
+                "end": 92
+              }
+            },
+            {
+              "kind": {
+                "VarDecl": {
+                  "name": "ok_bool",
+                  "ty": {
+                    "Enum": {
+                      "name": "Result_i32_bool",
+                      "variants": [
+                        [
+                          "Ok",
+                          "I32"
+                        ],
+                        [
+                          "Err",
+                          "Bool"
+                        ]
+                      ]
+                    }
+                  },
+                  "value": {
+                    "kind": {
+                      "EnumVariant": {
+                        "type_name": "Result_i32_bool",
+                        "variant": "Ok",
+                        "payload": {
+                          "kind": {
+                            "IntLiteral": 12
+                          },
+                          "ty": "I32",
+                          "span": {
+                            "file_id": 0,
+                            "start": 128,
+                            "end": 130
+                          }
+                        }
+                      }
+                    },
+                    "ty": {
+                      "Enum": {
+                        "name": "Result_i32_bool",
+                        "variants": [
+                          [
+                            "Ok",
+                            "I32"
+                          ],
+                          [
+                            "Err",
+                            "Bool"
+                          ]
+                        ]
+                      }
+                    },
+                    "span": {
+                      "file_id": 0,
+                      "start": 107,
+                      "end": 131
+                    }
+                  },
+                  "mutable": false
+                }
+              },
+              "span": {
+                "file_id": 0,
+                "start": 97,
+                "end": 131
+              }
+            },
+            {
+              "kind": {
+                "VarDecl": {
+                  "name": "err_i32",
+                  "ty": {
+                    "Enum": {
+                      "name": "Result_i32_i32",
+                      "variants": [
+                        [
+                          "Ok",
+                          "I32"
+                        ],
+                        [
+                          "Err",
+                          "I32"
+                        ]
+                      ]
+                    }
+                  },
+                  "value": {
+                    "kind": {
+                      "EnumVariant": {
+                        "type_name": "Result_i32_i32",
+                        "variant": "Err",
+                        "payload": {
+                          "kind": {
+                            "IntLiteral": 44
+                          },
+                          "ty": "I32",
+                          "span": {
+                            "file_id": 0,
+                            "start": 167,
+                            "end": 169
+                          }
+                        }
+                      }
+                    },
+                    "ty": {
+                      "Enum": {
+                        "name": "Result_i32_i32",
+                        "variants": [
+                          [
+                            "Ok",
+                            "I32"
+                          ],
+                          [
+                            "Err",
+                            "I32"
+                          ]
+                        ]
+                      }
+                    },
+                    "span": {
+                      "file_id": 0,
+                      "start": 146,
+                      "end": 170
+                    }
+                  },
+                  "mutable": false
+                }
+              },
+              "span": {
+                "file_id": 0,
+                "start": 136,
+                "end": 170
+              }
+            },
+            {
+              "kind": {
+                "VarDecl": {
+                  "name": "ok_i32",
+                  "ty": {
+                    "Enum": {
+                      "name": "Result_i32_i32",
+                      "variants": [
+                        [
+                          "Ok",
+                          "I32"
+                        ],
+                        [
+                          "Err",
+                          "I32"
+                        ]
+                      ]
+                    }
+                  },
+                  "value": {
+                    "kind": {
+                      "EnumVariant": {
+                        "type_name": "Result_i32_i32",
+                        "variant": "Ok",
+                        "payload": {
+                          "kind": {
+                            "IntLiteral": 5
+                          },
+                          "ty": "I32",
+                          "span": {
+                            "file_id": 0,
+                            "start": 204,
+                            "end": 205
+                          }
+                        }
+                      }
+                    },
+                    "ty": {
+                      "Enum": {
+                        "name": "Result_i32_i32",
+                        "variants": [
+                          [
+                            "Ok",
+                            "I32"
+                          ],
+                          [
+                            "Err",
+                            "I32"
+                          ]
+                        ]
+                      }
+                    },
+                    "span": {
+                      "file_id": 0,
+                      "start": 184,
+                      "end": 206
+                    }
+                  },
+                  "mutable": false
+                }
+              },
+              "span": {
+                "file_id": 0,
+                "start": 175,
+                "end": 206
+              }
+            },
+            {
+              "kind": {
+                "Expression": {
+                  "kind": {
+                    "FunctionCall": {
+                      "function": "io_println",
+                      "args": [
+                        {
+                          "kind": {
+                            "StringInterpolation": {
+                              "parts": [
+                                {
+                                  "Expr": {
+                                    "kind": {
+                                      "FunctionCall": {
+                                        "function": "Result.unwrap_err_i32_bool",
+                                        "args": [
+                                          {
+                                            "kind": {
+                                              "Variable": "err_bool"
+                                            },
+                                            "ty": {
+                                              "Enum": {
+                                                "name": "Result_i32_bool",
+                                                "variants": [
+                                                  [
+                                                    "Ok",
+                                                    "I32"
+                                                  ],
+                                                  [
+                                                    "Err",
+                                                    "Bool"
+                                                  ]
+                                                ]
+                                              }
+                                            },
+                                            "span": {
+                                              "file_id": 0,
+                                              "start": 226,
+                                              "end": 234
+                                            }
+                                          },
+                                          {
+                                            "kind": {
+                                              "BoolLiteral": false
+                                            },
+                                            "ty": "Bool",
+                                            "span": {
+                                              "file_id": 0,
+                                              "start": 246,
+                                              "end": 251
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "ty": "Bool",
+                                    "span": {
+                                      "file_id": 0,
+                                      "start": 226,
+                                      "end": 252
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "ty": "Str",
+                          "span": {
+                            "file_id": 0,
+                            "start": 224,
+                            "end": 253
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "ty": "Void",
+                  "span": {
+                    "file_id": 0,
+                    "start": 212,
+                    "end": 255
+                  }
+                }
+              },
+              "span": {
+                "file_id": 0,
+                "start": 212,
+                "end": 255
+              }
+            },
+            {
+              "kind": {
+                "Expression": {
+                  "kind": {
+                    "FunctionCall": {
+                      "function": "io_println",
+                      "args": [
+                        {
+                          "kind": {
+                            "StringInterpolation": {
+                              "parts": [
+                                {
+                                  "Expr": {
+                                    "kind": {
+                                      "FunctionCall": {
+                                        "function": "Result.unwrap_err_i32_bool",
+                                        "args": [
+                                          {
+                                            "kind": {
+                                              "Variable": "ok_bool"
+                                            },
+                                            "ty": {
+                                              "Enum": {
+                                                "name": "Result_i32_bool",
+                                                "variants": [
+                                                  [
+                                                    "Ok",
+                                                    "I32"
+                                                  ],
+                                                  [
+                                                    "Err",
+                                                    "Bool"
+                                                  ]
+                                                ]
+                                              }
+                                            },
+                                            "span": {
+                                              "file_id": 0,
+                                              "start": 274,
+                                              "end": 281
+                                            }
+                                          },
+                                          {
+                                            "kind": {
+                                              "BoolLiteral": false
+                                            },
+                                            "ty": "Bool",
+                                            "span": {
+                                              "file_id": 0,
+                                              "start": 293,
+                                              "end": 298
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "ty": "Bool",
+                                    "span": {
+                                      "file_id": 0,
+                                      "start": 274,
+                                      "end": 299
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "ty": "Str",
+                          "span": {
+                            "file_id": 0,
+                            "start": 272,
+                            "end": 300
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "ty": "Void",
+                  "span": {
+                    "file_id": 0,
+                    "start": 260,
+                    "end": 302
+                  }
+                }
+              },
+              "span": {
+                "file_id": 0,
+                "start": 260,
+                "end": 302
+              }
+            },
+            {
+              "kind": {
+                "Expression": {
+                  "kind": {
+                    "FunctionCall": {
+                      "function": "io_println",
+                      "args": [
+                        {
+                          "kind": {
+                            "StringInterpolation": {
+                              "parts": [
+                                {
+                                  "Expr": {
+                                    "kind": {
+                                      "FunctionCall": {
+                                        "function": "Result.unwrap_err_i32_i32",
+                                        "args": [
+                                          {
+                                            "kind": {
+                                              "Variable": "err_i32"
+                                            },
+                                            "ty": {
+                                              "Enum": {
+                                                "name": "Result_i32_i32",
+                                                "variants": [
+                                                  [
+                                                    "Ok",
+                                                    "I32"
+                                                  ],
+                                                  [
+                                                    "Err",
+                                                    "I32"
+                                                  ]
+                                                ]
+                                              }
+                                            },
+                                            "span": {
+                                              "file_id": 0,
+                                              "start": 321,
+                                              "end": 328
+                                            }
+                                          },
+                                          {
+                                            "kind": {
+                                              "IntLiteral": 0
+                                            },
+                                            "ty": "I32",
+                                            "span": {
+                                              "file_id": 0,
+                                              "start": 340,
+                                              "end": 341
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "ty": "I32",
+                                    "span": {
+                                      "file_id": 0,
+                                      "start": 321,
+                                      "end": 342
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "ty": "Str",
+                          "span": {
+                            "file_id": 0,
+                            "start": 319,
+                            "end": 343
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "ty": "Void",
+                  "span": {
+                    "file_id": 0,
+                    "start": 307,
+                    "end": 345
+                  }
+                }
+              },
+              "span": {
+                "file_id": 0,
+                "start": 307,
+                "end": 345
+              }
+            },
+            {
+              "kind": {
+                "Expression": {
+                  "kind": {
+                    "FunctionCall": {
+                      "function": "io_println",
+                      "args": [
+                        {
+                          "kind": {
+                            "StringInterpolation": {
+                              "parts": [
+                                {
+                                  "Expr": {
+                                    "kind": {
+                                      "FunctionCall": {
+                                        "function": "Result.unwrap_err_i32_i32",
+                                        "args": [
+                                          {
+                                            "kind": {
+                                              "Variable": "ok_i32"
+                                            },
+                                            "ty": {
+                                              "Enum": {
+                                                "name": "Result_i32_i32",
+                                                "variants": [
+                                                  [
+                                                    "Ok",
+                                                    "I32"
+                                                  ],
+                                                  [
+                                                    "Err",
+                                                    "I32"
+                                                  ]
+                                                ]
+                                              }
+                                            },
+                                            "span": {
+                                              "file_id": 0,
+                                              "start": 364,
+                                              "end": 370
+                                            }
+                                          },
+                                          {
+                                            "kind": {
+                                              "IntLiteral": 88
+                                            },
+                                            "ty": "I32",
+                                            "span": {
+                                              "file_id": 0,
+                                              "start": 382,
+                                              "end": 384
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "ty": "I32",
+                                    "span": {
+                                      "file_id": 0,
+                                      "start": 364,
+                                      "end": 385
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "ty": "Str",
+                          "span": {
+                            "file_id": 0,
+                            "start": 362,
+                            "end": 386
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "ty": "Void",
+                  "span": {
+                    "file_id": 0,
+                    "start": 350,
+                    "end": 388
+                  }
+                }
+              },
+              "span": {
+                "file_id": 0,
+                "start": 350,
+                "end": 388
+              }
+            }
+          ],
+          "expr": {
+            "kind": {
+              "IntLiteral": 0
+            },
+            "ty": "I32",
+            "span": {
+              "file_id": 0,
+              "start": 393,
+              "end": 394
+            }
+          },
+          "ty": "I32",
+          "span": {
+            "file_id": 0,
+            "start": 48,
+            "end": 396
+          }
+        },
+        "defers": [],
+        "span": {
+          "file_id": 0,
+          "start": 34,
+          "end": 396
+        }
+      },
+      {
+        "name": "Result.unwrap_err_i32_bool",
+        "params": [
+          {
+            "name": "self",
+            "ty": {
+              "Enum": {
+                "name": "Result_i32_bool",
+                "variants": [
+                  [
+                    "Ok",
+                    "I32"
+                  ],
+                  [
+                    "Err",
+                    "Bool"
+                  ]
+                ]
+              }
+            },
+            "span": {
+              "file_id": 1,
+              "start": 72,
+              "end": 82
+            }
+          },
+          {
+            "name": "fallback",
+            "ty": "Bool",
+            "span": {
+              "file_id": 1,
+              "start": 84,
+              "end": 95
+            }
+          }
+        ],
+        "return_type": "Bool",
+        "body": {
+          "statements": [],
+          "expr": {
+            "kind": {
+              "Match": {
+                "scrutinee": {
+                  "kind": {
+                    "Variable": "self"
+                  },
+                  "ty": {
+                    "Enum": {
+                      "name": "Result_i32_bool",
+                      "variants": [
+                        [
+                          "Ok",
+                          "I32"
+                        ],
+                        [
+                          "Err",
+                          "Bool"
+                        ]
+                      ]
+                    }
+                  },
+                  "span": {
+                    "file_id": 1,
+                    "start": 105,
+                    "end": 109
+                  }
+                },
+                "arms": [
+                  {
+                    "pattern": {
+                      "EnumVariant": {
+                        "type_name": "Result_i32_bool",
+                        "variant": "Ok",
+                        "bindings": []
+                      }
+                    },
+                    "body": {
+                      "statements": [],
+                      "expr": {
+                        "kind": {
+                          "Block": {
+                            "statements": [],
+                            "expr": {
+                              "kind": {
+                                "Variable": "fallback"
+                              },
+                              "ty": "Bool",
+                              "span": {
+                                "file_id": 1,
+                                "start": 130,
+                                "end": 138
+                              }
+                            },
+                            "ty": "Bool",
+                            "span": {
+                              "file_id": 1,
+                              "start": 128,
+                              "end": 140
+                            }
+                          }
+                        },
+                        "ty": "Bool",
+                        "span": {
+                          "file_id": 1,
+                          "start": 128,
+                          "end": 140
+                        }
+                      },
+                      "ty": "Bool",
+                      "span": {
+                        "file_id": 1,
+                        "start": 128,
+                        "end": 140
+                      }
+                    },
+                    "span": {
+                      "file_id": 1,
+                      "start": 122,
+                      "end": 140
+                    }
+                  },
+                  {
+                    "pattern": {
+                      "EnumVariant": {
+                        "type_name": "Result_i32_bool",
+                        "variant": "Err",
+                        "bindings": [
+                          [
+                            "error",
+                            "Bool"
+                          ]
+                        ]
+                      }
+                    },
+                    "body": {
+                      "statements": [],
+                      "expr": {
+                        "kind": {
+                          "Block": {
+                            "statements": [],
+                            "expr": {
+                              "kind": {
+                                "Variable": "error"
+                              },
+                              "ty": "Bool",
+                              "span": {
+                                "file_id": 1,
+                                "start": 164,
+                                "end": 169
+                              }
+                            },
+                            "ty": "Bool",
+                            "span": {
+                              "file_id": 1,
+                              "start": 162,
+                              "end": 171
+                            }
+                          }
+                        },
+                        "ty": "Bool",
+                        "span": {
+                          "file_id": 1,
+                          "start": 162,
+                          "end": 171
+                        }
+                      },
+                      "ty": "Bool",
+                      "span": {
+                        "file_id": 1,
+                        "start": 162,
+                        "end": 171
+                      }
+                    },
+                    "span": {
+                      "file_id": 1,
+                      "start": 151,
+                      "end": 171
+                    }
+                  }
+                ],
+                "kind": "EnumMatch"
+              }
+            },
+            "ty": "Bool",
+            "span": {
+              "file_id": 1,
+              "start": 105,
+              "end": 171
+            }
+          },
+          "ty": "Bool",
+          "span": {
+            "file_id": 1,
+            "start": 99,
+            "end": 173
+          }
+        },
+        "defers": [],
+        "span": {
+          "file_id": 1,
+          "start": 45,
+          "end": 173
+        }
+      },
+      {
+        "name": "Result.unwrap_err_i32_i32",
+        "params": [
+          {
+            "name": "self",
+            "ty": {
+              "Enum": {
+                "name": "Result_i32_i32",
+                "variants": [
+                  [
+                    "Ok",
+                    "I32"
+                  ],
+                  [
+                    "Err",
+                    "I32"
+                  ]
+                ]
+              }
+            },
+            "span": {
+              "file_id": 1,
+              "start": 72,
+              "end": 82
+            }
+          },
+          {
+            "name": "fallback",
+            "ty": "I32",
+            "span": {
+              "file_id": 1,
+              "start": 84,
+              "end": 95
+            }
+          }
+        ],
+        "return_type": "I32",
+        "body": {
+          "statements": [],
+          "expr": {
+            "kind": {
+              "Match": {
+                "scrutinee": {
+                  "kind": {
+                    "Variable": "self"
+                  },
+                  "ty": {
+                    "Enum": {
+                      "name": "Result_i32_i32",
+                      "variants": [
+                        [
+                          "Ok",
+                          "I32"
+                        ],
+                        [
+                          "Err",
+                          "I32"
+                        ]
+                      ]
+                    }
+                  },
+                  "span": {
+                    "file_id": 1,
+                    "start": 105,
+                    "end": 109
+                  }
+                },
+                "arms": [
+                  {
+                    "pattern": {
+                      "EnumVariant": {
+                        "type_name": "Result_i32_i32",
+                        "variant": "Ok",
+                        "bindings": []
+                      }
+                    },
+                    "body": {
+                      "statements": [],
+                      "expr": {
+                        "kind": {
+                          "Block": {
+                            "statements": [],
+                            "expr": {
+                              "kind": {
+                                "Variable": "fallback"
+                              },
+                              "ty": "I32",
+                              "span": {
+                                "file_id": 1,
+                                "start": 130,
+                                "end": 138
+                              }
+                            },
+                            "ty": "I32",
+                            "span": {
+                              "file_id": 1,
+                              "start": 128,
+                              "end": 140
+                            }
+                          }
+                        },
+                        "ty": "I32",
+                        "span": {
+                          "file_id": 1,
+                          "start": 128,
+                          "end": 140
+                        }
+                      },
+                      "ty": "I32",
+                      "span": {
+                        "file_id": 1,
+                        "start": 128,
+                        "end": 140
+                      }
+                    },
+                    "span": {
+                      "file_id": 1,
+                      "start": 122,
+                      "end": 140
+                    }
+                  },
+                  {
+                    "pattern": {
+                      "EnumVariant": {
+                        "type_name": "Result_i32_i32",
+                        "variant": "Err",
+                        "bindings": [
+                          [
+                            "error",
+                            "I32"
+                          ]
+                        ]
+                      }
+                    },
+                    "body": {
+                      "statements": [],
+                      "expr": {
+                        "kind": {
+                          "Block": {
+                            "statements": [],
+                            "expr": {
+                              "kind": {
+                                "Variable": "error"
+                              },
+                              "ty": "I32",
+                              "span": {
+                                "file_id": 1,
+                                "start": 164,
+                                "end": 169
+                              }
+                            },
+                            "ty": "I32",
+                            "span": {
+                              "file_id": 1,
+                              "start": 162,
+                              "end": 171
+                            }
+                          }
+                        },
+                        "ty": "I32",
+                        "span": {
+                          "file_id": 1,
+                          "start": 162,
+                          "end": 171
+                        }
+                      },
+                      "ty": "I32",
+                      "span": {
+                        "file_id": 1,
+                        "start": 162,
+                        "end": 171
+                      }
+                    },
+                    "span": {
+                      "file_id": 1,
+                      "start": 151,
+                      "end": 171
+                    }
+                  }
+                ],
+                "kind": "EnumMatch"
+              }
+            },
+            "ty": "I32",
+            "span": {
+              "file_id": 1,
+              "start": 105,
+              "end": 171
+            }
+          },
+          "ty": "I32",
+          "span": {
+            "file_id": 1,
+            "start": 99,
+            "end": 173
+          }
+        },
+        "defers": [],
+        "span": {
+          "file_id": 1,
+          "start": 45,
+          "end": 173
+        }
+      }
+    ],
+    "types": [
+      {
+        "name": "Result_i32_bool",
+        "kind": {
+          "Enum": {
+            "variants": [
+              {
+                "name": "Ok",
+                "tag": 0,
+                "payload": [
+                  [
+                    "payload",
+                    "I32"
+                  ]
+                ]
+              },
+              {
+                "name": "Err",
+                "tag": 1,
+                "payload": [
+                  [
+                    "payload",
+                    "Bool"
+                  ]
+                ]
+              }
+            ]
+          }
+        },
+        "methods": [],
+        "span": {
+          "file_id": 0,
+          "start": 65,
+          "end": 92
+        }
+      },
+      {
+        "name": "Result_i32_i32",
+        "kind": {
+          "Enum": {
+            "variants": [
+              {
+                "name": "Ok",
+                "tag": 0,
+                "payload": [
+                  [
+                    "payload",
+                    "I32"
+                  ]
+                ]
+              },
+              {
+                "name": "Err",
+                "tag": 1,
+                "payload": [
+                  [
+                    "payload",
+                    "I32"
+                  ]
+                ]
+              }
+            ]
+          }
+        },
+        "methods": [],
+        "span": {
+          "file_id": 0,
+          "start": 146,
+          "end": 170
+        }
+      }
+    ],
+    "globals": [],
+    "entry_point": "main"
+  }
+}

--- a/tests/integration/cli_build/frontend_json/hir_golden/generic_enums.rs
+++ b/tests/integration/cli_build/frontend_json/hir_golden/generic_enums.rs
@@ -55,6 +55,15 @@ fn emit_json_hir_multi_file_generic_result_multi_schema_matches_golden() {
 }
 
 #[test]
+fn emit_json_hir_multi_file_generic_result_error_multi_schema_matches_golden() {
+    assert_hir_golden(
+        "tests/zen/multi_file_generic_result_error_multi_specialization/main.zen",
+        "tests/fixtures/ir_json/hir_multi_file_generic_result_error_multi_specialization.golden.json",
+        "multi-file generic Result error-type multi-specialization",
+    );
+}
+
+#[test]
 fn emit_json_hir_multi_file_generic_enum_method_schema_matches_golden() {
     assert_hir_golden(
         "tests/zen/multi_file_generic_enum_method/main.zen",

--- a/tests/integration/cli_build/frontend_json/mir_golden/generic_enums.rs
+++ b/tests/integration/cli_build/frontend_json/mir_golden/generic_enums.rs
@@ -55,6 +55,15 @@ fn emit_json_mir_multi_file_generic_result_multi_schema_matches_golden() {
 }
 
 #[test]
+fn emit_json_mir_multi_file_generic_result_error_multi_schema_matches_golden() {
+    assert_mir_golden(
+        "tests/zen/multi_file_generic_result_error_multi_specialization/main.zen",
+        "tests/fixtures/ir_json/mir_multi_file_generic_result_error_multi_specialization.golden.json",
+        "multi-file generic Result error-type multi-specialization",
+    );
+}
+
+#[test]
 fn emit_json_mir_multi_file_generic_enum_method_schema_matches_golden() {
     assert_mir_golden(
         "tests/zen/multi_file_generic_enum_method/main.zen",

--- a/tests/integration/cli_build/frontend_json/module_graph/symbols/generic.rs
+++ b/tests/integration/cli_build/frontend_json/module_graph/symbols/generic.rs
@@ -189,6 +189,37 @@ fn emit_json_symbols_reports_multi_file_generic_result_multi_specialization_surf
     });
 }
 
+#[test]
+fn emit_json_symbols_reports_multi_file_generic_result_error_multi_specialization_surface() {
+    let modules = symbols_modules_for_fixture(
+        "tests/zen/multi_file_generic_result_error_multi_specialization/main.zen",
+        "multi-file generic Result error-type multi-specialization symbols",
+    );
+
+    assert_eq!(
+        modules.len(),
+        2,
+        "fixture should report main and result modules: {modules:?}"
+    );
+
+    let main = module_by_file(&modules, "main.zen");
+    assert_symbol(main, "Import", "Result", |symbol| {
+        symbol["import_source"] == "result"
+    });
+
+    let result = module_by_file(&modules, "result.zen");
+    assert_symbol(result, "Type", "Result", |symbol| {
+        symbol["is_public"] == true
+            && string_array_eq(&symbol["type_parameter_names"], &["T", "E"])
+            && string_array_eq(&symbol["variant_names"], &["Ok", "Err"])
+    });
+    assert_symbol(result, "Value", "Result.unwrap_err", |symbol| {
+        symbol["is_public"] == true
+            && string_array_eq(&symbol["parameter_type_names"], &["Self", "E"])
+            && symbol["return_type_name"] == "E"
+    });
+}
+
 fn symbols_modules_for_fixture(source_path: &str, description: &str) -> Vec<serde_json::Value> {
     let source_path = Path::new(env!("CARGO_MANIFEST_DIR")).join(source_path);
     let output = emit_json("symbols", &source_path, description);

--- a/tests/integration/cli_build/frontend_json/typed_golden/generic_enums.rs
+++ b/tests/integration/cli_build/frontend_json/typed_golden/generic_enums.rs
@@ -55,6 +55,15 @@ fn emit_json_typed_multi_file_generic_result_multi_schema_matches_golden() {
 }
 
 #[test]
+fn emit_json_typed_multi_file_generic_result_error_multi_schema_matches_golden() {
+    assert_typed_golden(
+        "multi_file_generic_result_error_multi_specialization/main.zen",
+        "tests/fixtures/ir_json/typed_multi_file_generic_result_error_multi_specialization.golden.json",
+        "multi-file generic Result error-type multi-specialization",
+    );
+}
+
+#[test]
 fn emit_json_typed_multi_file_generic_enum_method_schema_matches_golden() {
     assert_typed_golden(
         "multi_file_generic_enum_method/main.zen",


### PR DESCRIPTION
## Summary
- add typed/HIR/MIR JSON goldens for multi-file Result<T, E> error-type multi-specialization
- add symbols JSON coverage for the Result.unwrap_err generic source surface
- pin Result<i32, bool> and Result<i32, i32> as distinct compiler-owned JSON specializations before C generation

## Tests
- cargo test --test integration emit_json_typed_multi_file_generic_result_error_multi_schema_matches_golden -- --nocapture (red first before fixture generation)
- cargo test --test integration generic_result_error_multi -- --nocapture
- cargo test --test integration multi_file_generic_result_error_type_specializations_do_not_collapse -- --nocapture
- cargo fmt --check
- git diff --check
- cargo test --test docs_truth production_rust_files_stay_below_cleanup_threshold --quiet
- cargo test --test docs_truth zen_source_files_stay_below_cleanup_threshold --quiet
- cargo clippy -- -D warnings
- cargo test --lib --quiet
- cargo test --test docs_truth --quiet
- cargo test --tests --quiet