### PR TITLE
[codex] Split frontend JSON symbol tests

### DIFF
--- a/tests/docs_truth/repo_hygiene/file_size.rs
+++ b/tests/docs_truth/repo_hygiene/file_size.rs
@@ -4,6 +4,7 @@ mod codegen_test_splits;
 mod core_semantics_splits;
 mod declaration_validation_splits;
 mod focused_tests;
+mod frontend_json_splits;
 mod function_method_template_splits;
 mod generic_behavior_splits;
 mod integration_fixture_splits;

--- a/tests/docs_truth/repo_hygiene/file_size/frontend_json_splits.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/frontend_json_splits.rs
@@ -1,0 +1,32 @@
+use super::super::*;
+
+#[test]
+fn frontend_json_symbol_multi_specialization_tests_live_in_focused_helper() {
+    let root = read("tests/integration/cli_build/frontend_json/module_graph/symbols/generic.rs");
+    let multi_specialization = read(
+        "tests/integration/cli_build/frontend_json/module_graph/symbols/generic/result_multi_specialization.rs",
+    );
+
+    for test_name in [
+        "emit_json_symbols_reports_multi_file_generic_result_multi_specialization_surface",
+        "emit_json_symbols_reports_multi_file_generic_result_error_multi_specialization_surface",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "generic.rs should not own Result multi-specialization symbol surface test: {test_name}"
+        );
+        assert!(
+            multi_specialization.contains(&format!("fn {test_name}")),
+            "Result multi-specialization symbol surface tests should live in focused module: {test_name}"
+        );
+    }
+
+    assert!(
+        root.lines().count() < 190,
+        "generic.rs should stay focused on generic symbol surfaces and shared helpers"
+    );
+    assert!(
+        root.contains("mod result_multi_specialization;"),
+        "generic.rs should include the focused result_multi_specialization module"
+    );
+}

--- a/tests/integration/cli_build/frontend_json/module_graph/symbols/generic.rs
+++ b/tests/integration/cli_build/frontend_json/module_graph/symbols/generic.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+#[path = "generic/result_multi_specialization.rs"]
+mod result_multi_specialization;
+
 #[test]
 fn emit_json_symbols_reports_multi_file_generic_enum_method_surface() {
     let modules = symbols_modules_for_fixture(
@@ -155,68 +158,6 @@ fn emit_json_symbols_reports_multi_file_generic_method_nested_result_surface() {
         symbol["is_public"] == true
             && string_array_eq(&symbol["parameter_type_names"], &["Result<T, E>", "T"])
             && symbol["return_type_name"] == "T"
-    });
-}
-
-#[test]
-fn emit_json_symbols_reports_multi_file_generic_result_multi_specialization_surface() {
-    let modules = symbols_modules_for_fixture(
-        "tests/zen/multi_file_generic_result_enum_multi_specialization/main.zen",
-        "multi-file generic Result multi-specialization symbols",
-    );
-
-    assert_eq!(
-        modules.len(),
-        2,
-        "fixture should report main and result modules: {modules:?}"
-    );
-
-    let main = module_by_file(&modules, "main.zen");
-    assert_symbol(main, "Import", "Result", |symbol| {
-        symbol["import_source"] == "result"
-    });
-
-    let result = module_by_file(&modules, "result.zen");
-    assert_symbol(result, "Type", "Result", |symbol| {
-        symbol["is_public"] == true
-            && string_array_eq(&symbol["type_parameter_names"], &["T", "E"])
-            && string_array_eq(&symbol["variant_names"], &["Ok", "Err"])
-    });
-    assert_symbol(result, "Value", "Result.unwrap_or", |symbol| {
-        symbol["is_public"] == true
-            && string_array_eq(&symbol["parameter_type_names"], &["Self", "T"])
-            && symbol["return_type_name"] == "T"
-    });
-}
-
-#[test]
-fn emit_json_symbols_reports_multi_file_generic_result_error_multi_specialization_surface() {
-    let modules = symbols_modules_for_fixture(
-        "tests/zen/multi_file_generic_result_error_multi_specialization/main.zen",
-        "multi-file generic Result error-type multi-specialization symbols",
-    );
-
-    assert_eq!(
-        modules.len(),
-        2,
-        "fixture should report main and result modules: {modules:?}"
-    );
-
-    let main = module_by_file(&modules, "main.zen");
-    assert_symbol(main, "Import", "Result", |symbol| {
-        symbol["import_source"] == "result"
-    });
-
-    let result = module_by_file(&modules, "result.zen");
-    assert_symbol(result, "Type", "Result", |symbol| {
-        symbol["is_public"] == true
-            && string_array_eq(&symbol["type_parameter_names"], &["T", "E"])
-            && string_array_eq(&symbol["variant_names"], &["Ok", "Err"])
-    });
-    assert_symbol(result, "Value", "Result.unwrap_err", |symbol| {
-        symbol["is_public"] == true
-            && string_array_eq(&symbol["parameter_type_names"], &["Self", "E"])
-            && symbol["return_type_name"] == "E"
     });
 }
 

--- a/tests/integration/cli_build/frontend_json/module_graph/symbols/generic/result_multi_specialization.rs
+++ b/tests/integration/cli_build/frontend_json/module_graph/symbols/generic/result_multi_specialization.rs
@@ -1,0 +1,63 @@
+use super::*;
+
+#[test]
+fn emit_json_symbols_reports_multi_file_generic_result_multi_specialization_surface() {
+    let modules = symbols_modules_for_fixture(
+        "tests/zen/multi_file_generic_result_enum_multi_specialization/main.zen",
+        "multi-file generic Result multi-specialization symbols",
+    );
+
+    assert_eq!(
+        modules.len(),
+        2,
+        "fixture should report main and result modules: {modules:?}"
+    );
+
+    let main = module_by_file(&modules, "main.zen");
+    assert_symbol(main, "Import", "Result", |symbol| {
+        symbol["import_source"] == "result"
+    });
+
+    let result = module_by_file(&modules, "result.zen");
+    assert_symbol(result, "Type", "Result", |symbol| {
+        symbol["is_public"] == true
+            && string_array_eq(&symbol["type_parameter_names"], &["T", "E"])
+            && string_array_eq(&symbol["variant_names"], &["Ok", "Err"])
+    });
+    assert_symbol(result, "Value", "Result.unwrap_or", |symbol| {
+        symbol["is_public"] == true
+            && string_array_eq(&symbol["parameter_type_names"], &["Self", "T"])
+            && symbol["return_type_name"] == "T"
+    });
+}
+
+#[test]
+fn emit_json_symbols_reports_multi_file_generic_result_error_multi_specialization_surface() {
+    let modules = symbols_modules_for_fixture(
+        "tests/zen/multi_file_generic_result_error_multi_specialization/main.zen",
+        "multi-file generic Result error-type multi-specialization symbols",
+    );
+
+    assert_eq!(
+        modules.len(),
+        2,
+        "fixture should report main and result modules: {modules:?}"
+    );
+
+    let main = module_by_file(&modules, "main.zen");
+    assert_symbol(main, "Import", "Result", |symbol| {
+        symbol["import_source"] == "result"
+    });
+
+    let result = module_by_file(&modules, "result.zen");
+    assert_symbol(result, "Type", "Result", |symbol| {
+        symbol["is_public"] == true
+            && string_array_eq(&symbol["type_parameter_names"], &["T", "E"])
+            && string_array_eq(&symbol["variant_names"], &["Ok", "Err"])
+    });
+    assert_symbol(result, "Value", "Result.unwrap_err", |symbol| {
+        symbol["is_public"] == true
+            && string_array_eq(&symbol["parameter_type_names"], &["Self", "E"])
+            && symbol["return_type_name"] == "E"
+    });
+}


### PR DESCRIPTION
## Summary

- moves frontend JSON Result multi-specialization symbol-surface tests into a focused child module
- adds a docs-truth guard so those cases stay out of the generic symbol-surface parent
- keeps the shared helper parent focused and under the repo-hygiene threshold

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test frontend_json_symbol_multi_specialization_tests_live_in_focused_helper`
- `cargo test multi_specialization_surface`
- `cargo test --lib`
- `cargo test --tests`
