### PR TITLE
Share generated C specialization assertions

### DIFF
--- a/tests/docs_truth.rs
+++ b/tests/docs_truth.rs
@@ -10,14 +10,29 @@ fn read(path: impl AsRef<Path>) -> String {
 }
 
 fn generated_c_fixture_block<'a>(source: &'a str, fixture: &str) -> &'a str {
-    let start = source
+    let fixture_start = source
         .find(fixture)
         .unwrap_or_else(|| panic!("missing generated-C fixture block: {fixture}"));
+    let start = [
+        "let c_source = compile_to_c_with_generated_call_check",
+        "let c_source = compile_to_c_with_specialization_check",
+        "compile_to_c_with_specialization_check",
+    ]
+    .iter()
+    .filter_map(|marker| source[..fixture_start].rfind(marker))
+    .max()
+    .unwrap_or(fixture_start);
     let tail = &source[start..];
-    let next_block = tail[fixture.len()..]
-        .find("let c_source = compile_to_c_with_generated_call_check")
-        .map(|offset| fixture.len() + offset)
-        .unwrap_or(tail.len());
+    let next_block = [
+        "let c_source = compile_to_c_with_generated_call_check",
+        "let c_source = compile_to_c_with_specialization_check",
+        "compile_to_c_with_specialization_check",
+    ]
+    .iter()
+    .filter_map(|marker| tail[fixture.len()..].find(marker))
+    .min()
+    .map(|offset| fixture.len() + offset)
+    .unwrap_or(tail.len());
 
     &tail[..next_block]
 }

--- a/tests/docs_truth/phase_audit/generated_c_evidence.rs
+++ b/tests/docs_truth/phase_audit/generated_c_evidence.rs
@@ -25,34 +25,33 @@ fn multi_file_nested_generic_method_generated_c_pins_definition_counts() {
         "multi_file_type_method_nested_result_dependency/main.zen",
     );
 
-    for required in [
-        r#"assert_c_call_resolves_to_single_definition(&c_source, "Box_wrap_result_i32")"#,
-        r#"assert_c_call_resolves_to_single_definition(&c_source, "unwrap_result_Option_i32_StaticString")"#,
-        r#"assert_c_call_resolves_to_single_definition(&c_source, "unwrap_option_i32")"#,
-    ] {
-        assert!(
-            nested_method_block.contains(required),
-            "multi-file nested generic method generated-C tests should pin exact definition counts: {required}"
-        );
-    }
+    assert_specialization_call_names_pinned(
+        nested_method_block,
+        &[
+            "Box_wrap_result_i32",
+            "unwrap_result_Option_i32_StaticString",
+            "unwrap_option_i32",
+        ],
+        "multi-file nested generic method generated-C tests",
+    );
 }
 
 #[test]
 fn local_nested_generic_method_generated_c_pins_definition_counts() {
     let method_worklist =
         read("tests/integration/generic_specializations/method_worklist_generated_c.rs");
+    let nested_method_block =
+        generated_c_fixture_block(&method_worklist, "generic_method_nested_result.zen");
 
-    for required in [
-        "generic_method_nested_result.zen",
-        r#"assert_c_call_resolves_to_single_definition(&c_source, "Box_wrap_result_i32")"#,
-        r#"assert_c_call_resolves_to_single_definition(&c_source, "unwrap_result_Option_i32_StaticString")"#,
-        r#"assert_c_call_resolves_to_single_definition(&c_source, "unwrap_option_i32")"#,
-    ] {
-        assert!(
-            method_worklist.contains(required),
-            "local nested generic method generated-C tests should pin exact definition counts: {required}"
-        );
-    }
+    assert_specialization_call_names_pinned(
+        nested_method_block,
+        &[
+            "Box_wrap_result_i32",
+            "unwrap_result_Option_i32_StaticString",
+            "unwrap_option_i32",
+        ],
+        "local nested generic method generated-C tests",
+    );
 }
 
 #[test]
@@ -64,16 +63,11 @@ fn imported_transitive_worklist_generated_c_pins_definition_counts() {
         "multi_file_generic_imported_transitive_dependency/main.zen",
     );
 
-    for required in [
-        r#"assert_c_call_resolves_to_single_definition(&c_source, "inner_i32")"#,
-        r#"assert_c_call_resolves_to_single_definition(&c_source, "middle_i32")"#,
-        r#"assert_c_call_resolves_to_single_definition(&c_source, "outer_i32")"#,
-    ] {
-        assert!(
-            transitive_block.contains(required),
-            "imported transitive generic worklist tests should pin exact definition counts: {required}"
-        );
-    }
+    assert_specialization_call_names_pinned(
+        transitive_block,
+        &["inner_i32", "middle_i32", "outer_i32"],
+        "imported transitive generic worklist tests",
+    );
 }
 
 #[test]
@@ -96,6 +90,20 @@ fn scoped_imported_generic_ufc_generated_c_pins_recovery_evidence() {
         assert!(
             scoped_type_inference.contains(required),
             "scoped imported generic UFC generated-C proof should pin recovery evidence: {required}"
+        );
+    }
+}
+
+fn assert_specialization_call_names_pinned(block: &str, call_names: &[&str], label: &str) {
+    assert!(
+        block.contains("compile_to_c_with_specialization_check("),
+        "{label} should use the generated-C specialization facade"
+    );
+
+    for call_name in call_names {
+        assert!(
+            block.contains(&format!(r#""{call_name}""#)),
+            "{label} should pin exact definition counts through specialization call list: {call_name}"
         );
     }
 }

--- a/tests/docs_truth/repo_hygiene/codegen_c.rs
+++ b/tests/docs_truth/repo_hygiene/codegen_c.rs
@@ -87,21 +87,13 @@ fn codegen_c_expression_operator_spelling_lives_in_focused_helper() {
 }
 
 #[test]
-fn generated_c_tests_use_single_definition_assertion_helper() {
+fn generated_c_tests_use_facade_assertion_helpers() {
     let support = read("tests/integration/support.rs");
     let generated_c = read("tests/integration/support/generated_c.rs");
     let local_worklist =
         read("tests/integration/generic_specializations/method_worklist_generated_c.rs");
     let multi_file_worklist =
         read("tests/integration/generic_specializations/multifile_generated_c/method_worklist_dependencies.rs");
-    let transitive_worklist_block = generated_c_fixture_block(
-        &multi_file_worklist,
-        "multi_file_generic_imported_transitive_dependency/main.zen",
-    );
-    let multi_file_nested_method_block = generated_c_fixture_block(
-        &multi_file_worklist,
-        "multi_file_type_method_nested_result_dependency/main.zen",
-    );
     let enum_generated_c = read("tests/integration/generic_specializations/enum_generated_c.rs");
     let behavior_bounds =
         read("tests/integration/generic_specializations/behavior_bounds/local_and_defaults.rs");
@@ -120,8 +112,16 @@ fn generated_c_tests_use_single_definition_assertion_helper() {
         "generated-C support should expose a helper for call resolution plus exactly-one definition"
     );
     assert!(
+        generated_c.contains("fn assert_generated_c_specialization("),
+        "generated-C support should expose a facade for grouped specialization assertions"
+    );
+    assert!(
         support.contains("assert_c_call_resolves_to_single_definition"),
         "integration support should re-export the generated-C single-definition helper"
+    );
+    assert!(
+        support.contains("assert_generated_c_specialization"),
+        "integration support should re-export the generated-C specialization facade"
     );
     assert!(
         !support.contains("assert_c_function_definition_count"),
@@ -136,35 +136,20 @@ fn generated_c_tests_use_single_definition_assertion_helper() {
         "generated-C support should keep the split definition-count helper private"
     );
 
-    for (fixture, helper_call) in [
-        (
-            local_worklist.as_str(),
-            r#"assert_c_call_resolves_to_single_definition(&c_source, "Box_wrap_result_i32")"#,
-        ),
-        (
-            local_worklist.as_str(),
-            r#"assert_c_call_resolves_to_single_definition(&c_source, "unwrap_result_Option_i32_StaticString")"#,
-        ),
-        (
-            multi_file_nested_method_block,
-            r#"assert_c_call_resolves_to_single_definition(&c_source, "unwrap_result_Option_i32_StaticString")"#,
-        ),
-        (
-            multi_file_nested_method_block,
-            r#"assert_c_call_resolves_to_single_definition(&c_source, "unwrap_option_i32")"#,
-        ),
-        (
-            transitive_worklist_block,
-            r#"assert_c_call_resolves_to_single_definition(&c_source, "inner_i32")"#,
-        ),
-        (
-            transitive_worklist_block,
-            r#"assert_c_call_resolves_to_single_definition(&c_source, "outer_i32")"#,
-        ),
-    ] {
+    for fixture in [local_worklist.as_str(), multi_file_worklist.as_str()] {
         assert!(
-            fixture.contains(helper_call),
-            "Phase 5 generated-C evidence should use the single-definition helper: {helper_call}"
+            fixture.contains("compile_to_c_with_specialization_check("),
+            "method/worklist generated-C evidence should compile through the grouped specialization facade"
+        );
+    }
+    for fixture in [local_worklist.as_str(), multi_file_worklist.as_str()] {
+        assert!(
+            !fixture.contains("assert!(c_source.contains"),
+            "method/worklist generated-C tests should group required snippets through the specialization facade"
+        );
+        assert!(
+            !fixture.contains("assert!(!c_source.contains"),
+            "method/worklist generated-C tests should group forbidden snippets through the specialization facade"
         );
     }
 

--- a/tests/docs_truth/repo_hygiene/codegen_c/generated_c_support.rs
+++ b/tests/docs_truth/repo_hygiene/codegen_c/generated_c_support.rs
@@ -8,6 +8,7 @@ fn generated_c_support_scanners_stay_split_by_responsibility() {
     let calls = read("tests/integration/support/generated_c/calls.rs");
     let public_helpers = [
         "assert_c_call_resolves_to_single_definition",
+        "assert_generated_c_specialization",
         "assert_generated_c_calls_resolve_to_definitions",
         "assert_generated_c_function_definitions_are_unique",
         "has_c_call_outside_signature",

--- a/tests/integration/generic_specializations/method_worklist_generated_c.rs
+++ b/tests/integration/generic_specializations/method_worklist_generated_c.rs
@@ -2,24 +2,26 @@ use super::*;
 
 #[test]
 fn method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols() {
-    let c_source = compile_to_c_with_generated_call_check(&test_dir().join("generic_method.zen"));
-    assert!(c_source.contains("int32_t Box_get_i32(Box_i32 self)"));
-    assert!(c_source.contains("Box_get_i32(box)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "Box_get_i32");
-    assert!(!c_source.contains("Box_T"));
-    assert!(!c_source.contains("T Box_get"));
+    compile_to_c_with_specialization_check(
+        &test_dir().join("generic_method.zen"),
+        &["int32_t Box_get_i32(Box_i32 self)", "Box_get_i32(box)"],
+        &["Box_get_i32"],
+        &["Box_T", "T Box_get"],
+    );
 
-    let c_source =
-        compile_to_c_with_generated_call_check(&test_dir().join("generic_method_self.zen"));
-    assert!(c_source.contains("Box_i32 Box_copy_i32(Box_i32 self)"));
-    assert!(c_source.contains("Box_copy_i32(box)"));
-    assert!(c_source.contains("Box_Option_i32 Box_copy_Option_i32(Box_Option_i32 self)"));
-    assert!(c_source.contains("Box_copy_Option_i32(nested)"));
-    assert!(c_source.contains("Option_i32 Option_copy_i32(Option_i32 self)"));
-    assert!(c_source.contains("Option_copy_i32(option)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "Box_copy_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "Box_copy_Option_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "Option_copy_i32");
+    let c_source = compile_to_c_with_specialization_check(
+        &test_dir().join("generic_method_self.zen"),
+        &[
+            "Box_i32 Box_copy_i32(Box_i32 self)",
+            "Box_copy_i32(box)",
+            "Box_Option_i32 Box_copy_Option_i32(Box_Option_i32 self)",
+            "Box_copy_Option_i32(nested)",
+            "Option_i32 Option_copy_i32(Option_i32 self)",
+            "Option_copy_i32(option)",
+        ],
+        &["Box_copy_i32", "Box_copy_Option_i32", "Option_copy_i32"],
+        &["Box_copy(box", "Unknown"],
+    );
     assert!(
         c_source
             .find("struct Option_i32")
@@ -28,165 +30,179 @@ fn method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols() {
                 .find("struct Box_Option_i32")
                 .expect("Box_Option_i32 struct")
     );
-    assert!(!c_source.contains("Box_copy(box"));
-    assert!(!c_source.contains("Unknown"));
 
-    let c_source =
-        compile_to_c_with_generated_call_check(&test_dir().join("generic_method_self_phantom.zen"));
-    assert!(c_source.contains("Marker_i32 Marker_copy_i32(Marker_i32 self)"));
-    assert!(c_source.contains("Token_i32 Token_copy_i32(Token_i32 self)"));
-    assert!(c_source.contains("Marker_copy_i32(value)"));
-    assert!(c_source.contains("Token_copy_i32(token)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "Marker_copy_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "Token_copy_i32");
-    assert!(!c_source.contains("Marker_T"));
-    assert!(!c_source.contains("Token_T"));
+    compile_to_c_with_specialization_check(
+        &test_dir().join("generic_method_self_phantom.zen"),
+        &[
+            "Marker_i32 Marker_copy_i32(Marker_i32 self)",
+            "Token_i32 Token_copy_i32(Token_i32 self)",
+            "Marker_copy_i32(value)",
+            "Token_copy_i32(token)",
+        ],
+        &["Marker_copy_i32", "Token_copy_i32"],
+        &["Marker_T", "Token_T"],
+    );
 
-    let c_source = compile_to_c_with_generated_call_check(
+    compile_to_c_with_specialization_check(
         &test_dir().join("generic_method_self_param_order.zen"),
+        &[
+            "int32_t Box_tag_StaticString_i32(Box_i32 self, zen_str label)",
+            "Box_tag_StaticString_i32(box,",
+        ],
+        &["Box_tag_StaticString_i32"],
+        &["Box_tag_i32_StaticString"],
     );
-    assert!(c_source.contains("int32_t Box_tag_StaticString_i32(Box_i32 self, zen_str label)"));
-    assert!(c_source.contains("Box_tag_StaticString_i32(box,"));
-    assert_c_call_resolves_to_single_definition(&c_source, "Box_tag_StaticString_i32");
-    assert!(!c_source.contains("Box_tag_i32_StaticString"));
 
-    let c_source =
-        compile_to_c_with_generated_call_check(&test_dir().join("generic_method_worklist.zen"));
-    assert!(c_source.contains("int32_t inner_i32(int32_t value)"));
-    assert!(c_source.contains("int32_t Box_get_inner_i32(Box_i32 self)"));
-    assert!(c_source.contains("inner_i32(self.value)"));
-    assert!(c_source.contains("Box_get_inner_i32(box)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "inner_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "Box_get_inner_i32");
-    assert!(!c_source.contains("T inner"));
-    assert!(!c_source.contains("inner_T"));
+    compile_to_c_with_specialization_check(
+        &test_dir().join("generic_method_worklist.zen"),
+        &[
+            "int32_t inner_i32(int32_t value)",
+            "int32_t Box_get_inner_i32(Box_i32 self)",
+            "inner_i32(self.value)",
+            "Box_get_inner_i32(box)",
+        ],
+        &["inner_i32", "Box_get_inner_i32"],
+        &["T inner", "inner_T"],
+    );
 
-    let c_source = compile_to_c_with_generated_call_check(
+    compile_to_c_with_specialization_check(
         &test_dir().join("generic_method_method_worklist.zen"),
+        &[
+            "int32_t Box_inner_i32(Box_i32 self)",
+            "int32_t Box_get_inner_i32(Box_i32 self)",
+            "Box_inner_i32(self)",
+            "Box_get_inner_i32(box)",
+        ],
+        &["Box_inner_i32", "Box_get_inner_i32"],
+        &["T Box_inner"],
     );
-    assert!(c_source.contains("int32_t Box_inner_i32(Box_i32 self)"));
-    assert!(c_source.contains("int32_t Box_get_inner_i32(Box_i32 self)"));
-    assert!(c_source.contains("Box_inner_i32(self)"));
-    assert!(c_source.contains("Box_get_inner_i32(box)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "Box_inner_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "Box_get_inner_i32");
-    assert!(!c_source.contains("T Box_inner"));
 
-    let c_source = compile_to_c_with_generated_call_check(
+    compile_to_c_with_specialization_check(
         &test_dir().join("generic_method_worklist_dedup.zen"),
+        &[
+            "int32_t Box_inner_i32(Box_i32 self)",
+            "int32_t Box_left_inner_i32(Box_i32 self)",
+            "int32_t Box_right_inner_i32(Box_i32 self)",
+            "Box_inner_i32(self)",
+            "Box_left_inner_i32(box)",
+            "Box_right_inner_i32(box)",
+        ],
+        &["Box_inner_i32", "Box_left_inner_i32", "Box_right_inner_i32"],
+        &["T Box_inner"],
     );
-    assert!(c_source.contains("int32_t Box_inner_i32(Box_i32 self)"));
-    assert!(c_source.contains("int32_t Box_left_inner_i32(Box_i32 self)"));
-    assert!(c_source.contains("int32_t Box_right_inner_i32(Box_i32 self)"));
-    assert!(c_source.contains("Box_inner_i32(self)"));
-    assert!(c_source.contains("Box_left_inner_i32(box)"));
-    assert!(c_source.contains("Box_right_inner_i32(box)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "Box_inner_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "Box_left_inner_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "Box_right_inner_i32");
-    assert!(!c_source.contains("T Box_inner"));
 
-    let c_source = compile_to_c_with_generated_call_check(
+    compile_to_c_with_specialization_check(
         &test_dir().join("generic_method_nested_result.zen"),
+        &[
+            "typedef struct Result_Option_i32_StaticString Result_Option_i32_StaticString;",
+            "Result_Option_i32_StaticString Box_wrap_result_i32(Box_i32 self)",
+            "Box_wrap_result_i32(box)",
+            "unwrap_result_Option_i32_StaticString(wrapped,",
+            "unwrap_option_i32(some, 0LL)",
+        ],
+        &[
+            "Box_wrap_result_i32",
+            "unwrap_result_Option_i32_StaticString",
+            "unwrap_option_i32",
+        ],
+        &["Result_T", "Option_T", "T Box_wrap_result"],
     );
-    assert!(c_source
-        .contains("typedef struct Result_Option_i32_StaticString Result_Option_i32_StaticString;"));
-    assert!(c_source.contains("Result_Option_i32_StaticString Box_wrap_result_i32(Box_i32 self)"));
-    assert!(c_source.contains("Box_wrap_result_i32(box)"));
-    assert!(c_source.contains("unwrap_result_Option_i32_StaticString(wrapped,"));
-    assert!(c_source.contains("unwrap_option_i32(some, 0LL)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "Box_wrap_result_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "unwrap_result_Option_i32_StaticString");
-    assert_c_call_resolves_to_single_definition(&c_source, "unwrap_option_i32");
-    assert!(!c_source.contains("Result_T"));
-    assert!(!c_source.contains("Option_T"));
-    assert!(!c_source.contains("T Box_wrap_result"));
 
-    let c_source =
-        compile_to_c_with_generated_call_check(&test_dir().join("type_impl_methods.zen"));
-    assert!(c_source.contains("int32_t Point_get(Point self)"));
-    assert!(c_source.contains("int32_t Point_keep_i32(Point self, int32_t value)"));
-    assert!(c_source.contains("Point_get(point)"));
-    assert!(c_source.contains("Point_keep_i32(point, 7LL)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "Point_get");
-    assert_c_call_resolves_to_single_definition(&c_source, "Point_keep_i32");
-    assert!(!c_source.contains("T Point_keep"));
-    assert!(!c_source.contains("Point_keep(point"));
+    compile_to_c_with_specialization_check(
+        &test_dir().join("type_impl_methods.zen"),
+        &[
+            "int32_t Point_get(Point self)",
+            "int32_t Point_keep_i32(Point self, int32_t value)",
+            "Point_get(point)",
+            "Point_keep_i32(point, 7LL)",
+        ],
+        &["Point_get", "Point_keep_i32"],
+        &["T Point_keep", "Point_keep(point"],
+    );
 
-    let c_source =
-        compile_to_c_with_generated_call_check(&test_dir().join("generic_type_impl_methods.zen"));
-    assert!(c_source.contains("int32_t Box_get_i32(Box_i32 self)"));
-    assert!(c_source.contains("Box_i32 Box_replace_i32(Box_i32 self, int32_t value)"));
-    assert!(c_source.contains("Box_get_i32(next)"));
-    assert!(c_source.contains("Box_replace_i32(box, 42LL)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "Box_get_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "Box_replace_i32");
-    assert!(!c_source.contains("Box_T"));
-    assert!(!c_source.contains("T Box_get"));
-    assert!(!c_source.contains("T Box_replace"));
+    compile_to_c_with_specialization_check(
+        &test_dir().join("generic_type_impl_methods.zen"),
+        &[
+            "int32_t Box_get_i32(Box_i32 self)",
+            "Box_i32 Box_replace_i32(Box_i32 self, int32_t value)",
+            "Box_get_i32(next)",
+            "Box_replace_i32(box, 42LL)",
+        ],
+        &["Box_get_i32", "Box_replace_i32"],
+        &["Box_T", "T Box_get", "T Box_replace"],
+    );
 
-    let c_source = compile_to_c_with_generated_call_check(&test_dir().join("generic_vec.zen"));
-    assert!(c_source.contains("int32_t Vec_len_i32(Vec_i32 self)"));
-    assert!(c_source.contains("int32_t Vec_len_StaticString(Vec_StaticString self)"));
-    assert!(c_source.contains("Vec_len_i32(ints)"));
-    assert!(c_source.contains("Vec_len_StaticString(words)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "Vec_len_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "Vec_len_StaticString");
-    assert!(!c_source.contains("Vec_T"));
-    assert!(!c_source.contains("T Vec_len"));
+    compile_to_c_with_specialization_check(
+        &test_dir().join("generic_vec.zen"),
+        &[
+            "int32_t Vec_len_i32(Vec_i32 self)",
+            "int32_t Vec_len_StaticString(Vec_StaticString self)",
+            "Vec_len_i32(ints)",
+            "Vec_len_StaticString(words)",
+        ],
+        &["Vec_len_i32", "Vec_len_StaticString"],
+        &["Vec_T", "T Vec_len"],
+    );
 
-    let c_source = compile_to_c_with_generated_call_check(&test_dir().join("generic_worklist.zen"));
-    assert!(c_source.contains("int32_t inner_i32(int32_t value)"));
-    assert!(c_source.contains("int32_t outer_i32(int32_t value)"));
-    assert!(c_source.contains("inner_i32(value)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "inner_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "outer_i32");
-    assert!(!c_source.contains("T inner"));
-    assert!(!c_source.contains("inner_T"));
+    compile_to_c_with_specialization_check(
+        &test_dir().join("generic_worklist.zen"),
+        &[
+            "int32_t inner_i32(int32_t value)",
+            "int32_t outer_i32(int32_t value)",
+            "inner_i32(value)",
+        ],
+        &["inner_i32", "outer_i32"],
+        &["T inner", "inner_T"],
+    );
 
-    let c_source =
-        compile_to_c_with_generated_call_check(&test_dir().join("generic_worklist_dedup.zen"));
-    assert!(c_source.contains("int32_t left_i32(int32_t value)"));
-    assert!(c_source.contains("int32_t right_i32(int32_t value)"));
-    assert!(c_source.contains("inner_i32(value)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "inner_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "left_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "right_i32");
-    assert!(!c_source.contains("T inner"));
-    assert!(!c_source.contains("inner_T"));
+    compile_to_c_with_specialization_check(
+        &test_dir().join("generic_worklist_dedup.zen"),
+        &[
+            "int32_t left_i32(int32_t value)",
+            "int32_t right_i32(int32_t value)",
+            "inner_i32(value)",
+        ],
+        &["inner_i32", "left_i32", "right_i32"],
+        &["T inner", "inner_T"],
+    );
 
-    let c_source =
-        compile_to_c_with_generated_call_check(&test_dir().join("generic_recursive_function.zen"));
-    assert!(c_source.contains("int32_t repeat_i32(int32_t value, int32_t remaining)"));
-    assert!(c_source.contains("repeat_i32(value, (remaining - 1LL))"));
-    assert!(c_source.contains("repeat_i32(41LL, 3LL)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "repeat_i32");
-    assert!(!c_source.contains("T repeat"));
-    assert!(!c_source.contains("repeat_T"));
+    compile_to_c_with_specialization_check(
+        &test_dir().join("generic_recursive_function.zen"),
+        &[
+            "int32_t repeat_i32(int32_t value, int32_t remaining)",
+            "repeat_i32(value, (remaining - 1LL))",
+            "repeat_i32(41LL, 3LL)",
+        ],
+        &["repeat_i32"],
+        &["T repeat", "repeat_T"],
+    );
 
-    let c_source =
-        compile_to_c_with_generated_call_check(&test_dir().join("generic_recursive_method.zen"));
-    assert!(c_source.contains("int32_t Box_repeat_i32(Box_i32 self, int32_t remaining)"));
-    assert!(c_source.contains("Box_repeat_i32(self, (remaining - 1LL))"));
-    assert!(c_source.contains("Box_repeat_i32(box, 3LL)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "Box_repeat_i32");
-    assert!(!c_source.contains("T Box_repeat"));
+    compile_to_c_with_specialization_check(
+        &test_dir().join("generic_recursive_method.zen"),
+        &[
+            "int32_t Box_repeat_i32(Box_i32 self, int32_t remaining)",
+            "Box_repeat_i32(self, (remaining - 1LL))",
+            "Box_repeat_i32(box, 3LL)",
+        ],
+        &["Box_repeat_i32"],
+        &["T Box_repeat"],
+    );
 
-    let c_source =
-        compile_to_c_with_generated_call_check(&test_dir().join("generic_ufc_function.zen"));
-    assert!(c_source.contains("int32_t id_i32(int32_t value)"));
-    assert!(c_source.contains("id_i32(12LL)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "id_i32");
-    assert!(!c_source.contains("id(12LL)"));
-    assert!(!c_source.contains("T id"));
+    compile_to_c_with_specialization_check(
+        &test_dir().join("generic_ufc_function.zen"),
+        &["int32_t id_i32(int32_t value)", "id_i32(12LL)"],
+        &["id_i32"],
+        &["id(12LL)", "T id"],
+    );
 
-    let c_source =
-        compile_to_c_with_generated_call_check(&test_dir().join("generic_ufc_dedup.zen"));
-    assert!(c_source.contains("int32_t id_i32(int32_t value)"));
-    assert!(c_source.contains("id_i32(12LL)"));
-    assert!(c_source.contains("id_i32(30LL)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "id_i32");
-    assert!(!c_source.contains("id(12LL)"));
-    assert!(!c_source.contains("id(30LL)"));
-    assert!(!c_source.contains("T id"));
+    compile_to_c_with_specialization_check(
+        &test_dir().join("generic_ufc_dedup.zen"),
+        &[
+            "int32_t id_i32(int32_t value)",
+            "id_i32(12LL)",
+            "id_i32(30LL)",
+        ],
+        &["id_i32"],
+        &["id(12LL)", "id(30LL)", "T id"],
+    );
 }

--- a/tests/integration/generic_specializations/multifile_generated_c/method_worklist_dependencies.rs
+++ b/tests/integration/generic_specializations/multifile_generated_c/method_worklist_dependencies.rs
@@ -2,206 +2,212 @@ use super::*;
 
 #[test]
 fn multi_file_generic_method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols() {
-    let c_source = compile_to_c_with_generated_call_check(
+    compile_to_c_with_specialization_check(
         &test_dir().join("multi_file_generic_imported_type_dependency/main.zen"),
+        &[
+            "typedef struct Holder_i32 Holder_i32;",
+            "int32_t Holder_get_i32(Holder_i32 self)",
+            "int32_t get_held_i32(int32_t value)",
+            "const Holder_i32 holder = (Holder_i32){ .value = value }",
+            "Holder_get_i32(holder)",
+            "get_held_i32(73LL)",
+        ],
+        &["Holder_get_i32", "get_held_i32"],
+        &["Holder_T", "T Holder_get"],
     );
-    assert!(c_source.contains("typedef struct Holder_i32 Holder_i32;"));
-    assert!(c_source.contains("int32_t Holder_get_i32(Holder_i32 self)"));
-    assert!(c_source.contains("int32_t get_held_i32(int32_t value)"));
-    assert!(c_source.contains("const Holder_i32 holder = (Holder_i32){ .value = value }"));
-    assert!(c_source.contains("Holder_get_i32(holder)"));
-    assert!(c_source.contains("get_held_i32(73LL)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "Holder_get_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "get_held_i32");
-    assert!(!c_source.contains("Holder_T"));
-    assert!(!c_source.contains("T Holder_get"));
 
-    let c_source = compile_to_c_with_generated_call_check(
+    compile_to_c_with_specialization_check(
         &test_dir().join("multi_file_generic_imported_worklist_chain/main.zen"),
+        &[
+            "int32_t inner_i32(int32_t value)",
+            "int32_t middle_i32(int32_t value)",
+            "int32_t outer_i32(int32_t value)",
+            "inner_i32(value)",
+            "middle_i32(value)",
+            "outer_i32(83LL)",
+        ],
+        &["inner_i32", "middle_i32", "outer_i32"],
+        &["T inner", "T middle"],
     );
-    assert!(c_source.contains("int32_t inner_i32(int32_t value)"));
-    assert!(c_source.contains("int32_t middle_i32(int32_t value)"));
-    assert!(c_source.contains("int32_t outer_i32(int32_t value)"));
-    assert!(c_source.contains("inner_i32(value)"));
-    assert!(c_source.contains("middle_i32(value)"));
-    assert!(c_source.contains("outer_i32(83LL)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "inner_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "middle_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "outer_i32");
-    assert!(!c_source.contains("T inner"));
-    assert!(!c_source.contains("T middle"));
 
-    let c_source = compile_to_c_with_generated_call_check(
+    compile_to_c_with_specialization_check(
         &test_dir().join("multi_file_generic_imported_worklist_multi_specialization/main.zen"),
+        &[
+            "int32_t inner_i32(int32_t value)",
+            "bool inner_bool(bool value)",
+            "int32_t middle_i32(int32_t value)",
+            "bool middle_bool(bool value)",
+            "int32_t outer_i32(int32_t value)",
+            "bool outer_bool(bool value)",
+            "outer_i32(83LL)",
+            "outer_bool(true)",
+        ],
+        &[
+            "inner_i32",
+            "inner_bool",
+            "middle_i32",
+            "middle_bool",
+            "outer_i32",
+            "outer_bool",
+        ],
+        &["T inner", "T middle", "T outer"],
     );
-    assert!(c_source.contains("int32_t inner_i32(int32_t value)"));
-    assert!(c_source.contains("bool inner_bool(bool value)"));
-    assert!(c_source.contains("int32_t middle_i32(int32_t value)"));
-    assert!(c_source.contains("bool middle_bool(bool value)"));
-    assert!(c_source.contains("int32_t outer_i32(int32_t value)"));
-    assert!(c_source.contains("bool outer_bool(bool value)"));
-    assert!(c_source.contains("outer_i32(83LL)"));
-    assert!(c_source.contains("outer_bool(true)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "inner_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "inner_bool");
-    assert_c_call_resolves_to_single_definition(&c_source, "middle_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "middle_bool");
-    assert_c_call_resolves_to_single_definition(&c_source, "outer_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "outer_bool");
-    assert!(!c_source.contains("T inner"));
-    assert!(!c_source.contains("T middle"));
-    assert!(!c_source.contains("T outer"));
 
-    let c_source = compile_to_c_with_generated_call_check(
+    let c_source = compile_to_c_with_specialization_check(
         &test_dir().join("multi_file_generic_imported_diamond_same_name/main.zen"),
+        &[
+            "int32_t left_i32(int32_t value)",
+            "int32_t right_i32(int32_t value)",
+            "return 11LL;",
+            "return 29LL;",
+            "left_i32(1LL)",
+            "right_i32(2LL)",
+        ],
+        &["left_i32", "right_i32"],
+        &["T inner"],
     );
-    assert!(c_source.contains("int32_t left_i32(int32_t value)"));
-    assert!(c_source.contains("int32_t right_i32(int32_t value)"));
-    assert!(c_source.contains("return 11LL;"));
-    assert!(c_source.contains("return 29LL;"));
-    assert!(c_source.contains("left_i32(1LL)"));
-    assert!(c_source.contains("right_i32(2LL)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "left_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "right_i32");
     let left_inner = returned_call_name(&c_source, "left_i32");
     let right_inner = returned_call_name(&c_source, "right_i32");
     assert_eq!(left_inner, "inner_i32");
     assert_ne!(right_inner, "inner_i32");
     assert!(right_inner.ends_with("_inner_i32"));
     assert_c_call_resolves_to_single_definition(&c_source, &right_inner);
-    assert!(!c_source.contains("T inner"));
 
-    let c_source = compile_to_c_with_generated_call_check(
+    compile_to_c_with_specialization_check(
         &test_dir().join("multi_file_generic_recursive_function/main.zen"),
+        &[
+            "int32_t repeat_i32(int32_t value, int32_t remaining)",
+            "repeat_i32(value, (remaining - 1LL))",
+            "repeat_i32(97LL, 4LL)",
+        ],
+        &["repeat_i32"],
+        &["T repeat", "repeat_T"],
     );
-    assert!(c_source.contains("int32_t repeat_i32(int32_t value, int32_t remaining)"));
-    assert!(c_source.contains("repeat_i32(value, (remaining - 1LL))"));
-    assert!(c_source.contains("repeat_i32(97LL, 4LL)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "repeat_i32");
-    assert!(!c_source.contains("T repeat"));
-    assert!(!c_source.contains("repeat_T"));
 
-    let c_source = compile_to_c_with_generated_call_check(
+    compile_to_c_with_specialization_check(
         &test_dir().join("multi_file_generic_imported_transitive_dependency/main.zen"),
+        &[
+            "int32_t inner_i32(int32_t value)",
+            "int32_t middle_i32(int32_t value)",
+            "int32_t outer_i32(int32_t value)",
+            "inner_i32(value)",
+            "middle_i32(value)",
+            "outer_i32(89LL)",
+        ],
+        &["inner_i32", "middle_i32", "outer_i32"],
+        &["T inner", "T middle"],
     );
-    assert!(c_source.contains("int32_t inner_i32(int32_t value)"));
-    assert!(c_source.contains("int32_t middle_i32(int32_t value)"));
-    assert!(c_source.contains("int32_t outer_i32(int32_t value)"));
-    assert!(c_source.contains("inner_i32(value)"));
-    assert!(c_source.contains("middle_i32(value)"));
-    assert!(c_source.contains("outer_i32(89LL)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "inner_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "middle_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "outer_i32");
-    assert!(!c_source.contains("T inner"));
-    assert!(!c_source.contains("T middle"));
 
-    let c_source =
-        compile_to_c_with_generated_call_check(&test_dir().join("multi_file_type_impl/main.zen"));
-    assert!(c_source.contains("int32_t Box_get_i32(Box_i32 self)"));
-    assert!(c_source.contains("Box_get_i32(box)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "Box_get_i32");
-    assert!(!c_source.contains("Box_T"));
-    assert!(!c_source.contains("T Box_get"));
+    compile_to_c_with_specialization_check(
+        &test_dir().join("multi_file_type_impl/main.zen"),
+        &["int32_t Box_get_i32(Box_i32 self)", "Box_get_i32(box)"],
+        &["Box_get_i32"],
+        &["Box_T", "T Box_get"],
+    );
 
-    let c_source = compile_to_c_with_generated_call_check(
+    compile_to_c_with_specialization_check(
         &test_dir().join("multi_file_type_impl_imported_type_dependency/main.zen"),
+        &[
+            "typedef struct Holder_i32 Holder_i32;",
+            "int32_t Holder_get_i32(Holder_i32 self)",
+            "int32_t Box_get_held_i32(Box_i32 self)",
+            "const Holder_i32 holder = (Holder_i32){ .value = self.value }",
+            "Holder_get_i32(holder)",
+            "Box_get_held_i32(box)",
+        ],
+        &["Holder_get_i32", "Box_get_held_i32"],
+        &["Holder_T", "T Holder_get"],
     );
-    assert!(c_source.contains("typedef struct Holder_i32 Holder_i32;"));
-    assert!(c_source.contains("int32_t Holder_get_i32(Holder_i32 self)"));
-    assert!(c_source.contains("int32_t Box_get_held_i32(Box_i32 self)"));
-    assert!(c_source.contains("const Holder_i32 holder = (Holder_i32){ .value = self.value }"));
-    assert!(c_source.contains("Holder_get_i32(holder)"));
-    assert!(c_source.contains("Box_get_held_i32(box)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "Holder_get_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "Box_get_held_i32");
-    assert!(!c_source.contains("Holder_T"));
-    assert!(!c_source.contains("T Holder_get"));
 
-    let c_source = compile_to_c_with_generated_call_check(
+    compile_to_c_with_specialization_check(
         &test_dir().join("multi_file_type_impl_return_enum_dependency/main.zen"),
+        &[
+            "typedef struct Option_i32 Option_i32;",
+            "Option_i32 Box_wrap_i32(Box_i32 self)",
+            "int32_t Box_value_or_i32(Box_i32 self, int32_t fallback)",
+            "Box_wrap_i32(self)",
+            "Box_value_or_i32(box, 0LL)",
+        ],
+        &["Box_wrap_i32", "Box_value_or_i32"],
+        &["Option_T", "T Box_wrap"],
     );
-    assert!(c_source.contains("typedef struct Option_i32 Option_i32;"));
-    assert!(c_source.contains("Option_i32 Box_wrap_i32(Box_i32 self)"));
-    assert!(c_source.contains("int32_t Box_value_or_i32(Box_i32 self, int32_t fallback)"));
-    assert!(c_source.contains("Box_wrap_i32(self)"));
-    assert!(c_source.contains("Box_value_or_i32(box, 0LL)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "Box_wrap_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "Box_value_or_i32");
-    assert!(!c_source.contains("Option_T"));
-    assert!(!c_source.contains("T Box_wrap"));
 
-    let c_source =
-        compile_to_c_with_generated_call_check(&test_dir().join("multi_file_type_method/main.zen"));
-    assert!(c_source.contains("int32_t Point_keep_i32(Point self, int32_t value)"));
-    assert!(c_source.contains("Point_keep_i32(point, 13LL)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "Point_keep_i32");
-    assert!(!c_source.contains("T Point_keep"));
-    assert!(!c_source.contains("Point_keep(point"));
+    compile_to_c_with_specialization_check(
+        &test_dir().join("multi_file_type_method/main.zen"),
+        &[
+            "int32_t Point_keep_i32(Point self, int32_t value)",
+            "Point_keep_i32(point, 13LL)",
+        ],
+        &["Point_keep_i32"],
+        &["T Point_keep", "Point_keep(point"],
+    );
 
-    let c_source = compile_to_c_with_generated_call_check(
+    compile_to_c_with_specialization_check(
         &test_dir().join("multi_file_type_method_worklist/main.zen"),
+        &[
+            "int32_t inner_i32(int32_t value)",
+            "int32_t Box_get_inner_i32(Box_i32 self)",
+            "inner_i32(self.value)",
+            "Box_get_inner_i32(box)",
+        ],
+        &["inner_i32", "Box_get_inner_i32"],
+        &["T inner", "inner_T"],
     );
-    assert!(c_source.contains("int32_t inner_i32(int32_t value)"));
-    assert!(c_source.contains("int32_t Box_get_inner_i32(Box_i32 self)"));
-    assert!(c_source.contains("inner_i32(self.value)"));
-    assert!(c_source.contains("Box_get_inner_i32(box)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "inner_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "Box_get_inner_i32");
-    assert!(!c_source.contains("T inner"));
-    assert!(!c_source.contains("inner_T"));
 
-    let c_source = compile_to_c_with_generated_call_check(
+    compile_to_c_with_specialization_check(
         &test_dir().join("multi_file_type_method_method_dependency/main.zen"),
+        &[
+            "int32_t Box_inner_i32(Box_i32 self)",
+            "int32_t Box_get_inner_i32(Box_i32 self)",
+            "Box_inner_i32(self)",
+            "Box_get_inner_i32(box)",
+        ],
+        &["Box_inner_i32", "Box_get_inner_i32"],
+        &["T Box_inner"],
     );
-    assert!(c_source.contains("int32_t Box_inner_i32(Box_i32 self)"));
-    assert!(c_source.contains("int32_t Box_get_inner_i32(Box_i32 self)"));
-    assert!(c_source.contains("Box_inner_i32(self)"));
-    assert!(c_source.contains("Box_get_inner_i32(box)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "Box_inner_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "Box_get_inner_i32");
-    assert!(!c_source.contains("T Box_inner"));
 
-    let c_source = compile_to_c_with_generated_call_check(
+    compile_to_c_with_specialization_check(
         &test_dir().join("multi_file_type_method_imported_dependency/main.zen"),
+        &[
+            "int32_t inner_i32(int32_t value)",
+            "int32_t Box_get_inner_i32(Box_i32 self)",
+            "inner_i32(self.value)",
+            "Box_get_inner_i32(box)",
+        ],
+        &["inner_i32", "Box_get_inner_i32"],
+        &["T inner"],
     );
-    assert!(c_source.contains("int32_t inner_i32(int32_t value)"));
-    assert!(c_source.contains("int32_t Box_get_inner_i32(Box_i32 self)"));
-    assert!(c_source.contains("inner_i32(self.value)"));
-    assert!(c_source.contains("Box_get_inner_i32(box)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "inner_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "Box_get_inner_i32");
-    assert!(!c_source.contains("T inner"));
 
-    let c_source = compile_to_c_with_generated_call_check(
+    compile_to_c_with_specialization_check(
         &test_dir().join("multi_file_type_method_return_enum_dependency/main.zen"),
+        &[
+            "typedef struct Option_i32 Option_i32;",
+            "Option_i32 Box_wrap_i32(Box_i32 self)",
+            "int32_t Box_value_or_i32(Box_i32 self, int32_t fallback)",
+            "Box_wrap_i32(self)",
+            "Box_value_or_i32(box, 0LL)",
+        ],
+        &["Box_wrap_i32", "Box_value_or_i32"],
+        &["Option_T", "T Box_wrap"],
     );
-    assert!(c_source.contains("typedef struct Option_i32 Option_i32;"));
-    assert!(c_source.contains("Option_i32 Box_wrap_i32(Box_i32 self)"));
-    assert!(c_source.contains("int32_t Box_value_or_i32(Box_i32 self, int32_t fallback)"));
-    assert!(c_source.contains("Box_wrap_i32(self)"));
-    assert!(c_source.contains("Box_value_or_i32(box, 0LL)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "Box_wrap_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "Box_value_or_i32");
-    assert!(!c_source.contains("Option_T"));
-    assert!(!c_source.contains("T Box_wrap"));
 
-    let c_source = compile_to_c_with_generated_call_check(
+    compile_to_c_with_specialization_check(
         &test_dir().join("multi_file_type_method_nested_result_dependency/main.zen"),
+        &[
+            "typedef struct Option_i32 Option_i32;",
+            "typedef struct Result_Option_i32_StaticString Result_Option_i32_StaticString;",
+            "Result_Option_i32_StaticString Box_wrap_result_i32(Box_i32 self)",
+            "Box_wrap_result_i32(box)",
+            "unwrap_result_Option_i32_StaticString(wrapped,",
+            "unwrap_option_i32(some, 0LL)",
+        ],
+        &[
+            "Box_wrap_result_i32",
+            "unwrap_result_Option_i32_StaticString",
+            "unwrap_option_i32",
+        ],
+        &["Option_T", "Result_Option_T", "T Box_wrap_result"],
     );
-    assert!(c_source.contains("typedef struct Option_i32 Option_i32;"));
-    assert!(c_source
-        .contains("typedef struct Result_Option_i32_StaticString Result_Option_i32_StaticString;"));
-    assert!(c_source.contains("Result_Option_i32_StaticString Box_wrap_result_i32(Box_i32 self)"));
-    assert!(c_source.contains("Box_wrap_result_i32(box)"));
-    assert!(c_source.contains("unwrap_result_Option_i32_StaticString(wrapped,"));
-    assert!(c_source.contains("unwrap_option_i32(some, 0LL)"));
-    assert_c_call_resolves_to_single_definition(&c_source, "Box_wrap_result_i32");
-    assert_c_call_resolves_to_single_definition(&c_source, "unwrap_result_Option_i32_StaticString");
-    assert_c_call_resolves_to_single_definition(&c_source, "unwrap_option_i32");
-    assert!(!c_source.contains("Option_T"));
-    assert!(!c_source.contains("Result_Option_T"));
-    assert!(!c_source.contains("T Box_wrap_result"));
 }
 
 fn returned_call_name(c_source: &str, function_name: &str) -> String {

--- a/tests/integration/support.rs
+++ b/tests/integration/support.rs
@@ -12,8 +12,8 @@ mod generated_c;
 
 pub use generated_c::{
     assert_c_call_resolves_to_single_definition, assert_generated_c_calls_resolve_to_definitions,
-    assert_generated_c_function_definitions_are_unique, has_c_call_outside_signature,
-    undefined_generated_c_calls,
+    assert_generated_c_function_definitions_are_unique, assert_generated_c_specialization,
+    has_c_call_outside_signature, undefined_generated_c_calls,
 };
 
 /// Root of the test fixtures.
@@ -62,6 +62,22 @@ pub fn compile_to_c(zen_path: &Path) -> String {
 pub fn compile_to_c_with_generated_call_check(zen_path: &Path) -> String {
     let c_source = compile_to_c(zen_path);
     assert_generated_c_calls_resolve_to_definitions(&c_source);
+    c_source
+}
+
+pub fn compile_to_c_with_specialization_check(
+    zen_path: &Path,
+    required_snippets: &[&str],
+    single_definition_calls: &[&str],
+    forbidden_snippets: &[&str],
+) -> String {
+    let c_source = compile_to_c_with_generated_call_check(zen_path);
+    assert_generated_c_specialization(
+        &c_source,
+        required_snippets,
+        single_definition_calls,
+        forbidden_snippets,
+    );
     c_source
 }
 

--- a/tests/integration/support/generated_c.rs
+++ b/tests/integration/support/generated_c.rs
@@ -43,6 +43,37 @@ pub fn assert_c_call_resolves_to_single_definition(c_source: &str, name: &str) {
     assert_c_function_definition_count(c_source, name, 1);
 }
 
+pub fn assert_generated_c_specialization(
+    c_source: &str,
+    required_snippets: &[&str],
+    single_definition_calls: &[&str],
+    forbidden_snippets: &[&str],
+) {
+    assert_c_source_contains_all(c_source, required_snippets);
+    for name in single_definition_calls {
+        assert_c_call_resolves_to_single_definition(c_source, name);
+    }
+    assert_c_source_lacks_all(c_source, forbidden_snippets);
+}
+
+fn assert_c_source_contains_all(c_source: &str, snippets: &[&str]) {
+    for snippet in snippets {
+        assert!(
+            c_source.contains(snippet),
+            "expected generated C to contain `{snippet}`:\n{c_source}"
+        );
+    }
+}
+
+fn assert_c_source_lacks_all(c_source: &str, snippets: &[&str]) {
+    for snippet in snippets {
+        assert!(
+            !c_source.contains(snippet),
+            "expected generated C to omit `{snippet}`:\n{c_source}"
+        );
+    }
+}
+
 pub fn assert_generated_c_calls_resolve_to_definitions(c_source: &str) {
     let undefined = undefined_generated_c_calls(c_source);
     assert!(


### PR DESCRIPTION
## Summary
- add a generated-C specialization assertion facade and compile helper
- refactor local and multi-file method/worklist generated-C tests onto the facade
- update docs-truth and phase-audit guards to pin the grouped assertion shape

## Tests
- cargo test --test integration generic_specializations::method_worklist_generated_c::method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols
- cargo test --test integration generic_specializations::multifile_generated_c::method_worklist_dependencies::multi_file_generic_method_and_worklist_specializations_do_not_emit_unspecialized_c_symbols
- cargo test --test docs_truth repo_hygiene::codegen_c
- cargo test --test docs_truth phase_audit::generated_c_evidence
- cargo test --test docs_truth repo_hygiene::file_size::thresholds::production_rust_files_stay_below_cleanup_threshold
- cargo fmt --check
- git diff --check
- cargo clippy -- -D warnings
- cargo test --lib
- cargo test --tests
