### PR TITLE
Share file size split guard helpers

### DIFF
--- a/tests/docs_truth/repo_hygiene/file_size.rs
+++ b/tests/docs_truth/repo_hygiene/file_size.rs
@@ -22,6 +22,7 @@ mod resolver_struct_enum_metadata_splits;
 mod resolver_validation_splits;
 mod resolver_validation_test_splits;
 mod resolver_value_metadata_splits;
+mod split_guard;
 mod thresholds;
 mod typechecker_semantic_splits;
 mod typechecker_test_splits;

--- a/tests/docs_truth/repo_hygiene/file_size/core_semantics_splits.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/core_semantics_splits.rs
@@ -1,77 +1,73 @@
-use super::super::*;
+use super::split_guard::{
+    assert_file_contains, assert_file_lacks, assert_file_line_count_below,
+    assert_needles_moved_to_focused_file,
+};
 
 #[test]
 fn core_feature_gate_type_tests_live_in_focused_helper() {
-    let root = read("src/typechecker/tests/core_semantics/feature_gates.rs");
-    let gated_types = read("src/typechecker/tests/core_semantics/feature_gates/gated_types.rs");
-    let module = read("src/typechecker/tests/core_semantics.rs");
+    const ROOT: &str = "src/typechecker/tests/core_semantics/feature_gates.rs";
 
-    for test_name in [
-        "typed_allocator_type_is_rejected_as_gated_not_unknown",
-        "sync_and_async_typed_allocator_modes_are_rejected_as_gated_not_unknown",
-        "dynamic_string_type_is_rejected_as_allocator_backed_gate",
-        "sync_async_effect_modes_are_rejected_as_gated_not_unknown",
-        "actor_framework_types_are_rejected_as_gated_not_unknown",
-        "bare_actor_framework_types_are_rejected_as_gated_not_unknown",
-    ] {
-        assert!(
-            !root.contains(&format!("fn {test_name}")),
-            "feature_gates.rs should not own gated builtin type test: {test_name}"
-        );
-        assert!(
-            gated_types.contains(&format!("fn {test_name}")),
-            "gated builtin type tests should live in focused module: {test_name}"
-        );
-    }
-
-    assert!(
-        root.lines().count() < 120,
-        "feature_gates.rs should stay focused on syntax and method feature gates"
+    assert_needles_moved_to_focused_file(
+        ROOT,
+        "src/typechecker/tests/core_semantics/feature_gates/gated_types.rs",
+        &[
+            "fn typed_allocator_type_is_rejected_as_gated_not_unknown",
+            "fn sync_and_async_typed_allocator_modes_are_rejected_as_gated_not_unknown",
+            "fn dynamic_string_type_is_rejected_as_allocator_backed_gate",
+            "fn sync_async_effect_modes_are_rejected_as_gated_not_unknown",
+            "fn actor_framework_types_are_rejected_as_gated_not_unknown",
+            "fn bare_actor_framework_types_are_rejected_as_gated_not_unknown",
+        ],
+        "feature_gates.rs",
+        "gated builtin type focused module",
     );
-    assert!(
-        root.contains("mod gated_types;"),
-        "feature_gates.rs should include the focused gated_types module"
+    assert_file_line_count_below(
+        ROOT,
+        120,
+        "feature_gates.rs should stay focused on syntax and method feature gates",
     );
-    assert!(
-        module.contains("mod feature_gates;"),
-        "core_semantics.rs should include feature gate tests"
+    assert_file_contains(
+        ROOT,
+        "mod gated_types;",
+        "feature_gates.rs should include the focused gated_types module",
+    );
+    assert_file_contains(
+        "src/typechecker/tests/core_semantics.rs",
+        "mod feature_gates;",
+        "core_semantics.rs should include feature gate tests",
     );
 }
 
 #[test]
 fn core_assignment_tests_live_in_focused_helper() {
-    let root = read("src/typechecker/tests/core_semantics/enum_assignment_and_modules.rs");
-    let assignments =
-        read("src/typechecker/tests/core_semantics/enum_assignment_and_modules/assignments.rs");
+    const ROOT: &str = "src/typechecker/tests/core_semantics/enum_assignment_and_modules.rs";
 
-    for test_name in [
-        "assignment_to_immutable_binding_is_error",
-        "assignment_to_mutable_closure_parameter_is_allowed",
-        "assignment_type_mismatch_is_error",
-    ] {
-        assert!(
-            !root.contains(&format!("fn {test_name}")),
-            "enum_assignment_and_modules.rs should not own assignment test: {test_name}"
-        );
-        assert!(
-            assignments.contains(&format!("fn {test_name}")),
-            "assignment tests should live in focused module: {test_name}"
-        );
-    }
-
-    assert!(
-        root.lines().count() < 200,
+    assert_needles_moved_to_focused_file(
+        ROOT,
+        "src/typechecker/tests/core_semantics/enum_assignment_and_modules/assignments.rs",
+        &[
+            "fn assignment_to_immutable_binding_is_error",
+            "fn assignment_to_mutable_closure_parameter_is_allowed",
+            "fn assignment_type_mismatch_is_error",
+        ],
+        "enum_assignment_and_modules.rs",
+        "assignment focused module",
+    );
+    assert_file_line_count_below(
+        ROOT,
+        200,
         "enum_assignment_and_modules.rs should stay focused on enum, module, field, conversion, and fallthrough checks"
     );
-    assert!(
-        root.contains("mod assignments;"),
-        "enum_assignment_and_modules.rs should include the focused assignments module"
+    assert_file_contains(
+        ROOT,
+        "mod assignments;",
+        "enum_assignment_and_modules.rs should include the focused assignments module",
     );
 }
 
 #[test]
 fn intrinsic_gate_tests_live_in_focused_helpers() {
-    let root = read("src/typechecker/tests/core_semantics/intrinsic_gates.rs");
+    const ROOT: &str = "src/typechecker/tests/core_semantics/intrinsic_gates.rs";
     let module_dir = "src/typechecker/tests/core_semantics/intrinsic_gates";
 
     for (module, test_name) in [
@@ -101,117 +97,108 @@ fn intrinsic_gate_tests_live_in_focused_helpers() {
             "primitive_and_enum_type_match_intrinsics_are_rejected_as_gated_not_unknown",
         ),
     ] {
-        let focused = read(format!("{module_dir}/{module}.rs"));
-        assert!(
-            !root.contains(&format!("fn {test_name}")),
-            "intrinsic_gates.rs should not own gated intrinsic family test: {test_name}"
+        let focused_path = format!("{module_dir}/{module}.rs");
+        let test_needle = format!("fn {test_name}");
+        let module_needle = format!("mod {module};");
+
+        assert_needles_moved_to_focused_file(
+            ROOT,
+            &focused_path,
+            &[test_needle.as_str()],
+            "intrinsic_gates.rs",
+            "gated intrinsic family focused module",
         );
-        assert!(
-            root.contains(&format!("mod {module};")),
-            "intrinsic_gates.rs should include focused module `{module}`"
-        );
-        assert!(
-            focused.contains(&format!("fn {test_name}")),
-            "gated intrinsic family test should live in focused module `{module}`: {test_name}"
+        assert_file_contains(
+            ROOT,
+            &module_needle,
+            "intrinsic_gates.rs should include focused intrinsic module",
         );
     }
 
-    assert!(
-        !root.contains("#[test]"),
-        "intrinsic_gates.rs should stay as a router and not define tests directly"
+    assert_file_lacks(
+        ROOT,
+        "#[test]",
+        "intrinsic_gates.rs should stay as a router and not define tests directly",
     );
-    assert!(
-        root.lines().count() < 80,
-        "intrinsic_gates.rs should stay as a small router for gated intrinsic tests"
+    assert_file_line_count_below(
+        ROOT,
+        80,
+        "intrinsic_gates.rs should stay as a small router for gated intrinsic tests",
     );
 }
 
 #[test]
 fn core_type_substitution_tests_live_in_focused_helper() {
-    let root = read("src/typechecker/tests/core_semantics/type_helpers.rs");
-    let substitution = read("src/typechecker/tests/core_semantics/type_helpers/substitution.rs");
+    const ROOT: &str = "src/typechecker/tests/core_semantics/type_helpers.rs";
 
-    for test_name in [
-        "substitute_type_basic",
-        "substitute_type_covers_all_composite_type_shapes",
-        "substitute_type_preserves_function_type_arguments_in_nested_generics",
-    ] {
-        assert!(
-            !root.contains(&format!("fn {test_name}")),
-            "type_helpers.rs should not own type-substitution test: {test_name}"
-        );
-        assert!(
-            substitution.contains(&format!("fn {test_name}")),
-            "type-substitution tests should live in focused helper: {test_name}"
-        );
-    }
-
-    assert!(
-        root.lines().count() < 150,
-        "type_helpers.rs should stay focused on compatibility, resolution, coercion, and inference"
+    assert_needles_moved_to_focused_file(
+        ROOT,
+        "src/typechecker/tests/core_semantics/type_helpers/substitution.rs",
+        &[
+            "fn substitute_type_basic",
+            "fn substitute_type_covers_all_composite_type_shapes",
+            "fn substitute_type_preserves_function_type_arguments_in_nested_generics",
+        ],
+        "type_helpers.rs",
+        "type-substitution focused helper",
     );
-    assert!(
-        root.contains("mod substitution;"),
-        "type_helpers.rs should include the focused substitution module"
+    assert_file_line_count_below(
+        ROOT,
+        150,
+        "type_helpers.rs should stay focused on compatibility, resolution, coercion, and inference",
+    );
+    assert_file_contains(
+        ROOT,
+        "mod substitution;",
+        "type_helpers.rs should include the focused substitution module",
     );
 }
 
 #[test]
 fn core_match_semantics_tests_live_in_focused_helpers() {
-    let root = read("src/typechecker/tests/core_semantics/match_semantics.rs");
-    let enum_matches = read("src/typechecker/tests/core_semantics/match_semantics/enum_matches.rs");
-    let bool_matches = read("src/typechecker/tests/core_semantics/match_semantics/bool_matches.rs");
-    let result_types = read("src/typechecker/tests/core_semantics/match_semantics/result_types.rs");
+    const ROOT: &str = "src/typechecker/tests/core_semantics/match_semantics.rs";
 
-    for test_name in [
-        "enum_match_missing_variant_is_error",
-        "enum_match_duplicate_variant_is_error",
-        "enum_match_unknown_variant_is_error",
-        "enum_match_payload_shape_is_checked",
-        "enum_match_wildcard_after_all_variants_is_redundant",
-        "enum_match_variant_after_wildcard_is_redundant",
-    ] {
-        assert!(
-            !root.contains(&format!("fn {test_name}")),
-            "match_semantics.rs should not own enum match test: {test_name}"
-        );
-        assert!(
-            enum_matches.contains(&format!("fn {test_name}")),
-            "enum match test should live in focused helper: {test_name}"
-        );
-    }
-
-    for test_name in [
-        "bool_match_missing_arm_is_error_for_value_match",
-        "bool_match_duplicate_arm_is_error",
-    ] {
-        assert!(
-            !root.contains(&format!("fn {test_name}")),
-            "match_semantics.rs should not own bool match test: {test_name}"
-        );
-        assert!(
-            bool_matches.contains(&format!("fn {test_name}")),
-            "bool match test should live in focused helper: {test_name}"
-        );
-    }
-
-    assert!(
-        !root.contains("fn match_arm_return_does_not_force_never_result_type"),
-        "match_semantics.rs should not own match result-type tests"
+    assert_needles_moved_to_focused_file(
+        ROOT,
+        "src/typechecker/tests/core_semantics/match_semantics/enum_matches.rs",
+        &[
+            "fn enum_match_missing_variant_is_error",
+            "fn enum_match_duplicate_variant_is_error",
+            "fn enum_match_unknown_variant_is_error",
+            "fn enum_match_payload_shape_is_checked",
+            "fn enum_match_wildcard_after_all_variants_is_redundant",
+            "fn enum_match_variant_after_wildcard_is_redundant",
+        ],
+        "match_semantics.rs",
+        "enum match focused helper",
     );
-    assert!(
-        result_types.contains("fn match_arm_return_does_not_force_never_result_type"),
-        "match result-type tests should live in focused helper"
+    assert_needles_moved_to_focused_file(
+        ROOT,
+        "src/typechecker/tests/core_semantics/match_semantics/bool_matches.rs",
+        &[
+            "fn bool_match_missing_arm_is_error_for_value_match",
+            "fn bool_match_duplicate_arm_is_error",
+        ],
+        "match_semantics.rs",
+        "bool match focused helper",
     );
-
-    assert!(
-        root.lines().count() < 80,
-        "match_semantics.rs should stay as a small router for match semantic tests"
+    assert_needles_moved_to_focused_file(
+        ROOT,
+        "src/typechecker/tests/core_semantics/match_semantics/result_types.rs",
+        &["fn match_arm_return_does_not_force_never_result_type"],
+        "match_semantics.rs",
+        "match result-type focused helper",
+    );
+    assert_file_line_count_below(
+        ROOT,
+        80,
+        "match_semantics.rs should stay as a small router for match semantic tests",
     );
     for module in ["enum_matches", "bool_matches", "result_types"] {
-        assert!(
-            root.contains(&format!("mod {module};")),
-            "match_semantics.rs should include focused module `{module}`"
+        assert_file_contains(
+            ROOT,
+            &format!("mod {module};"),
+            "match_semantics.rs should include focused match semantic module",
         );
     }
 }

--- a/tests/docs_truth/repo_hygiene/file_size/resolver_validation_splits.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/resolver_validation_splits.rs
@@ -1,218 +1,189 @@
-use super::super::*;
+use super::split_guard::{
+    assert_file_contains, assert_file_line_count_below, assert_needles_moved_to_focused_file,
+};
 
 #[test]
 fn source_dependency_callable_helpers_live_in_focused_module() {
-    let root = read("src/typechecker/resolver_validation/imports_source_dependencies.rs");
-    let callables =
-        read("src/typechecker/resolver_validation/imports_source_dependency_callables.rs");
-    let includes = read("src/typechecker/resolver_validation.rs");
+    const ROOT: &str = "src/typechecker/resolver_validation/imports_source_dependencies.rs";
 
-    for helper in [
-        "fn insert_source_import_type_method_dependencies(",
-        "fn insert_source_imported_type_method_dependency(",
-        "fn insert_source_function_dependency(",
-        "fn insert_source_method_dependency(",
-        "fn insert_source_callable_dependency(",
-    ] {
-        assert!(
-            !root.contains(helper),
-            "imports_source_dependencies.rs should not own callable helper `{helper}`"
-        );
-        assert!(
-            callables.contains(helper),
-            "imported callable source dependency helper should live in focused module: {helper}"
-        );
-    }
-
-    assert!(
-        root.lines().count() < 180,
+    assert_needles_moved_to_focused_file(
+        ROOT,
+        "src/typechecker/resolver_validation/imports_source_dependency_callables.rs",
+        &[
+            "fn insert_source_import_type_method_dependencies(",
+            "fn insert_source_imported_type_method_dependency(",
+            "fn insert_source_function_dependency(",
+            "fn insert_source_method_dependency(",
+            "fn insert_source_callable_dependency(",
+        ],
+        "imports_source_dependencies.rs",
+        "imported callable source dependency focused module",
+    );
+    assert_file_line_count_below(
+        ROOT,
+        180,
         "imports_source_dependencies.rs should stay focused on dependency collection and type metadata"
     );
-    assert!(
-        includes
-            .contains("include!(\"resolver_validation/imports_source_dependency_callables.rs\");"),
-        "resolver_validation.rs should include focused callable dependency helpers"
+    assert_file_contains(
+        "src/typechecker/resolver_validation.rs",
+        "include!(\"resolver_validation/imports_source_dependency_callables.rs\");",
+        "resolver_validation.rs should include focused callable dependency helpers",
     );
 }
 
 #[test]
 fn imported_declaration_graph_seeding_lives_in_focused_module() {
-    let root = read("src/typechecker/resolver_validation/imports_dependencies.rs");
-    let graph_seeding = read("src/typechecker/resolver_validation/imports_graph_seeding.rs");
-    let includes = read("src/typechecker/resolver_validation.rs");
+    const ROOT: &str = "src/typechecker/resolver_validation/imports_dependencies.rs";
 
-    for helper in ["fn seed_module_graph_import("] {
-        assert!(
-            !root.contains(helper),
-            "imports_dependencies.rs should not own imported graph seeding helper `{helper}`"
-        );
-        assert!(
-            graph_seeding.contains(helper),
-            "imported graph seeding helper should live in focused module: {helper}"
-        );
-    }
-
-    assert!(
-        root.lines().count() < 190,
-        "imports_dependencies.rs should stay focused on imported dependency traversal"
+    assert_needles_moved_to_focused_file(
+        ROOT,
+        "src/typechecker/resolver_validation/imports_graph_seeding.rs",
+        &["fn seed_module_graph_import("],
+        "imports_dependencies.rs",
+        "imported graph seeding focused module",
     );
-    assert!(
-        includes.contains("include!(\"resolver_validation/imports_graph_seeding.rs\");"),
-        "resolver_validation.rs should include focused imported graph seeding helpers"
+    assert_file_line_count_below(
+        ROOT,
+        190,
+        "imports_dependencies.rs should stay focused on imported dependency traversal",
+    );
+    assert_file_contains(
+        "src/typechecker/resolver_validation.rs",
+        "include!(\"resolver_validation/imports_graph_seeding.rs\");",
+        "resolver_validation.rs should include focused imported graph seeding helpers",
     );
 }
 
 #[test]
 fn imported_behavior_extends_helpers_live_in_focused_module() {
-    let root = read("src/typechecker/resolver_validation/imports_behavior_dependencies.rs");
-    let extends = read("src/typechecker/resolver_validation/imports_behavior_extends.rs");
-    let includes = read("src/typechecker/resolver_validation.rs");
+    const ROOT: &str = "src/typechecker/resolver_validation/imports_behavior_dependencies.rs";
 
-    for helper in [
-        "fn seed_behavior_extends_for_imported_behavior(",
-        "fn seed_behavior_extends_for_imported_behavior_inner(",
-    ] {
-        assert!(
-            !root.contains(helper),
-            "imports_behavior_dependencies.rs should not own behavior-extends helper `{helper}`"
-        );
-        assert!(
-            extends.contains(helper),
-            "imported behavior-extends helper should live in focused module: {helper}"
-        );
-    }
-
-    assert!(
-        root.lines().count() < 190,
-        "imports_behavior_dependencies.rs should stay focused on impl dependency seeding"
+    assert_needles_moved_to_focused_file(
+        ROOT,
+        "src/typechecker/resolver_validation/imports_behavior_extends.rs",
+        &[
+            "fn seed_behavior_extends_for_imported_behavior(",
+            "fn seed_behavior_extends_for_imported_behavior_inner(",
+        ],
+        "imports_behavior_dependencies.rs",
+        "imported behavior-extends focused module",
     );
-    assert!(
-        includes.contains("include!(\"resolver_validation/imports_behavior_extends.rs\");"),
-        "resolver_validation.rs should include focused imported behavior-extends helpers"
+    assert_file_line_count_below(
+        ROOT,
+        190,
+        "imports_behavior_dependencies.rs should stay focused on impl dependency seeding",
+    );
+    assert_file_contains(
+        "src/typechecker/resolver_validation.rs",
+        "include!(\"resolver_validation/imports_behavior_extends.rs\");",
+        "resolver_validation.rs should include focused imported behavior-extends helpers",
     );
 }
 
 #[test]
 fn replay_behavior_association_tasks_live_in_focused_module() {
-    let root = read("src/typechecker/resolver_validation/replay_tasks.rs");
-    let associations = read("src/typechecker/resolver_validation/replay_task_association_lists.rs");
-    let includes = read("src/typechecker/resolver_validation.rs");
+    const ROOT: &str = "src/typechecker/resolver_validation/replay_tasks.rs";
 
-    for helper in [
-        "fn collect_resolver_behavior_association_list_tasks",
-        "fn collect_resolver_behavior_association_list_tasks_from_declaration_tasks",
-        "fn push_resolver_type_behavior_association_list_task",
-        "fn push_resolver_behavior_parent_list_task",
-    ] {
-        assert!(
-            !root.contains(helper),
-            "replay_tasks.rs should not own behavior association helper `{helper}`"
-        );
-        assert!(
-            associations.contains(helper),
-            "behavior association replay helper should live in focused module: {helper}"
-        );
-    }
-
-    assert!(
-        root.lines().count() < 200,
-        "replay_tasks.rs should stay focused on declaration replay collection"
+    assert_needles_moved_to_focused_file(
+        ROOT,
+        "src/typechecker/resolver_validation/replay_task_association_lists.rs",
+        &[
+            "fn collect_resolver_behavior_association_list_tasks",
+            "fn collect_resolver_behavior_association_list_tasks_from_declaration_tasks",
+            "fn push_resolver_type_behavior_association_list_task",
+            "fn push_resolver_behavior_parent_list_task",
+        ],
+        "replay_tasks.rs",
+        "behavior association replay focused module",
     );
-    assert!(
-        includes.contains("include!(\"resolver_validation/replay_task_association_lists.rs\");"),
-        "resolver_validation.rs should include focused behavior association replay helpers"
+    assert_file_line_count_below(
+        ROOT,
+        200,
+        "replay_tasks.rs should stay focused on declaration replay collection",
+    );
+    assert_file_contains(
+        "src/typechecker/resolver_validation.rs",
+        "include!(\"resolver_validation/replay_task_association_lists.rs\");",
+        "resolver_validation.rs should include focused behavior association replay helpers",
     );
 }
 
 #[test]
 fn expected_behavior_edge_helpers_live_in_focused_support_module() {
-    let root = read("src/typechecker/resolver_validation_support/behavior_refs.rs");
-    let edges = read("src/typechecker/resolver_validation_support/expected_behavior_edges.rs");
-    let includes = read("src/typechecker/resolver_validation_support.rs");
+    const ROOT: &str = "src/typechecker/resolver_validation_support/behavior_refs.rs";
 
-    for helper in [
-        "struct ExpectedBehaviorEdge",
-        "struct ExpectedBehaviorEdgeMetadata",
-        "struct ExpectedBehaviorEdges",
-        "struct ExpectedBehaviorAssociations",
-    ] {
-        assert!(
-            !root.contains(helper),
-            "behavior_refs.rs should not own expected behavior edge helper `{helper}`"
-        );
-        assert!(
-            edges.contains(helper),
-            "expected behavior edge helper should live in focused module: {helper}"
-        );
-    }
-
-    assert!(
-        root.lines().count() < 170,
-        "behavior_refs.rs should stay focused on role validation and actual metadata selection"
+    assert_needles_moved_to_focused_file(
+        ROOT,
+        "src/typechecker/resolver_validation_support/expected_behavior_edges.rs",
+        &[
+            "struct ExpectedBehaviorEdge",
+            "struct ExpectedBehaviorEdgeMetadata",
+            "struct ExpectedBehaviorEdges",
+            "struct ExpectedBehaviorAssociations",
+        ],
+        "behavior_refs.rs",
+        "expected behavior edge focused support module",
     );
-    assert!(
-        includes.contains("include!(\"resolver_validation_support/expected_behavior_edges.rs\");"),
-        "resolver_validation_support.rs should include focused expected behavior edge helpers"
+    assert_file_line_count_below(
+        ROOT,
+        170,
+        "behavior_refs.rs should stay focused on role validation and actual metadata selection",
+    );
+    assert_file_contains(
+        "src/typechecker/resolver_validation_support.rs",
+        "include!(\"resolver_validation_support/expected_behavior_edges.rs\");",
+        "resolver_validation_support.rs should include focused expected behavior edge helpers",
     );
 }
 
 #[test]
 fn scalar_absence_descriptors_live_in_focused_support_module() {
-    let root = read("src/typechecker/resolver_validation_support/absence_symbol_descriptors.rs");
-    let scalars = read("src/typechecker/resolver_validation_support/absence_scalar_descriptors.rs");
-    let includes = read("src/typechecker/resolver_validation_support.rs");
+    const ROOT: &str = "src/typechecker/resolver_validation_support/absence_symbol_descriptors.rs";
 
-    for helper in [
-        "struct MutabilityAbsenceValidation",
-        "struct SourceAbsenceValidation",
-    ] {
-        assert!(
-            !root.contains(helper),
-            "absence_symbol_descriptors.rs should not own scalar absence descriptor `{helper}`"
-        );
-        assert!(
-            scalars.contains(helper),
-            "scalar absence descriptor should live in focused module: {helper}"
-        );
-    }
-
-    assert!(
-        root.lines().count() < 190,
-        "absence_symbol_descriptors.rs should stay focused on behavior absence descriptors"
+    assert_needles_moved_to_focused_file(
+        ROOT,
+        "src/typechecker/resolver_validation_support/absence_scalar_descriptors.rs",
+        &[
+            "struct MutabilityAbsenceValidation",
+            "struct SourceAbsenceValidation",
+        ],
+        "absence_symbol_descriptors.rs",
+        "scalar absence descriptor focused support module",
     );
-    assert!(
-        includes
-            .contains("include!(\"resolver_validation_support/absence_scalar_descriptors.rs\");"),
-        "resolver_validation_support.rs should include focused scalar absence descriptors"
+    assert_file_line_count_below(
+        ROOT,
+        190,
+        "absence_symbol_descriptors.rs should stay focused on behavior absence descriptors",
+    );
+    assert_file_contains(
+        "src/typechecker/resolver_validation_support.rs",
+        "include!(\"resolver_validation_support/absence_scalar_descriptors.rs\");",
+        "resolver_validation_support.rs should include focused scalar absence descriptors",
     );
 }
 
 #[test]
 fn expected_pattern_local_traversal_lives_in_focused_support_module() {
-    let root = read("src/typechecker/resolver_validation_support/expected_local_traversal.rs");
-    let patterns = read("src/typechecker/resolver_validation_support/expected_pattern_locals.rs");
-    let includes = read("src/typechecker/resolver_validation_support.rs");
+    const ROOT: &str = "src/typechecker/resolver_validation_support/expected_local_traversal.rs";
 
-    for helper in [
-        "fn expected_resolver_pattern_locals(",
-        "fn expected_resolver_pattern_binding(",
-    ] {
-        assert!(
-            !root.contains(helper),
-            "expected_local_traversal.rs should not own pattern-local helper `{helper}`"
-        );
-        assert!(
-            patterns.contains(helper),
-            "expected pattern-local helper should live in focused support module: {helper}"
-        );
-    }
-
-    assert!(
-        root.lines().count() < 200,
-        "expected_local_traversal.rs should stay focused on expression and statement traversal"
+    assert_needles_moved_to_focused_file(
+        ROOT,
+        "src/typechecker/resolver_validation_support/expected_pattern_locals.rs",
+        &[
+            "fn expected_resolver_pattern_locals(",
+            "fn expected_resolver_pattern_binding(",
+        ],
+        "expected_local_traversal.rs",
+        "expected pattern-local focused support module",
     );
-    assert!(
-        includes.contains("include!(\"resolver_validation_support/expected_pattern_locals.rs\");"),
-        "resolver_validation_support.rs should include focused expected pattern-local helpers"
+    assert_file_line_count_below(
+        ROOT,
+        200,
+        "expected_local_traversal.rs should stay focused on expression and statement traversal",
+    );
+    assert_file_contains(
+        "src/typechecker/resolver_validation_support.rs",
+        "include!(\"resolver_validation_support/expected_pattern_locals.rs\");",
+        "resolver_validation_support.rs should include focused expected pattern-local helpers",
     );
 }

--- a/tests/docs_truth/repo_hygiene/file_size/split_guard.rs
+++ b/tests/docs_truth/repo_hygiene/file_size/split_guard.rs
@@ -1,0 +1,41 @@
+use super::super::*;
+
+pub(super) fn assert_needles_moved_to_focused_file(
+    root_path: &str,
+    focused_path: &str,
+    needles: &[&str],
+    root_label: &str,
+    focused_label: &str,
+) {
+    let root = read(root_path);
+    let focused = read(focused_path);
+
+    for needle in needles {
+        assert!(
+            !root.contains(needle),
+            "{root_label} should not own moved item `{needle}`"
+        );
+        assert!(
+            focused.contains(needle),
+            "{focused_label} should contain moved item `{needle}`"
+        );
+    }
+}
+
+pub(super) fn assert_file_contains(path: &str, needle: &str, message: &str) {
+    let source = read(path);
+
+    assert!(source.contains(needle), "{message}");
+}
+
+pub(super) fn assert_file_lacks(path: &str, needle: &str, message: &str) {
+    let source = read(path);
+
+    assert!(!source.contains(needle), "{message}");
+}
+
+pub(super) fn assert_file_line_count_below(path: &str, max_lines: usize, message: &str) {
+    let source = read(path);
+
+    assert!(source.lines().count() < max_lines, "{message}");
+}


### PR DESCRIPTION
## Summary
- add a shared docs-truth helper for moved-item, include, absence, and line-count split guards
- refactor resolver-validation file-size guards onto the helper
- refactor core-semantics file-size guards onto the helper

## Tests
- cargo test --test docs_truth repo_hygiene::file_size
- cargo fmt --check
- git diff --check
- cargo clippy -- -D warnings
- cargo test --lib
- cargo test --tests
