### PR TITLE
[codex] Split declaration resolver behavior tasks

### DIFF
--- a/src/typechecker/tests/declaration_validation/resolver_replay.rs
+++ b/src/typechecker/tests/declaration_validation/resolver_replay.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+mod behavior_tasks;
 mod semantic_bundles;
 
 #[test]
@@ -51,91 +52,6 @@ Point: { x: i32 = 1 }
     assert!(matches!(
         type_reference_tasks.as_slice(),
         [ResolverTypeReferenceValidationTask::Struct { name: "Point", .. }]
-    ));
-}
-
-#[test]
-fn resolver_behavior_declaration_metadata_tasks_collect_only_behavior_work() {
-    let program = parse_program(
-        r#"
-Point: { x: i32 }
-
-Json<T>: behavior {
-    encode: (Self) T
-}
-
-main = () i32 { 1 }
-"#,
-    );
-
-    let tasks =
-        TypeChecker::collect_resolver_behavior_declaration_metadata_tasks(&program.declarations);
-
-    assert_eq!(tasks.len(), 1);
-    assert_eq!(tasks[0].name, "Json");
-}
-
-#[test]
-fn resolver_behavior_replay_task_helper_pushes_metadata_and_type_refs_together() {
-    let program = parse_program(
-        r#"
-Json<T>: behavior {
-    encode: (Self) T
-}
-"#,
-    );
-    let mut behavior_tasks = Vec::new();
-    let mut type_reference_tasks = Vec::new();
-
-    let handled = TypeChecker::push_resolver_behavior_replay_tasks(
-        &program.declarations[0],
-        &mut behavior_tasks,
-        &mut type_reference_tasks,
-    );
-
-    assert!(handled);
-    assert_eq!(behavior_tasks.len(), 1);
-    assert_eq!(behavior_tasks[0].name, "Json");
-    assert!(matches!(
-        type_reference_tasks.as_slice(),
-        [ResolverTypeReferenceValidationTask::Behavior { name: "Json", .. }]
-    ));
-}
-
-#[test]
-fn resolver_behavior_impl_replay_task_helper_pushes_metadata_and_type_refs_together() {
-    let program = parse_program(
-        r#"
-Point: { x: i32 }
-
-Json: behavior {
-    encode: (Self) StaticString
-}
-
-Point.implements(Json) {
-    encode = (self: Point) StaticString { "point" }
-}
-"#,
-    );
-    let mut behavior_impl_tasks = Vec::new();
-    let mut type_reference_tasks = Vec::new();
-
-    let handled = TypeChecker::push_resolver_behavior_impl_replay_tasks(
-        &program.declarations[2],
-        &mut behavior_impl_tasks,
-        &mut type_reference_tasks,
-    );
-
-    assert!(handled);
-    assert_eq!(behavior_impl_tasks.len(), 1);
-    assert_eq!(behavior_impl_tasks[0].ast_type_name, "Point");
-    assert_eq!(behavior_impl_tasks[0].behavior, "Json");
-    assert!(matches!(
-        type_reference_tasks.as_slice(),
-        [ResolverTypeReferenceValidationTask::ImplBlock {
-            type_name: "Point",
-            ..
-        }]
     ));
 }
 
@@ -207,33 +123,4 @@ make = () Point { Point { x: 1 } }
         type_reference_tasks.as_slice(),
         [ResolverTypeReferenceValidationTask::Function { name: "make", .. }]
     ));
-}
-
-#[test]
-fn resolver_behavior_impl_block_declaration_tasks_collect_only_behavior_impls() {
-    let program = parse_program(
-        r#"
-Point: { x: i32 }
-
-Json: behavior {
-    encode: (Self) StaticString
-}
-
-Point.impl = {
-    x_value = (value: Point) i32 { value.x }
-}
-
-Point.implements(Json) {
-    encode = (value: Point) StaticString { "point" }
-}
-"#,
-    );
-
-    let tasks =
-        TypeChecker::collect_resolver_behavior_impl_block_declaration_tasks(&program.declarations);
-
-    assert_eq!(tasks.len(), 1);
-    assert_eq!(tasks[0].ast_type_name, "Point");
-    assert_eq!(tasks[0].behavior, "Json");
-    assert_eq!(tasks[0].methods.len(), 1);
 }

--- a/src/typechecker/tests/declaration_validation/resolver_replay/behavior_tasks.rs
+++ b/src/typechecker/tests/declaration_validation/resolver_replay/behavior_tasks.rs
@@ -1,0 +1,115 @@
+use super::*;
+
+#[test]
+fn resolver_behavior_declaration_metadata_tasks_collect_only_behavior_work() {
+    let program = parse_program(
+        r#"
+Point: { x: i32 }
+
+Json<T>: behavior {
+    encode: (Self) T
+}
+
+main = () i32 { 1 }
+"#,
+    );
+
+    let tasks =
+        TypeChecker::collect_resolver_behavior_declaration_metadata_tasks(&program.declarations);
+
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0].name, "Json");
+}
+
+#[test]
+fn resolver_behavior_replay_task_helper_pushes_metadata_and_type_refs_together() {
+    let program = parse_program(
+        r#"
+Json<T>: behavior {
+    encode: (Self) T
+}
+"#,
+    );
+    let mut behavior_tasks = Vec::new();
+    let mut type_reference_tasks = Vec::new();
+
+    let handled = TypeChecker::push_resolver_behavior_replay_tasks(
+        &program.declarations[0],
+        &mut behavior_tasks,
+        &mut type_reference_tasks,
+    );
+
+    assert!(handled);
+    assert_eq!(behavior_tasks.len(), 1);
+    assert_eq!(behavior_tasks[0].name, "Json");
+    assert!(matches!(
+        type_reference_tasks.as_slice(),
+        [ResolverTypeReferenceValidationTask::Behavior { name: "Json", .. }]
+    ));
+}
+
+#[test]
+fn resolver_behavior_impl_replay_task_helper_pushes_metadata_and_type_refs_together() {
+    let program = parse_program(
+        r#"
+Point: { x: i32 }
+
+Json: behavior {
+    encode: (Self) StaticString
+}
+
+Point.implements(Json) {
+    encode = (self: Point) StaticString { "point" }
+}
+"#,
+    );
+    let mut behavior_impl_tasks = Vec::new();
+    let mut type_reference_tasks = Vec::new();
+
+    let handled = TypeChecker::push_resolver_behavior_impl_replay_tasks(
+        &program.declarations[2],
+        &mut behavior_impl_tasks,
+        &mut type_reference_tasks,
+    );
+
+    assert!(handled);
+    assert_eq!(behavior_impl_tasks.len(), 1);
+    assert_eq!(behavior_impl_tasks[0].ast_type_name, "Point");
+    assert_eq!(behavior_impl_tasks[0].behavior, "Json");
+    assert!(matches!(
+        type_reference_tasks.as_slice(),
+        [ResolverTypeReferenceValidationTask::ImplBlock {
+            type_name: "Point",
+            ..
+        }]
+    ));
+}
+
+#[test]
+fn resolver_behavior_impl_block_declaration_tasks_collect_only_behavior_impls() {
+    let program = parse_program(
+        r#"
+Point: { x: i32 }
+
+Json: behavior {
+    encode: (Self) StaticString
+}
+
+Point.impl = {
+    x_value = (value: Point) i32 { value.x }
+}
+
+Point.implements(Json) {
+    encode = (value: Point) StaticString { "point" }
+}
+"#,
+    );
+
+    let tasks =
+        TypeChecker::collect_resolver_behavior_impl_block_declaration_tasks(&program.declarations);
+
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0].ast_type_name, "Point");
+    assert_eq!(tasks[0].behavior, "Json");
+    assert_eq!(tasks[0].methods.len(), 1);
+}

--- a/tests/docs_truth/repo_hygiene/file_size/declaration_validation_splits.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/declaration_validation_splits.rs
@@ -31,3 +31,35 @@ fn resolver_semantic_bundle_task_tests_live_in_focused_helper() {
         "semantic_bundles.rs should include the focused task_collection module"
     );
 }
+
+#[test]
+fn resolver_replay_behavior_task_tests_live_in_focused_helper() {
+    let root = read("src/typechecker/tests/declaration_validation/resolver_replay.rs");
+    let behavior_tasks =
+        read("src/typechecker/tests/declaration_validation/resolver_replay/behavior_tasks.rs");
+
+    for test_name in [
+        "resolver_behavior_declaration_metadata_tasks_collect_only_behavior_work",
+        "resolver_behavior_replay_task_helper_pushes_metadata_and_type_refs_together",
+        "resolver_behavior_impl_replay_task_helper_pushes_metadata_and_type_refs_together",
+        "resolver_behavior_impl_block_declaration_tasks_collect_only_behavior_impls",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "resolver_replay.rs should not own behavior replay task test: {test_name}"
+        );
+        assert!(
+            behavior_tasks.contains(&format!("fn {test_name}")),
+            "behavior replay task tests should live in focused helper: {test_name}"
+        );
+    }
+
+    assert!(
+        root.lines().count() < 150,
+        "resolver_replay.rs should stay focused on type and callable replay task helpers"
+    );
+    assert!(
+        root.contains("mod behavior_tasks;"),
+        "resolver_replay.rs should include the focused behavior_tasks module"
+    );
+}


### PR DESCRIPTION
## Summary

- moves declaration-validation behavior replay task tests into a focused resolver replay helper
- adds a docs-truth guard so `resolver_replay.rs` stays focused on type and callable replay task helpers
- keeps the declaration-validation resolver replay root below the focused file-size threshold

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test resolver_replay_behavior_task_tests_live_in_focused_helper`
- `cargo test declaration_validation::resolver_replay`
- `cargo test --lib`
- `cargo test --tests`
