### PR TITLE
[codex] Split core type substitution tests

### DIFF
--- a/src/typechecker/tests/core_semantics/type_helpers.rs
+++ b/src/typechecker/tests/core_semantics/type_helpers.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod substitution;
+
 #[test]
 fn types_compatible_basics() {
     let tc = TypeChecker::new();
@@ -126,111 +128,4 @@ fn infer_type_args_basic() {
     let arg_types = vec![Type::I32];
     let subs = tc.infer_type_args(&type_params, &params, &arg_types);
     assert_eq!(subs.get("T"), Some(&Type::I32));
-}
-
-#[test]
-fn substitute_type_basic() {
-    let tc = TypeChecker::new();
-    let mut subs = HashMap::new();
-    subs.insert("T".to_string(), Type::I32);
-    // T → I32
-    assert_eq!(
-        tc.substitute_type(&AstType::Named("T".into()), &subs),
-        Type::I32
-    );
-    // Ptr<T> → Ptr<I32>
-    assert_eq!(
-        tc.substitute_type(&AstType::Ptr(Box::new(AstType::Named("T".into()))), &subs),
-        Type::Ptr(Box::new(Type::I32))
-    );
-    // Non-generic type unchanged
-    assert_eq!(tc.substitute_type(&AstType::Bool, &subs), Type::Bool);
-}
-
-#[test]
-fn substitute_type_covers_all_composite_type_shapes() {
-    let tc = TypeChecker::new();
-    let mut subs = HashMap::new();
-    subs.insert("T".to_string(), Type::I32);
-
-    assert_eq!(
-        tc.substitute_type(
-            &AstType::RawPtr(Box::new(AstType::Named("T".into()))),
-            &subs
-        ),
-        Type::RawPtr(Box::new(Type::I32))
-    );
-    assert_eq!(
-        tc.substitute_type(
-            &AstType::MutPtr(Box::new(AstType::Named("T".into()))),
-            &subs
-        ),
-        Type::MutPtr(Box::new(Type::I32))
-    );
-    assert_eq!(
-        tc.substitute_type(&AstType::Slice(Box::new(AstType::Named("T".into()))), &subs),
-        Type::Slice(Box::new(Type::I32))
-    );
-    assert_eq!(
-        tc.substitute_type(
-            &AstType::Array {
-                elem: Box::new(AstType::Named("T".into())),
-                size: Some(3),
-            },
-            &subs,
-        ),
-        Type::Array {
-            elem: Box::new(Type::I32),
-            size: Some(3),
-        }
-    );
-    assert_eq!(
-        tc.substitute_type(
-            &AstType::Function {
-                params: vec![AstType::Named("T".into())],
-                ret: Box::new(AstType::Named("T".into())),
-            },
-            &subs,
-        ),
-        Type::Function {
-            params: vec![Type::I32],
-            ret: Box::new(Type::I32),
-        }
-    );
-}
-
-#[test]
-fn substitute_type_preserves_function_type_arguments_in_nested_generics() {
-    let mut tc = TypeChecker::new();
-    tc.structs.insert(
-        "Box".to_string(),
-        StructInfo {
-            specialization_scope: None,
-            name: "Box".to_string(),
-            fields: vec![("value".to_string(), AstType::Named("T".to_string()))],
-            field_defaults: HashMap::new(),
-            type_params: vec!["T".to_string()],
-            type_param_bounds: HashMap::new(),
-        },
-    );
-    let function_type = Type::Function {
-        params: vec![Type::I32],
-        ret: Box::new(Type::I32),
-    };
-    let mut subs = HashMap::new();
-    subs.insert("T".to_string(), function_type.clone());
-
-    assert_eq!(
-        tc.substitute_type(
-            &AstType::Generic {
-                name: "Box".to_string(),
-                type_args: vec![AstType::Named("T".to_string())],
-            },
-            &subs,
-        ),
-        Type::Struct {
-            name: "Box_fn_i32_ret_i32".to_string(),
-            fields: vec![("value".to_string(), function_type)],
-        }
-    );
 }

--- a/src/typechecker/tests/core_semantics/type_helpers/substitution.rs
+++ b/src/typechecker/tests/core_semantics/type_helpers/substitution.rs
@@ -1,0 +1,106 @@
+use super::*;
+
+#[test]
+fn substitute_type_basic() {
+    let tc = TypeChecker::new();
+    let mut subs = HashMap::new();
+    subs.insert("T".to_string(), Type::I32);
+
+    assert_eq!(
+        tc.substitute_type(&AstType::Named("T".into()), &subs),
+        Type::I32
+    );
+    assert_eq!(
+        tc.substitute_type(&AstType::Ptr(Box::new(AstType::Named("T".into()))), &subs),
+        Type::Ptr(Box::new(Type::I32))
+    );
+    assert_eq!(tc.substitute_type(&AstType::Bool, &subs), Type::Bool);
+}
+
+#[test]
+fn substitute_type_covers_all_composite_type_shapes() {
+    let tc = TypeChecker::new();
+    let mut subs = HashMap::new();
+    subs.insert("T".to_string(), Type::I32);
+
+    assert_eq!(
+        tc.substitute_type(
+            &AstType::RawPtr(Box::new(AstType::Named("T".into()))),
+            &subs
+        ),
+        Type::RawPtr(Box::new(Type::I32))
+    );
+    assert_eq!(
+        tc.substitute_type(
+            &AstType::MutPtr(Box::new(AstType::Named("T".into()))),
+            &subs
+        ),
+        Type::MutPtr(Box::new(Type::I32))
+    );
+    assert_eq!(
+        tc.substitute_type(&AstType::Slice(Box::new(AstType::Named("T".into()))), &subs),
+        Type::Slice(Box::new(Type::I32))
+    );
+    assert_eq!(
+        tc.substitute_type(
+            &AstType::Array {
+                elem: Box::new(AstType::Named("T".into())),
+                size: Some(3),
+            },
+            &subs,
+        ),
+        Type::Array {
+            elem: Box::new(Type::I32),
+            size: Some(3),
+        }
+    );
+    assert_eq!(
+        tc.substitute_type(
+            &AstType::Function {
+                params: vec![AstType::Named("T".into())],
+                ret: Box::new(AstType::Named("T".into())),
+            },
+            &subs,
+        ),
+        Type::Function {
+            params: vec![Type::I32],
+            ret: Box::new(Type::I32),
+        }
+    );
+}
+
+#[test]
+fn substitute_type_preserves_function_type_arguments_in_nested_generics() {
+    let mut tc = TypeChecker::new();
+    tc.structs.insert(
+        "Box".to_string(),
+        StructInfo {
+            specialization_scope: None,
+            name: "Box".to_string(),
+            fields: vec![("value".to_string(), AstType::Named("T".to_string()))],
+            field_defaults: HashMap::new(),
+            type_params: vec!["T".to_string()],
+            type_param_bounds: HashMap::new(),
+        },
+    );
+    let function_type = Type::Function {
+        params: vec![Type::I32],
+        ret: Box::new(Type::I32),
+    };
+    let mut subs = HashMap::new();
+    subs.insert("T".to_string(), function_type.clone());
+
+    assert_eq!(
+        tc.substitute_type(
+            &AstType::Generic {
+                name: "Box".to_string(),
+                type_args: vec![AstType::Named("T".to_string())],
+            },
+            &subs,
+        ),
+        Type::Struct {
+            name: "Box_fn_i32_ret_i32".to_string(),
+            fields: vec![("value".to_string(), function_type)],
+        }
+    );
+}

--- a/tests/docs_truth/repo_hygiene/file_size/core_semantics_splits.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/core_semantics_splits.rs
@@ -125,3 +125,33 @@ fn intrinsic_gate_tests_live_in_focused_helpers() {
         "intrinsic_gates.rs should stay as a small router for gated intrinsic tests"
     );
 }
+
+#[test]
+fn core_type_substitution_tests_live_in_focused_helper() {
+    let root = read("src/typechecker/tests/core_semantics/type_helpers.rs");
+    let substitution = read("src/typechecker/tests/core_semantics/type_helpers/substitution.rs");
+
+    for test_name in [
+        "substitute_type_basic",
+        "substitute_type_covers_all_composite_type_shapes",
+        "substitute_type_preserves_function_type_arguments_in_nested_generics",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "type_helpers.rs should not own type-substitution test: {test_name}"
+        );
+        assert!(
+            substitution.contains(&format!("fn {test_name}")),
+            "type-substitution tests should live in focused helper: {test_name}"
+        );
+    }
+
+    assert!(
+        root.lines().count() < 150,
+        "type_helpers.rs should stay focused on compatibility, resolution, coercion, and inference"
+    );
+    assert!(
+        root.contains("mod substitution;"),
+        "type_helpers.rs should include the focused substitution module"
+    );
+}


### PR DESCRIPTION
## Summary

- moves core type substitution tests into a focused `type_helpers/substitution.rs` helper
- adds a docs-truth guard so `type_helpers.rs` stays focused on compatibility, resolution, coercion, and inference
- removes stale arrow comments from the moved substitution assertions

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test core_type_substitution_tests_live_in_focused_helper`
- `cargo test core_semantics::type_helpers`
- `cargo test --lib`
- `cargo test --tests`
