### PR TITLE
Split resolver metadata behavior ref restoration tests

### DIFF
--- a/src/typechecker/tests/resolver_metadata/metadata_restoration.rs
+++ b/src/typechecker/tests/resolver_metadata/metadata_restoration.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod behavior_refs;
+
 #[test]
 fn resolver_params_from_metadata_preserves_ast_param_shape() {
     let existing_span = Span::new(1, 10, 15);
@@ -194,51 +196,4 @@ fn resolver_behavior_methods_from_metadata_preserves_defaults_by_resolver_order(
         methods[1].default_body,
         Some(Expression::IntLiteral { value: 1, .. })
     ));
-}
-
-#[test]
-fn behavior_parent_refs_from_metadata_restores_keys_and_type_args() {
-    let tc = TypeChecker::new();
-    let metadata = vec![
-        BehaviorRefMetadata {
-            name: "Json".to_string(),
-            type_args: vec![AstType::Named("T".to_string())],
-        },
-        BehaviorRefMetadata {
-            name: "Debug".to_string(),
-            type_args: vec![],
-        },
-    ];
-
-    let refs = tc.behavior_parent_refs_from_metadata(&metadata);
-
-    assert_eq!(refs[0].behavior, "Json");
-    assert_eq!(refs[0].type_args, vec![AstType::Named("T".to_string())]);
-    assert_eq!(refs[0].key, "Json_T");
-    assert_eq!(refs[1].behavior, "Debug");
-    assert!(refs[1].type_args.is_empty());
-    assert_eq!(refs[1].key, "Debug");
-}
-
-#[test]
-fn behavior_impl_refs_from_metadata_restores_type_and_behavior_keys() {
-    let tc = TypeChecker::new();
-    let metadata = vec![
-        BehaviorRefMetadata {
-            name: "Json".to_string(),
-            type_args: vec![AstType::Str],
-        },
-        BehaviorRefMetadata {
-            name: "Debug".to_string(),
-            type_args: vec![],
-        },
-    ];
-
-    assert_eq!(
-        tc.behavior_impl_refs_from_metadata("Point", &metadata),
-        vec![
-            ("Point".to_string(), "Json_StaticString".to_string()),
-            ("Point".to_string(), "Debug".to_string()),
-        ]
-    );
 }

--- a/src/typechecker/tests/resolver_metadata/metadata_restoration/behavior_refs.rs
+++ b/src/typechecker/tests/resolver_metadata/metadata_restoration/behavior_refs.rs
@@ -1,0 +1,48 @@
+use super::*;
+
+#[test]
+fn behavior_parent_refs_from_metadata_restores_keys_and_type_args() {
+    let tc = TypeChecker::new();
+    let metadata = vec![
+        BehaviorRefMetadata {
+            name: "Json".to_string(),
+            type_args: vec![AstType::Named("T".to_string())],
+        },
+        BehaviorRefMetadata {
+            name: "Debug".to_string(),
+            type_args: vec![],
+        },
+    ];
+
+    let refs = tc.behavior_parent_refs_from_metadata(&metadata);
+
+    assert_eq!(refs[0].behavior, "Json");
+    assert_eq!(refs[0].type_args, vec![AstType::Named("T".to_string())]);
+    assert_eq!(refs[0].key, "Json_T");
+    assert_eq!(refs[1].behavior, "Debug");
+    assert!(refs[1].type_args.is_empty());
+    assert_eq!(refs[1].key, "Debug");
+}
+
+#[test]
+fn behavior_impl_refs_from_metadata_restores_type_and_behavior_keys() {
+    let tc = TypeChecker::new();
+    let metadata = vec![
+        BehaviorRefMetadata {
+            name: "Json".to_string(),
+            type_args: vec![AstType::Str],
+        },
+        BehaviorRefMetadata {
+            name: "Debug".to_string(),
+            type_args: vec![],
+        },
+    ];
+
+    assert_eq!(
+        tc.behavior_impl_refs_from_metadata("Point", &metadata),
+        vec![
+            ("Point".to_string(), "Json_StaticString".to_string()),
+            ("Point".to_string(), "Debug".to_string()),
+        ]
+    );
+}

--- a/tests/docs_truth/repo_hygiene/file_size.rs
+++ b/tests/docs_truth/repo_hygiene/file_size.rs
@@ -11,6 +11,7 @@ mod lexer_and_monomorphize;
 mod module_system_splits;
 mod parser_enum_splits;
 mod parser_expression_splits;
+mod resolver_metadata_restoration_splits;
 mod resolver_phase2_splits;
 mod resolver_validation_splits;
 mod resolver_validation_test_splits;

--- a/tests/docs_truth/repo_hygiene/file_size/resolver_metadata_restoration_splits.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/resolver_metadata_restoration_splits.rs
@@ -1,0 +1,31 @@
+use super::super::*;
+
+#[test]
+fn resolver_metadata_restoration_behavior_ref_tests_live_in_focused_helper() {
+    let root = read("src/typechecker/tests/resolver_metadata/metadata_restoration.rs");
+    let behavior_refs =
+        read("src/typechecker/tests/resolver_metadata/metadata_restoration/behavior_refs.rs");
+
+    for test_name in [
+        "behavior_parent_refs_from_metadata_restores_keys_and_type_args",
+        "behavior_impl_refs_from_metadata_restores_type_and_behavior_keys",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "metadata_restoration.rs should not own behavior-ref restoration test: {test_name}"
+        );
+        assert!(
+            behavior_refs.contains(&format!("fn {test_name}")),
+            "behavior-ref restoration tests should live in focused module: {test_name}"
+        );
+    }
+
+    assert!(
+        root.lines().count() < 210,
+        "metadata_restoration.rs should stay focused on callable, enum, struct, and behavior method restoration"
+    );
+    assert!(
+        root.contains("mod behavior_refs;"),
+        "metadata_restoration.rs should include the focused behavior_refs module"
+    );
+}


### PR DESCRIPTION
## Summary
- move behavior-ref restoration tests out of metadata_restoration.rs into a focused helper module
- add a docs-truth guard so behavior-ref restoration tests stay split
- keep metadata_restoration.rs focused on callable, enum, struct, and behavior method restoration

## Verification
- cargo fmt --check
- git diff --check
- git diff --cached --check
- cargo test --test docs_truth resolver_metadata_restoration_behavior_ref_tests_live_in_focused_helper -- --nocapture
- cargo test --lib resolver_metadata::metadata_restoration -- --nocapture
- cargo clippy -- -D warnings
- cargo test --lib
- cargo test --tests