### PR TITLE
Split parser expression keyword guards

### DIFF
--- a/tests/docs_truth/repo_hygiene/parser_keywords.rs
+++ b/tests/docs_truth/repo_hygiene/parser_keywords.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+mod expression_keywords;
 mod spelling_splits;
 
 fn parser_keyword_sources() -> String {
@@ -16,93 +17,6 @@ fn parser_keyword_sources() -> String {
     .map(read)
     .collect::<Vec<_>>()
     .join("\n")
-}
-
-#[test]
-fn parser_prefix_keywords_use_owned_keyword_enum() {
-    let atoms = read("src/parser/atoms.rs");
-    let keywords = parser_keyword_sources();
-
-    for forbidden in [
-        "match name.as_str()",
-        r#""true" =>"#,
-        r#""false" =>"#,
-        r#""return" =>"#,
-        r#""break" =>"#,
-        r#""continue" =>"#,
-        r#""loop" =>"#,
-        r#""cast" =>"#,
-    ] {
-        assert!(
-            !atoms.contains(forbidden),
-            "parser prefix keyword dispatch should use ParserPrefixKeyword, not raw spelling checks: {forbidden}"
-        );
-    }
-
-    for required in [
-        "enum ParserPrefixKeyword",
-        "const ALL: &[ParserPrefixKeyword]",
-        "impl FromStr for ParserPrefixKeyword",
-        ".find(|keyword| keyword.as_str() == value)",
-        "name.parse::<ParserPrefixKeyword>()",
-    ] {
-        assert!(
-            atoms.contains(required) || keywords.contains(required),
-            "parser prefix keyword spelling should live in ParserPrefixKeyword: {required}"
-        );
-    }
-}
-
-#[test]
-fn parser_pattern_keywords_use_owned_keyword_enum() {
-    let patterns = read("src/parser/patterns.rs");
-    let keywords = parser_keyword_sources();
-
-    for forbidden in [r#"name == "true""#, r#"name == "false""#, r#"name == "_""#] {
-        assert!(
-            !patterns.contains(forbidden),
-            "parser pattern keyword dispatch should use ParserPatternKeyword, not raw spelling checks: {forbidden}"
-        );
-    }
-
-    for required in [
-        "enum ParserPatternKeyword",
-        "const ALL: &[ParserPatternKeyword]",
-        "impl FromStr for ParserPatternKeyword",
-        ".find(|keyword| keyword.as_str() == value)",
-        "name.parse::<ParserPatternKeyword>()",
-    ] {
-        assert!(
-            patterns.contains(required) || keywords.contains(required),
-            "parser pattern keyword spelling should live in ParserPatternKeyword: {required}"
-        );
-    }
-}
-
-#[test]
-fn parser_this_methods_use_owned_method_enum() {
-    let atoms = read("src/parser/atoms.rs");
-    let keywords = parser_keyword_sources();
-
-    for forbidden in [r#"method == "defer""#] {
-        assert!(
-            !atoms.contains(forbidden),
-            "parser @this method dispatch should use ParserThisMethod, not raw spelling checks: {forbidden}"
-        );
-    }
-
-    for required in [
-        "enum ParserThisMethod",
-        "const ALL: &[ParserThisMethod]",
-        "impl FromStr for ParserThisMethod",
-        ".find(|method| method.as_str() == value)",
-        "method.parse::<ParserThisMethod>()",
-    ] {
-        assert!(
-            atoms.contains(required) || keywords.contains(required),
-            "parser @this method spelling should live in ParserThisMethod: {required}"
-        );
-    }
 }
 
 #[test]

--- a/tests/docs_truth/repo_hygiene/parser_keywords/expression_keywords.rs
+++ b/tests/docs_truth/repo_hygiene/parser_keywords/expression_keywords.rs
@@ -1,0 +1,88 @@
+use super::*;
+
+#[test]
+fn parser_prefix_keywords_use_owned_keyword_enum() {
+    let atoms = read("src/parser/atoms.rs");
+    let keywords = parser_keyword_sources();
+
+    for forbidden in [
+        "match name.as_str()",
+        r#""true" =>"#,
+        r#""false" =>"#,
+        r#""return" =>"#,
+        r#""break" =>"#,
+        r#""continue" =>"#,
+        r#""loop" =>"#,
+        r#""cast" =>"#,
+    ] {
+        assert!(
+            !atoms.contains(forbidden),
+            "parser prefix keyword dispatch should use ParserPrefixKeyword, not raw spelling checks: {forbidden}"
+        );
+    }
+
+    for required in [
+        "enum ParserPrefixKeyword",
+        "const ALL: &[ParserPrefixKeyword]",
+        "impl FromStr for ParserPrefixKeyword",
+        ".find(|keyword| keyword.as_str() == value)",
+        "name.parse::<ParserPrefixKeyword>()",
+    ] {
+        assert!(
+            atoms.contains(required) || keywords.contains(required),
+            "parser prefix keyword spelling should live in ParserPrefixKeyword: {required}"
+        );
+    }
+}
+
+#[test]
+fn parser_pattern_keywords_use_owned_keyword_enum() {
+    let patterns = read("src/parser/patterns.rs");
+    let keywords = parser_keyword_sources();
+
+    for forbidden in [r#"name == "true""#, r#"name == "false""#, r#"name == "_""#] {
+        assert!(
+            !patterns.contains(forbidden),
+            "parser pattern keyword dispatch should use ParserPatternKeyword, not raw spelling checks: {forbidden}"
+        );
+    }
+
+    for required in [
+        "enum ParserPatternKeyword",
+        "const ALL: &[ParserPatternKeyword]",
+        "impl FromStr for ParserPatternKeyword",
+        ".find(|keyword| keyword.as_str() == value)",
+        "name.parse::<ParserPatternKeyword>()",
+    ] {
+        assert!(
+            patterns.contains(required) || keywords.contains(required),
+            "parser pattern keyword spelling should live in ParserPatternKeyword: {required}"
+        );
+    }
+}
+
+#[test]
+fn parser_this_methods_use_owned_method_enum() {
+    let atoms = read("src/parser/atoms.rs");
+    let keywords = parser_keyword_sources();
+
+    for forbidden in [r#"method == "defer""#] {
+        assert!(
+            !atoms.contains(forbidden),
+            "parser @this method dispatch should use ParserThisMethod, not raw spelling checks: {forbidden}"
+        );
+    }
+
+    for required in [
+        "enum ParserThisMethod",
+        "const ALL: &[ParserThisMethod]",
+        "impl FromStr for ParserThisMethod",
+        ".find(|method| method.as_str() == value)",
+        "method.parse::<ParserThisMethod>()",
+    ] {
+        assert!(
+            atoms.contains(required) || keywords.contains(required),
+            "parser @this method spelling should live in ParserThisMethod: {required}"
+        );
+    }
+}

--- a/tests/docs_truth/repo_hygiene/parser_keywords/spelling_splits.rs
+++ b/tests/docs_truth/repo_hygiene/parser_keywords/spelling_splits.rs
@@ -53,3 +53,34 @@ fn parser_keyword_spelling_impls_live_in_focused_helpers() {
         "parser keyword root should stay focused on keyword enum definitions"
     );
 }
+
+#[test]
+fn parser_expression_keyword_guards_live_in_focused_module() {
+    let root = read("tests/docs_truth/repo_hygiene/parser_keywords.rs");
+    let expression_keywords =
+        read("tests/docs_truth/repo_hygiene/parser_keywords/expression_keywords.rs");
+
+    for test_name in [
+        "parser_prefix_keywords_use_owned_keyword_enum",
+        "parser_pattern_keywords_use_owned_keyword_enum",
+        "parser_this_methods_use_owned_method_enum",
+    ] {
+        assert!(
+            !root.contains(&format!("fn {test_name}")),
+            "parser_keywords.rs should not own expression keyword guard: {test_name}"
+        );
+        assert!(
+            expression_keywords.contains(&format!("fn {test_name}")),
+            "expression keyword guard should live in focused module: {test_name}"
+        );
+    }
+
+    assert!(
+        root.lines().count() < 150,
+        "parser_keywords.rs should stay focused on module root, declaration keyword, and shared keyword source guards"
+    );
+    assert!(
+        root.contains("mod expression_keywords;"),
+        "parser_keywords.rs should include focused expression keyword guards"
+    );
+}


### PR DESCRIPTION
## Summary
- move prefix, pattern, and @this parser keyword docs-truth guards into a focused module
- keep parser_keywords.rs focused on shared keyword sources plus module-root/declaration keyword guards
- add a docs-truth guard for the split

## Tests
- cargo test --test docs_truth parser_expression_keyword_guards_live_in_focused_module
- cargo test --test docs_truth repo_hygiene::parser_keywords
- cargo fmt --check
- git diff --check
- cargo clippy -- -D warnings
- cargo test --lib
- cargo test --tests
