### PR TITLE
[codex] pin imported generic diagnostic codes

### DIFF
--- a/tests/docs_truth/phase_audit.rs
+++ b/tests/docs_truth/phase_audit.rs
@@ -1,4 +1,6 @@
 #[path = "phase_audit/completion_audit.rs"]
 mod completion_audit;
+#[path = "phase_audit/imported_generic_diagnostics.rs"]
+mod imported_generic_diagnostics;
 #[path = "phase_audit/phase_plan.rs"]
 mod phase_plan;

--- a/tests/docs_truth/phase_audit/imported_generic_diagnostics.rs
+++ b/tests/docs_truth/phase_audit/imported_generic_diagnostics.rs
@@ -1,0 +1,44 @@
+use super::super::*;
+
+#[test]
+fn imported_generic_diagnostics_pin_stable_codes() {
+    let support = read("tests/integration/frontend_diagnostics/support.rs");
+    let arity = read("tests/integration/frontend_diagnostics/imported_generic_arity.rs");
+    let calls = read("tests/integration/frontend_diagnostics/imported_generic_calls.rs");
+
+    assert!(
+        support.contains("fn frontend_diagnostics("),
+        "frontend diagnostics tests should inspect real Diagnostic values"
+    );
+    assert!(
+        support.contains("fn assert_diagnostic_code_and_message("),
+        "frontend diagnostics tests should share a code-plus-message assertion helper"
+    );
+
+    for source in [arity.as_str(), calls.as_str()] {
+        assert!(
+            !source.contains("compile_to_c_panic_message"),
+            "imported generic diagnostics should not rely on panic-message substrings"
+        );
+        assert!(
+            source.contains("frontend_diagnostics(&main_path)"),
+            "imported generic diagnostics should collect real Diagnostic values"
+        );
+    }
+
+    for (source, code) in [
+        (arity.as_str(), "E5001"),
+        (calls.as_str(), "E5000"),
+        (calls.as_str(), "E5001"),
+        (calls.as_str(), "E5002"),
+        (calls.as_str(), "E6004"),
+    ] {
+        let normalized = source.split_whitespace().collect::<String>();
+        assert!(
+            normalized.contains(&format!(
+                r#"assert_diagnostic_code_and_message(&diagnostics,"{code}""#
+            )),
+            "imported generic diagnostics should pin diagnostic code {code}"
+        );
+    }
+}

--- a/tests/docs_truth/repo_hygiene/frontend_diagnostics.rs
+++ b/tests/docs_truth/repo_hygiene/frontend_diagnostics.rs
@@ -56,8 +56,13 @@ fn imported_generic_call_diagnostics_pin_function_method_and_ufc_cases() {
         "conflicting inferred type argument `T` for generic method `Box.choose`",
         "non-generic function `id_i32` does not accept type arguments",
         "type `Point` does not implement behavior `Json` required by `T`",
-        "!message.contains(\"argument 2\")",
-        "!message.contains(\"has no method `encode`\")",
+        r#""E5000""#,
+        r#""E5001""#,
+        r#""E5002""#,
+        r#""E6004""#,
+        "assert_no_diagnostic_message(",
+        r#""argument 2""#,
+        r#""has no method `encode`""#,
     ] {
         assert!(
             calls.contains(required),

--- a/tests/integration/frontend_diagnostics.rs
+++ b/tests/integration/frontend_diagnostics.rs
@@ -11,7 +11,7 @@ mod imported_generic_calls;
 #[path = "frontend_diagnostics/support.rs"]
 mod support;
 
-use support::{compile_to_c_panic_message, write_tmp_module};
+use support::{assert_diagnostic_code_and_message, frontend_diagnostics, write_tmp_module};
 
 #[test]
 fn integration_frontend_helper_runs_resolver_diagnostics() {
@@ -25,11 +25,13 @@ main = () i32 {
 }
 "#,
     );
-    let message = compile_to_c_panic_message(&zen_path);
+    let diagnostics = frontend_diagnostics(&zen_path);
 
-    assert!(
-        message.contains("unknown value symbol 'missing_local'"),
-        "expected resolver diagnostic, panic={message}"
+    assert_diagnostic_code_and_message(
+        &diagnostics,
+        "E3500",
+        "unknown value symbol 'missing_local'",
+        "resolver",
     );
 }
 
@@ -60,10 +62,12 @@ main = () i32 {
 }
 "#,
     );
-    let message = compile_to_c_panic_message(&main_path);
+    let diagnostics = frontend_diagnostics(&main_path);
 
-    assert!(
-        message.contains("return type mismatch: expected `i32`, found `bool`"),
-        "expected imported module type diagnostic, panic={message}"
+    assert_diagnostic_code_and_message(
+        &diagnostics,
+        "E3030",
+        "return type mismatch: expected `i32`, found `bool`",
+        "imported module type",
     );
 }

--- a/tests/integration/frontend_diagnostics/imported_generic_arity.rs
+++ b/tests/integration/frontend_diagnostics/imported_generic_arity.rs
@@ -1,4 +1,7 @@
-use super::support::{compile_to_c_panic_message, write_tmp_module};
+use super::support::{
+    assert_diagnostic_code_and_message, assert_no_diagnostic_message, frontend_diagnostics,
+    write_tmp_module,
+};
 
 #[test]
 fn imported_generic_enum_method_explicit_type_arg_arity_is_error() {
@@ -30,19 +33,23 @@ main = () i32 {
 }
 "#,
     );
-    let message = compile_to_c_panic_message(&main_path);
+    let diagnostics = frontend_diagnostics(&main_path);
 
-    assert!(
-        message.contains("generic method `Result.unwrap_or` expects 2 type arguments, found 1"),
-        "expected imported generic method arity diagnostic, panic={message}"
+    assert_diagnostic_code_and_message(
+        &diagnostics,
+        "E5001",
+        "generic method `Result.unwrap_or` expects 2 type arguments, found 1",
+        "imported generic method arity",
     );
-    assert!(
-        !message.contains("cannot infer type argument"),
-        "imported generic method arity failure should not also report inference, panic={message}"
+    assert_no_diagnostic_message(
+        &diagnostics,
+        "cannot infer type argument",
+        "imported generic method arity failure",
     );
-    assert!(
-        !message.contains("argument 2"),
-        "imported generic method arity failure should not also report argument mismatch, panic={message}"
+    assert_no_diagnostic_message(
+        &diagnostics,
+        "argument 2",
+        "imported generic method arity failure",
     );
 }
 
@@ -69,19 +76,23 @@ main = () i32 {
 }
 "#,
     );
-    let message = compile_to_c_panic_message(&main_path);
+    let diagnostics = frontend_diagnostics(&main_path);
 
-    assert!(
-        message.contains("generic function `take_second` expects 2 type arguments, found 1"),
-        "expected imported generic function arity diagnostic, panic={message}"
+    assert_diagnostic_code_and_message(
+        &diagnostics,
+        "E5001",
+        "generic function `take_second` expects 2 type arguments, found 1",
+        "imported generic function arity",
     );
-    assert!(
-        !message.contains("cannot infer type argument"),
-        "imported generic function arity failure should not also report inference, panic={message}"
+    assert_no_diagnostic_message(
+        &diagnostics,
+        "cannot infer type argument",
+        "imported generic function arity failure",
     );
-    assert!(
-        !message.contains("argument 1"),
-        "imported generic function arity failure should not also report argument mismatch, panic={message}"
+    assert_no_diagnostic_message(
+        &diagnostics,
+        "argument 1",
+        "imported generic function arity failure",
     );
 }
 
@@ -114,22 +125,28 @@ main = () i32 {
 }
 "#,
     );
-    let message = compile_to_c_panic_message(&main_path);
+    let diagnostics = frontend_diagnostics(&main_path);
 
-    assert!(
-        message.contains("generic struct `Box` expects 1 type arguments, found 2"),
-        "expected imported generic struct constructor arity diagnostic, panic={message}"
+    assert_diagnostic_code_and_message(
+        &diagnostics,
+        "E5001",
+        "generic struct `Box` expects 1 type arguments, found 2",
+        "imported generic struct constructor arity",
     );
-    assert!(
-        message.contains("generic enum `Option` expects 1 type arguments, found 2"),
-        "expected imported generic enum constructor arity diagnostic, panic={message}"
+    assert_diagnostic_code_and_message(
+        &diagnostics,
+        "E5001",
+        "generic enum `Option` expects 1 type arguments, found 2",
+        "imported generic enum constructor arity",
     );
-    assert!(
-        !message.contains("field `value` for struct `Box`"),
-        "imported generic struct constructor arity failure should not also report field mismatch, panic={message}"
+    assert_no_diagnostic_message(
+        &diagnostics,
+        "field `value` for struct `Box`",
+        "imported generic struct constructor arity failure",
     );
-    assert!(
-        !message.contains("payload for enum variant"),
-        "imported generic enum constructor arity failure should not also report payload mismatch, panic={message}"
+    assert_no_diagnostic_message(
+        &diagnostics,
+        "payload for enum variant",
+        "imported generic enum constructor arity failure",
     );
 }

--- a/tests/integration/frontend_diagnostics/imported_generic_calls.rs
+++ b/tests/integration/frontend_diagnostics/imported_generic_calls.rs
@@ -1,4 +1,7 @@
-use super::support::{compile_to_c_panic_message, write_tmp_module};
+use super::support::{
+    assert_diagnostic_code_and_message, assert_no_diagnostic_message, frontend_diagnostics,
+    write_tmp_module,
+};
 
 #[test]
 fn imported_generic_function_inference_conflict_is_error() {
@@ -24,15 +27,18 @@ main = () i32 {
 }
 "#,
     );
-    let message = compile_to_c_panic_message(&main_path);
+    let diagnostics = frontend_diagnostics(&main_path);
 
-    assert!(
-        message.contains("conflicting inferred type argument `T` for generic function `choose`"),
-        "expected imported generic function inference conflict, panic={message}"
+    assert_diagnostic_code_and_message(
+        &diagnostics,
+        "E5000",
+        "conflicting inferred type argument `T` for generic function `choose`",
+        "imported generic function inference conflict",
     );
-    assert!(
-        !message.contains("argument 2"),
-        "inference conflict should not also report argument mismatch, panic={message}"
+    assert_no_diagnostic_message(
+        &diagnostics,
+        "argument 2",
+        "imported generic function inference conflict",
     );
 }
 
@@ -65,15 +71,18 @@ main = () i32 {
 }
 "#,
     );
-    let message = compile_to_c_panic_message(&main_path);
+    let diagnostics = frontend_diagnostics(&main_path);
 
-    assert!(
-        message.contains("conflicting inferred type argument `T` for generic method `Box.choose`"),
-        "expected imported generic method inference conflict, panic={message}"
+    assert_diagnostic_code_and_message(
+        &diagnostics,
+        "E5000",
+        "conflicting inferred type argument `T` for generic method `Box.choose`",
+        "imported generic method inference conflict",
     );
-    assert!(
-        !message.contains("argument 2"),
-        "inference conflict should not also report argument mismatch, panic={message}"
+    assert_no_diagnostic_message(
+        &diagnostics,
+        "argument 2",
+        "imported generic method inference conflict",
     );
 }
 
@@ -101,15 +110,18 @@ main = () i32 {
 }
 "#,
     );
-    let message = compile_to_c_panic_message(&main_path);
+    let diagnostics = frontend_diagnostics(&main_path);
 
-    assert!(
-        message.contains("generic function `take_second` expects 2 type arguments, found 1"),
-        "expected imported generic UFC arity diagnostic, panic={message}"
+    assert_diagnostic_code_and_message(
+        &diagnostics,
+        "E5001",
+        "generic function `take_second` expects 2 type arguments, found 1",
+        "imported generic UFC arity",
     );
-    assert!(
-        !message.contains("argument 2"),
-        "imported generic UFC arity failure should not also report argument mismatch, panic={message}"
+    assert_no_diagnostic_message(
+        &diagnostics,
+        "argument 2",
+        "imported generic UFC arity failure",
     );
 }
 
@@ -137,11 +149,13 @@ main = () i32 {
 }
 "#,
     );
-    let message = compile_to_c_panic_message(&main_path);
+    let diagnostics = frontend_diagnostics(&main_path);
 
-    assert!(
-        message.contains("non-generic function `id_i32` does not accept type arguments"),
-        "expected imported non-generic UFC type-argument diagnostic, panic={message}"
+    assert_diagnostic_code_and_message(
+        &diagnostics,
+        "E5002",
+        "non-generic function `id_i32` does not accept type arguments",
+        "imported non-generic UFC type-argument",
     );
 }
 
@@ -185,14 +199,17 @@ main = () i32 {
 }
 "#,
     );
-    let message = compile_to_c_panic_message(&main_path);
+    let diagnostics = frontend_diagnostics(&main_path);
 
-    assert!(
-        message.contains("type `Point` does not implement behavior `Json` required by `T`"),
-        "expected imported generic UFC behavior-bound diagnostic, panic={message}"
+    assert_diagnostic_code_and_message(
+        &diagnostics,
+        "E6004",
+        "type `Point` does not implement behavior `Json` required by `T`",
+        "imported generic UFC behavior bound",
     );
-    assert!(
-        !message.contains("has no method `encode`"),
-        "bound failure should not also specialize into an unknown-method diagnostic, panic={message}"
+    assert_no_diagnostic_message(
+        &diagnostics,
+        "has no method `encode`",
+        "imported generic UFC behavior-bound failure",
     );
 }

--- a/tests/integration/frontend_diagnostics/support.rs
+++ b/tests/integration/frontend_diagnostics/support.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
 
-use crate::compile_to_c;
+use zen::error::{Diagnostic, FileTable};
+use zen::module_system::ModuleSystem;
+use zen::typechecker::TypeChecker;
 
 pub(crate) fn write_tmp_module(dir: &Path, name: &str, source: &str) -> PathBuf {
     let path = dir.join(name);
@@ -8,13 +10,39 @@ pub(crate) fn write_tmp_module(dir: &Path, name: &str, source: &str) -> PathBuf 
     path
 }
 
-pub(crate) fn compile_to_c_panic_message(zen_path: &Path) -> String {
-    let panic = std::panic::catch_unwind(|| compile_to_c(zen_path))
-        .expect_err("compile_to_c should reject frontend diagnostics");
-    panic
-        .downcast_ref::<String>()
-        .map(String::as_str)
-        .or_else(|| panic.downcast_ref::<&str>().copied())
-        .unwrap_or("<non-string panic>")
-        .to_string()
+pub(crate) fn frontend_diagnostics(zen_path: &Path) -> Vec<Diagnostic> {
+    let mut files = FileTable::new();
+    let mut module_system = ModuleSystem::new();
+    let graph = match module_system.load_module_graph(zen_path, &mut files) {
+        Ok(graph) => graph,
+        Err(errs) => return errs.into_iter().map(Diagnostic::from).collect(),
+    };
+
+    let mut checker = TypeChecker::new();
+    checker
+        .check_module_graph_entry(&graph)
+        .expect_err("frontend diagnostics fixture should fail typechecking")
+}
+
+pub(crate) fn assert_diagnostic_code_and_message(
+    diagnostics: &[Diagnostic],
+    code: &str,
+    message: &str,
+    label: &str,
+) {
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == code && diagnostic.message.contains(message)),
+        "expected {label} diagnostic {code} containing `{message}`, got {diagnostics:?}"
+    );
+}
+
+pub(crate) fn assert_no_diagnostic_message(diagnostics: &[Diagnostic], message: &str, label: &str) {
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diagnostic| !diagnostic.message.contains(message)),
+        "{label} should not include diagnostic containing `{message}`, got {diagnostics:?}"
+    );
 }


### PR DESCRIPTION
## Summary
- replace imported generic panic-message checks with direct Diagnostic assertions
- pin imported generic arity, inference, non-generic type-arg, and bound failures to E5000/E5001/E5002/E6004
- add docs-truth coverage so imported generic diagnostics keep using code-plus-message checks

## Validation
- cargo fmt --check
- git diff --check
- cargo clippy -- -D warnings
- cargo test --lib
- cargo test --tests
- cargo test --test integration frontend_diagnostics -- --nocapture
- cargo test --test docs_truth imported_generic -- --nocapture