### PR TITLE
[codex] Split resolver enum function payload tests

### DIFF
--- a/src/typechecker/tests/resolver_struct_enum_metadata/enum_metadata.rs
+++ b/src/typechecker/tests/resolver_struct_enum_metadata/enum_metadata.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod function_payloads;
+
 #[test]
 fn check_program_with_symbols_validates_resolver_enum_variant_payload_counts() {
     let program = parse_program(
@@ -76,89 +78,6 @@ Option: Some(i32), None
             .message
             .contains("resolver variant symbol 'Some' has payload type 'bool', expected 'i32'")),
         "expected resolver enum variant payload type diagnostic, got {err:?}"
-    );
-}
-
-#[test]
-fn check_program_with_symbols_validates_resolver_enum_function_type_payloads() {
-    let program = parse_program(
-        r#"
-Callback: Wrap((i32) i32), None
-"#,
-    );
-    let mut symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    symbols.set_variant_payload_type_name_for_test(
-        Namespace::Variant,
-        "Wrap",
-        Some("i32".to_string()),
-    );
-    let mut tc = TypeChecker::new();
-
-    let err = tc
-        .check_program_with_symbols(&program, &symbols)
-        .expect_err("resolver enum function type payload mismatch should fail");
-
-    assert!(
-        err.iter().any(|d| d.message.contains(
-            "resolver variant symbol 'Wrap' has payload type 'i32', expected '(i32) i32'"
-        )),
-        "expected resolver enum function type payload diagnostic, got {err:?}"
-    );
-}
-
-#[test]
-fn check_program_with_symbols_validates_resolver_enum_typed_payload_metadata() {
-    let program = parse_program(
-        r#"
-Callback: Wrap((i32) i32), None
-"#,
-    );
-    let mut symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    symbols.set_variant_payload_type_for_test(Namespace::Variant, "Wrap", Some(AstType::I32));
-    let mut tc = TypeChecker::new();
-
-    let err = tc
-        .check_program_with_symbols(&program, &symbols)
-        .expect_err("resolver typed enum payload metadata mismatch should fail");
-
-    assert!(
-        err.iter().any(|d| d.message.contains(
-            "resolver variant symbol 'Wrap' has typed payload type 'i32', expected '(i32) i32'"
-        )),
-        "expected resolver typed enum payload diagnostic, got {err:?}"
-    );
-}
-
-#[test]
-fn check_program_with_symbols_validates_resolver_generic_enum_function_type_payloads() {
-    let program = parse_program(
-        r#"
-Callback<T>: Wrap((T) T), None
-"#,
-    );
-    let mut symbols = crate::resolver::Resolver::new()
-        .resolve_program(&program)
-        .expect("resolver succeeds");
-    symbols.set_variant_payload_type_name_for_test(
-        Namespace::Variant,
-        "Wrap",
-        Some("T".to_string()),
-    );
-    let mut tc = TypeChecker::new();
-
-    let err = tc
-        .check_program_with_symbols(&program, &symbols)
-        .expect_err("resolver generic enum function type payload mismatch should fail");
-
-    assert!(
-        err.iter().any(|d| d
-            .message
-            .contains("resolver variant symbol 'Wrap' has payload type 'T', expected '(T) T'")),
-        "expected resolver generic enum function type payload diagnostic, got {err:?}"
     );
 }
 

--- a/src/typechecker/tests/resolver_struct_enum_metadata/enum_metadata/function_payloads.rs
+++ b/src/typechecker/tests/resolver_struct_enum_metadata/enum_metadata/function_payloads.rs
@@ -1,0 +1,84 @@
+use super::*;
+
+#[test]
+fn check_program_with_symbols_validates_resolver_enum_function_type_payloads() {
+    let program = parse_program(
+        r#"
+Callback: Wrap((i32) i32), None
+"#,
+    );
+    let mut symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    symbols.set_variant_payload_type_name_for_test(
+        Namespace::Variant,
+        "Wrap",
+        Some("i32".to_string()),
+    );
+    let mut tc = TypeChecker::new();
+
+    let err = tc
+        .check_program_with_symbols(&program, &symbols)
+        .expect_err("resolver enum function type payload mismatch should fail");
+
+    assert!(
+        err.iter().any(|d| d.message.contains(
+            "resolver variant symbol 'Wrap' has payload type 'i32', expected '(i32) i32'"
+        )),
+        "expected resolver enum function type payload diagnostic, got {err:?}"
+    );
+}
+
+#[test]
+fn check_program_with_symbols_validates_resolver_enum_typed_payload_metadata() {
+    let program = parse_program(
+        r#"
+Callback: Wrap((i32) i32), None
+"#,
+    );
+    let mut symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    symbols.set_variant_payload_type_for_test(Namespace::Variant, "Wrap", Some(AstType::I32));
+    let mut tc = TypeChecker::new();
+
+    let err = tc
+        .check_program_with_symbols(&program, &symbols)
+        .expect_err("resolver typed enum payload metadata mismatch should fail");
+
+    assert!(
+        err.iter().any(|d| d.message.contains(
+            "resolver variant symbol 'Wrap' has typed payload type 'i32', expected '(i32) i32'"
+        )),
+        "expected resolver typed enum payload diagnostic, got {err:?}"
+    );
+}
+
+#[test]
+fn check_program_with_symbols_validates_resolver_generic_enum_function_type_payloads() {
+    let program = parse_program(
+        r#"
+Callback<T>: Wrap((T) T), None
+"#,
+    );
+    let mut symbols = crate::resolver::Resolver::new()
+        .resolve_program(&program)
+        .expect("resolver succeeds");
+    symbols.set_variant_payload_type_name_for_test(
+        Namespace::Variant,
+        "Wrap",
+        Some("T".to_string()),
+    );
+    let mut tc = TypeChecker::new();
+
+    let err = tc
+        .check_program_with_symbols(&program, &symbols)
+        .expect_err("resolver generic enum function type payload mismatch should fail");
+
+    assert!(
+        err.iter().any(|d| d
+            .message
+            .contains("resolver variant symbol 'Wrap' has payload type 'T', expected '(T) T'")),
+        "expected resolver generic enum function type payload diagnostic, got {err:?}"
+    );
+}

--- a/tests/docs_truth/repo_hygiene/file_size.rs
+++ b/tests/docs_truth/repo_hygiene/file_size.rs
@@ -17,6 +17,7 @@ mod resolver_metadata_impl_method_splits;
 mod resolver_metadata_requirement_splits;
 mod resolver_metadata_restoration_splits;
 mod resolver_phase2_splits;
+mod resolver_struct_enum_metadata_splits;
 mod resolver_validation_splits;
 mod resolver_validation_test_splits;
 mod thresholds;

--- a/tests/docs_truth/repo_hygiene/file_size/resolver_struct_enum_metadata_splits.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/resolver_struct_enum_metadata_splits.rs
@@ -1,0 +1,33 @@
+use super::super::*;
+
+#[test]
+fn resolver_enum_function_payload_tests_live_in_focused_helper() {
+    let root = read("src/typechecker/tests/resolver_struct_enum_metadata/enum_metadata.rs");
+    let function_payloads = read(
+        "src/typechecker/tests/resolver_struct_enum_metadata/enum_metadata/function_payloads.rs",
+    );
+
+    for test_name in [
+        "check_program_with_symbols_validates_resolver_enum_function_type_payloads",
+        "check_program_with_symbols_validates_resolver_enum_typed_payload_metadata",
+        "check_program_with_symbols_validates_resolver_generic_enum_function_type_payloads",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "enum_metadata.rs should not own function-type enum payload test: {test_name}"
+        );
+        assert!(
+            function_payloads.contains(&format!("fn {test_name}")),
+            "function-type enum payload tests should live in focused helper: {test_name}"
+        );
+    }
+
+    assert!(
+        root.lines().count() < 170,
+        "enum_metadata.rs should stay focused on enum variant metadata counts, visibility, names, and owners"
+    );
+    assert!(
+        root.contains("mod function_payloads;"),
+        "enum_metadata.rs should include the focused function_payloads module"
+    );
+}


### PR DESCRIPTION
## Summary

- moves resolver enum function-type payload metadata tests into a focused child module
- adds a docs-truth guard so enum metadata root stays focused on counts, visibility, names, and owners
- keeps the resolver struct/enum metadata test files below focused size thresholds

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test resolver_enum_function_payload_tests_live_in_focused_helper`
- `cargo test resolver_struct_enum_metadata::enum_metadata`
- `cargo test --lib`
- `cargo test --tests`
