### PR TITLE
Split local import resolution helpers

### DIFF
--- a/src/module_system/import_resolution.rs
+++ b/src/module_system/import_resolution.rs
@@ -1,5 +1,4 @@
-use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::ast::{Declaration, Program};
 use crate::error::{CompileError, FileTable, Span};
@@ -8,6 +7,7 @@ use super::root_prefix::parse_module_root_prefix;
 use super::ModuleSystem;
 
 mod imported_declarations;
+mod local_imports;
 mod stdlib_gates;
 mod stdlib_paths;
 
@@ -96,54 +96,6 @@ impl ModuleSystem {
         }
 
         program.declarations.extend(imported_decls);
-        Ok(())
-    }
-
-    pub(super) fn local_import_file_path(
-        &self,
-        base_dir: &Path,
-        module_path: &[String],
-        span: Span,
-    ) -> Result<PathBuf, Vec<CompileError>> {
-        let rel_path: PathBuf = module_path.iter().collect();
-        let mut file_path = base_dir.join(&rel_path);
-        if file_path.extension().is_none() {
-            file_path.set_extension("zen");
-        }
-
-        if !file_path.exists() {
-            return Err(vec![CompileError::Resolution(
-                format!(
-                    "cannot find imported module '{}' (looked for {})",
-                    module_path.join("."),
-                    file_path.display()
-                ),
-                Some(span),
-            )]);
-        }
-
-        Ok(file_path)
-    }
-
-    pub(super) fn reject_duplicate_requested_imports(
-        &self,
-        names: &[String],
-        module_path: &[String],
-        span: Span,
-    ) -> Result<(), Vec<CompileError>> {
-        let mut requested_names = HashSet::new();
-        for name in names {
-            if !requested_names.insert(name.as_str()) {
-                return Err(vec![CompileError::Resolution(
-                    format!(
-                        "duplicate import '{}' from module '{}'",
-                        name,
-                        module_path.join(".")
-                    ),
-                    Some(span),
-                )]);
-            }
-        }
         Ok(())
     }
 

--- a/src/module_system/import_resolution/local_imports.rs
+++ b/src/module_system/import_resolution/local_imports.rs
@@ -1,0 +1,56 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use crate::error::{CompileError, Span};
+
+use super::super::ModuleSystem;
+
+impl ModuleSystem {
+    pub(in crate::module_system) fn local_import_file_path(
+        &self,
+        base_dir: &Path,
+        module_path: &[String],
+        span: Span,
+    ) -> Result<PathBuf, Vec<CompileError>> {
+        let rel_path: PathBuf = module_path.iter().collect();
+        let mut file_path = base_dir.join(&rel_path);
+        if file_path.extension().is_none() {
+            file_path.set_extension("zen");
+        }
+
+        if !file_path.exists() {
+            return Err(vec![CompileError::Resolution(
+                format!(
+                    "cannot find imported module '{}' (looked for {})",
+                    module_path.join("."),
+                    file_path.display()
+                ),
+                Some(span),
+            )]);
+        }
+
+        Ok(file_path)
+    }
+
+    pub(in crate::module_system) fn reject_duplicate_requested_imports(
+        &self,
+        names: &[String],
+        module_path: &[String],
+        span: Span,
+    ) -> Result<(), Vec<CompileError>> {
+        let mut requested_names = HashSet::new();
+        for name in names {
+            if !requested_names.insert(name.as_str()) {
+                return Err(vec![CompileError::Resolution(
+                    format!(
+                        "duplicate import '{}' from module '{}'",
+                        name,
+                        module_path.join(".")
+                    ),
+                    Some(span),
+                )]);
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/module_system/import_resolution/stdlib_paths.rs
+++ b/src/module_system/import_resolution/stdlib_paths.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use super::*;
 
 impl ModuleSystem {

--- a/tests/docs_truth/repo_hygiene/module_system.rs
+++ b/tests/docs_truth/repo_hygiene/module_system.rs
@@ -114,6 +114,35 @@ fn imported_declaration_selection_lives_in_focused_helper() {
 }
 
 #[test]
+fn local_import_resolution_helpers_live_in_focused_helper() {
+    let import_resolution = read("src/module_system/import_resolution.rs");
+    let local_imports = read("src/module_system/import_resolution/local_imports.rs");
+
+    for helper in [
+        "fn local_import_file_path",
+        "fn reject_duplicate_requested_imports",
+    ] {
+        assert!(
+            !import_resolution.contains(helper),
+            "import routing dispatcher should not own local import helper: {helper}"
+        );
+        assert!(
+            local_imports.contains(helper),
+            "local import helper should live in focused helper: {helper}"
+        );
+    }
+
+    assert!(
+        import_resolution.lines().count() < 210,
+        "import routing dispatcher should stay focused on routing imports"
+    );
+    assert!(
+        import_resolution.contains("mod local_imports;"),
+        "import routing should load focused local import helper"
+    );
+}
+
+#[test]
 fn graph_loading_export_lookup_lives_in_focused_helper() {
     let graph_loading = read("src/module_system/graph_loading.rs");
     let exported_symbols = read("src/module_system/graph_loading/exported_symbols.rs");


### PR DESCRIPTION
## Summary
- move local import path resolution and duplicate import-request validation out of the import routing dispatcher
- make stdlib path helper own its PathBuf import instead of depending on the parent module
- add a docs-truth guard for the focused local import helper module

## Tests
- cargo test --test docs_truth local_import_resolution_helpers_live_in_focused_helper
- cargo test module_system::tests
- cargo fmt --check
- git diff --check
- cargo clippy -- -D warnings
- cargo test --lib
- cargo test --tests