### PR TITLE
[codex] split generated C support scanners

### DIFF
--- a/tests/docs_truth/repo_hygiene/codegen_c.rs
+++ b/tests/docs_truth/repo_hygiene/codegen_c.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+#[path = "codegen_c/generated_c_support.rs"]
+mod generated_c_support;
+
 #[test]
 fn codegen_c_function_emission_lives_in_focused_helper() {
     let types = read("src/codegen/c/types.rs");

--- a/tests/docs_truth/repo_hygiene/codegen_c/generated_c_support.rs
+++ b/tests/docs_truth/repo_hygiene/codegen_c/generated_c_support.rs
@@ -1,0 +1,122 @@
+use super::*;
+
+#[test]
+fn generated_c_support_scanners_stay_split_by_responsibility() {
+    let support = read("tests/integration/support.rs");
+    let root = read("tests/integration/support/generated_c.rs");
+    let definitions = read("tests/integration/support/generated_c/definitions.rs");
+    let calls = read("tests/integration/support/generated_c/calls.rs");
+    let public_helpers = [
+        "assert_c_call_resolves_to_single_definition",
+        "assert_generated_c_calls_resolve_to_definitions",
+        "assert_generated_c_function_definitions_are_unique",
+        "has_c_call_outside_signature",
+        "undefined_generated_c_calls",
+    ];
+    let private_helpers = [
+        "assert_c_function_definition",
+        "assert_c_function_definition_count",
+        "assert_c_call_resolves_to_definition",
+        "c_function_definitions",
+        "c_function_definition_name",
+        "generated_c_calls_on_line",
+        "is_any_c_function_signature_line",
+        "is_c_function_signature_line",
+        "is_tracked_c_function_name",
+        "is_untracked_c_call_name",
+    ];
+
+    for module in ["mod calls;", "mod definitions;"] {
+        assert!(
+            root.contains(module),
+            "generated-C support should load focused scanner module `{module}`"
+        );
+    }
+
+    assert_helpers_live_in_focused_module(
+        &root,
+        &definitions,
+        &[
+            "fn c_function_definitions(",
+            "fn c_function_definition_name(",
+        ],
+        "definition scanner",
+    );
+    assert_helpers_live_in_focused_module(
+        &root,
+        &calls,
+        &[
+            "fn generated_c_calls_on_line(",
+            "fn is_any_c_function_signature_line(",
+            "fn is_untracked_c_call_name(",
+        ],
+        "call scanner",
+    );
+
+    let mut root_public_helpers = public_functions(&root);
+    root_public_helpers.sort_unstable();
+    let mut expected_public_helpers = public_helpers;
+    expected_public_helpers.sort_unstable();
+    assert_eq!(
+        root_public_helpers, expected_public_helpers,
+        "generated-C support root should expose only the stable facade helpers"
+    );
+
+    let support_export_block = support
+        .split("pub use generated_c::{")
+        .nth(1)
+        .and_then(|tail| tail.split("};").next())
+        .expect("integration support should re-export generated-C helpers from one block");
+    let mut support_exports: Vec<_> = support_export_block
+        .split(',')
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .collect();
+    support_exports.sort_unstable();
+    assert_eq!(
+        support_exports, expected_public_helpers,
+        "integration support should re-export only the generated-C facade helpers"
+    );
+
+    for helper in public_helpers {
+        assert!(
+            support.contains(helper),
+            "integration support should re-export generated-C facade helper `{helper}`"
+        );
+    }
+    for helper in private_helpers {
+        assert!(
+            !support_export_block
+                .split(',')
+                .map(str::trim)
+                .any(|export| export == helper),
+            "integration support should not re-export generated-C scanner/internal helper `{helper}`"
+        );
+    }
+}
+
+fn assert_helpers_live_in_focused_module(
+    root: &str,
+    focused: &str,
+    helpers: &[&str],
+    responsibility: &str,
+) {
+    for helper in helpers {
+        assert!(
+            !root.contains(helper),
+            "generated-C support root should not own {responsibility} `{helper}`"
+        );
+        assert!(
+            focused.contains(helper),
+            "generated-C {responsibility} should own `{helper}`"
+        );
+    }
+}
+
+fn public_functions(source: &str) -> Vec<&str> {
+    source
+        .lines()
+        .filter_map(|line| line.trim_start().strip_prefix("pub fn "))
+        .filter_map(|line| line.split('(').next())
+        .collect()
+}

--- a/tests/integration/generated_c_assertions.rs
+++ b/tests/integration/generated_c_assertions.rs
@@ -27,6 +27,7 @@ int32_t inner_i32(int32_t value) {
 
 int32_t outer_i32(int32_t value) {
     printf("%d", value);
+    unwrap_result_Option_i32_StaticString(value);
     missing_stmt_i32(value);
     return missing_i32(value) + inner_i32(value) + id(12LL);
 }
@@ -35,6 +36,7 @@ int32_t outer_i32(int32_t value) {
     assert_eq!(
         undefined_generated_c_calls(c_source),
         vec![
+            "unwrap_result_Option_i32_StaticString".to_string(),
             "missing_stmt_i32".to_string(),
             "missing_i32".to_string(),
             "id".to_string()

--- a/tests/integration/support/generated_c.rs
+++ b/tests/integration/support/generated_c.rs
@@ -1,23 +1,12 @@
-fn assert_c_function_definition(c_source: &str, name: &str) {
-    let needle = format!(" {name}(");
-    assert!(
-        c_source
-            .lines()
-            .any(|line| line.trim_end().ends_with('{') && line.contains(&needle)),
-        "expected generated C definition for `{name}`:\n{c_source}"
-    );
-}
+#[path = "generated_c/calls.rs"]
+mod calls;
+#[path = "generated_c/definitions.rs"]
+mod definitions;
 
-fn assert_c_function_definition_count(c_source: &str, name: &str, expected: usize) {
-    let actual = c_function_definitions(c_source)
-        .iter()
-        .filter(|definition| definition.as_str() == name)
-        .count();
-    assert_eq!(
-        actual, expected,
-        "expected {expected} generated C definitions for `{name}`, found {actual}:\n{c_source}"
-    );
-}
+use calls::{generated_c_calls_on_line, is_any_c_function_signature_line};
+use definitions::{
+    assert_c_function_definition, assert_c_function_definition_count, c_function_definitions,
+};
 
 pub fn assert_generated_c_function_definitions_are_unique(c_source: &str) {
     let definitions = c_function_definitions(c_source);
@@ -86,132 +75,6 @@ pub fn undefined_generated_c_calls(c_source: &str) -> Vec<String> {
     undefined
 }
 
-fn c_function_definitions(c_source: &str) -> Vec<String> {
-    c_source
-        .lines()
-        .filter_map(|line| c_function_definition_name(line.trim()))
-        .collect()
-}
-
-fn c_function_definition_name(trimmed: &str) -> Option<String> {
-    if !trimmed.ends_with('{') {
-        return None;
-    }
-
-    let paren = trimmed.find('(')?;
-    let before = trimmed[..paren].trim_end();
-    let name_start = before
-        .rfind(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '_'))
-        .map_or(0, |idx| idx + 1);
-    let name = &before[name_start..];
-
-    if is_tracked_c_function_name(name) {
-        Some(name.to_string())
-    } else {
-        None
-    }
-}
-
-fn is_any_c_function_signature_line(trimmed: &str) -> bool {
-    if !(trimmed.ends_with(';') || trimmed.ends_with('{')) {
-        return false;
-    }
-
-    let Some(paren) = trimmed.find('(') else {
-        return false;
-    };
-    let before = &trimmed[..paren];
-    let name_start = before
-        .trim_end()
-        .rfind(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '_'))
-        .map_or(0, |idx| idx + 1);
-    let return_type = before[..name_start].trim();
-    let name = before[name_start..].trim();
-
-    !return_type.is_empty()
-        && is_tracked_c_function_name(name)
-        && !before.contains('=')
-        && !before.contains("return")
-}
-
-fn generated_c_calls_on_line(trimmed: &str) -> Vec<String> {
-    let mut calls = Vec::new();
-    let bytes = trimmed.as_bytes();
-    let mut index = 0;
-
-    while let Some(relative) = trimmed[index..].find('(') {
-        let paren = index + relative;
-        let mut start = paren;
-        while start > 0 {
-            let ch = bytes[start - 1] as char;
-            if ch.is_ascii_alphanumeric() || ch == '_' {
-                start -= 1;
-            } else {
-                break;
-            }
-        }
-
-        let name = &trimmed[start..paren];
-        if is_tracked_c_function_name(name) && !calls.iter().any(|call| call == name) {
-            calls.push(name.to_string());
-        }
-
-        index = paren + 1;
-    }
-
-    calls
-}
-
-fn is_tracked_c_function_name(name: &str) -> bool {
-    name.chars()
-        .next()
-        .is_some_and(|ch| ch.is_ascii_alphabetic() || ch == '_')
-        && name
-            .chars()
-            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
-        && !is_untracked_c_call_name(name)
-}
-
-fn is_untracked_c_call_name(name: &str) -> bool {
-    matches!(
-        name,
-        "abort"
-            | "ceil"
-            | "floor"
-            | "for"
-            | "fprintf"
-            | "fputc"
-            | "free"
-            | "fwrite"
-            | "if"
-            | "malloc"
-            | "memcpy"
-            | "pow"
-            | "printf"
-            | "snprintf"
-            | "sizeof"
-            | "sqrt"
-            | "strlen"
-            | "switch"
-            | "while"
-    )
-}
-
 pub fn has_c_call_outside_signature(c_source: &str, name: &str) -> bool {
-    let call = format!("{name}(");
-    c_source.lines().any(|line| {
-        let trimmed = line.trim();
-        trimmed.contains(&call) && !is_c_function_signature_line(trimmed, name)
-    })
-}
-
-fn is_c_function_signature_line(trimmed: &str, name: &str) -> bool {
-    let needle = format!(" {name}(");
-    let Some(call_start) = trimmed.find(&needle) else {
-        return false;
-    };
-    let prefix = &trimmed[..call_start];
-    !prefix.contains('=')
-        && !prefix.contains("return")
-        && (trimmed.ends_with(';') || trimmed.ends_with('{'))
+    calls::has_c_call_outside_signature(c_source, name)
 }

--- a/tests/integration/support/generated_c/calls.rs
+++ b/tests/integration/support/generated_c/calls.rs
@@ -1,0 +1,103 @@
+pub(super) fn has_c_call_outside_signature(c_source: &str, name: &str) -> bool {
+    let call = format!("{name}(");
+    c_source.lines().any(|line| {
+        let trimmed = line.trim();
+        trimmed.contains(&call) && !is_c_function_signature_line(trimmed, name)
+    })
+}
+
+pub(super) fn is_any_c_function_signature_line(trimmed: &str) -> bool {
+    if !(trimmed.ends_with(';') || trimmed.ends_with('{')) {
+        return false;
+    }
+
+    let Some(paren) = trimmed.find('(') else {
+        return false;
+    };
+    let before = &trimmed[..paren];
+    let name_start = before
+        .trim_end()
+        .rfind(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '_'))
+        .map_or(0, |idx| idx + 1);
+    let return_type = before[..name_start].trim();
+    let name = before[name_start..].trim();
+
+    !return_type.is_empty()
+        && is_tracked_c_function_name(name)
+        && !before.contains('=')
+        && !before.contains("return")
+}
+
+pub(super) fn generated_c_calls_on_line(trimmed: &str) -> Vec<String> {
+    let mut calls = Vec::new();
+    let bytes = trimmed.as_bytes();
+    let mut index = 0;
+
+    while let Some(relative) = trimmed[index..].find('(') {
+        let paren = index + relative;
+        let mut start = paren;
+        while start > 0 {
+            let ch = bytes[start - 1] as char;
+            if ch.is_ascii_alphanumeric() || ch == '_' {
+                start -= 1;
+            } else {
+                break;
+            }
+        }
+
+        let name = &trimmed[start..paren];
+        if is_tracked_c_function_name(name) && !calls.iter().any(|call| call == name) {
+            calls.push(name.to_string());
+        }
+
+        index = paren + 1;
+    }
+
+    calls
+}
+
+pub(super) fn is_tracked_c_function_name(name: &str) -> bool {
+    name.chars()
+        .next()
+        .is_some_and(|ch| ch.is_ascii_alphabetic() || ch == '_')
+        && name
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+        && !is_untracked_c_call_name(name)
+}
+
+fn is_untracked_c_call_name(name: &str) -> bool {
+    matches!(
+        name,
+        "abort"
+            | "ceil"
+            | "floor"
+            | "for"
+            | "fprintf"
+            | "fputc"
+            | "free"
+            | "fwrite"
+            | "if"
+            | "malloc"
+            | "memcpy"
+            | "pow"
+            | "printf"
+            | "snprintf"
+            | "sizeof"
+            | "sqrt"
+            | "strlen"
+            | "switch"
+            | "while"
+    )
+}
+
+fn is_c_function_signature_line(trimmed: &str, name: &str) -> bool {
+    let needle = format!(" {name}(");
+    let Some(call_start) = trimmed.find(&needle) else {
+        return false;
+    };
+    let prefix = &trimmed[..call_start];
+    !prefix.contains('=')
+        && !prefix.contains("return")
+        && (trimmed.ends_with(';') || trimmed.ends_with('{'))
+}

--- a/tests/integration/support/generated_c/definitions.rs
+++ b/tests/integration/support/generated_c/definitions.rs
@@ -1,0 +1,48 @@
+use super::calls::is_tracked_c_function_name;
+
+pub(super) fn assert_c_function_definition(c_source: &str, name: &str) {
+    let needle = format!(" {name}(");
+    assert!(
+        c_source
+            .lines()
+            .any(|line| line.trim_end().ends_with('{') && line.contains(&needle)),
+        "expected generated C definition for `{name}`:\n{c_source}"
+    );
+}
+
+pub(super) fn assert_c_function_definition_count(c_source: &str, name: &str, expected: usize) {
+    let actual = c_function_definitions(c_source)
+        .iter()
+        .filter(|definition| definition.as_str() == name)
+        .count();
+    assert_eq!(
+        actual, expected,
+        "expected {expected} generated C definitions for `{name}`, found {actual}:\n{c_source}"
+    );
+}
+
+pub(super) fn c_function_definitions(c_source: &str) -> Vec<String> {
+    c_source
+        .lines()
+        .filter_map(|line| c_function_definition_name(line.trim()))
+        .collect()
+}
+
+fn c_function_definition_name(trimmed: &str) -> Option<String> {
+    if !trimmed.ends_with('{') {
+        return None;
+    }
+
+    let paren = trimmed.find('(')?;
+    let before = trimmed[..paren].trim_end();
+    let name_start = before
+        .rfind(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '_'))
+        .map_or(0, |idx| idx + 1);
+    let name = &before[name_start..];
+
+    if is_tracked_c_function_name(name) {
+        Some(name.to_string())
+    } else {
+        None
+    }
+}


### PR DESCRIPTION
## Summary
- split generated-C integration support into a small facade plus focused call and definition scanner modules
- add a docs-truth guard for scanner responsibility and the stable generated-C support export surface
- strengthen the generated-C missing-call scanner test with a mangled generic call name

## Validation
- cargo fmt --check
- git diff --check
- cargo clippy -- -D warnings
- cargo test --lib
- cargo test --tests
- cargo test --test integration generated_c_assertions -- --nocapture
- cargo test --test docs_truth generated_c -- --nocapture