### PR TITLE
[codex] Split resolver phase2 enum metadata tests

### DIFF
--- a/tests/docs_truth/repo_hygiene/file_size/resolver_phase2_splits.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/resolver_phase2_splits.rs
@@ -91,3 +91,51 @@ fn resolver_phase2_struct_literal_tests_live_in_focused_helper() {
         "struct_metadata.rs should include the focused struct literal module by path"
     );
 }
+
+#[test]
+fn resolver_phase2_enum_function_payload_tests_live_in_focused_helper() {
+    let root = read("tests/resolver_phase2/enum_metadata.rs");
+    let function_payloads = read("tests/resolver_phase2/enum_metadata/function_payloads.rs");
+    let variant_names = read("tests/resolver_phase2/enum_metadata/variant_names.rs");
+
+    for test_name in [
+        "resolver_records_enum_function_type_payloads",
+        "resolver_records_generic_enum_function_type_payloads",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "enum_metadata.rs should not own function-type enum payload resolver test: {test_name}"
+        );
+        assert!(
+            function_payloads.contains(&format!("fn {test_name}")),
+            "function-type enum payload resolver tests should live in focused helper: {test_name}"
+        );
+    }
+    for test_name in [
+        "resolver_records_enum_variant_names",
+        "resolver_allows_same_variant_names_in_different_enums",
+        "resolver_rejects_duplicate_variant_names_in_same_enum",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "enum_metadata.rs should not own variant-name resolver test: {test_name}"
+        );
+        assert!(
+            variant_names.contains(&format!("fn {test_name}")),
+            "variant-name resolver tests should live in focused helper: {test_name}"
+        );
+    }
+
+    assert!(
+        root.lines().count() < 150,
+        "enum_metadata.rs should stay focused on enum owners, payload counts, and nominal payloads"
+    );
+    assert!(
+        root.contains("#[path = \"enum_metadata/function_payloads.rs\"]"),
+        "enum_metadata.rs should include the focused function_payloads module by path"
+    );
+    assert!(
+        root.contains("#[path = \"enum_metadata/variant_names.rs\"]"),
+        "enum_metadata.rs should include the focused variant_names module by path"
+    );
+}

--- a/tests/resolver_phase2/enum_metadata.rs
+++ b/tests/resolver_phase2/enum_metadata.rs
@@ -1,5 +1,10 @@
 use super::*;
 
+#[path = "enum_metadata/function_payloads.rs"]
+mod function_payloads;
+#[path = "enum_metadata/variant_names.rs"]
+mod variant_names;
+
 #[test]
 fn resolver_records_enum_variant_payload_counts() {
     let program = parse_program(
@@ -23,83 +28,6 @@ Option: Some(i32), None
             .expect("None variant symbol")
             .variant_payload_count,
         Some(0)
-    );
-}
-
-#[test]
-fn resolver_records_enum_variant_names() {
-    let program = parse_program(
-        r#"
-Option: Some(i32), None
-"#,
-    );
-
-    let table = Resolver::new().resolve_program(&program).expect("resolve");
-
-    assert_eq!(
-        table
-            .lookup(Namespace::Type, "Option")
-            .expect("Option type symbol")
-            .variant_names
-            .as_deref(),
-        Some(&["Some".to_string(), "None".to_string()][..])
-    );
-}
-
-#[test]
-fn resolver_allows_same_variant_names_in_different_enums() {
-    let program = parse_program(
-        r#"
-Option:
-    None,
-    Some(i32)
-
-Maybe:
-    None,
-    Some(bool)
-"#,
-    );
-
-    let table = Resolver::new()
-        .resolve_program(&program)
-        .expect("variant names should be scoped to their owner enum");
-
-    assert_eq!(
-        table
-            .symbols()
-            .iter()
-            .filter(|symbol| symbol.namespace == Namespace::Variant && symbol.name == "None")
-            .count(),
-        2
-    );
-    assert_eq!(
-        table
-            .symbols()
-            .iter()
-            .filter(|symbol| symbol.namespace == Namespace::Variant && symbol.name == "Some")
-            .count(),
-        2
-    );
-}
-
-#[test]
-fn resolver_rejects_duplicate_variant_names_in_same_enum() {
-    let program = parse_program(
-        r#"
-Option:
-    None,
-    None
-"#,
-    );
-
-    let err = Resolver::new()
-        .resolve_program(&program)
-        .expect_err("duplicate variant names in one enum should be rejected");
-
-    assert!(
-        err.iter()
-            .any(|d| d.message.contains("duplicate variant symbol 'None'")),
-        "expected duplicate variant diagnostic, got {err:?}"
     );
 }
 
@@ -184,56 +112,5 @@ Result<T, E>: Ok(T), Err(E)
             .variant_payload_type_name
             .as_deref(),
         Some("E")
-    );
-}
-
-#[test]
-fn resolver_records_enum_function_type_payloads() {
-    let program = parse_program(
-        r#"
-Callback: Wrap((i32) i32), None
-"#,
-    );
-
-    let table = Resolver::new().resolve_program(&program).expect("resolve");
-
-    assert_eq!(
-        table
-            .lookup(Namespace::Variant, "Wrap")
-            .expect("Wrap variant symbol")
-            .variant_payload_type_name
-            .as_deref(),
-        Some("(i32) i32")
-    );
-    assert_eq!(
-        table
-            .lookup(Namespace::Variant, "Wrap")
-            .expect("Wrap variant symbol")
-            .variant_payload_type
-            .as_ref(),
-        Some(&zen::ast::AstType::Function {
-            params: vec![zen::ast::AstType::I32],
-            ret: Box::new(zen::ast::AstType::I32),
-        })
-    );
-}
-
-#[test]
-fn resolver_records_generic_enum_function_type_payloads() {
-    let program = parse_program(
-        r#"
-Callback<T>: Wrap((T) T), None
-"#,
-    );
-
-    let table = Resolver::new().resolve_program(&program).expect("resolve");
-
-    assert_eq!(
-        table
-            .lookup(Namespace::Variant, "Wrap")
-            .expect("Wrap variant symbol")
-            .variant_payload_type_name
-            .as_deref(),
-        Some("(T) T")
     );
 }

--- a/tests/resolver_phase2/enum_metadata/function_payloads.rs
+++ b/tests/resolver_phase2/enum_metadata/function_payloads.rs
@@ -1,0 +1,52 @@
+use super::*;
+
+#[test]
+fn resolver_records_enum_function_type_payloads() {
+    let program = parse_program(
+        r#"
+Callback: Wrap((i32) i32), None
+"#,
+    );
+
+    let table = Resolver::new().resolve_program(&program).expect("resolve");
+
+    assert_eq!(
+        table
+            .lookup(Namespace::Variant, "Wrap")
+            .expect("Wrap variant symbol")
+            .variant_payload_type_name
+            .as_deref(),
+        Some("(i32) i32")
+    );
+    assert_eq!(
+        table
+            .lookup(Namespace::Variant, "Wrap")
+            .expect("Wrap variant symbol")
+            .variant_payload_type
+            .as_ref(),
+        Some(&zen::ast::AstType::Function {
+            params: vec![zen::ast::AstType::I32],
+            ret: Box::new(zen::ast::AstType::I32),
+        })
+    );
+}
+
+#[test]
+fn resolver_records_generic_enum_function_type_payloads() {
+    let program = parse_program(
+        r#"
+Callback<T>: Wrap((T) T), None
+"#,
+    );
+
+    let table = Resolver::new().resolve_program(&program).expect("resolve");
+
+    assert_eq!(
+        table
+            .lookup(Namespace::Variant, "Wrap")
+            .expect("Wrap variant symbol")
+            .variant_payload_type_name
+            .as_deref(),
+        Some("(T) T")
+    );
+}

--- a/tests/resolver_phase2/enum_metadata/variant_names.rs
+++ b/tests/resolver_phase2/enum_metadata/variant_names.rs
@@ -1,0 +1,78 @@
+use super::*;
+
+#[test]
+fn resolver_records_enum_variant_names() {
+    let program = parse_program(
+        r#"
+Option: Some(i32), None
+"#,
+    );
+
+    let table = Resolver::new().resolve_program(&program).expect("resolve");
+
+    assert_eq!(
+        table
+            .lookup(Namespace::Type, "Option")
+            .expect("Option type symbol")
+            .variant_names
+            .as_deref(),
+        Some(&["Some".to_string(), "None".to_string()][..])
+    );
+}
+
+#[test]
+fn resolver_allows_same_variant_names_in_different_enums() {
+    let program = parse_program(
+        r#"
+Option:
+    None,
+    Some(i32)
+
+Maybe:
+    None,
+    Some(bool)
+"#,
+    );
+
+    let table = Resolver::new()
+        .resolve_program(&program)
+        .expect("variant names should be scoped to their owner enum");
+
+    assert_eq!(
+        table
+            .symbols()
+            .iter()
+            .filter(|symbol| symbol.namespace == Namespace::Variant && symbol.name == "None")
+            .count(),
+        2
+    );
+    assert_eq!(
+        table
+            .symbols()
+            .iter()
+            .filter(|symbol| symbol.namespace == Namespace::Variant && symbol.name == "Some")
+            .count(),
+        2
+    );
+}
+
+#[test]
+fn resolver_rejects_duplicate_variant_names_in_same_enum() {
+    let program = parse_program(
+        r#"
+Option:
+    None,
+    None
+"#,
+    );
+
+    let err = Resolver::new()
+        .resolve_program(&program)
+        .expect_err("duplicate variant names in one enum should be rejected");
+
+    assert!(
+        err.iter()
+            .any(|d| d.message.contains("duplicate variant symbol 'None'")),
+        "expected duplicate variant diagnostic, got {err:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- moves resolver phase2 enum function-payload metadata tests into a focused helper
- moves enum variant-name/scoping tests into a focused helper
- extends docs-truth file-size guards so the enum metadata root stays focused on owner, payload count, and nominal payload metadata

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test resolver_phase2_enum_function_payload_tests_live_in_focused_helper`
- `cargo test resolver_records_enum`
- `cargo test --lib`
- `cargo test --tests`
