### PR TITLE
[codex] Split resolver-backed helper tests

### DIFF
--- a/src/typechecker/tests/resolver_metadata/impl_and_method_helpers.rs
+++ b/src/typechecker/tests/resolver_metadata/impl_and_method_helpers.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod resolver_backed_collection;
+
 #[test]
 fn impl_effective_method_name_prefers_resolver_then_ast_then_collected_signature() {
     let mut tc = TypeChecker::new();
@@ -38,50 +40,6 @@ fn impl_effective_method_name_prefers_resolver_then_ast_then_collected_signature
         "describe"
     );
     assert!(unmatched.is_empty());
-}
-
-#[test]
-fn resolver_backed_impl_method_key_requires_resolver_collection() {
-    let mut program = parse_program(
-        r#"
-Point: { x: i32 }
-Json: behavior {
-    encode: (Self) StaticString
-}
-
-Point.implements(Json) {
-    encode = (value: Point) StaticString { "point" }
-}
-"#,
-    );
-    let symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    let (span, ast_key) = if let Declaration::ImplBlock {
-        type_name, methods, ..
-    } = &mut program.declarations[2]
-    {
-        *type_name = "Missing".to_string();
-        if let Declaration::Function { name, span, .. } = &mut methods[0] {
-            *name = "missing".to_string();
-            (*span, TypeChecker::method_key(type_name, name))
-        } else {
-            panic!("expected impl method");
-        }
-    } else {
-        panic!("expected impl block");
-    };
-    let mut tc = TypeChecker::new();
-
-    assert_eq!(
-        tc.resolver_backed_impl_method_key(Some(&symbols), &ast_key, "Missing", span),
-        None
-    );
-    tc.resolver_backed_collection = true;
-    assert_eq!(
-        tc.resolver_backed_impl_method_key(Some(&symbols), &ast_key, "Missing", span),
-        Some("Point.encode".to_string())
-    );
 }
 
 #[test]
@@ -170,73 +128,4 @@ fn resolver_backed_behavior_impl_method_signature_name_prefers_resolver_key() {
         Some("debug".to_string())
     );
     assert!(required.is_empty());
-}
-
-#[test]
-fn resolver_backed_method_signature_requires_resolver_collection() {
-    let mut tc = TypeChecker::new();
-    tc.methods.insert(
-        "Point.encode".to_string(),
-        FuncInfo {
-            name: "Point.encode".to_string(),
-            params: Vec::new(),
-            return_type: AstType::Str,
-            type_params: Vec::new(),
-            type_param_bounds: HashMap::new(),
-        },
-    );
-
-    assert!(tc
-        .resolver_backed_method_signature("Point", "encode")
-        .is_none());
-    tc.resolver_backed_collection = true;
-    assert_eq!(
-        tc.resolver_backed_method_signature("Point", "encode")
-            .map(|info| info.return_type.clone()),
-        Some(AstType::Str)
-    );
-}
-
-#[test]
-fn behavior_default_synthesis_skip_requires_resolver_collection_and_missing_impl_ref() {
-    let mut tc = TypeChecker::new();
-    tc.resolver_missing_behavior_impl_refs
-        .insert("Point".to_string());
-
-    assert!(!tc.should_skip_behavior_default_synthesis("Point"));
-    tc.resolver_backed_collection = true;
-    assert!(tc.should_skip_behavior_default_synthesis("Point"));
-    assert!(!tc.should_skip_behavior_default_synthesis("Other"));
-}
-
-#[test]
-fn resolver_backed_behavior_collection_defers_generic_metadata_to_resolver() {
-    let program = parse_program(
-        r#"
-Json<T: Json<T>>: behavior {
-    encode: (Self) T {
-        1
-    }
-}
-"#,
-    );
-    let mut tc = TypeChecker::new();
-
-    tc.with_resolver_backed_collection(|checker| {
-        checker.collect_declarations(&program.declarations);
-    });
-
-    let behavior = tc.behaviors.get("Json").expect("behavior stub");
-    assert!(
-            behavior.type_params.is_empty(),
-            "resolver-backed behavior collection should not keep AST generic names before resolver metadata"
-        );
-    assert!(
-            behavior.type_param_bounds.is_empty(),
-            "resolver-backed behavior collection should not keep AST generic bounds before resolver metadata"
-        );
-    assert!(
-            behavior.methods[0].default_body.is_some(),
-            "resolver-backed behavior collection should still keep default bodies for later resolver metadata restoration"
-        );
 }

--- a/src/typechecker/tests/resolver_metadata/impl_and_method_helpers/resolver_backed_collection.rs
+++ b/src/typechecker/tests/resolver_metadata/impl_and_method_helpers/resolver_backed_collection.rs
@@ -1,0 +1,114 @@
+use super::*;
+
+#[test]
+fn resolver_backed_impl_method_key_requires_resolver_collection() {
+    let mut program = parse_program(
+        r#"
+Point: { x: i32 }
+Json: behavior {
+    encode: (Self) StaticString
+}
+
+Point.implements(Json) {
+    encode = (value: Point) StaticString { "point" }
+}
+"#,
+    );
+    let symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    let (span, ast_key) = if let Declaration::ImplBlock {
+        type_name, methods, ..
+    } = &mut program.declarations[2]
+    {
+        *type_name = "Missing".to_string();
+        if let Declaration::Function { name, span, .. } = &mut methods[0] {
+            *name = "missing".to_string();
+            (*span, TypeChecker::method_key(type_name, name))
+        } else {
+            panic!("expected impl method");
+        }
+    } else {
+        panic!("expected impl block");
+    };
+    let mut tc = TypeChecker::new();
+
+    assert_eq!(
+        tc.resolver_backed_impl_method_key(Some(&symbols), &ast_key, "Missing", span),
+        None
+    );
+    tc.resolver_backed_collection = true;
+    assert_eq!(
+        tc.resolver_backed_impl_method_key(Some(&symbols), &ast_key, "Missing", span),
+        Some("Point.encode".to_string())
+    );
+}
+
+#[test]
+fn resolver_backed_method_signature_requires_resolver_collection() {
+    let mut tc = TypeChecker::new();
+    tc.methods.insert(
+        "Point.encode".to_string(),
+        FuncInfo {
+            name: "Point.encode".to_string(),
+            params: Vec::new(),
+            return_type: AstType::Str,
+            type_params: Vec::new(),
+            type_param_bounds: HashMap::new(),
+        },
+    );
+
+    assert!(tc
+        .resolver_backed_method_signature("Point", "encode")
+        .is_none());
+    tc.resolver_backed_collection = true;
+    assert_eq!(
+        tc.resolver_backed_method_signature("Point", "encode")
+            .map(|info| info.return_type.clone()),
+        Some(AstType::Str)
+    );
+}
+
+#[test]
+fn behavior_default_synthesis_skip_requires_resolver_collection_and_missing_impl_ref() {
+    let mut tc = TypeChecker::new();
+    tc.resolver_missing_behavior_impl_refs
+        .insert("Point".to_string());
+
+    assert!(!tc.should_skip_behavior_default_synthesis("Point"));
+    tc.resolver_backed_collection = true;
+    assert!(tc.should_skip_behavior_default_synthesis("Point"));
+    assert!(!tc.should_skip_behavior_default_synthesis("Other"));
+}
+
+#[test]
+fn resolver_backed_behavior_collection_defers_generic_metadata_to_resolver() {
+    let program = parse_program(
+        r#"
+Json<T: Json<T>>: behavior {
+    encode: (Self) T {
+        1
+    }
+}
+"#,
+    );
+    let mut tc = TypeChecker::new();
+
+    tc.with_resolver_backed_collection(|checker| {
+        checker.collect_declarations(&program.declarations);
+    });
+
+    let behavior = tc.behaviors.get("Json").expect("behavior stub");
+    assert!(
+        behavior.type_params.is_empty(),
+        "resolver-backed behavior collection should not keep AST generic names before resolver metadata"
+    );
+    assert!(
+        behavior.type_param_bounds.is_empty(),
+        "resolver-backed behavior collection should not keep AST generic bounds before resolver metadata"
+    );
+    assert!(
+        behavior.methods[0].default_body.is_some(),
+        "resolver-backed behavior collection should still keep default bodies for later resolver metadata restoration"
+    );
+}

--- a/tests/docs_truth/repo_hygiene/file_size.rs
+++ b/tests/docs_truth/repo_hygiene/file_size.rs
@@ -11,6 +11,7 @@ mod lexer_and_monomorphize;
 mod module_system_splits;
 mod parser_enum_splits;
 mod parser_expression_splits;
+mod resolver_metadata_impl_method_splits;
 mod resolver_metadata_requirement_splits;
 mod resolver_metadata_restoration_splits;
 mod resolver_phase2_splits;

--- a/tests/docs_truth/repo_hygiene/file_size/resolver_metadata_impl_method_splits.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/resolver_metadata_impl_method_splits.rs
@@ -1,0 +1,33 @@
+use super::super::*;
+
+#[test]
+fn resolver_backed_collection_gates_live_in_focused_helper() {
+    let root = read("src/typechecker/tests/resolver_metadata/impl_and_method_helpers.rs");
+    let resolver_backed =
+        read("src/typechecker/tests/resolver_metadata/impl_and_method_helpers/resolver_backed_collection.rs");
+
+    for test_name in [
+        "resolver_backed_impl_method_key_requires_resolver_collection",
+        "resolver_backed_method_signature_requires_resolver_collection",
+        "behavior_default_synthesis_skip_requires_resolver_collection_and_missing_impl_ref",
+        "resolver_backed_behavior_collection_defers_generic_metadata_to_resolver",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "impl_and_method_helpers.rs should not own resolver-backed collection gate test: {test_name}"
+        );
+        assert!(
+            resolver_backed.contains(&format!("fn {test_name}")),
+            "resolver-backed collection gate tests should live in focused module: {test_name}"
+        );
+    }
+
+    assert!(
+        root.lines().count() < 170,
+        "impl_and_method_helpers.rs should stay focused on effective method names and signatures"
+    );
+    assert!(
+        root.contains("mod resolver_backed_collection;"),
+        "impl_and_method_helpers.rs should include the focused resolver_backed_collection module"
+    );
+}


### PR DESCRIPTION
## Summary

- moves resolver-backed collection gate tests out of `impl_and_method_helpers.rs` into a focused child module
- adds a docs-truth guard so those gate tests stay split from effective method-name/signature helper coverage
- keeps the resolver metadata helper root under the focused file-size threshold

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test resolver_backed_collection_gates_live_in_focused_helper`
- `cargo test resolver_metadata::impl_and_method_helpers`
- `cargo test --lib`
- `cargo test --tests`
