### PR TITLE
[codex] Split import visibility dependency tests

### DIFF
--- a/tests/docs_truth/repo_hygiene/file_size.rs
+++ b/tests/docs_truth/repo_hygiene/file_size.rs
@@ -8,6 +8,7 @@ mod frontend_json_splits;
 mod function_method_template_splits;
 mod generic_behavior_splits;
 mod integration_fixture_splits;
+mod integration_import_visibility_splits;
 mod lexer_and_monomorphize;
 mod module_system_splits;
 mod parser_enum_splits;

--- a/tests/docs_truth/repo_hygiene/file_size/integration_import_visibility_splits.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/integration_import_visibility_splits.rs
@@ -1,0 +1,45 @@
+use super::super::*;
+
+#[test]
+fn import_visibility_dependency_panic_capture_stays_shared() {
+    let root = read("tests/integration/import_visibility_dependencies.rs");
+    let imported_type =
+        read("tests/integration/import_visibility_dependencies/imported_type_dependencies.rs");
+
+    assert_eq!(
+        root.matches("fn compile_error_message(").count(),
+        1,
+        "import visibility dependency tests should share compile-error panic capture"
+    );
+    assert_eq!(
+        root.matches("std::panic::catch_unwind").count(),
+        1,
+        "compile-error panic capture should not be repeated across each dependency test"
+    );
+    assert_eq!(
+        root.matches(".downcast_ref::<String>()").count(),
+        1,
+        "panic downcast boilerplate should live in the shared helper"
+    );
+    for test_name in [
+        "imported_type_impl_imported_type_dependencies_are_not_directly_visible",
+        "imported_generic_function_imported_type_dependencies_are_not_directly_visible",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "import_visibility_dependencies.rs should not own imported-type dependency test: {test_name}"
+        );
+        assert!(
+            imported_type.contains(&format!("fn {test_name}")),
+            "imported-type dependency visibility tests should live in focused helper: {test_name}"
+        );
+    }
+    assert!(
+        root.lines().count() < 150,
+        "import_visibility_dependencies.rs should stay focused on fixture shape, not repeated panic plumbing"
+    );
+    assert!(
+        root.contains("#[path = \"import_visibility_dependencies/imported_type_dependencies.rs\"]"),
+        "import_visibility_dependencies.rs should include the focused imported_type_dependencies module by path"
+    );
+}

--- a/tests/integration/import_visibility_dependencies.rs
+++ b/tests/integration/import_visibility_dependencies.rs
@@ -1,134 +1,27 @@
 use super::*;
 
-#[test]
-fn imported_type_impl_imported_type_dependencies_are_not_directly_visible() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let helper_path = tmp.path().join("helper.zen");
-    std::fs::write(
-        &helper_path,
-        r#"
-pub Holder<T>: {
-    value: T
+#[path = "import_visibility_dependencies/imported_type_dependencies.rs"]
+mod imported_type_dependencies;
+
+fn write_module(path: &std::path::Path, contents: &str) {
+    std::fs::write(path, contents).unwrap_or_else(|err| panic!("write {}: {err}", path.display()));
 }
 
-pub Holder.get<T> = (self: Holder<T>) T {
-    self.value
-}
-"#,
-    )
-    .expect("write helper module");
+fn compile_error_message(source_path: &std::path::Path, expectation: &str) -> String {
+    let panic = std::panic::catch_unwind(|| compile_to_c(source_path)).expect_err(expectation);
 
-    let model_path = tmp.path().join("model.zen");
-    std::fs::write(
-        &model_path,
-        r#"
-{ Holder } = helper
-
-pub Box<T>: {
-    value: T
-}
-
-Box.impl = {
-    pub get_held<T> = (self: Box<T>) T {
-        holder = Holder<T> { value: self.value }
-        holder.get<T>()
-    }
-}
-"#,
-    )
-    .expect("write imported module");
-
-    let main_path = tmp.path().join("main.zen");
-    std::fs::write(
-        &main_path,
-        r#"
-{ Box } = model
-
-main = () i32 {
-    holder = Holder<i32> { value: 61 }
-    holder.get<i32>()
-}
-"#,
-    )
-    .expect("write entry module");
-
-    let panic = std::panic::catch_unwind(|| compile_to_c(&main_path))
-        .expect_err("compile_to_c should reject direct source-module imported type use");
-    let message = panic
+    panic
         .downcast_ref::<String>()
         .map(String::as_str)
         .or_else(|| panic.downcast_ref::<&str>().copied())
-        .unwrap_or("<non-string panic>");
+        .unwrap_or("<non-string panic>")
+        .to_string()
+}
 
+fn assert_message_contains_any(message: &str, expected: &[&str], context: &str) {
     assert!(
-        message.contains("unknown type symbol 'Holder'")
-            || message.contains("unknown type `Holder`")
-            || message.contains("unknown generic type `Holder`")
-            || message.contains("type `Holder_i32` has no method `get`"),
-        "expected unimported helper type or method diagnostic, panic={message}"
-    );
-}
-
-#[test]
-fn imported_generic_function_imported_type_dependencies_are_not_directly_visible() {
-    let tmp = tempfile::tempdir().expect("create temp dir");
-    let helper_path = tmp.path().join("helper.zen");
-    std::fs::write(
-        &helper_path,
-        r#"
-pub Holder<T>: {
-    value: T
-}
-
-pub Holder.get<T> = (self: Holder<T>) T {
-    self.value
-}
-"#,
-    )
-    .expect("write helper module");
-
-    let model_path = tmp.path().join("model.zen");
-    std::fs::write(
-        &model_path,
-        r#"
-{ Holder } = helper
-
-pub get_held<T> = (value: T) T {
-    holder = Holder<T> { value: value }
-    holder.get<T>()
-}
-"#,
-    )
-    .expect("write imported module");
-
-    let main_path = tmp.path().join("main.zen");
-    std::fs::write(
-        &main_path,
-        r#"
-{ get_held } = model
-
-main = () i32 {
-    holder = Holder<i32> { value: 73 }
-    holder.get<i32>()
-}
-"#,
-    )
-    .expect("write entry module");
-
-    let panic = std::panic::catch_unwind(|| compile_to_c(&main_path))
-        .expect_err("compile_to_c should reject direct source-module imported type use");
-    let message = panic
-        .downcast_ref::<String>()
-        .map(String::as_str)
-        .or_else(|| panic.downcast_ref::<&str>().copied())
-        .unwrap_or("<non-string panic>");
-
-    assert!(
-        message.contains("unknown type symbol 'Holder'")
-            || message.contains("unknown type `Holder`")
-            || message.contains("unknown generic type `Holder`")
-            || message.contains("type `Holder_i32` has no method `get`"),
-        "expected unimported helper type or method diagnostic, panic={message}"
+        expected.iter().any(|needle| message.contains(needle)),
+        "{context}, panic={message}"
     );
 }
 
@@ -136,7 +29,7 @@ main = () i32 {
 fn imported_generic_function_transitive_dependencies_are_not_directly_visible() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let helper_path = tmp.path().join("helper.zen");
-    std::fs::write(
+    write_module(
         &helper_path,
         r#"
 inner<T> = (value: T) T {
@@ -147,11 +40,10 @@ pub middle<T> = (value: T) T {
     inner(value)
 }
 "#,
-    )
-    .expect("write helper module");
+    );
 
     let model_path = tmp.path().join("model.zen");
-    std::fs::write(
+    write_module(
         &model_path,
         r#"
 { middle } = helper
@@ -160,11 +52,10 @@ pub outer<T> = (value: T) T {
     middle(value)
 }
 "#,
-    )
-    .expect("write imported module");
+    );
 
     let main_path = tmp.path().join("main.zen");
-    std::fs::write(
+    write_module(
         &main_path,
         r#"
 { outer } = model
@@ -173,21 +64,19 @@ main = () i32 {
     middle<i32>(89)
 }
 "#,
-    )
-    .expect("write entry module");
+    );
 
-    let panic = std::panic::catch_unwind(|| compile_to_c(&main_path))
-        .expect_err("compile_to_c should reject direct transitive helper calls");
-    let message = panic
-        .downcast_ref::<String>()
-        .map(String::as_str)
-        .or_else(|| panic.downcast_ref::<&str>().copied())
-        .unwrap_or("<non-string panic>");
-
-    assert!(
-        message.contains("unknown value symbol 'middle'")
-            || message.contains("undefined function `middle`"),
-        "expected unimported transitive helper diagnostic, panic={message}"
+    let message = compile_error_message(
+        &main_path,
+        "compile_to_c should reject direct transitive helper calls",
+    );
+    assert_message_contains_any(
+        &message,
+        &[
+            "unknown value symbol 'middle'",
+            "undefined function `middle`",
+        ],
+        "expected unimported transitive helper diagnostic",
     );
 }
 
@@ -195,7 +84,7 @@ main = () i32 {
 fn imported_function_signature_type_dependencies_are_not_directly_visible() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let model_path = tmp.path().join("model.zen");
-    std::fs::write(
+    write_module(
         &model_path,
         r#"
 pub Point: {
@@ -206,11 +95,10 @@ pub make_point = () Point {
     Point { x: 109 }
 }
 "#,
-    )
-    .expect("write imported module");
+    );
 
     let main_path = tmp.path().join("main.zen");
-    std::fs::write(
+    write_module(
         &main_path,
         r#"
 { make_point } = model
@@ -220,21 +108,19 @@ main = () i32 {
     point.x
 }
 "#,
-    )
-    .expect("write entry module");
+    );
 
-    let panic = std::panic::catch_unwind(|| compile_to_c(&main_path))
-        .expect_err("compile_to_c should reject direct signature dependency type use");
-    let message = panic
-        .downcast_ref::<String>()
-        .map(String::as_str)
-        .or_else(|| panic.downcast_ref::<&str>().copied())
-        .unwrap_or("<non-string panic>");
-
-    assert!(
-        message.contains("unknown type symbol 'Point'")
-            || message.contains("unknown type `Point`")
-            || message.contains("unknown struct `Point`"),
-        "expected unimported signature dependency type diagnostic, panic={message}"
+    let message = compile_error_message(
+        &main_path,
+        "compile_to_c should reject direct signature dependency type use",
+    );
+    assert_message_contains_any(
+        &message,
+        &[
+            "unknown type symbol 'Point'",
+            "unknown type `Point`",
+            "unknown struct `Point`",
+        ],
+        "expected unimported signature dependency type diagnostic",
     );
 }

--- a/tests/integration/import_visibility_dependencies/imported_type_dependencies.rs
+++ b/tests/integration/import_visibility_dependencies/imported_type_dependencies.rs
@@ -1,0 +1,125 @@
+use super::*;
+
+#[test]
+fn imported_type_impl_imported_type_dependencies_are_not_directly_visible() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let helper_path = tmp.path().join("helper.zen");
+    write_module(
+        &helper_path,
+        r#"
+pub Holder<T>: {
+    value: T
+}
+
+pub Holder.get<T> = (self: Holder<T>) T {
+    self.value
+}
+"#,
+    );
+
+    let model_path = tmp.path().join("model.zen");
+    write_module(
+        &model_path,
+        r#"
+{ Holder } = helper
+
+pub Box<T>: {
+    value: T
+}
+
+Box.impl = {
+    pub get_held<T> = (self: Box<T>) T {
+        holder = Holder<T> { value: self.value }
+        holder.get<T>()
+    }
+}
+"#,
+    );
+
+    let main_path = tmp.path().join("main.zen");
+    write_module(
+        &main_path,
+        r#"
+{ Box } = model
+
+main = () i32 {
+    holder = Holder<i32> { value: 61 }
+    holder.get<i32>()
+}
+"#,
+    );
+
+    let message = compile_error_message(
+        &main_path,
+        "compile_to_c should reject direct source-module imported type use",
+    );
+    assert_message_contains_any(
+        &message,
+        &[
+            "unknown type symbol 'Holder'",
+            "unknown type `Holder`",
+            "unknown generic type `Holder`",
+            "type `Holder_i32` has no method `get`",
+        ],
+        "expected unimported helper type or method diagnostic",
+    );
+}
+
+#[test]
+fn imported_generic_function_imported_type_dependencies_are_not_directly_visible() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let helper_path = tmp.path().join("helper.zen");
+    write_module(
+        &helper_path,
+        r#"
+pub Holder<T>: {
+    value: T
+}
+
+pub Holder.get<T> = (self: Holder<T>) T {
+    self.value
+}
+"#,
+    );
+
+    let model_path = tmp.path().join("model.zen");
+    write_module(
+        &model_path,
+        r#"
+{ Holder } = helper
+
+pub get_held<T> = (value: T) T {
+    holder = Holder<T> { value: value }
+    holder.get<T>()
+}
+"#,
+    );
+
+    let main_path = tmp.path().join("main.zen");
+    write_module(
+        &main_path,
+        r#"
+{ get_held } = model
+
+main = () i32 {
+    holder = Holder<i32> { value: 73 }
+    holder.get<i32>()
+}
+"#,
+    );
+
+    let message = compile_error_message(
+        &main_path,
+        "compile_to_c should reject direct source-module imported type use",
+    );
+    assert_message_contains_any(
+        &message,
+        &[
+            "unknown type symbol 'Holder'",
+            "unknown type `Holder`",
+            "unknown generic type `Holder`",
+            "type `Holder_i32` has no method `get`",
+        ],
+        "expected unimported helper type or method diagnostic",
+    );
+}


### PR DESCRIPTION
## Summary

- centralizes compile-error panic capture/downcast plumbing for import visibility dependency tests
- moves imported-type dependency visibility cases into a focused child module
- adds a docs-truth guard for the helper and split boundary

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test import_visibility_dependency_panic_capture_stays_shared`
- `cargo test import_visibility_dependencies`
- `cargo test --lib`
- `cargo test --tests`
